### PR TITLE
Adding description field to config

### DIFF
--- a/docs/create/xgboost.md
+++ b/docs/create/xgboost.md
@@ -17,10 +17,10 @@ This is the part you want to replace with your own code. Using a Hugging Face tr
 ```python
 import xgboost as xgb
 from sklearn.datasets import make_classification
-from sklearn.model_selection import train_test_split    
+from sklearn.model_selection import train_test_split
 
 def create_data():
-    X, y = make_classification(n_samples=100, 
+    X, y = make_classification(n_samples=100,
                            n_informative=5,
                            n_classes=2)
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.25)
@@ -28,14 +28,14 @@ def create_data():
     test = xgb.DMatrix(X_test, y_test)
     return train, test
 
-train, test = create_data()   
+train, test = create_data()
 params = {
     "learning_rate": 0.01,
     "max_depth": 3
 }
 # training, we set the early stopping rounds parameter
-model = xgb.train(params, 
-        train, evals=[(train, "train"), (test, "validation")], 
+model = xgb.train(params,
+        train, evals=[(train, "train"), (test, "validation")],
         num_boost_round=100, early_stopping_rounds=20)
 ```
 

--- a/docs/deploy/gcp.md
+++ b/docs/deploy/gcp.md
@@ -8,14 +8,14 @@ Prerequisites:
 * [GCloud SDK](https://cloud.google.com/sdk/docs/install)
 
 
-1. Set up 
+1. Set up
 
 2. Enable:
 
-    1) Cloud Run API 
+    1) Cloud Run API
     2) Artifact Registry API
-    3) Cloud Build API. Wait a few minutes, if you get: 
-    
+    3) Cloud Build API. Wait a few minutes, if you get:
+
         INVALID_ARGUMENT: could not resolve source: googleapi: Error 403: XXXXXXXXXXX@cloudbuild.gserviceaccount.com does not have storage.objects.get access to the Google Cloud Storage object
 
     in your GCP Project. Runing the command below, also gives you the option to enable these APIs through the command line! (https://cloud.google.com/endpoints/docs/openapi/enable-api)

--- a/docs/develop/examples.md
+++ b/docs/develop/examples.md
@@ -1,6 +1,6 @@
 # Sample inputs
 
-Examples make your model easy to use for yourself and others. Easy to forget the exact inputs it needs, makes it better documented and more accessible. Also it gives you a way of testing your model because you know what a reasonable output would be for the input. 
+Examples make your model easy to use for yourself and others. Easy to forget the exact inputs it needs, makes it better documented and more accessible. Also it gives you a way of testing your model because you know what a reasonable output would be for the input.
 
 What is the examples file
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -24,14 +24,14 @@ Args:
 
 Builds the docker image for a Truss.
 
-Args: 
+Args:
 * TARGET DIRECTORY: A Truss directory. If none, use current directory.
 * BUILD_DIR: Image context. If none, a temp directory is created.
 
 #### cleanup
 
 Clean up truss data.
-    
+
 Truss creates temporary directories for various operations
 such as for building docker images. This command clears
 that data to free up disk space.

--- a/docs/reference/client.md
+++ b/docs/reference/client.md
@@ -6,32 +6,32 @@ A list of the functions available with `import truss` and their arguments and pr
 
     cleanup()
         Cleans up .truss directory.
-    
+
     from_directory(truss_directory: str) -> truss.truss_handle.TrussHandle
         Get a handle to a Truss. A Truss is a build context designed to be built
         as a container locally or uploaded into a baseten serving environment.
-        
+
         Args:
             truss_directory (str): The local directory of an existing Truss
         Returns:
             TrussHandle
-    
+
     init(target_directory: str, data_files: List[str] = None, requirements_file: str = None) -> truss.truss_handle.TrussHandle
         Initialize an empty placeholder Truss. A Truss is a build context designed
         to be built as a container locally or uploaded into a baseten serving
         environment. This placeholder structure can be filled to represent ML
         models.
-        
+
         Args:
             target_directory: Absolute or relative path of the directory to create
                               Truss in. The directory is created if it doesn't exist.
-    
+
     kill_all()
-    
+
     mk_truss(model: Any, target_directory: str = None, data_files: List[str] = None, requirements_file: str = None) -> truss.truss_handle.TrussHandle
         Create a Truss with the given model. A Truss is a build context designed to
         be built as a container locally or uploaded into a baseten serving environment.
-        
+
         Args:
             model (an in-memory model object): A model object to be deployed (e.g. a keras, sklearn, or pytorch model
                 object)
@@ -48,116 +48,115 @@ A list of the functions available with `import truss` and their arguments and pr
 
     class TrussHandle(builtins.object)
      |  TrussHandle(truss_dir: pathlib.Path) -> None
-     |  
+     |
      |  Methods defined here:
-     |  
+     |
      |  __init__(self, truss_dir: pathlib.Path) -> None
      |      Initialize self.  See help(type(self)) for accurate signature.
-     |  
+     |
      |  add_data(self, file_dir_or_glob: str)
      |      Add data to a truss model.
-     |      
+     |
      |      Accepts a file path, a directory path or a glob. Everything is copied
      |      under the truss model's data directory.
-     |  
+     |
      |  add_environment_variable(self, env_var_name: str, env_var_value: str)
      |      Add an environment variable to truss model's config.
-     |  
+     |
      |  add_example(self, example_name: str, example: dict)
      |      Add example for truss model.
-     |      
+     |
      |      If the example with the given name already exists then it is overwritten.
-     |  
+     |
      |  add_python_requirement(self, python_requirement: str)
      |      Add a python requirement to truss model's config.
-     |  
+     |
      |  add_secret(self, secret_name: str, default_secret_value: str = '')
-     |  
+     |
      |  add_system_package(self, system_package: str)
      |      Add a system package requirement to truss model's config.
-     |  
+     |
      |  build_docker_image(self, build_dir: pathlib.Path = None, tag: str = None)
      |      Builds docker image
-     |  
+     |
      |  container_logs(self)
-     |  
+     |
      |  docker_build_setup(self, build_dir: pathlib.Path = None)
      |      Set up a directory to build docker image from.
-     |      
+     |
      |      Returns:
      |          docker build command.
-     |  
+     |
      |  docker_predict(self, request: dict, build_dir: pathlib.Path = None, tag: str = None, local_port: int = 8080, detach: bool = True)
      |      Builds docker image, runs that as a docker container
      |      and makes a prediction request to the server running on the container.
      |      Kills the container afterwards. Mostly useful for testing.
-     |  
+     |
      |  docker_run(self, build_dir: pathlib.Path = None, tag: str = None, local_port: int = 8080, detach=True)
      |      Builds a docker image and runs it as a container.
-     |      
+     |
      |      Returns:
      |          Container, which can be used to get information about the running,
      |          including its id. The id can be used to kill the container.
-     |  
+     |
      |  enable_gpu(self)
      |      Enable gpu use for given model.
-     |      
+     |
      |      This is suggestive, model serving environment may still use cpu, e.g. if
      |      the setup doesn't have access to a GPU.
-     |      
+     |
      |      Note that truss would typically use a larger docker base image when this
      |      is enabled, for example to include the cuda libraries.
-     |  
+     |
      |  example(self, name_or_index: Union[str, int]) -> Dict
      |      Return lookup an example by name or index.
-     |      
+     |
      |      Index is 0 based. e.g. example(0) returns the first example.
-     |  
+     |
      |  examples(self) -> Dict[str, Dict]
      |      List truss model's examples.
-     |      
+     |
      |      Examples are a simple `name to input` dictionary.
-     |  
+     |
      |  generate_readme(self)
-     |  
+     |
      |  get_docker_containers_from_labels(self, all=False)
-     |  
+     |
      |  get_docker_images_from_label(self)
-     |  
+     |
      |  get_urls_from_truss(self)
-     |  
+     |
      |  kill_container(self)
-     |  
+     |
      |  server_predict(self, request: dict)
      |      Run the prediction flow locally.
-     |  
+     |
      |  update_examples(self, examples: Dict[str, Dict])
      |      Update truss model's examples.
-     |      
+     |
      |      Existing examples are replaced whole with the given ones.
-     |  
+     |
      |  update_requirements(self, requirements: List[str])
      |      Update requirements in truss model's config.
-     |      
+     |
      |      Replaces requirements in truss model's config with the provided list.
-     |  
+     |
      |  update_requirements_from_file(self, requirements_filepath: str)
      |      Update requirements in truss model's config.
-     |      
+     |
      |      Replaces requirements in truss model's config with those from the file
      |      at the given path.
-     |  
+     |
      |  ----------------------------------------------------------------------
      |  Readonly properties defined here:
-     |  
+     |
      |  spec
-     |  
+     |
      |  ----------------------------------------------------------------------
      |  Data descriptors defined here:
-     |  
+     |
      |  __dict__
      |      dictionary for instance variables (if defined)
-     |  
+     |
      |  __weakref__
      |      list of weak references to the object (if defined)
-

--- a/truss/tests/conftest.py
+++ b/truss/tests/conftest.py
@@ -475,6 +475,16 @@ def custom_model_truss_dir_with_pre_and_post_str_example(tmp_path):
 
 
 @pytest.fixture
+def custom_model_truss_dir_with_pre_and_post_description(tmp_path):
+    dir_path = tmp_path / 'custom_truss_with_pre_post'
+    sc = init(str(dir_path))
+    with sc.spec.model_class_filepath.open('w') as file:
+        file.write(CUSTOM_MODEL_CODE_WITH_PRE_AND_POST_PROCESS)
+    sc.update_description("This model adds 3 to all inputs")
+    yield dir_path
+
+
+@pytest.fixture
 def custom_model_truss_dir_for_gpu(tmp_path):
     dir_path = tmp_path / 'custom_truss'
     sc = init(str(dir_path))

--- a/truss/tests/test_truss_handle.py
+++ b/truss/tests/test_truss_handle.py
@@ -19,6 +19,13 @@ def test_spec(custom_model_truss_dir_with_pre_and_post):
     assert spec.truss_dir == dir_path
 
 
+def test_description(custom_model_truss_dir_with_pre_and_post_description):
+    dir_path = custom_model_truss_dir_with_pre_and_post_description
+    th = TrussHandle(dir_path)
+    spec = th.spec
+    assert spec.description == "This model adds 3 to all inputs"
+
+
 def test_server_predict(custom_model_truss_dir_with_pre_and_post):
     th = TrussHandle(custom_model_truss_dir_with_pre_and_post)
     resp = th.server_predict({

--- a/truss/truss_config.py
+++ b/truss/truss_config.py
@@ -74,6 +74,7 @@ class TrussConfig:
     python_version: str = DEFAULT_PYTHON_VERSION
     examples_filename: str = DEFAULT_EXAMPLES_FILENAME
     secrets: Dict[str, str] = field(default_factory=dict)
+    description: str = None
 
     @staticmethod
     def from_dict(d):
@@ -94,6 +95,7 @@ class TrussConfig:
             model_name=d.get('model_name', None),
             examples_filename=d.get('examples_filename', DEFAULT_EXAMPLES_FILENAME),
             secrets=d.get('secrets', {}),
+            description=d.get('description', None)
         )
         config.validate()
         return config
@@ -125,6 +127,7 @@ class TrussConfig:
             'model_name': self.model_name,
             'examples_filename': self.examples_filename,
             'secrets': self.secrets,
+            'description': self.description
         }
 
     def clone(self):

--- a/truss/truss_handle.py
+++ b/truss/truss_handle.py
@@ -290,6 +290,11 @@ class TrussHandle:
     def generate_readme(self):
         return generate_readme(self._spec)
 
+    def update_description(self, description: str):
+        self._update_config(lambda conf: replace(
+            conf,
+            description=description))
+
 
 def _prediction_flow(model, request: dict):
     """This flow attempts to mimic the request life-cycle of a kfserving server"""

--- a/truss/truss_spec.py
+++ b/truss/truss_spec.py
@@ -123,6 +123,10 @@ class TrussSpec:
     def secrets(self) -> Dict[str, str]:
         return self._config.secrets
 
+    @property
+    def description(self) -> str:
+        return self._config.description
+
 
 def _join_lines(lines: List[str]) -> str:
     return '\n'.join(lines) + '\n'


### PR DESCRIPTION
**What:** Allowing users to define a free-form description field in `config.yaml`. 
**Why:** Providing a space for developers and users to discuss their model with no constraints is important for documentation and for when readme generation occurs. 