### PR TITLE
Fix tensorflow model deploy from google colab

### DIFF
--- a/truss/model_inference.py
+++ b/truss/model_inference.py
@@ -69,9 +69,11 @@ def pip_freeze():
 def _get_entries_for_packages(list_of_requirements, desired_requirements):
     name_to_req_str = {}
     for req_name in desired_requirements:
-        for full_req_str in list_of_requirements:
-            if req_name == full_req_str.split('==')[0]:
-                name_to_req_str[req_name] = full_req_str
+        for req_spec_full_str in list_of_requirements:
+            req_spec_name, req_version = req_spec_full_str.split('==')
+            req_version_base = req_version.split('+')[0]
+            if req_name == req_spec_name:
+                name_to_req_str[req_name] = f'{req_name}=={req_version_base}'
     return name_to_req_str
 
 

--- a/truss/tests/test_model_inference.py
+++ b/truss/tests/test_model_inference.py
@@ -1,9 +1,11 @@
 import pytest
 
 from truss.constants import PYTORCH
-from truss.model_inference import (PYTORCH_REQ_MODULE_NAME, TENSORFLOW_REQ_MODULE_NAME, _get_entries_for_packages, infer_model_information,
+from truss.model_inference import (PYTORCH_REQ_MODULE_NAME,
+                                   TENSORFLOW_REQ_MODULE_NAME,
+                                   _get_entries_for_packages,
+                                   infer_model_information,
                                    validate_provided_parameters_with_model)
-
 
 SAMPLE_PIP_FREEZE_OUTPUT = [
     'tensorflow==2.9.1',


### PR DESCRIPTION
From `tensorflow==2.8.2+zzzcolab20220527125636` on google colab we extract `tensorflow==2.8.2`.