### PR TITLE
Fix Poetry Installation

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && /bin/bash /tmp/library-scripts/common-debian.sh "${INSTALL
     && rm -rf /var/lib/apt/lists/* /tmp/library-scripts/
 
 USER vscode
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
+RUN curl -sSL https://install.python-poetry.org | python
 ENV PATH=/home/vscode/.poetry/bin:$PATH
 
 USER root


### PR DESCRIPTION
The old poetry installation step no longer works.

```
[~/truss]$ curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py |python                                                                                                      [main]
Retrieving Poetry metadata

This installer is deprecated, and scheduled for removal from the Poetry repository on or after January 1, 2023.
See https://github.com/python-poetry/poetry/issues/6377 for details.

You should migrate to https://install.python-poetry.org instead, which supports all versions of Poetry, and allows for `self update` of versions 1.1.7 or newer.
Instructions are available at https://python-poetry.org/docs/#installation.

Without an explicit version, this installer will attempt to install the latest version of Poetry.
This installer cannot install Poetry 1.2.0a1 or newer (and installs will be unable to `self update` to 1.2.0a1 or newer).

To continue to use this deprecated installer, you must specify an explicit version with --version <version> or POETRY_VERSION=<version>.
Alternatively, if you wish to force this deprecated installer to use the latest installable release, set GET_POETRY_IGNORE_DEPRECATION=1.

Version 1.2.0 is not supported by this installer! Please specify a version prior to 1.2.0a1 to continue!
```

# Testing

Successfully built Codespace using this branch 