### PR TITLE
Adding auto-readme generation for Truss

### DIFF
--- a/truss/constants.py
+++ b/truss/constants.py
@@ -24,6 +24,9 @@ SYSTEM_PACKAGES_TXT_FILENAME = 'system_packages.txt'
 SERVER_DOCKERFILE_TEMPLATE_NAME = 'server.Dockerfile.jinja'
 MODEL_DOCKERFILE_NAME = 'Dockerfile'
 
+README_TEMPLATE_NAME = 'README.md.jinja'
+MODEL_README_NAME = 'README.md'
+
 CONFIG_FILE = 'config.yaml'
 DOCKERFILE = "Dockerfile"
 # Used to indicate whether to associate a container with Truss

--- a/truss/contexts/image_builder/image_builder.py
+++ b/truss/contexts/image_builder/image_builder.py
@@ -2,7 +2,8 @@ from pathlib import Path
 
 from jinja2 import Template
 
-from truss.constants import (MODEL_DOCKERFILE_NAME, REQUIREMENTS_TXT_FILENAME,
+from truss.constants import (MODEL_DOCKERFILE_NAME, MODEL_README_NAME,
+                             README_TEMPLATE_NAME, REQUIREMENTS_TXT_FILENAME,
                              SERVER_CODE_DIR, SERVER_DOCKERFILE_TEMPLATE_NAME,
                              SERVER_REQUIREMENTS_TXT_FILENAME,
                              SYSTEM_PACKAGES_TXT_FILENAME, TEMPLATES_DIR)
@@ -79,6 +80,15 @@ class ImageBuilder:
             docker_file_path = build_dir / MODEL_DOCKERFILE_NAME
             with docker_file_path.open('w') as docker_file:
                 docker_file.write(dockerfile_contents)
+
+        readme_template_path = TEMPLATES_DIR / README_TEMPLATE_NAME
+
+        with readme_template_path.open() as readme_template_file:
+            readme_template = Template(readme_template_file.read())
+            readme_contents = readme_template.render(config=self._spec.config)
+            readme_file_path = build_dir / MODEL_README_NAME
+            with readme_file_path.open('w') as readme_file:
+                readme_file.write(readme_contents)
 
     def docker_build_command(self, build_dir) -> str:
         return f'docker build {build_dir} -t {self.default_tag}'

--- a/truss/contexts/image_builder/image_builder.py
+++ b/truss/contexts/image_builder/image_builder.py
@@ -85,7 +85,14 @@ class ImageBuilder:
 
         with readme_template_path.open() as readme_template_file:
             readme_template = Template(readme_template_file.read())
-            readme_contents = readme_template.render(config=self._spec.config)
+            # examples.yaml may not exist
+            try:
+                examples_raw = self._spec.examples
+            except FileNotFoundError:
+                examples_raw = None
+            # examples.yaml may be empty
+            examples = dict(examples_raw) if examples_raw else None
+            readme_contents = readme_template.render(config=self._spec.config, examples=examples)
             readme_file_path = build_dir / MODEL_README_NAME
             with readme_file_path.open('w') as readme_file:
                 readme_file.write(readme_contents)

--- a/truss/contexts/image_builder/image_builder.py
+++ b/truss/contexts/image_builder/image_builder.py
@@ -86,13 +86,9 @@ class ImageBuilder:
         with readme_template_path.open() as readme_template_file:
             readme_template = Template(readme_template_file.read())
             # examples.yaml may not exist
-            try:
-                examples_raw = self._spec.examples
-            except FileNotFoundError:
-                examples_raw = None
-            # examples.yaml may be empty
-            examples_config = dict(examples_raw) if examples_raw else None
-            readme_contents = readme_template.render(config=self._spec.config, examples=examples_config)
+            # if examples.yaml does exist, but it's empty, examples_raw is None
+            examples_raw = self._spec.examples if self._spec.examples_path.exists() else None
+            readme_contents = readme_template.render(config=self._spec.config, examples=examples_raw)
             readme_file_path = build_dir / MODEL_README_NAME
             with readme_file_path.open('w') as readme_file:
                 readme_file.write(readme_contents)

--- a/truss/contexts/image_builder/image_builder.py
+++ b/truss/contexts/image_builder/image_builder.py
@@ -91,8 +91,8 @@ class ImageBuilder:
             except FileNotFoundError:
                 examples_raw = None
             # examples.yaml may be empty
-            examples = dict(examples_raw) if examples_raw else None
-            readme_contents = readme_template.render(config=self._spec.config, examples=examples)
+            examples_config = dict(examples_raw) if examples_raw else None
+            readme_contents = readme_template.render(config=self._spec.config, examples=examples_config)
             readme_file_path = build_dir / MODEL_README_NAME
             with readme_file_path.open('w') as readme_file:
                 readme_file.write(readme_contents)

--- a/truss/readme_generator.py
+++ b/truss/readme_generator.py
@@ -11,7 +11,5 @@ def generate_readme(_spec: TrussSpec) -> str:
         # examples.yaml may not exist
         # if examples.yaml does exist, but it's empty, examples_raw is None
         examples_raw = _spec.examples if _spec.examples_path.exists() else None
-        print("asdfasdfasdfasdfs")
-        print(examples_raw)
         readme_contents = readme_template.render(config=_spec.config, examples=examples_raw)
     return readme_contents

--- a/truss/readme_generator.py
+++ b/truss/readme_generator.py
@@ -1,0 +1,17 @@
+from jinja2 import Template
+
+from truss.constants import README_TEMPLATE_NAME, TEMPLATES_DIR
+from truss.truss_spec import TrussSpec
+
+
+def generate_readme(_spec: TrussSpec) -> str:
+    readme_template_path = TEMPLATES_DIR / README_TEMPLATE_NAME
+    with readme_template_path.open() as readme_template_file:
+        readme_template = Template(readme_template_file.read())
+        # examples.yaml may not exist
+        # if examples.yaml does exist, but it's empty, examples_raw is None
+        examples_raw = _spec.examples if _spec.examples_path.exists() else None
+        print("asdfasdfasdfasdfs")
+        print(examples_raw)
+        readme_contents = readme_template.render(config=_spec.config, examples=examples_raw)
+    return readme_contents

--- a/truss/templates/README.md.jinja
+++ b/truss/templates/README.md.jinja
@@ -20,15 +20,34 @@ truss run-image
 There are two ways to run inference on your Truss model.
 #### Via Truss CLI
 ```
+{%- if examples == None %}
 truss predict --target_directory ./  --request '{"inputs": YOUR_INPUT}'
+{% else %}
+    {%- for first_key, first_value in examples.items() %}
+        {%- for second_key, second_value in first_value.items() %}
+truss predict --target_directory ./  --request '{"inputs": {{ second_value[0] }}}'
+        {%- endfor %}
+    {%- endfor %}
+{%- endif %}
 ```
 
 #### Via CURL
 In order to run inference via CURL, we assume you've built and run the Docker image generated from your Truss. Refer above for more instructions on how to do this.
 ```
+{%- if examples == None %}
 curl -H 'Content-Type: application/json' \
-   -d '{"inputs": YOUR_INPUT}' \
-   -X POST http://localhost:8080/v1/models/model:predict
+-d '{"inputs": YOUR_INPUT}' \
+-X POST http://localhost:8080/v1/models/model:predict
+{% else %}
+    {%- for first_key, first_value in examples.items() %}
+        {%- for second_key, second_value in first_value.items() %}
+curl -H 'Content-Type: application/json' \
+-d '{"inputs": {{ second_value[0] }} \
+-X POST http://localhost:8080/v1/models/model:predict
+        {%- endfor %}
+    {%- endfor %}
+{%- endif %}
+
 ```
 
 ### Running all of the example inputs on your Truss
@@ -38,7 +57,13 @@ truss run-example
 
 ### Run a specific example input on your Truss
 ```
-truss run-example --name NAME_OF_EXAMPLE
+{%- if examples == None %}
+truss run-example --name EXAMPLE_NAME
+{% else %}
+    {%- for key, value in examples.items() %}
+truss run-example --name {{ key }}
+    {%- endfor %}
+{%- endif %}
 ```
 
 ### Adding pre/postprocessing code

--- a/truss/templates/README.md.jinja
+++ b/truss/templates/README.md.jinja
@@ -1,9 +1,9 @@
 {% if config.model_name == None %}
-## Model how-to
+# Model how-to
 {% else %}
-## {{ config.model_name }} how-to
+# {{ config.model_name }} how-to
 {% endif %}
-Welcome to your {{ config.model_framework.value }} model's Truss. Below are some useful commands to work with this Truss. For all the commands below, make sure you're in this directory when you run them.
+Welcome to your {{ config.model_framework.value }} model's Truss. Below are some useful commands to work with this Truss. For all the commands below, make sure you're in this directory when you run them. You can find the docs for Truss [here](https://truss.baseten.co).
 
 ### Build a Docker image from your Truss
 ```

--- a/truss/templates/README.md.jinja
+++ b/truss/templates/README.md.jinja
@@ -42,7 +42,7 @@ curl -H 'Content-Type: application/json' \
     {%- for first_key, first_value in examples.items() %}
         {%- for second_key, second_value in first_value.items() %}
 curl -H 'Content-Type: application/json' \
--d '{"inputs": {{ second_value[0] }} \
+-d '{"inputs": {{ second_value[0] }} }' \
 -X POST http://localhost:8080/v1/models/model:predict
         {%- endfor %}
     {%- endfor %}

--- a/truss/templates/README.md.jinja
+++ b/truss/templates/README.md.jinja
@@ -1,0 +1,5 @@
+{% if config.model_name == None %}
+## Model how-to
+{% else %}
+## {{ config.model_name }} how-to
+{% endif %}

--- a/truss/templates/README.md.jinja
+++ b/truss/templates/README.md.jinja
@@ -3,3 +3,54 @@
 {% else %}
 ## {{ config.model_name }} how-to
 {% endif %}
+Welcome to your {{ config.model_framework.value }} model's Truss. Below are some useful commands to work with this Truss. For all the commands below, make sure you're in this directory when you run them.
+
+### Build a Docker image from your Truss
+```
+truss build-image
+```
+
+### Run the Docker image from your Truss
+```
+# We assume you've built the image first.
+truss run-image
+```
+
+### Run inference on your Truss
+There are two ways to run inference on your Truss model.
+#### Via Truss CLI
+```
+truss predict --target_directory ./  --request '{"inputs": YOUR_INPUT}'
+```
+
+#### Via CURL
+In order to run inference via CURL, we assume you've built and run the Docker image generated from your Truss. Refer above for more instructions on how to do this.
+```
+curl -H 'Content-Type: application/json' \
+   -d '{"inputs": YOUR_INPUT}' \
+   -X POST http://localhost:8080/v1/models/model:predict
+```
+
+### Running all of the example inputs on your Truss
+```
+truss run-example
+```
+
+### Run a specific example input on your Truss
+```
+truss run-example --name NAME_OF_EXAMPLE
+```
+
+### Adding pre/postprocessing code
+You may find that you'd like to preprocess the inputs to your model or postprocess the outputs of your model.
+1. Navigate to `model/{{ config.model_class_filename }}`. This is where your preprocessing/postprocessing logic will live.
+2. Define a `preprocess` or `postprocess` function as such.
+```
+def preprocess(self, request: Dict) -> Dict:
+    # Code that runs before inference
+    return request
+
+def postprocess(self, request: Dict) -> Dict:
+    # Code that runs after inference
+    return request
+```

--- a/truss/test_data/readme_int_example.md
+++ b/truss/test_data/readme_int_example.md
@@ -1,0 +1,54 @@
+# Model how-to
+
+Welcome to your custom model's Truss. Below are some useful commands to work with this Truss. For all the commands below, make sure you're in this directory when you run them. You can find the docs for Truss [here](https://truss.baseten.co).
+
+### Build a Docker image from your Truss
+```
+truss build-image
+```
+
+### Run the Docker image from your Truss
+```
+# We assume you've built the image first.
+truss run-image
+```
+
+### Run inference on your Truss
+There are two ways to run inference on your Truss model.
+#### Via Truss CLI
+```
+truss predict --target_directory ./  --request '{"inputs": [0]}'
+```
+
+#### Via CURL
+In order to run inference via CURL, we assume you've built and run the Docker image generated from your Truss. Refer above for more instructions on how to do this.
+```
+curl -H 'Content-Type: application/json' \
+-d '{"inputs": [0] }' \
+-X POST http://localhost:8080/v1/models/model:predict
+
+```
+
+### Running all of the example inputs on your Truss
+```
+truss run-example
+```
+
+### Run a specific example input on your Truss
+```
+truss run-example --name example1
+```
+
+### Adding pre/postprocessing code
+You may find that you'd like to preprocess the inputs to your model or postprocess the outputs of your model.
+1. Navigate to `model/model.py`. This is where your preprocessing/postprocessing logic will live.
+2. Define a `preprocess` or `postprocess` function as such.
+```
+def preprocess(self, request: Dict) -> Dict:
+    # Code that runs before inference
+    return request
+
+def postprocess(self, request: Dict) -> Dict:
+    # Code that runs after inference
+    return request
+```

--- a/truss/test_data/readme_no_example.md
+++ b/truss/test_data/readme_no_example.md
@@ -1,0 +1,57 @@
+# Model how-to
+
+Welcome to your custom model's Truss. Below are some useful commands to work with this Truss. For all the commands below, make sure you're in this directory when you run them. You can find the docs for Truss [here](https://truss.baseten.co).
+
+### Build a Docker image from your Truss
+```
+truss build-image
+```
+
+### Run the Docker image from your Truss
+```
+# We assume you've built the image first.
+truss run-image
+```
+
+### Run inference on your Truss
+There are two ways to run inference on your Truss model.
+#### Via Truss CLI
+```
+truss predict --target_directory ./  --request '{"inputs": YOUR_INPUT}'
+
+```
+
+#### Via CURL
+In order to run inference via CURL, we assume you've built and run the Docker image generated from your Truss. Refer above for more instructions on how to do this.
+```
+curl -H 'Content-Type: application/json' \
+-d '{"inputs": YOUR_INPUT}' \
+-X POST http://localhost:8080/v1/models/model:predict
+
+
+```
+
+### Running all of the example inputs on your Truss
+```
+truss run-example
+```
+
+### Run a specific example input on your Truss
+```
+truss run-example --name EXAMPLE_NAME
+
+```
+
+### Adding pre/postprocessing code
+You may find that you'd like to preprocess the inputs to your model or postprocess the outputs of your model.
+1. Navigate to `model/model.py`. This is where your preprocessing/postprocessing logic will live.
+2. Define a `preprocess` or `postprocess` function as such.
+```
+def preprocess(self, request: Dict) -> Dict:
+    # Code that runs before inference
+    return request
+
+def postprocess(self, request: Dict) -> Dict:
+    # Code that runs after inference
+    return request
+```

--- a/truss/test_data/readme_str_example.md
+++ b/truss/test_data/readme_str_example.md
@@ -1,0 +1,54 @@
+# Model how-to
+
+Welcome to your custom model's Truss. Below are some useful commands to work with this Truss. For all the commands below, make sure you're in this directory when you run them. You can find the docs for Truss [here](https://truss.baseten.co).
+
+### Build a Docker image from your Truss
+```
+truss build-image
+```
+
+### Run the Docker image from your Truss
+```
+# We assume you've built the image first.
+truss run-image
+```
+
+### Run inference on your Truss
+There are two ways to run inference on your Truss model.
+#### Via Truss CLI
+```
+truss predict --target_directory ./  --request '{"inputs": {'image_url': 'https://github.com/pytorch/hub/raw/master/images/dog.jpg'}}'
+```
+
+#### Via CURL
+In order to run inference via CURL, we assume you've built and run the Docker image generated from your Truss. Refer above for more instructions on how to do this.
+```
+curl -H 'Content-Type: application/json' \
+-d '{"inputs": {'image_url': 'https://github.com/pytorch/hub/raw/master/images/dog.jpg'} }' \
+-X POST http://localhost:8080/v1/models/model:predict
+
+```
+
+### Running all of the example inputs on your Truss
+```
+truss run-example
+```
+
+### Run a specific example input on your Truss
+```
+truss run-example --name example1
+```
+
+### Adding pre/postprocessing code
+You may find that you'd like to preprocess the inputs to your model or postprocess the outputs of your model.
+1. Navigate to `model/model.py`. This is where your preprocessing/postprocessing logic will live.
+2. Define a `preprocess` or `postprocess` function as such.
+```
+def preprocess(self, request: Dict) -> Dict:
+    # Code that runs before inference
+    return request
+
+def postprocess(self, request: Dict) -> Dict:
+    # Code that runs after inference
+    return request
+```

--- a/truss/tests/conftest.py
+++ b/truss/tests/conftest.py
@@ -308,6 +308,15 @@ def huggingface_transformer_t5_small_model():
 
 
 @pytest.fixture
+def custom_model_truss_dir_with_pre_and_post_no_example(tmp_path):
+    dir_path = tmp_path / 'custom_truss_with_pre_post_no_example'
+    sc = init(str(dir_path))
+    with sc.spec.model_class_filepath.open('w') as file:
+        file.write(CUSTOM_MODEL_CODE_WITH_PRE_AND_POST_PROCESS)
+    yield dir_path
+
+
+@pytest.fixture
 def custom_model_truss_dir_with_pre_and_post(tmp_path):
     dir_path = tmp_path / 'custom_truss_with_pre_post'
     sc = init(str(dir_path))
@@ -316,6 +325,22 @@ def custom_model_truss_dir_with_pre_and_post(tmp_path):
     sc.update_examples({
         'example1': {
             'inputs': [[0]]
+        }
+    })
+    yield dir_path
+
+
+@pytest.fixture
+def custom_model_truss_dir_with_pre_and_post_str_example(tmp_path):
+    dir_path = tmp_path / 'custom_truss_with_pre_post_str_example'
+    sc = init(str(dir_path))
+    with sc.spec.model_class_filepath.open('w') as file:
+        file.write(CUSTOM_MODEL_CODE_WITH_PRE_AND_POST_PROCESS)
+    sc.update_examples({
+        'example1': {
+            'inputs': [{
+                'image_url' : 'https://github.com/pytorch/hub/raw/master/images/dog.jpg'
+            }]
         }
     })
     yield dir_path

--- a/truss/tests/test_truss_handle.py
+++ b/truss/tests/test_truss_handle.py
@@ -30,10 +30,8 @@ def test_readme_generation_int_example(custom_model_truss_dir_with_pre_and_post)
     sc = TrussHandle(custom_model_truss_dir_with_pre_and_post)
     readme_contents = sc.generate_readme()
     readme_contents = readme_contents.replace('\n', '')
-    readme_correct_path = Path(__file__).parent.parent / 'test_data' / 'readme_int_example.md'
-    with open(readme_correct_path, 'r') as readme_correct_file:
-        readme_correct = readme_correct_file.read().replace('\n', '')
-    assert readme_contents == readme_correct
+    correct_readme_contents = _read_readme('readme_int_example.md')
+    assert readme_contents == correct_readme_contents
 
 
 def test_readme_generation_no_example(custom_model_truss_dir_with_pre_and_post_no_example):
@@ -42,20 +40,16 @@ def test_readme_generation_no_example(custom_model_truss_dir_with_pre_and_post_n
     os.remove(sc._spec.examples_path)
     readme_contents = sc.generate_readme()
     readme_contents = readme_contents.replace('\n', '')
-    readme_correct_path = Path(__file__).parent.parent / 'test_data' / 'readme_no_example.md'
-    with open(readme_correct_path, 'r') as readme_correct_file:
-        readme_correct = readme_correct_file.read().replace('\n', '')
-    assert readme_contents == readme_correct
+    correct_readme_contents = _read_readme('readme_no_example.md')
+    assert readme_contents == correct_readme_contents
 
 
 def test_readme_generation_str_example(custom_model_truss_dir_with_pre_and_post_str_example):
     sc = TrussHandle(custom_model_truss_dir_with_pre_and_post_str_example)
     readme_contents = sc.generate_readme()
     readme_contents = readme_contents.replace('\n', '')
-    readme_correct_path = Path(__file__).parent.parent / 'test_data' / 'readme_str_example.md'
-    with open(readme_correct_path, 'r') as readme_correct_file:
-        readme_correct = readme_correct_file.read().replace('\n', '')
-    assert readme_contents == readme_correct
+    correct_readme_contents = _read_readme('readme_str_example.md')
+    assert readme_contents == correct_readme_contents
 
 
 @pytest.mark.integration
@@ -406,3 +400,9 @@ def _ensure_kill_all():
             return
         attempts += 1
         time.sleep(1)
+
+
+def _read_readme(filename: str) -> str:
+    readme_correct_path = Path(__file__).parent.parent / 'test_data' / filename
+    readme_contents = readme_correct_path.open().read().replace('\n', '')
+    return readme_contents

--- a/truss/tests/test_truss_handle.py
+++ b/truss/tests/test_truss_handle.py
@@ -1,4 +1,6 @@
+import os
 import time
+from pathlib import Path
 
 import pytest
 
@@ -22,6 +24,38 @@ def test_server_predict(custom_model_truss_dir_with_pre_and_post):
         'inputs': [1, 2, 3, 4],
     })
     assert resp == {'predictions': [4, 5, 6, 7]}
+
+
+def test_readme_generation_int_example(custom_model_truss_dir_with_pre_and_post):
+    sc = TrussHandle(custom_model_truss_dir_with_pre_and_post)
+    readme_contents = sc.generate_readme()
+    readme_contents = readme_contents.replace('\n', '')
+    readme_correct_path = Path(__file__).parent.parent / 'test_data' / 'readme_int_example.md'
+    with open(readme_correct_path, 'r') as readme_correct_file:
+        readme_correct = readme_correct_file.read().replace('\n', '')
+    assert readme_contents == readme_correct
+
+
+def test_readme_generation_no_example(custom_model_truss_dir_with_pre_and_post_no_example):
+    sc = TrussHandle(custom_model_truss_dir_with_pre_and_post_no_example)
+    # Remove the examples file
+    os.remove(sc._spec.examples_path)
+    readme_contents = sc.generate_readme()
+    readme_contents = readme_contents.replace('\n', '')
+    readme_correct_path = Path(__file__).parent.parent / 'test_data' / 'readme_no_example.md'
+    with open(readme_correct_path, 'r') as readme_correct_file:
+        readme_correct = readme_correct_file.read().replace('\n', '')
+    assert readme_contents == readme_correct
+
+
+def test_readme_generation_str_example(custom_model_truss_dir_with_pre_and_post_str_example):
+    sc = TrussHandle(custom_model_truss_dir_with_pre_and_post_str_example)
+    readme_contents = sc.generate_readme()
+    readme_contents = readme_contents.replace('\n', '')
+    readme_correct_path = Path(__file__).parent.parent / 'test_data' / 'readme_str_example.md'
+    with open(readme_correct_path, 'r') as readme_correct_file:
+        readme_correct = readme_correct_file.read().replace('\n', '')
+    assert readme_contents == readme_correct
 
 
 @pytest.mark.integration

--- a/truss/truss_handle.py
+++ b/truss/truss_handle.py
@@ -16,6 +16,7 @@ from truss.contexts.local_loader.load_local import LoadLocal
 from truss.docker import (Docker, get_container_logs, get_containers,
                           get_images, get_urls_from_container, kill_containers)
 from truss.local.local_config_handler import LocalConfigHandler
+from truss.readme_generator import generate_readme
 from truss.truss_config import TrussConfig
 from truss.truss_spec import TrussSpec
 from truss.utils import (copy_file_path, copy_tree_path,
@@ -273,6 +274,9 @@ class TrussHandle:
         for container in containers:
             urls.extend(get_urls_from_container(container))
         return urls
+
+    def generate_readme(self):
+        return generate_readme(self._spec)
 
 
 def _prediction_flow(model, request: dict):


### PR DESCRIPTION
**What:** Auto-generate a README for a Truss based on the `config.yaml` and `examples.yaml`. The README contains instructions on how to build and run a Docker image from the Truss, how to run inference on the Truss, and how to add pre/postprocessing to a Truss. 

**How:** When creating a Truss (i.e when `build-context` is run), we populate a Jinja template with information from the relevant YAML files. 

**Why:** To improve developer productivity when working with a Truss 