### PR TITLE
Use nvidia runtime for gpu

### DIFF
--- a/truss/truss_handle.py
+++ b/truss/truss_handle.py
@@ -77,7 +77,7 @@ class TrussHandle:
                 f'src={str(secrets_mount_dir_path)}',
                 'target=/secrets',
             ]],
-            runtime='nvidia' if self._spec.config.resources.use_gpu else None,
+            gpus='all' if self._spec.config.resources.use_gpu else None,
         )
         model_base_url = f'http://localhost:{local_port}/'
         try:

--- a/truss/truss_handle.py
+++ b/truss/truss_handle.py
@@ -76,7 +76,8 @@ class TrussHandle:
                 'type=bind',
                 f'src={str(secrets_mount_dir_path)}',
                 'target=/secrets',
-            ]]
+            ]],
+            runtime='nvidia' if self._spec.config.resources.use_gpu else None,
         )
         model_base_url = f'http://localhost:{local_port}/'
         try:


### PR DESCRIPTION
What: Docker needs nvidia runtime for being able to make use of GPU.
How: Use the 'nvidia' docker runtime when running a truss that's marked to use GPU.

The GPU docker image that truss currently uses is cuda specific and thus it also needs a specific docker runtime. When we support more ways of accessing GPUs this might change.

I manually tested this change on an AWS GPU EC2 instance.