### PR TITLE
Handle missing data directory in a truss

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 *.pth
+*.code-workspace
 backend/*.sqlite3
 .DS_Store
 .env

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.0.26"
+version = "0.0.27"
 description = ""
 authors = ["Pankaj Gupta <pankaj@baseten.co>", "Phil Howes <phil@baseten.co>"]
 include = ["*.txt", "*.Dockerfile", "*.md"]

--- a/truss/contexts/image_builder/image_builder.py
+++ b/truss/contexts/image_builder/image_builder.py
@@ -77,7 +77,11 @@ class ImageBuilder:
 
         with dockerfile_template_path.open() as dockerfile_template_file:
             dockerfile_template = Template(dockerfile_template_file.read())
-            dockerfile_contents = dockerfile_template.render(config=self._spec.config)
+            data_dir_exists = (build_dir / self._spec.config.data_dir).exists()
+            dockerfile_contents = dockerfile_template.render(
+                config=self._spec.config,
+                data_dir_exists=data_dir_exists,
+            )
             docker_file_path = build_dir / MODEL_DOCKERFILE_NAME
             with docker_file_path.open('w') as docker_file:
                 docker_file.write(dockerfile_contents)

--- a/truss/templates/server.Dockerfile.jinja
+++ b/truss/templates/server.Dockerfile.jinja
@@ -78,8 +78,10 @@ ENV PORT 8080
 ENV APP_HOME /app
 WORKDIR $APP_HOME
 COPY ./server /app
-COPY ./model /app/model
-COPY ./data* /app/data
+COPY ./{{ config.model_module_dir }} /app/model
+{% if data_dir_exists %}
+COPY ./{{config.data_dir}} /app/data
+{% endif %}
 COPY ./config.yaml /app/config.yaml
 
 {% for env_var_name, env_var_value in config.environment_variables.items() %}


### PR DESCRIPTION
While the `COPY dir* target` works in docker when dir is missing, it doesn't work with kaniko. Instead add an explicit check through jinja template. Also fix the model module directory, use it from config rather than hardcoded.