### PR TITLE
Support bundled packages

### DIFF
--- a/docs/create/pytorch.md
+++ b/docs/create/pytorch.md
@@ -1,6 +1,6 @@
 # Create a Truss of a PyTorch model
 
-[PyTorch](https://www.pytorch.org/) is a supported framework on Truss. To package a PyTorch model, follow the steps below or run [this colab notebook]().
+[PyTorch](https://pytorch.org/) is a supported framework on Truss. To package a PyTorch model, follow the steps below or run [this colab notebook]().
 
 ### Install packages
 

--- a/docs/develop/bundled-packages.md
+++ b/docs/develop/bundled-packages.md
@@ -1,0 +1,18 @@
+# Bundled packages
+
+There are times when model code depends on internal packages that are not
+available on pypi. This code can be bundled as submodule under the model module
+but that may not work all the time. e.g. the in-memory model may refer to these
+packages as top level modules and that may not work when they become submodules.
+Bundled packages can help in that scenario.
+
+Top level packages can be bundled with the truss by placing them in the
+`packages` folder under the truss directory. These packages then become
+available as top level modules to the model class's code when it executes in the
+local, docker or baseten deployed environments.
+
+Great care should be taken to avoid conflicts between these packages with any
+python requirements. Note that the serving environment may itself be dependent
+on some standard python modules such as `requests` and `kserve`, so it's best to
+avoid using package names that may conflict with any standard or popular python
+packages.

--- a/examples/clip/model/model.py
+++ b/examples/clip/model/model.py
@@ -1,12 +1,11 @@
 from io import BytesIO
 from typing import Dict, List
 
+import clip
 import numpy as np
 import requests
 import torch
 from PIL import Image
-
-import clip
 
 DEFAULT_CLIP_MODEL = "ViT-B/32"
 

--- a/examples/dalle/model/dalle_mini_model.py
+++ b/examples/dalle/model/dalle_mini_model.py
@@ -3,16 +3,15 @@ import random
 from functools import partial
 from io import BytesIO
 
-import numpy as np
-from PIL import Image
-from tqdm.notebook import trange
-
 import jax
 import jax.numpy as jnp
+import numpy as np
 import wandb
 from dalle_mini import DalleBart, DalleBartProcessor
 from flax.jax_utils import replicate
 from flax.training.common_utils import shard_prng_key
+from PIL import Image
+from tqdm.notebook import trange
 from vqgan_jax.modeling_flax_vqgan import VQModel
 
 # dalle-mini

--- a/examples/gfpgan/model/restoration_model.py
+++ b/examples/gfpgan/model/restoration_model.py
@@ -1,14 +1,13 @@
 import logging
 import tempfile
 
+import cv2
 import numpy as np
 import requests
-from PIL import Image
-
-import cv2
 from basicsr.archs.rrdbnet_arch import RRDBNet
 from gfpgan import GFPGANer
 from model.utils import upload_file_to_s3
+from PIL import Image
 from realesrgan import RealESRGANer
 
 logger = logging.getLogger(__name__)

--- a/examples/image_segmentation/model/model.py
+++ b/examples/image_segmentation/model/model.py
@@ -6,9 +6,8 @@ from typing import Dict, List
 
 import numpy as np
 import torch
-from PIL import Image
-
 import torchvision.transforms as T
+from PIL import Image
 from torchvision import models
 
 logger = logging.getLogger(__name__)

--- a/truss/cli.py
+++ b/truss/cli.py
@@ -171,12 +171,12 @@ def run_example(target_directory, name, local):
     if name is not None:
         example = tr.example(name)
         click.echo(f'Running example: {name}')
-        return predict_fn(example)
+        return predict_fn(example.input)
     else:
         example_outputs = []
-        for name, example in tr.examples().items():
-            click.echo(f'Running example: {name}')
-            example_outputs.append(predict_fn(example))
+        for example in tr.examples():
+            click.echo(f'Running example: {example.name}')
+            example_outputs.append(predict_fn(example.input))
         return example_outputs
 
 

--- a/truss/contexts/image_builder/image_builder.py
+++ b/truss/contexts/image_builder/image_builder.py
@@ -79,9 +79,11 @@ class ImageBuilder:
         with dockerfile_template_path.open() as dockerfile_template_file:
             dockerfile_template = Template(dockerfile_template_file.read())
             data_dir_exists = (build_dir / self._spec.config.data_dir).exists()
+            bundled_packages_dir_exists = (build_dir / self._spec.config.bundled_packages_dir).exists()
             dockerfile_contents = dockerfile_template.render(
                 config=self._spec.config,
                 data_dir_exists=data_dir_exists,
+                bundled_packages_dir_exists=bundled_packages_dir_exists,
             )
             docker_file_path = build_dir / MODEL_DOCKERFILE_NAME
             with docker_file_path.open('w') as docker_file:

--- a/truss/contexts/local_loader/load_local.py
+++ b/truss/contexts/local_loader/load_local.py
@@ -22,7 +22,11 @@ class LoadLocal(TrussContext):
     @staticmethod
     def run(truss_dir: Path):
         spec = TrussSpec(truss_dir)
-        with model_class_module_loaded(str(truss_dir), spec.model_module_fullname) as module:
+        with model_class_module_loaded(
+            str(truss_dir),
+            spec.model_module_fullname,
+            spec.bundled_packages_dir.name,
+        ) as module:
             model_class = getattr(module, spec.model_class_name)
             model_class_signature = inspect.signature(model_class)
             model_init_params = {}

--- a/truss/model_inference.py
+++ b/truss/model_inference.py
@@ -76,10 +76,14 @@ def _get_entries_for_packages(list_of_requirements, desired_requirements):
     name_to_req_str = {}
     for req_name in desired_requirements:
         for req_spec_full_str in list_of_requirements:
-            req_spec_name, req_version = req_spec_full_str.split('==')
-            req_version_base = req_version.split('+')[0]
-            if req_name == req_spec_name:
-                name_to_req_str[req_name] = f'{req_name}=={req_version_base}'
+            if '==' in req_spec_full_str:
+                req_spec_name, req_version = req_spec_full_str.split('==')
+                req_version_base = req_version.split('+')[0]
+                if req_name == req_spec_name:
+                    name_to_req_str[req_name] = f'{req_name}=={req_version_base}'
+            else:
+                name_to_req_str[req_name] = req_spec_full_str
+
     return name_to_req_str
 
 

--- a/truss/templates/server.Dockerfile.jinja
+++ b/truss/templates/server.Dockerfile.jinja
@@ -82,6 +82,9 @@ COPY ./{{ config.model_module_dir }} /app/model
 {% if data_dir_exists %}
 COPY ./{{config.data_dir}} /app/data
 {% endif %}
+{% if bundled_packages_dir_exists %}
+COPY ./{{config.bundled_packages_dir}} /packages
+{% endif %}
 COPY ./config.yaml /app/config.yaml
 
 {% for env_var_name, env_var_value in config.environment_variables.items() %}

--- a/truss/templates/server/common/truss_server.py
+++ b/truss/templates/server/common/truss_server.py
@@ -4,19 +4,16 @@ from http import HTTPStatus  # noqa: E402
 
 import numpy as np  # noqa: E402
 import tornado.web  # noqa: E402
-from kfserving.handlers.http import HTTPHandler  # noqa: E402
-from kfserving.kfserver import HealthHandler, KFServer, ListHandler
-from pythonjsonlogger import jsonlogger  # noqa: E402
-
 from common.lib_support import ensure_kfserving_installed
 from common.serialization import DeepNumpyEncoder  # noqa: E402
 from common.serialization import truss_msgpack_deserialize  # noqa: E402
 from common.serialization import truss_msgpack_serialize  # noqa: E402
 from common.util import \
     assign_request_to_inputs_instances_after_validation  # noqa: E402
-
+from kfserving.handlers.http import HTTPHandler  # noqa: E402
 from kfserving.kfserver import LivenessHandler  # noqa: E402; noqa: E402
-
+from kfserving.kfserver import HealthHandler, KFServer, ListHandler
+from pythonjsonlogger import jsonlogger  # noqa: E402
 
 ensure_kfserving_installed()
 

--- a/truss/templates/server/inference_server.py
+++ b/truss/templates/server/inference_server.py
@@ -1,5 +1,4 @@
 import yaml
-
 from common.truss_server import TrussServer
 from model_wrapper import ModelWrapper
 

--- a/truss/templates/server/model_wrapper.py
+++ b/truss/templates/server/model_wrapper.py
@@ -1,12 +1,12 @@
 import importlib
 import inspect
 import logging
+import sys
 import traceback
 from pathlib import Path
 from typing import Dict, List
 
 import kfserving
-
 from secrets_resolver import SecretsResolver
 
 MODEL_BASENAME = 'model'
@@ -19,6 +19,10 @@ class ModelWrapper(kfserving.KFModel):
         self._model = None
 
     def load(self):
+        if 'bundled_packages_dir' in self._config:
+            bundled_packages_path = Path('/packages')
+            if bundled_packages_path.exists():
+                sys.path.append(str(bundled_packages_path))
         model_module_name = str(Path(self._config['model_class_filename']).with_suffix(''))
         module = importlib.import_module(f"{self._config['model_module_dir']}.{model_module_name}")
         model_class = getattr(module, self._config['model_class_name'])

--- a/truss/tests/contexts/local_loader/test_model_module_finder.py
+++ b/truss/tests/contexts/local_loader/test_model_module_finder.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from truss.contexts.local_loader.model_module_loader import \
     model_class_module_loaded
+from truss.truss_config import DEFAULT_BUNDLED_PACKAGES_DIR
 
 ORIG_MODEL_CLASS_CONTENT = '''
 class Model:
@@ -40,6 +41,20 @@ NEW_SUBMODULE_FILE_CONTENT = '''
 Y = 4
 '''
 
+ORIG_MODEL_CLASS_USING_ADDITIONAL_MODULE_CONTENT = '''
+from test_module import test
+class Model:
+    x = test.A
+'''
+
+ORIG_ADDITIONAL_MODULE_CONTENT = '''
+A = 1
+'''
+
+NEW_ADDITIONAL_MODULE_CONTENT = '''
+A = 2
+'''
+
 
 def test_model_module_finder():
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -58,6 +73,40 @@ def test_model_module_finder_reload():
     with tempfile.TemporaryDirectory() as temp_dir:
         _write_model_module_files(temp_dir, NEW_MODEL_CLASS_CONTENT)
         with model_class_module_loaded(temp_dir, 'model.model') as model_module:
+            model_class = getattr(model_module, 'Model')
+            assert model_class.x == 2
+
+
+def test_model_module_finder_additional_modules():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        _write_model_module_files(
+            temp_dir,
+            ORIG_MODEL_CLASS_USING_ADDITIONAL_MODULE_CONTENT,
+            additional_module_file_content=ORIG_ADDITIONAL_MODULE_CONTENT,
+        )
+        with model_class_module_loaded(temp_dir, 'model.model', DEFAULT_BUNDLED_PACKAGES_DIR) as model_module:
+            model_class = getattr(model_module, 'Model')
+            assert model_class.x == 1
+
+
+def test_model_module_finder_additional_modules_reload():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        _write_model_module_files(
+            temp_dir,
+            ORIG_MODEL_CLASS_USING_ADDITIONAL_MODULE_CONTENT,
+            additional_module_file_content=ORIG_ADDITIONAL_MODULE_CONTENT,
+        )
+        with model_class_module_loaded(temp_dir, 'model.model', DEFAULT_BUNDLED_PACKAGES_DIR) as model_module:
+            model_class = getattr(model_module, 'Model')
+            assert model_class.x == 1
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        _write_model_module_files(
+            temp_dir,
+            ORIG_MODEL_CLASS_USING_ADDITIONAL_MODULE_CONTENT,
+            additional_module_file_content=NEW_ADDITIONAL_MODULE_CONTENT,
+        )
+        with model_class_module_loaded(temp_dir, 'model.model', DEFAULT_BUNDLED_PACKAGES_DIR) as model_module:
             model_class = getattr(model_module, 'Model')
             assert model_class.x == 2
 
@@ -88,13 +137,14 @@ def test_model_module_finder_reload_non_model_file_updated():
 
 
 def _write_model_module_files(
-    scaffold_dir: str,
+    truss_dir: str,
     model_file_content: str,
     util_file_content: str = None,
     submodule_file_content: str = None,
+    additional_module_file_content: str = None,
 ):
-    model_dir_path = Path(scaffold_dir) / 'model'
-    model_dir_path.mkdir()
+    model_dir_path = Path(truss_dir) / 'model'
+    model_dir_path.mkdir(parents=True)
     with (model_dir_path / 'model.py').open('w') as f:
         f.write(model_file_content)
     if util_file_content is not None:
@@ -106,3 +156,9 @@ def _write_model_module_files(
         submodule_path.mkdir()
         with (submodule_path / 'subfile.py').open('w') as f:
             f.write(submodule_file_content)
+
+    if additional_module_file_content is not None:
+        test_module_path = Path(truss_dir) / DEFAULT_BUNDLED_PACKAGES_DIR / 'test_module'
+        test_module_path.mkdir(parents=True)
+        with (test_module_path / 'test.py').open('w') as f:
+            f.write(additional_module_file_content)

--- a/truss/tests/samples.py
+++ b/truss/tests/samples.py
@@ -15,14 +15,14 @@ import numpy as np
 ##############################################################################
 import pandas as pd
 import tensorflow as tf
+from my_pytorch_model import MyModel, MyModelWithArgs
 from sklearn.datasets import load_iris
 from sklearn.ensemble import RandomForestClassifier
 from tensorflow.keras import layers
 from tensorflow.keras.layers.experimental import preprocessing
-
-from my_pytorch_model import MyModel, MyModelWithArgs
 # Create a fake dataset to include with the deployment
 from test_folder.utils.embedding_util import create_reference_embeddings
+
 from truss.build import mk_truss, scaffold, scaffold_custom
 from truss.constants import HUGGINGFACE_TRANSFORMER
 from truss.definitions.base import build_scaffold_directory

--- a/truss/tests/test_truss_handle.py
+++ b/truss/tests/test_truss_handle.py
@@ -134,6 +134,15 @@ def test_docker_predict(custom_model_truss_dir_with_pre_and_post):
 
 
 @pytest.mark.integration
+def test_docker_predict_with_bundled_packages(custom_model_truss_dir_with_bundled_packages):
+    th = TrussHandle(custom_model_truss_dir_with_bundled_packages)
+    tag = 'test-docker-predict-bundled-packages-tag:0.0.1'
+    with ensure_kill_all():
+        result = th.docker_predict({'inputs': [1, 2]}, tag=tag)
+        assert result == {'predictions': [1]}
+
+
+@pytest.mark.integration
 def test_docker_multiple_predict(custom_model_truss_dir_with_pre_and_post):
     th = TrussHandle(custom_model_truss_dir_with_pre_and_post)
     tag = 'test-docker-predict-tag:0.0.1'

--- a/truss/truss_config.py
+++ b/truss/truss_config.py
@@ -11,6 +11,7 @@ from truss.validation import (validate_cpu_spec, validate_memory_spec,
 DEFAULT_MODEL_FRAMEWORK_TYPE = ModelFrameworkType.CUSTOM
 DEFAULT_MODEL_TYPE = 'Model'
 DEFAULT_MODEL_MODULE_DIR = 'model'
+DEFAULT_BUNDLED_PACKAGES_DIR = 'packages'
 DEFAULT_MODEL_CLASS_FILENAME = 'model.py'
 DEFAULT_MODEL_CLASS_NAME = 'Model'
 DEFAULT_TRUSS_STRUCTURE_VERSION = '2.0'
@@ -55,7 +56,6 @@ class Resources:
 class TrussConfig:
     model_framework: ModelFrameworkType = DEFAULT_MODEL_FRAMEWORK_TYPE
     model_type: str = DEFAULT_MODEL_TYPE
-    # todo document model_name - ask phil
     model_name: str = None
 
     model_module_dir: str = DEFAULT_MODEL_MODULE_DIR
@@ -75,6 +75,7 @@ class TrussConfig:
     examples_filename: str = DEFAULT_EXAMPLES_FILENAME
     secrets: Dict[str, str] = field(default_factory=dict)
     description: str = None
+    bundled_packages_dir: str = DEFAULT_BUNDLED_PACKAGES_DIR
 
     @staticmethod
     def from_dict(d):
@@ -96,6 +97,7 @@ class TrussConfig:
             examples_filename=d.get('examples_filename', DEFAULT_EXAMPLES_FILENAME),
             secrets=d.get('secrets', {}),
             description=d.get('description', None),
+            bundled_packages_dir=d.get('bundled_packages_dir', DEFAULT_BUNDLED_PACKAGES_DIR),
         )
         config.validate()
         return config
@@ -128,6 +130,7 @@ class TrussConfig:
             'examples_filename': self.examples_filename,
             'secrets': self.secrets,
             'description': self.description,
+            'bundled_packages_dir': self.bundled_packages_dir,
         }
 
     def clone(self):

--- a/truss/truss_spec.py
+++ b/truss/truss_spec.py
@@ -33,6 +33,10 @@ class TrussSpec:
         return self._truss_dir / self._config.model_module_dir
 
     @property
+    def bundled_packages_dir(self) -> Path:
+        return self._truss_dir / self._config.bundled_packages_dir
+
+    @property
     def model_class_filepath(self) -> Path:
         conf = self._config
         return self._truss_dir / conf.model_module_dir / conf.model_class_filename


### PR DESCRIPTION
*I still need to write integration tests and docs, but wanted to send out for early review for the code.*

This change adds support for bundled packages, which are python packages that can be bundled alongside the model. Use case is bundling internal packages that not available on pypi. These bundled packages become available to the model code as top level modules.


Update:
It also fixes a couple breaks I saw
- Running examples from cli
- python requirements without an '==' in them