### PR TITLE
Avoid using colon equals operator that breaks compatibility with python 3.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.1.4rc1"
+version = "0.1.4rc2"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/patch/hash.py
+++ b/truss/patch/hash.py
@@ -42,8 +42,13 @@ def _file_content_hash_loaded_hasher(file: Path):
     buffer = bytearray(128 * 1024)
     mem_view = memoryview(buffer)
     with file.open("rb") as f:
-        while n := f.readinto(mem_view):
-            hasher.update(mem_view[:n])
+        done = False
+        while not done:
+            n = f.readinto(mem_view)
+            if n > 0:
+                hasher.update(mem_view[:n])
+            else:
+                done = True
     return hasher
 
 


### PR DESCRIPTION
The `:=` operator is not available in 3.7, which is the default for google colab notebooks and a very popular python version in DS community still. Replace that use.