### PR TITLE
Adding cleanup command

### DIFF
--- a/truss/build.py
+++ b/truss/build.py
@@ -1,3 +1,4 @@
+import os
 from distutils.dir_util import remove_tree
 from pathlib import Path
 from typing import Any, List
@@ -105,11 +106,17 @@ def from_directory(truss_directory: str) -> TrussHandle:
 
 def cleanup():
     """
-    Cleans up .baseten directory.
+    Cleans up .truss directory.
     """
-    baseten_dir = Path.home() / '.baseten'
-    remove_tree(baseten_dir)
-    baseten_dir.mkdir(exist_ok=True)
+    build_folder_path = Path(
+        Path.home(),
+        '.truss'
+    )
+    if (build_folder_path.exists()):
+        for obj in build_folder_path.glob('**/*'):
+            if (not obj.name == 'config.yaml') and (obj.is_file()):
+                os.remove(obj)
+    return
 
 
 def _update_truss_props(

--- a/truss/build.py
+++ b/truss/build.py
@@ -1,5 +1,4 @@
 import os
-from distutils.dir_util import remove_tree
 from pathlib import Path
 from typing import Any, List
 

--- a/truss/cli.py
+++ b/truss/cli.py
@@ -214,17 +214,11 @@ def kill_all():
 @error_handling
 def cleanup() -> None:
     """
-    Cleans up .truss folder
+    Clean up truss data.
+
+    Truss creates temporary directories for various operations such as for building docker images. This command clears that data to free up disk space.
     """
-    build_folder_path = Path(
-        Path.home(),
-        '.truss'
-    )
-    if (build_folder_path.exists()):
-        for obj in build_folder_path.glob('**/*'):
-            if (not obj.name == 'config.yaml') and (obj.is_file()):
-                os.remove(obj)
-    return
+    truss.build.cleanup()
 
 
 def _get_truss_from_directory(target_directory: str = None):

--- a/truss/cli.py
+++ b/truss/cli.py
@@ -216,7 +216,9 @@ def cleanup() -> None:
     """
     Clean up truss data.
 
-    Truss creates temporary directories for various operations such as for building docker images. This command clears that data to free up disk space.
+    Truss creates temporary directories for various operations
+    such as for building docker images. This command clears
+    that data to free up disk space.
     """
     truss.build.cleanup()
 

--- a/truss/cli.py
+++ b/truss/cli.py
@@ -217,13 +217,13 @@ def cleanup() -> None:
     """
     build_folder_path = Path(
         Path.home(),
-        '.truss' 
+        '.truss'
     )
     if (build_folder_path.exists()):
         for obj in build_folder_path.glob('**/*'):
             if (not obj.name == 'config.yaml') and (obj.is_file()):
                 os.remove(obj)
-    return 
+    return
 
 def _get_truss_from_directory(target_directory: str = None):
     """Gets Truss from directory. If none, use the current directory"""

--- a/truss/cli.py
+++ b/truss/cli.py
@@ -209,6 +209,21 @@ def kill_all():
     "Kills all truss containers that are not manually persisted"
     truss.kill_all()
 
+@cli_group.command()
+@error_handling
+def cleanup() -> None:
+    """
+    Cleans up .truss folder
+    """
+    build_folder_path = Path(
+        Path.home(),
+        '.truss' 
+    )
+    if (build_folder_path.exists()):
+        for obj in build_folder_path.glob('**/*'):
+            if (not obj.name == 'config.yaml') and (obj.is_file()):
+                os.remove(obj)
+    return 
 
 def _get_truss_from_directory(target_directory: str = None):
     """Gets Truss from directory. If none, use the current directory"""

--- a/truss/cli.py
+++ b/truss/cli.py
@@ -209,6 +209,7 @@ def kill_all():
     "Kills all truss containers that are not manually persisted"
     truss.kill_all()
 
+
 @cli_group.command()
 @error_handling
 def cleanup() -> None:
@@ -224,6 +225,7 @@ def cleanup() -> None:
             if (not obj.name == 'config.yaml') and (obj.is_file()):
                 os.remove(obj)
     return
+
 
 def _get_truss_from_directory(target_directory: str = None):
     """Gets Truss from directory. If none, use the current directory"""


### PR DESCRIPTION
**What:** CLI command to cleanup temporary build folder when users run `build-context` or `build-image`. 
**Why:** These build folders tend to take up a lot of disk space so providing a quick way to cleanup these folders is beneficial to devs. 