### PR TITLE
Update authors so that we can be contacted

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "truss"
 version = "0.0.20"
 description = ""
-authors = ["Alex Gillmor <alex@baseten.co>"]
+authors = ["Pankaj Gupta <pankaj@baseten.co>", "Phil Howes <phil@baseten.co>"]
 include = ["*.txt", "*.Dockerfile", "*.md"]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
While we want to recognize Alex's contribution to the project, only active maintainers should be listed as Authors on PyPi.