### PR TITLE
Print truss handle errors in notebook

### DIFF
--- a/docs/deploy/baseten.md
+++ b/docs/deploy/baseten.md
@@ -51,7 +51,7 @@ basten.deploy_truss(
 )
 ```
 
-Secrets can be securely stored in your Baseten organization by following [this documentation](https://docs.baseten.co/applications/files/secret-management).
+Secrets can be securely stored in your Baseten organization by following [this documentation](https://docs.baseten.co/settings/secrets).
 
 {% hint style="warning" %}
 Unlike when Truss secrets are bound using environment variables, Baseten mounts secrets, so do not use the `TRUSS_SECRET_` prefix when setting secret names.

--- a/docs/develop/configuration.md
+++ b/docs/develop/configuration.md
@@ -217,4 +217,4 @@ Secret names need to confirm to the [k8s secret name guidelines](https://kuberne
 How secrets are mounted at runtime depends on the serving environment. For example, when
 running on Docker locally, Truss allows specifying secrets in
 `~/.truss/config.yaml`, while on Baseten, secrets can be specified as regular
-[organization secrets](https://docs.baseten.co/applications/files/secret-management).
+[organization secrets](https://docs.baseten.co/settings/secrets).

--- a/docs/develop/secrets.md
+++ b/docs/develop/secrets.md
@@ -106,7 +106,7 @@ basten.deploy_truss(
 )
 ```
 
-Secrets can be securely stored in your Baseten organization by following [this documentation](https://docs.baseten.co/applications/files/secret-management).
+Secrets can be securely stored in your Baseten organization by following [this documentation](https://docs.baseten.co/settings/secrets).
 
 {% hint style="warning" %}
 Baseten mounts secrets, so do not use the `TRUSS_SECRET_` prefix when setting secret names.

--- a/truss/notebook.py
+++ b/truss/notebook.py
@@ -1,0 +1,12 @@
+def is_notebook_or_ipython() -> bool:
+    """Based on https://stackoverflow.com/a/39662359"""
+    try:
+        shell = get_ipython().__class__.__name__
+        if shell == "ZMQInteractiveShell":
+            return True  # Jupyter notebook or qtconsole
+        elif shell == "TerminalInteractiveShell":
+            return True  # Terminal running IPython
+        else:
+            return False  # Other type (?)
+    except NameError:
+        return False  # Probably standard Python interpreter

--- a/truss/truss_handle.py
+++ b/truss/truss_handle.py
@@ -22,8 +22,8 @@ from truss.docker import (
     kill_containers,
 )
 from truss.local.local_config_handler import LocalConfigHandler
+from truss.notebook import is_notebook_or_ipython
 from truss.readme_generator import generate_readme
-from truss.setup_logging import is_notebook_or_ipython
 from truss.truss_config import TrussConfig
 from truss.truss_spec import TrussSpec
 from truss.types import Example

--- a/truss/truss_handle.py
+++ b/truss/truss_handle.py
@@ -1,6 +1,7 @@
 import copy
 import glob
 import logging
+import sys
 from dataclasses import replace
 from pathlib import Path
 from typing import Callable, List, Optional, Union
@@ -22,6 +23,7 @@ from truss.docker import (
 )
 from truss.local.local_config_handler import LocalConfigHandler
 from truss.readme_generator import generate_readme
+from truss.setup_logging import is_notebook_or_ipython
 from truss.truss_config import TrussConfig
 from truss.truss_spec import TrussSpec
 from truss.types import Example
@@ -29,6 +31,10 @@ from truss.utils import copy_file_path, copy_tree_path, get_max_modified_time_of
 from truss.validation import validate_secret_name
 
 logger = logging.getLogger(__name__)
+
+if is_notebook_or_ipython():
+    logger.setLevel(logging.INFO)
+    logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 class TrussHandle:
@@ -92,7 +98,7 @@ class TrussHandle:
             _wait_for_model_server(model_base_url)
         except Exception as e:
             for log in self.container_logs():
-                logging.info(log)
+                logger.info(log)
             raise e
         logger.info(
             f"Model server started on port {local_port}, docker container id {container.id}"


### PR DESCRIPTION
What:
Logging handlers are not set up by default on ipython and jupyter notebook, so our logging statements don't show up. 

How:
It would be too much to require users to enable logging in their notebook. Instead we use this heuristic approach, and I'm open to other ideas.
We try to detect if we are in a notebook or python environment, and if so we set up a stdout handler for truss handle logs and set the logging level to info.