### PR TITLE
Fail prediction request fast if inference server has crashed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.1.5rc1"
+version = "0.1.5"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/templates/control/control/endpoints.py
+++ b/truss/templates/control/control/endpoints.py
@@ -2,7 +2,6 @@ import requests
 from flask import Blueprint, Response, current_app, jsonify, request
 from requests.exceptions import ConnectionError
 from tenacity import Retrying, retry_if_exception_type, stop_after_attempt, wait_fixed
-from werkzeug.exceptions import InternalServerError
 
 INFERENCE_SERVER_START_WAIT_SECS = 60
 
@@ -18,7 +17,9 @@ def index():
 @control_app.route("/v1/<path:path>", methods=["GET", "POST"])
 def proxy(path):
     inference_server_port = current_app.config["inference_server_port"]
-    inference_server_process_controller = current_app.config["inference_server_process_controller"]
+    inference_server_process_controller = current_app.config[
+        "inference_server_process_controller"
+    ]
 
     # Wait a bit for inference server to start
     for attempt in Retrying(
@@ -39,10 +40,12 @@ def proxy(path):
                 # do it only if request fails with connection error. If the inference server
                 # process is running then we continue waiting for it to start (by retrying),
                 # otherwise we bail.
-                if not inference_server_process_controller.is_inference_server_running():
+                if (
+                    not inference_server_process_controller.is_inference_server_running()
+                ):
                     return Response(
-                        'Inference server is not running, make sure model code doesn\'t have any errors',
-                        500
+                        "Inference server is not running, make sure model code doesn't have any errors",
+                        500,
                     )
                 raise exp
 

--- a/truss/templates/control/control/endpoints.py
+++ b/truss/templates/control/control/endpoints.py
@@ -43,10 +43,9 @@ def proxy(path):
                 if (
                     not inference_server_process_controller.is_inference_server_running()
                 ):
-                    return Response(
-                        "Inference server is not running, make sure model code doesn't have any errors",
-                        500,
-                    )
+                    error_msg = "It appears your model has stopped running. This often means' \
+                        ' it crashed and may need a fix to get it running again."
+                    return Response(error_msg, 500)
                 raise exp
 
     headers = [(name, value) for (name, value) in resp.raw.headers.items()]

--- a/truss/templates/control/control/helpers/inference_server_controller.py
+++ b/truss/templates/control/control/helpers/inference_server_controller.py
@@ -39,7 +39,7 @@ class InferenceServerController:
             if req_hash == self._current_running_hash:
                 # We are in sync, ok to start running inference server now, if
                 # it's not running.
-                if not self._process_controller.inference_server_running():
+                if not self._process_controller.inference_server_started():
                     self._process_controller.start()
                 self._app_logger.info("Request hash same as current hash, skipping.")
                 return

--- a/truss/templates/control/control/helpers/inference_server_process_controller.py
+++ b/truss/templates/control/control/helpers/inference_server_process_controller.py
@@ -15,7 +15,7 @@ class InferenceServerProcessController:
         self._inference_server_home = inference_server_home
         self._inference_server_process_args = inference_server_process_args
         self._inference_server_port = inference_server_port
-        self._inference_server_running = False
+        self._inference_server_started = False
 
     def start(self):
         with current_directory(self._inference_server_home):
@@ -25,7 +25,7 @@ class InferenceServerProcessController:
                 self._inference_server_process_args,
                 env=inf_env,
             )
-            self._inference_server_running = True
+            self._inference_server_started = True
 
     def stop(self):
         if self._inference_server_process is not None:
@@ -33,7 +33,17 @@ class InferenceServerProcessController:
             poll = self._inference_server_process.poll()
             if poll is None:
                 self._inference_server_process.kill()
-                self._inference_server_running = False
+                self._inference_server_started = False
 
-    def inference_server_running(self) -> bool:
-        return self._inference_server_running
+    def inference_server_started(self) -> bool:
+        return self._inference_server_started
+
+    def is_inference_server_running(self) -> bool:
+        # Explicitly check if inference server process is up, this is a bit expensive.
+        if not self._inference_server_started:
+            return False
+        
+        if self._inference_server_process is None:
+            return False
+
+        return self._inference_server_process.poll() is None

--- a/truss/templates/control/control/helpers/inference_server_process_controller.py
+++ b/truss/templates/control/control/helpers/inference_server_process_controller.py
@@ -42,7 +42,7 @@ class InferenceServerProcessController:
         # Explicitly check if inference server process is up, this is a bit expensive.
         if not self._inference_server_started:
             return False
-        
+
         if self._inference_server_process is None:
             return False
 

--- a/truss/tests/test_truss_handle.py
+++ b/truss/tests/test_truss_handle.py
@@ -626,7 +626,7 @@ class Model:
             result = th.docker_predict({"inputs": [1]}, tag=tag)
         resp = exc_info.value.response
         assert resp.status_code == 500
-        assert 'Inference server is not running' in resp.text
+        assert "Inference server is not running" in resp.text
 
         # Should be able to fix code after
         good_model_code = """

--- a/truss/tests/test_truss_handle.py
+++ b/truss/tests/test_truss_handle.py
@@ -626,7 +626,7 @@ class Model:
             result = th.docker_predict({"inputs": [1]}, tag=tag)
         resp = exc_info.value.response
         assert resp.status_code == 500
-        assert "Inference server is not running" in resp.text
+        assert "model has stopped running" in resp.text
 
         # Should be able to fix code after
         good_model_code = """

--- a/truss/tests/test_truss_handle.py
+++ b/truss/tests/test_truss_handle.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
 from truss.docker import Docker, DockerStates
 from truss.errors import ContainerIsDownError, ContainerNotFoundError
 from truss.local.local_config_handler import LocalConfigHandler
@@ -604,6 +605,39 @@ class Model:
         assert result[0] == 2
         # A new image should have been created
         assert len(th.get_all_docker_images()) == orig_num_truss_images + 1
+
+
+@pytest.mark.integration
+def test_control_truss_local_update_that_crashes_inference_server(custom_model_control):
+    th = TrussHandle(custom_model_control)
+    tag = "test-docker-custom-model-control-tag:0.0.1"
+    with ensure_kill_all():
+        result = th.docker_predict({"inputs": [1]}, tag=tag)
+        assert result[0] == 1
+
+        bad_model_code = """
+class Model:
+    def malformed
+"""
+        model_code_file_path = custom_model_control / "model" / "model.py"
+        with model_code_file_path.open("w") as model_code_file:
+            model_code_file.write(bad_model_code)
+        with pytest.raises(requests.exceptions.HTTPError) as exc_info:
+            result = th.docker_predict({"inputs": [1]}, tag=tag)
+        resp = exc_info.value.response
+        assert resp.status_code == 500
+        assert 'Inference server is not running' in resp.text
+
+        # Should be able to fix code after
+        good_model_code = """
+class Model:
+    def predict(self, request):
+        return [2 for i in request['inputs']]
+"""
+        with model_code_file_path.open("w") as model_code_file:
+            model_code_file.write(good_model_code)
+        result = th.docker_predict({"inputs": [1]}, tag=tag)
+        assert result[0] == 2
 
 
 def test_handle_if_container_dne(custom_model_truss_dir):


### PR DESCRIPTION
Instead of retrying for a minute, check if the inference server is dead (probably due to bad code) and fail early. This way users would know of the breakage quicker, for a better user experience than waiting for a whole minute to find out.