### PR TITLE
Fix flaky test

### DIFF
--- a/truss/tests/test_truss_util.py
+++ b/truss/tests/test_truss_util.py
@@ -7,6 +7,7 @@ from truss import utils
 def test_max_modified():
     epoch_time = int(time.time())
     with utils.given_or_temporary_dir() as dir:
+        time.sleep(0.1)
         t1 = utils.get_max_modified_time_of_dir(dir)
         assert t1 > epoch_time
         time.sleep(0.1)


### PR DESCRIPTION
# Problem

The `test_max_modified` test currently flakes out sometimes (see [example](https://github.com/basetenlabs/truss/actions/runs/3010053637)), and fails because of timestamp-related non-determinism. In this particular example, there was a mismatch between the time as read in Python vs. the time read from the filesystem (for some reason, Python returned a slightly later timestamp, even though the code ran earlier). 

# Solution

Add an extra sleep. I considered using [freezegun](https://github.com/spulec/freezegun) for this, but since the code actually gets timestamps from the filesystem, freezing time didn't really help.