### PR TITLE
Allow skipping confirm with `truss init` from the cli

### DIFF
--- a/docs/deploy/gcp.md
+++ b/docs/deploy/gcp.md
@@ -29,7 +29,7 @@ truss.docker_build_setup(build_dir=TARGET_TRUSS_BUILD_DIRECTORY)
 
 Enable the following three APIs:
 
-1. Cloud Run API 
+1. Cloud Run API
 2. Artifact Registry API
 3. Cloud Build API
 
@@ -39,9 +39,9 @@ Then deploy your model from the terminal!
 gcloud run deploy tensorflow-truss-model --source tensorflow_truss_build --allow-unauthenticated --memory 8GiB
 ```
 
-If you get the following error: 
+If you get the following error:
 
-```    
+```
 INVALID_ARGUMENT: could not resolve source: googleapi: Error 403: XXXXXXXXXXX@cloudbuild.gserviceaccount.com does not have storage.objects.get access to the Google Cloud Storage object
 ```
 

--- a/docs/develop/examples.md
+++ b/docs/develop/examples.md
@@ -1,12 +1,12 @@
 # Sample inputs
 
-When you test your model locally, you likely have a go-to set of inputs to make sure everything is working. To improve the developer experience and document the input format, the `examples.yaml` file stores sample inputs. No more forgetting if your model takes a list or a dictionary, and no more copying inputs between model invocation tests. 
+When you test your model locally, you likely have a go-to set of inputs to make sure everything is working. To improve the developer experience and document the input format, the `examples.yaml` file stores sample inputs. No more forgetting if your model takes a list or a dictionary, and no more copying inputs between model invocation tests.
 
 Format each example as follows:
 
 ```yaml
 - name: example_name
-  input: 
+  input:
 	inputs:
 		- [10, 20, 30]
 ```

--- a/docs/develop/localhost.md
+++ b/docs/develop/localhost.md
@@ -14,7 +14,7 @@ In local development, you can test and iterate on aspects of your model and envi
 * Pre- and post-processing functions: Is your model accepting and outputting well-formatted data?
 * Examples: Does your model perform as expected on sample inputs?
 
-There are two ways to interface with a Truss locally. The first is via [the Python Truss object interface](../reference/client.md#truss-use), and the second via [the command line](../reference/cli.md). 
+There are two ways to interface with a Truss locally. The first is via [the Python Truss object interface](../reference/client.md#truss-use), and the second via [the command line](../reference/cli.md).
 
 ### Python client
 
@@ -32,7 +32,7 @@ tr.docker_predict({"inputs": [0, 0, 0, 0]})
 
 ### Command line interface
 
-Alternately, you can run your Truss from the command line. 
+Alternately, you can run your Truss from the command line.
 
 ```
 truss predict path_to_my_truss '{"inputs": [0, 0, 0, 0]}'

--- a/docs/develop/processing.md
+++ b/docs/develop/processing.md
@@ -35,7 +35,7 @@ Here is a contrived post-processing function that calls a validation function be
 
 ```python
 def postprocess(self, request: Dict) -> Dict:
-    if self._validate_output(request): 
+    if self._validate_output(request):
         return {"Error": "Validation failed"}
     return request
 ```

--- a/docs/reference/client.md
+++ b/docs/reference/client.md
@@ -7,35 +7,35 @@ A list of the functions available with `import truss` and their arguments and pr
 #### cleanup()
 
 Cleans up .truss directory.
-    
+
 #### from_directory(truss_directory: str) -> truss.truss_handle.TrussHandle
 
 Get a handle to a Truss. A Truss is a build context designed to be built as a container locally or uploaded into a model serving environment.
-        
+
 Args:
 * truss_directory (str): The local directory of an existing Truss
 
 Returns:
 * TrussHandle
-    
+
 #### init(target_directory: str, data_files: List[str] = None, requirements_file: str = None) -> truss.truss_handle.TrussHandle
 
 Initialize an empty placeholder Truss. A Truss is a build context designed
 to be built as a container locally or uploaded into a model serving
 environment. This placeholder structure can be filled to represent ML
 models.
-        
+
 Args:
 
 * target_directory: Absolute or relative path of the directory to create Truss in. The directory is created if it doesn't exist.
 
 #### kill_all()
-    
+
 #### mk_truss(model: Any, target_directory: str = None, data_files: List[str] = None, requirements_file: str = None) -> truss.truss_handle.TrussHandle
 
 Create a Truss with the given model. A Truss is a build context designed to
 be built as a container locally or uploaded into a model serving environment.
-        
+
 Args:
 
 * model (an in-memory model object): A model object to be deployed (e.g. a keras sklearn, or pytorch model object)
@@ -49,96 +49,96 @@ Returns:
 
 ### Truss Use
 
-  
+
 #### add_data(self, file_dir_or_glob: str)
       Add data to a truss model.
-      
+
       Accepts a file path, a directory path or a glob. Everything is copied
       under the truss model's data directory.
-  
+
 #### add_environment_variable(self, env_var_name: str, env_var_value: str)
       Add an environment variable to truss model's config.
-  
+
 #### add_example(self, example_name: str, example: dict)
       Add example for truss model.
-      
+
       If the example with the given name already exists then it is overwritten.
-  
+
 #### add_python_requirement(self, python_requirement: str)
       Add a python requirement to truss model's config.
-  
+
 #### add_secret(self, secret_name: str, default_secret_value: str = '')
-  
+
 #### add_system_package(self, system_package: str)
       Add a system package requirement to truss model's config.
-  
+
 #### build_docker_image(self, build_dir: pathlib.Path = None, tag: str = None)
       Builds docker image
-  
+
 #### container_logs(self)
-  
+
 #### docker_build_setup(self, build_dir: pathlib.Path = None)
       Set up a directory to build docker image from.
-      
+
       Returns:
           docker build command.
-  
+
 #### docker_predict(self, request: dict, build_dir: pathlib.Path = None, tag: str = None, local_port: int = 8080, detach: bool = True)
       Builds docker image, runs that as a docker container
       and makes a prediction request to the server running on the container.
       Kills the container afterwards. Mostly useful for testing.
-  
+
 #### docker_run(self, build_dir: pathlib.Path = None, tag: str = None, local_port: int = 8080, detach=True)
       Builds a docker image and runs it as a container.
-      
+
       Returns:
           Container, which can be used to get information about the running,
           including its id. The id can be used to kill the container.
-  
+
 #### enable_gpu(self)
       Enable gpu use for given model.
-      
+
       This is suggestive, model serving environment may still use cpu, e.g. if
       the setup doesn't have access to a GPU.
-      
+
       Note that truss would typically use a larger docker base image when this
       is enabled, for example to include the cuda libraries.
-  
+
 #### example(self, name_or_index: Union[str, int]) -> Dict
       Return lookup an example by name or index.
-      
+
       Index is 0 based. e.g. example(0) returns the first example.
-  
+
 #### examples(self) -> Dict[str, Dict]
       List truss model's examples.
-      
+
       Examples are a simple `name to input` dictionary.
-  
+
 #### generate_readme(self)
-  
+
 #### get_docker_containers_from_labels(self, all=False)
-  
+
 #### get_docker_images_from_label(self)
-  
+
 #### get_urls_from_truss(self)
-  
+
 #### kill_container(self)
-  
+
 #### server_predict(self, request: dict)
       Run the prediction flow locally.
-  
+
 #### update_examples(self, examples: Dict[str, Dict])
       Update truss model's examples.
-      
+
       Existing examples are replaced whole with the given ones.
-  
+
 #### update_requirements(self, requirements: List[str])
       Update requirements in truss model's config.
-      
+
       Replaces requirements in truss model's config with the provided list.
-  
+
 #### update_requirements_from_file(self, requirements_filepath: str)
       Update requirements in truss model's config.
-      
+
       Replaces requirements in truss model's config with those from the file
       at the given path.

--- a/truss/cli.py
+++ b/truss/cli.py
@@ -43,15 +43,15 @@ def cli_group():
 
 @cli_group.command()
 @click.argument("target_directory", required=True)
-@click.option("-y", is_flag=True, show_default=True, default=False, help="Skip confirmation prompt.")
+@click.option("-s", "--skip-confirm", is_flag=True, show_default=True, default=False, help="Skip confirmation prompt.")
 @error_handling
-def init(target_directory, y):
+def init(target_directory, skip_confirm):
     """ Initializes an empty Truss directory.
 
     TARGET_DIRECTORY: A Truss is created in this directory
     """
     tr_path = Path(target_directory)
-    if y or click.confirm(f'A Truss will be created at {tr_path}'):
+    if skip_confirm or click.confirm(f'A Truss will be created at {tr_path}'):
         truss.init(target_directory=target_directory)
         click.echo(f"Truss was created in {tr_path}")
 
@@ -113,7 +113,8 @@ def run_image(target_directory, build_dir, tag, port, detach):
         build_dir = Path(build_dir)
     urls = tr.get_urls_from_truss()
     if urls:
-        click.confirm(f"Container already exists at {urls}. Are you sure you want to continue?")
+        click.confirm(
+            f"Container already exists at {urls}. Are you sure you want to continue?")
     tr.docker_run(build_dir=build_dir, tag=tag, local_port=port, detach=detach)
 
 
@@ -135,7 +136,8 @@ def predict(target_directory, request, build_dir, tag, port, run_local, request_
         with open(request_file) as json_file:
             request_data = json.load(json_file)
     else:
-        raise ValueError("At least one of request or request-file must be supplied.")
+        raise ValueError(
+            "At least one of request or request-file must be supplied.")
 
     tr = _get_truss_from_directory(target_directory=target_directory)
     if run_local:

--- a/truss/cli.py
+++ b/truss/cli.py
@@ -43,14 +43,15 @@ def cli_group():
 
 @cli_group.command()
 @click.argument("target_directory", required=True)
+@click.option("-y", is_flag=True, show_default=True, default=False, help="Skip confirmation prompt.")
 @error_handling
-def init(target_directory):
+def init(target_directory, y):
     """ Initializes an empty Truss directory.
 
     TARGET_DIRECTORY: A Truss is created in this directory
     """
     tr_path = Path(target_directory)
-    if click.confirm(f'A Truss will be created at {tr_path}'):
+    if y or click.confirm(f'A Truss will be created at {tr_path}'):
         truss.init(target_directory=target_directory)
         click.echo(f"Truss was created in {tr_path}")
 


### PR DESCRIPTION
When running batch jobs or inside notebooks, the confirmation is inconvenient.