### PR TITLE
Support using docker via sudo based on truss local config

### DIFF
--- a/truss/docker.py
+++ b/truss/docker.py
@@ -2,6 +2,7 @@ import logging
 from typing import Dict
 
 from truss.constants import TRUSS_DIR
+from truss.local.local_config_handler import LocalConfigHandler
 
 
 class Docker:
@@ -10,8 +11,11 @@ class Docker:
     @staticmethod
     def client():
         if Docker._client is None:
-            from python_on_whales import docker
-            Docker._client = docker
+            from python_on_whales import DockerClient, docker
+            if LocalConfigHandler.get_config().use_sudo:
+                Docker._client = DockerClient(client_call=['sudo', 'docker'])
+            else:
+                Docker._client = docker
         return Docker._client
 
 

--- a/truss/local/local_config.py
+++ b/truss/local/local_config.py
@@ -8,11 +8,13 @@ import yaml
 @dataclass
 class LocalConfig:
     secrets: Dict[str, str] = field(default_factory=dict)
+    use_sudo: bool = False
 
     @staticmethod
     def from_dict(d):
         return LocalConfig(
             secrets=d.get('secrets', {}),
+            use_sudo=d.get('use_sudo', False),
         )
 
     @staticmethod
@@ -23,6 +25,7 @@ class LocalConfig:
     def to_dict(self):
         return {
             'secrets': self.secrets,
+            'use_sudo': self.use_sudo,
         }
 
     def write_to_yaml_file(self, path: Path):


### PR DESCRIPTION
What: Default installation of docker for many environments is such that running docker commands for building images and running containers require sudo. 

Now, if user specifies use_sudo to be true in their local truss config, then docker commands will automatically be run with sudo. We assume passwordless sudo, otherwise this won't work. This is exactly how python-on-whales provides out of the box and is considered sufficient for now.