### PR TITLE
Supporting spec version

### DIFF
--- a/truss/truss_config.py
+++ b/truss/truss_config.py
@@ -142,6 +142,7 @@ class TrussConfig:
             "secrets": self.secrets,
             "description": self.description,
             "bundled_packages_dir": self.bundled_packages_dir,
+            "spec_version": self.spec_version,
         }
 
     def clone(self):

--- a/truss/truss_config.py
+++ b/truss/truss_config.py
@@ -21,6 +21,7 @@ DEFAULT_MODEL_INPUT_TYPE = "Any"
 DEFAULT_PYTHON_VERSION = "py39"
 DEFAULT_DATA_DIRECTORY = "data"
 DEFAULT_EXAMPLES_FILENAME = "examples.yaml"
+DEFAULT_SPEC_VERSION = "2.0"
 
 DEFAULT_CPU = "500m"
 DEFAULT_MEMORY = "512Mi"
@@ -78,6 +79,7 @@ class TrussConfig:
     secrets: Dict[str, str] = field(default_factory=dict)
     description: str = None
     bundled_packages_dir: str = DEFAULT_BUNDLED_PACKAGES_DIR
+    spec_version: str = DEFAULT_SPEC_VERSION
 
     @staticmethod
     def from_dict(d):
@@ -106,6 +108,7 @@ class TrussConfig:
             bundled_packages_dir=d.get(
                 "bundled_packages_dir", DEFAULT_BUNDLED_PACKAGES_DIR
             ),
+            spec_version=d.get("spec_version", DEFAULT_SPEC_VERSION),
         )
         config.validate()
         return config

--- a/truss/truss_config.py
+++ b/truss/truss_config.py
@@ -79,11 +79,16 @@ class TrussConfig:
     secrets: Dict[str, str] = field(default_factory=dict)
     description: str = None
     bundled_packages_dir: str = DEFAULT_BUNDLED_PACKAGES_DIR
+    # spec_version is a version string
     spec_version: str = DEFAULT_SPEC_VERSION
 
     @staticmethod
     def from_dict(d):
         config = TrussConfig(
+            # Users that are calling `from_directory` on an existing Truss
+            # should default to 1.0 whereas users creating a new Truss
+            # should default to 2.0.
+            spec_version=d.get("spec_version", "1.0"),
             model_type=d.get("model_type", DEFAULT_MODEL_TYPE),
             model_framework=ModelFrameworkType(
                 d.get("model_framework", DEFAULT_MODEL_FRAMEWORK_TYPE.value)
@@ -108,7 +113,6 @@ class TrussConfig:
             bundled_packages_dir=d.get(
                 "bundled_packages_dir", DEFAULT_BUNDLED_PACKAGES_DIR
             ),
-            spec_version=d.get("spec_version", DEFAULT_SPEC_VERSION),
         )
         config.validate()
         return config

--- a/truss/truss_config.py
+++ b/truss/truss_config.py
@@ -22,6 +22,7 @@ DEFAULT_PYTHON_VERSION = "py39"
 DEFAULT_DATA_DIRECTORY = "data"
 DEFAULT_EXAMPLES_FILENAME = "examples.yaml"
 DEFAULT_SPEC_VERSION = "2.0"
+DEFAULT_SPEC_VERSION_FROM_DIRECTORY = "1.0"
 
 DEFAULT_CPU = "500m"
 DEFAULT_MEMORY = "512Mi"
@@ -88,7 +89,7 @@ class TrussConfig:
             # Users that are calling `from_directory` on an existing Truss
             # should default to 1.0 whereas users creating a new Truss
             # should default to 2.0.
-            spec_version=d.get("spec_version", "1.0"),
+            spec_version=d.get("spec_version", DEFAULT_SPEC_VERSION_FROM_DIRECTORY),
             model_type=d.get("model_type", DEFAULT_MODEL_TYPE),
             model_framework=ModelFrameworkType(
                 d.get("model_framework", DEFAULT_MODEL_FRAMEWORK_TYPE.value)

--- a/truss/truss_spec.py
+++ b/truss/truss_spec.py
@@ -46,6 +46,10 @@ class TrussSpec:
         return self._config
 
     @property
+    def spec_version(self) -> str:
+        return self._config.spec_version
+
+    @property
     def python_version(self) -> str:
         return self._config.python_version
 


### PR DESCRIPTION
This PR adds support for a new key in config.yaml `spec_version`.