### PR TITLE
Fix requirements inference

### DIFF
--- a/truss/model_inference.py
+++ b/truss/model_inference.py
@@ -82,7 +82,7 @@ def _get_entries_for_packages(list_of_requirements, desired_requirements):
                 if req_name == req_spec_name:
                     name_to_req_str[req_name] = f'{req_name}=={req_version_base}'
             else:
-                name_to_req_str[req_name] = req_spec_full_str
+                continue
 
     return name_to_req_str
 


### PR DESCRIPTION
pip freeze returns a notice to upgrade pip version and that breaks this inference. Skipping any lines that don't have an `==` in them to avoid that. This is a temporary and ad-hoc fix, we need to figure out a better fix that takes account of pip_freeze output better.