### PR TITLE
Catching exceptions during auto README generation

### DIFF
--- a/truss/contexts/image_builder/image_builder.py
+++ b/truss/contexts/image_builder/image_builder.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import click
 from jinja2 import Template
 
 from truss.constants import (MODEL_DOCKERFILE_NAME, MODEL_README_NAME,
@@ -83,9 +84,21 @@ class ImageBuilder:
                 docker_file.write(dockerfile_contents)
 
         readme_file_path = build_dir / MODEL_README_NAME
-        readme_contents = generate_readme(self._spec)
-        with readme_file_path.open('w') as readme_file:
-            readme_file.write(readme_contents)
+        try:
+            readme_contents = generate_readme(self._spec)
+            with readme_file_path.open('w') as readme_file:
+                readme_file.write(readme_contents)
+        except Exception as e:
+            click.echo(
+                click.style
+                (
+                    f'''WARNING: Auto-readme generation has failed.
+                    This is probably due to a malformed config.yaml or
+                    malformed examples.yaml. Error is:
+                    {e}
+                    ''', fg='yellow'
+                )
+            )
 
     def docker_build_command(self, build_dir) -> str:
         return f'docker build {build_dir} -t {self.default_tag}'


### PR DESCRIPTION
**What:** The automated README generation runs during the build process for a Truss. Sometimes, due to malformed yaml files, README generation throws an error which exists the build process. In this PR, we catch exceptions generated during the build process, log a warning to the user and continue with the build process. 