### PR TITLE
Adding description field to config file

### DIFF
--- a/truss/tests/conftest.py
+++ b/truss/tests/conftest.py
@@ -475,6 +475,16 @@ def custom_model_truss_dir_with_pre_and_post_str_example(tmp_path):
 
 
 @pytest.fixture
+def custom_model_truss_dir_with_pre_and_post_description(tmp_path):
+    dir_path = tmp_path / 'custom_truss_with_pre_post'
+    sc = init(str(dir_path))
+    with sc.spec.model_class_filepath.open('w') as file:
+        file.write(CUSTOM_MODEL_CODE_WITH_PRE_AND_POST_PROCESS)
+    sc.update_description("This model adds 3 to all inputs")
+    yield dir_path
+
+
+@pytest.fixture
 def custom_model_truss_dir_for_gpu(tmp_path):
     dir_path = tmp_path / 'custom_truss'
     sc = init(str(dir_path))

--- a/truss/tests/test_truss_handle.py
+++ b/truss/tests/test_truss_handle.py
@@ -19,6 +19,13 @@ def test_spec(custom_model_truss_dir_with_pre_and_post):
     assert spec.truss_dir == dir_path
 
 
+def test_description(custom_model_truss_dir_with_pre_and_post_description):
+    dir_path = custom_model_truss_dir_with_pre_and_post_description
+    th = TrussHandle(dir_path)
+    spec = th.spec
+    assert spec.description == "This model adds 3 to all inputs"
+
+
 def test_server_predict(custom_model_truss_dir_with_pre_and_post):
     th = TrussHandle(custom_model_truss_dir_with_pre_and_post)
     resp = th.server_predict({

--- a/truss/truss_config.py
+++ b/truss/truss_config.py
@@ -74,6 +74,7 @@ class TrussConfig:
     python_version: str = DEFAULT_PYTHON_VERSION
     examples_filename: str = DEFAULT_EXAMPLES_FILENAME
     secrets: Dict[str, str] = field(default_factory=dict)
+    description: str = None
 
     @staticmethod
     def from_dict(d):
@@ -94,6 +95,7 @@ class TrussConfig:
             model_name=d.get('model_name', None),
             examples_filename=d.get('examples_filename', DEFAULT_EXAMPLES_FILENAME),
             secrets=d.get('secrets', {}),
+            description=d.get('description', None),
         )
         config.validate()
         return config
@@ -125,6 +127,7 @@ class TrussConfig:
             'model_name': self.model_name,
             'examples_filename': self.examples_filename,
             'secrets': self.secrets,
+            'description': self.description,
         }
 
     def clone(self):

--- a/truss/truss_handle.py
+++ b/truss/truss_handle.py
@@ -290,6 +290,11 @@ class TrussHandle:
     def generate_readme(self):
         return generate_readme(self._spec)
 
+    def update_description(self, description: str):
+        self._update_config(lambda conf: replace(
+            conf,
+            description=description))
+
 
 def _prediction_flow(model, request: dict):
     """This flow attempts to mimic the request life-cycle of a kfserving server"""

--- a/truss/truss_spec.py
+++ b/truss/truss_spec.py
@@ -123,6 +123,10 @@ class TrussSpec:
     def secrets(self) -> Dict[str, str]:
         return self._config.secrets
 
+    @property
+    def description(self) -> str:
+        return self._config.description
+
 
 def _join_lines(lines: List[str]) -> str:
     return '\n'.join(lines) + '\n'


### PR DESCRIPTION
**What:** Allowing users to define a free-form description field in config.yaml.
**Why:** Providing a space for developers and users to discuss their model with no constraints is important for documentation and for when readme generation occurs.