### PR TITLE
Convert invoice parser model to Truss

### DIFF
--- a/examples/invoice-parser/config.yaml
+++ b/examples/invoice-parser/config.yaml
@@ -1,0 +1,39 @@
+data_dir: data
+environment_variables: {}
+examples_filename: examples.yaml
+input_type: Any
+model_class_filename: model.py
+model_class_name: InvoiceParserModel
+model_framework: custom
+model_metadata: {}
+model_module_dir: model
+model_name: null
+model_type: custom
+python_version: py39
+requirements: 
+  - cachetools==4.2.2
+  - certifi==2020.12.5
+  - chardet==4.0.0
+  - google-api-core==1.28.0
+  - google-auth==1.30.1
+  - google-cloud-documentai==0.4.0
+  - googleapis-common-protos==1.53.0
+  - grpcio==1.38.0
+  - idna==2.10
+  - packaging==20.9
+  - proto-plus==1.18.1
+  - protobuf==3.17.1
+  - pyasn1==0.4.8
+  - pyasn1-modules==0.2.8
+  - pyparsing==2.4.7
+  - pytz==2021.1
+  - requests==2.25.1
+  - rsa==4.7.2
+  - six==1.16.0
+  - urllib3==1.26.5
+resources:
+  cpu: 500m
+  memory: 512m
+  use_gpu: false
+secrets:
+system_packages: []

--- a/examples/invoice-parser/config.yaml
+++ b/examples/invoice-parser/config.yaml
@@ -10,7 +10,7 @@ model_module_dir: model
 model_name: null
 model_type: custom
 python_version: py39
-requirements: 
+requirements:
   - cachetools==4.2.2
   - certifi==2020.12.5
   - chardet==4.0.0
@@ -36,4 +36,14 @@ resources:
   memory: 512m
   use_gpu: false
 secrets:
+    type: samplevalue
+    project_id: samplevalue
+    private_key_id: samplevalue
+    private_key: samplevalue
+    client_email: samplevalue
+    client_id: samplevalue
+    auth_uri: samplevalue
+    token_uri: samplevalue
+    auth_provider_x509_cert_url: samplevalue
+    client_x509_cert_url: samplevalue
 system_packages: []

--- a/examples/invoice-parser/examples.yaml
+++ b/examples/invoice-parser/examples.yaml
@@ -1,0 +1,3 @@
+example1:
+  inputs:
+    - [0]

--- a/examples/invoice-parser/examples.yaml
+++ b/examples/invoice-parser/examples.yaml
@@ -1,3 +1,3 @@
 example1:
   inputs:
-    - [0]
+    - ['https://slicedinvoices.com/pdf/wordpress-pdf-invoice-plugin-sample.pdf']

--- a/examples/invoice-parser/model/model.py
+++ b/examples/invoice-parser/model/model.py
@@ -1,0 +1,23 @@
+from typing import Dict, List
+
+from .parser_utils import extract_pdf_data
+
+
+
+class InvoiceParserModel(object):
+    def __init__(self, **kwargs) -> None:
+        self._config = kwargs['config']
+
+
+    def predict(self, request: Dict) -> Dict[str, List]:
+        inputs = request['inputs']
+        parsed_invoices = []
+        secret = self._config['secrets']
+        for url in inputs:
+            parsed_invoices.append(
+                {
+                    "parsed_data": extract_pdf_data(url, secret),
+                    "pdf_url": url,
+                }
+            )
+        return parsed_invoices

--- a/examples/invoice-parser/model/model.py
+++ b/examples/invoice-parser/model/model.py
@@ -3,11 +3,16 @@ from typing import Dict, List
 from .parser_utils import extract_pdf_data
 
 
-
 class InvoiceParserModel(object):
+    """
+    This model does not work out of the box. You must provide
+    creds to access the Google Cloud service used here. These
+    creds can be placed in the `config.yaml` file (under secrets).
+    To access these secrets, you can find them in the `_config` object
+    under `_config["secrets"][KEY_NAME]`.
+    """
     def __init__(self, **kwargs) -> None:
         self._config = kwargs['config']
-
 
     def predict(self, request: Dict) -> Dict[str, List]:
         inputs = request['inputs']

--- a/examples/invoice-parser/model/parser_utils.py
+++ b/examples/invoice-parser/model/parser_utils.py
@@ -3,10 +3,10 @@ import requests
 from google.cloud import documentai_v1 as documentai
 from google.oauth2 import service_account
 
-
-PROJECT_ID = ""
-LOCATION = ""
-PROCESSOR_ID = ""
+# These values must be provided for this service to run.
+PROJECT_ID = 'sample'
+LOCATION = 'sample'
+PROCESSOR_ID = 'sample'
 CONFIDENCE_THRESHOLD = 0.5
 
 

--- a/examples/invoice-parser/model/parser_utils.py
+++ b/examples/invoice-parser/model/parser_utils.py
@@ -1,0 +1,115 @@
+
+import requests
+from google.cloud import documentai_v1 as documentai
+from google.oauth2 import service_account
+
+
+PROJECT_ID = ""
+LOCATION = ""
+PROCESSOR_ID = ""
+CONFIDENCE_THRESHOLD = 0.5
+
+
+def extract_pdf_data(file_url: str, creds: dict):
+    '''
+    Extracts structured data from pdfs.
+    Args:
+        file_url: The url for a pdf file.
+    '''
+
+    credentials = service_account.Credentials.from_service_account_info(creds)
+    client = documentai.DocumentProcessorServiceClient(credentials=credentials)
+    res = requests.get(file_url)
+    input_config = documentai.types.RawDocument(
+        content=res.content, mime_type='application/pdf')
+    name = f'projects/{PROJECT_ID}/locations/{LOCATION}/processors/{PROCESSOR_ID}'
+
+    request = {"name": name, "raw_document": input_config}
+    result = client.process_document(request=request)
+    document = result.document
+
+    extracted_data = extract_invoice_data(document)
+
+    return extracted_data
+
+
+def extract_invoice_data(document):
+    extracted_data = []
+    document_lines = []
+    for page in document.pages:
+        document_lines.extend(page.lines)
+
+    for entity in document.entities:
+        bounding_boxes = get_line_bbox_for_segment(
+            entity.text_anchor.text_segments[0].start_index,
+            entity.text_anchor.text_segments[-1].end_index, document_lines)
+        extract = {
+            'field': entity.type_,
+            'field_confidence': entity.confidence,
+            'field_bbox': bounding_boxes,
+            'field_value': entity.mention_text,
+            'field_value_confidence': entity.confidence,
+            'field_value_bbox': bounding_boxes,
+        }
+        if extract['field_confidence'] > CONFIDENCE_THRESHOLD and\
+                extract['field_value_confidence'] > CONFIDENCE_THRESHOLD:
+            extracted_data.append(extract)
+    return extracted_data
+
+
+def get_line_bbox_for_segment(segment_min, segment_max, lines):
+    matching_lines = [
+        li for li in lines
+        if li.layout.text_anchor.text_segments[0].start_index <= segment_min
+        and segment_max <= li.layout.text_anchor.text_segments[-1].end_index
+    ]
+    matching_lines += [
+        li for li in lines
+        if li.layout.text_anchor.text_segments[0].start_index >= segment_min
+        and li.layout.text_anchor.text_segments[-1].end_index <= segment_max
+    ]
+    x_min = min([
+        vertex.x for vertex in min(matching_lines,
+                                   key=lambda x: [
+                                       vertex.x for vertex in x.layout.
+                                       bounding_poly.normalized_vertices
+                                   ]).layout.bounding_poly.normalized_vertices
+    ])
+    x_max = max([
+        vertex.x for vertex in max(matching_lines,
+                                   key=lambda x: [
+                                       vertex.x for vertex in x.layout.
+                                       bounding_poly.normalized_vertices
+                                   ]).layout.bounding_poly.normalized_vertices
+    ])
+    y_min = min([
+        vertex.y for vertex in min(matching_lines,
+                                   key=lambda x: [
+                                       vertex.y for vertex in x.layout.
+                                       bounding_poly.normalized_vertices
+                                   ]).layout.bounding_poly.normalized_vertices
+    ])
+    y_max = max([
+        vertex.y for vertex in max(matching_lines,
+                                   key=lambda x: [
+                                       vertex.y for vertex in x.layout.
+                                       bounding_poly.normalized_vertices
+                                   ]).layout.bounding_poly.normalized_vertices
+    ])
+    return [{
+        'x': x_min,
+        'y': y_min
+    }, {
+        'x': x_max,
+        'y': y_min
+    }, {
+        'x': x_max,
+        'y': y_max
+    }, {
+        'x': x_min,
+        'y': y_max
+    }]
+
+
+def dict_from_vertices(vertices):
+    return [{'x': v.x, 'y': v.y} for v in vertices]


### PR DESCRIPTION
**What:** A Truss directory that contains a PDF parser (used for invoice parsing, etc) 

**Testing** 
- Make sure you have Truss installed on your system and you're inside the `/examples/invoice-parser` folder
- To run in Docker image, execute 
```
truss predict --target_directory ./ --request '{"inputs": ["https://slicedinvoices.com/pdf/wordpress-pdf-invoice-plugin-sample.pdf"]}' 
```
- To run locally, execute 
```
truss predict --target_directory ./ --request '{"inputs": ["https://slicedinvoices.com/pdf/wordpress-pdf-invoice-plugin-sample.pdf"]}'  --run-local
```