### PR TITLE
Fix truss image build for control plane for gpu

### DIFF
--- a/truss/templates/server.Dockerfile.jinja
+++ b/truss/templates/server.Dockerfile.jinja
@@ -46,6 +46,7 @@ RUN apt update && \
     apt update -y && \
     apt install -y python3.9 && \
     apt install -y python3.9-distutils && \
+    apt install -y python3.9-venv && \
     rm -rf /var/lib/apt/lists
 
 RUN ln -sf /usr/bin/python3.9 /usr/bin/python3 && \
@@ -98,7 +99,7 @@ ENV {{ env_var_name }} {{ env_var_value }}
 ENV HASH_TRUSS {{truss_hash}}
 ENV CONTROL_SERVER_PORT 8080
 ENV INFERENCE_SERVER_PORT 8090
-RUN python -m venv .env && .env/bin/pip3 install -r /control/requirements.txt
+RUN python3 -m venv .env && .env/bin/pip3 install -r /control/requirements.txt
 CMD exec .env/bin/python3 /control/control/server.py
 {% else %}
 

--- a/truss/tests/test_truss_handle.py
+++ b/truss/tests/test_truss_handle.py
@@ -93,6 +93,16 @@ def test_build_docker_image_gpu(custom_model_truss_dir_for_gpu, tmp_path):
 
 
 @pytest.mark.integration
+def test_build_docker_image_control_gpu(custom_model_truss_dir_for_gpu, tmp_path):
+    th = TrussHandle(custom_model_truss_dir_for_gpu)
+    th.use_control_plane(True)
+    tag = "test-build-image-control-gpu-tag:0.0.1"
+    build_dir = tmp_path / "scaffold_build_dir"
+    image = th.build_docker_image(tag=tag, build_dir=build_dir)
+    assert image.repo_tags[0] == tag
+
+
+@pytest.mark.integration
 def test_docker_run(custom_model_truss_dir_with_pre_and_post):
     th = TrussHandle(custom_model_truss_dir_with_pre_and_post)
     tag = "test-docker-run-tag:0.0.1"


### PR DESCRIPTION
Gpu image was missing the python-venv system package and we also needed to refer to it as python 3. I have added to test so we don't miss this in future.