### PR TITLE
Convert GPTJ to Truss

### DIFF
--- a/examples/gptj/config.yaml
+++ b/examples/gptj/config.yaml
@@ -1,0 +1,20 @@
+data_dir: data
+environment_variables: {}
+examples_filename: examples.yaml
+input_type: Any
+model_class_filename: model.py
+model_class_name: GPTJTransformerModel
+model_framework: custom
+model_metadata: {}
+model_module_dir: model
+model_name: null
+model_type: custom
+python_version: py39
+requirements:
+  - torch==1.11.0
+  - transformers==4.18.0
+  - accelerate==0.10.0
+resources:
+  use_gpu: true
+secrets: {}
+system_packages: []

--- a/examples/gptj/examples.yaml
+++ b/examples/gptj/examples.yaml
@@ -1,0 +1,3 @@
+example1:
+  inputs:
+    - [0]

--- a/examples/gptj/examples.yaml
+++ b/examples/gptj/examples.yaml
@@ -1,3 +1,3 @@
 example1:
   inputs:
-    - [0]
+    - prompt: "Hello world"

--- a/examples/gptj/model/model.py
+++ b/examples/gptj/model/model.py
@@ -1,0 +1,92 @@
+from typing import Dict, List
+
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+MAX_MAX_LENGTH = 512
+MIN_MAX_LENGTH = 64
+
+
+SUPPORTED_MODEL_PARAMS = {
+    'max_length',
+    'min_length',
+    'do_sample',
+    'early_stopping',
+    'num_beams',
+    'temperature',
+    'top_k',
+    'top_p',
+    'repetition_penalty',
+    'length_penalty',
+    'encoder_no_repeat_ngram_size',
+    'num_return_sequences',
+    'max_time',
+    'num_beam_groups',
+    'diversity_penalty',
+    'remove_invalid_values',
+}
+
+
+def _process_request_into_model_call(request_dict):
+    model_parameters = {}
+    for param in SUPPORTED_MODEL_PARAMS:
+        if param in request_dict:
+            model_parameters[param] = request_dict[param]
+            if param == 'max_length' and model_parameters[param] > MAX_MAX_LENGTH:
+                model_parameters[param] = MAX_MAX_LENGTH
+            if param == 'min_length' and model_parameters[param] > MIN_MAX_LENGTH:
+                model_parameters[param] = MIN_MAX_LENGTH
+    return model_parameters
+
+
+class GPTJTransformerModel(object):
+    def __init__(self, **kwargs) -> None:
+        self._data_dir = kwargs['data_dir']
+        self._config = kwargs['config']
+        self._model = None
+
+    def load(self):
+        # Load model here and assign to self._model.
+        self.device = 0 if torch.cuda.is_available() else 'cpu'
+        self._tokenizer = AutoTokenizer.from_pretrained("EleutherAI/gpt-j-6B")
+        self._model = AutoModelForCausalLM.from_pretrained(
+            "EleutherAI/gpt-j-6B", revision="float16", torch_dtype=torch.float16).to(self.device)
+        self.ready = True
+
+    def preprocess(self, request: Dict) -> Dict:
+        """
+        Incorporate pre-processing required by the model if desired here.
+
+        These might be feature transformations that are tightly coupled to the model.
+        """
+        return request
+
+    def postprocess(self, request: Dict) -> Dict:
+        """
+        Incorporate post-processing required by the model if desired here.
+        """
+        return request
+
+    def predict(self, request: Dict) -> Dict[str, List]:
+        response = {}
+        outputs = []
+        inputs = request['inputs'] # noqa
+        # We expect a list of queries
+        with torch.no_grad():
+            for query in inputs:
+                prompt = query['prompt']
+                output = self._tokenizer([prompt], return_tensors="pt", return_attention_mask=True)
+                attention_mask = output.attention_mask
+                input_ids = output.input_ids
+                params = _process_request_into_model_call(request)
+                gen_tokens = self._model.generate(
+                    input_ids.to(self.device),
+                    attention_mask=attention_mask.to(self.device),
+                    **params,
+                )
+                gen_text = self._tokenizer.batch_decode(gen_tokens)[0]
+                outputs.append(gen_text)
+
+        # Invoke model and calculate predictions here.
+        response['predictions'] = outputs
+        return response

--- a/examples/gptj/requirements.txt
+++ b/examples/gptj/requirements.txt
@@ -1,5 +1,0 @@
--i https://pypi.org/simple
-
-torch==1.11.0
-transformers==4.18.0
-accelerate==0.10.0

--- a/examples/gptj/requirements.txt
+++ b/examples/gptj/requirements.txt
@@ -1,0 +1,5 @@
+-i https://pypi.org/simple
+
+torch==1.11.0
+transformers==4.18.0
+accelerate==0.10.0


### PR DESCRIPTION
**What:** Converting GPT-J model to Truss scaffold 

**Testing** 
- Make sure you have Truss installed on your system and that you're inside the `/examples/gptj` folder. _Your system ideally should have a GPU else inference will be run on CPU which takes a while_. 

- To run in Docker image, execute 
```
truss predict --target_directory ./ --request '{"inputs": [{"prompt" : "Hello world! "}]}'
```
- To run locally, execute 
```
truss predict --target_directory ./ --request '{"inputs": [{"prompt" : "Hello world! "}]}' --run-local
```