### PR TITLE
Improve DX with clean primary function names

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ rfc = RandomForestClassifier()
 rfc.fit(data_x, data_y)
 
 # Create the Truss (serializing & packaging model)
-tr = truss.mk_truss(rfc, target_directory="iris_rfc_truss")
+tr = truss.create(rfc, target_directory="iris_rfc_truss")
 
 # Serve a prediction from the model
 tr.server_predict({"inputs": [[0, 0, 0, 0]]})
@@ -76,7 +76,7 @@ tr.server_predict({"inputs": [[0, 0, 0, 0]]})
 
 ### Package your model
 
-The `truss.mk_truss()` command can be used with any supported framework:
+The `truss.create()` command can be used with any supported framework:
 
 * [Hugging Face](https://truss.baseten.co/create/huggingface)
 * [LightGBM](https://truss.baseten.co/create/lightgbm)

--- a/docs/create/huggingface.md
+++ b/docs/create/huggingface.md
@@ -29,12 +29,12 @@ model = pipeline('fill-mask', model='bert-base-uncased')
 
 ### Create a Truss
 
-Use the `mk_truss` command to package your model into a Truss.
+Use the `create` command to package your model into a Truss.
 
 ```python
-from truss import mk_truss
+from truss import create
 
-tr = mk_truss(model, target_directory="huggingface_truss")
+tr = create(model, target_directory="huggingface_truss")
 ```
 
 Check the target directory to see your new Truss!

--- a/docs/create/lightgbm.md
+++ b/docs/create/lightgbm.md
@@ -51,12 +51,12 @@ model = lgb.train(params=params, train_set=train, valid_sets=test)
 
 ### Create a Truss
 
-Use the `mk_truss` command to package your model into a Truss.
+Use the `create` command to package your model into a Truss.
 
 ```python
-from truss import mk_truss
+from truss import create
 
-tr = mk_truss(model, target_directory="lightgbm_truss")
+tr = create(model, target_directory="lightgbm_truss")
 ```
 
 Check the target directory to see your new Truss!

--- a/docs/create/manual.md
+++ b/docs/create/manual.md
@@ -16,7 +16,7 @@ To familiarize yourself with the structure of Truss, review the [structure refer
 
 ### Adding the model binary
 
-First, you'll need to add a model binary to your new Truss. On supported frameworks, this is provided automatically by the `mk_truss` command. For a custom Truss, it can come from many sources, such as:
+First, you'll need to add a model binary to your new Truss. On supported frameworks, this is provided automatically by the `create` command. For a custom Truss, it can come from many sources, such as:
 
 * Pickling your model
 * Serializing your model
@@ -46,7 +46,7 @@ Also, your model gets access to certain values, including the `config.yaml` file
 
 ## Example code
 
-While XGBoost is a supported framework — you can make a Truss from an XGBoost model with `mk_truss` — we'll use the manual method here for demonstration.
+While XGBoost is a supported framework — you can make a Truss from an XGBoost model with `create` — we'll use the manual method here for demonstration.
 
 If you haven't already, create a Truss by running:
 

--- a/docs/create/mlflow.md
+++ b/docs/create/mlflow.md
@@ -35,14 +35,14 @@ with mlflow.start_run():
 
 ### Create a Truss
 
-Truss uses MLflow's [pyfunc](https://www.mlflow.org/docs/latest/python_api/mlflow.pyfunc.html) module in the packaging process. Once you have loaded the model, use the `mk_truss` command to package your model into a Truss.
+Truss uses MLflow's [pyfunc](https://www.mlflow.org/docs/latest/python_api/mlflow.pyfunc.html) module in the packaging process. Once you have loaded the model, use the `create` command to package your model into a Truss.
 
 ```python
 import os
 import truss
 
 model = mlflow.pyfunc.load_model(MODEL_URI)
-tr = truss.mk_truss(model, target_directory="./mlflow_truss")
+tr = truss.create(model, target_directory="./mlflow_truss")
 ```
 
 Check the target directory to see your new Truss!

--- a/docs/create/pytorch.md
+++ b/docs/create/pytorch.md
@@ -143,12 +143,12 @@ model, _ , _ = train_the_model()
 
 ### Create a Truss
 
-Use the `mk_truss` command to package your model into a Truss.
+Use the `create` command to package your model into a Truss.
 
 ```python
-from truss import mk_truss
+from truss import create
 
-tr = mk_truss(model, target_directory="pytorch_truss")
+tr = create(model, target_directory="pytorch_truss")
 ```
 
 Check the target directory to see your new Truss!

--- a/docs/create/sklearn.md
+++ b/docs/create/sklearn.md
@@ -30,12 +30,12 @@ model.fit(data_x, data_y)
 
 ### Create a Truss
 
-Use the `mk_truss` command to package your model into a Truss.
+Use the `create` command to package your model into a Truss.
 
 ```python
-from truss import mk_truss
+from truss import create
 
-tr = mk_truss(model, target_directory="sklearn_truss")
+tr = create(model, target_directory="sklearn_truss")
 ```
 
 Check the target directory to see your new Truss!

--- a/docs/create/tensorflow.md
+++ b/docs/create/tensorflow.md
@@ -32,12 +32,12 @@ model = tf.keras.applications.ResNet50V2(
 
 ### Create a Truss
 
-Use the `mk_truss` command to package your model into a Truss.
+Use the `create` command to package your model into a Truss.
 
 ```python
-from truss import mk_truss
+from truss import create
 
-tr = mk_truss(model, target_directory="tensorflow_truss")
+tr = create(model, target_directory="tensorflow_truss")
 ```
 
 Check the target directory to see your new Truss!

--- a/docs/create/xgboost.md
+++ b/docs/create/xgboost.md
@@ -46,12 +46,12 @@ model = xgb.train(params,
 
 ### Create a Truss
 
-Use the `mk_truss` command to package your model into a Truss.
+Use the `create` command to package your model into a Truss.
 
 ```python
-from truss import mk_truss
+from truss import create
 
-tr = mk_truss(model, target_directory="xgboost_truss")
+tr = create(model, target_directory="xgboost_truss")
 ```
 
 Check the target directory to see your new Truss!

--- a/docs/deploy/baseten.md
+++ b/docs/deploy/baseten.md
@@ -15,7 +15,7 @@ pip install --upgrade baseten
 
 {% hint style="info" %}
 
-If your model is already in memory (you created it with `mk_truss`), you can skip loading it into memory from the directory.
+If your model is already in memory (you created it with `create`), you can skip loading it into memory from the directory.
 
 {% endhint %}
 
@@ -24,7 +24,7 @@ Before deploying your Truss, you may need to load it into memory in a Jupyter no
 ```python
 import truss
 
-my_truss = truss.from_directory("my_truss_lives_here")
+my_truss = truss.load("my_truss_lives_here")
 ```
 
 Once your Truss is in memory, simply run the following:

--- a/docs/develop/localhost.md
+++ b/docs/develop/localhost.md
@@ -21,7 +21,7 @@ There are two ways to interface with a Truss locally. The first is via [the Pyth
 When interacting with your Truss via the Python client, the first thing is to make sure it is in-memory. If you just created the Truss, it'll be in memory already, but if not, you'll need to load it with the following command:
 
 ```python
-tr = truss.from_directory("path_to_my_truss")
+tr = truss.load("path_to_my_truss")
 ```
 
 From there, you can invoke the Truss to serve the model in your Python environment. Just run:

--- a/docs/e2e.md
+++ b/docs/e2e.md
@@ -22,14 +22,14 @@ If you want to follow this tutorial for a particular framework and don't have a 
 
 ## Step 1: Create a Truss
 
-Truss works across model frameworks, and the most common model frameworks are supported with the one-line `mk_truss` command. Click the framework you built your model in to see specific packaging instructions for that format.
+Truss works across model frameworks, and the most common model frameworks are supported with the one-line `create` command. Click the framework you built your model in to see specific packaging instructions for that format.
 
 For the following formats, if you have an in-memory trained model object `model`, just call the following:
 
 ```python
-from truss import mk_truss
+from truss import create
 
-mk_truss(model, target_directory="my_truss")
+create(model, target_directory="my_truss")
 ```
 
 Supported frameworks:

--- a/docs/notebooks/aws_example.ipynb
+++ b/docs/notebooks/aws_example.ipynb
@@ -49,7 +49,7 @@
    "outputs": [],
    "source": [
     "# Make scaffold \n",
-    "scaffold = truss.mk_truss(rfc_model, target_directory='test_rfc_1')\n",
+    "scaffold = truss.create(rfc_model, target_directory='test_rfc_1')\n",
     "# This will produce a folder `test_rfc_1/` relative to your current directory. \n",
     "# Now we'll use Truss to build a Docker image on our local system\n",
     "scaffold.build_docker_image()"

--- a/docs/notebooks/huggingface_example.ipynb
+++ b/docs/notebooks/huggingface_example.ipynb
@@ -44,9 +44,9 @@
       },
       "outputs": [],
       "source": [
-        "from truss import mk_truss\n",
+        "from truss import create\n",
         "\n",
-        "tr = mk_truss(model, target_directory=\"huggingface_truss\")"
+        "tr = create(model, target_directory=\"huggingface_truss\")"
       ]
     },
     {

--- a/docs/notebooks/lightgbm_example.ipynb
+++ b/docs/notebooks/lightgbm_example.ipynb
@@ -68,9 +68,9 @@
       },
       "outputs": [],
       "source": [
-        "from truss import mk_truss\n",
+        "from truss import create\n",
         "\n",
-        "tr = mk_truss(model, target_directory=\"lightgbm_truss\")"
+        "tr = create(model, target_directory=\"lightgbm_truss\")"
       ]
     },
     {

--- a/docs/notebooks/mlflow_example.ipynb
+++ b/docs/notebooks/mlflow_example.ipynb
@@ -85,7 +85,7 @@
         "import truss\n",
         "\n",
         "model = mlflow.pyfunc.load_model(MODEL_URI)\n",
-        "tr = truss.mk_truss(model, target_directory=\"./mlflow_truss\")"
+        "tr = truss.create(model, target_directory=\"./mlflow_truss\")"
       ]
     },
     {

--- a/docs/notebooks/sklearn_example.ipynb
+++ b/docs/notebooks/sklearn_example.ipynb
@@ -60,7 +60,7 @@
       "outputs": [],
       "source": [
         "# Create the Truss (serializing & packaging model)\n",
-        "tr = truss.mk_truss(rfc, \"iris-rfc\")"
+        "tr = truss.create(rfc, \"iris-rfc\")"
       ]
     },
     {

--- a/docs/notebooks/tensorflow_example.ipynb
+++ b/docs/notebooks/tensorflow_example.ipynb
@@ -49,10 +49,10 @@
       },
       "outputs": [],
       "source": [
-        "from truss import mk_truss\n",
+        "from truss import create\n",
         "\n",
         "# Create the Truss (serializing & packaging model)\n",
-        "tr = mk_truss(model, target_directory=\"tensorflow_truss\")"
+        "tr = create(model, target_directory=\"tensorflow_truss\")"
       ]
     },
     {

--- a/docs/notebooks/xgboost_example.ipynb
+++ b/docs/notebooks/xgboost_example.ipynb
@@ -63,9 +63,9 @@
       },
       "outputs": [],
       "source": [
-        "from truss import mk_truss\n",
+        "from truss import create\n",
         "\n",
-        "tr = mk_truss(model, target_directory=\"xgboost_truss\")"
+        "tr = create(model, target_directory=\"xgboost_truss\")"
       ]
     },
     {

--- a/docs/reference/client.md
+++ b/docs/reference/client.md
@@ -8,7 +8,7 @@ A list of the functions available with `import truss` and their arguments and pr
 
 Cleans up .truss directory.
 
-#### from_directory(truss_directory: str) -> truss.truss_handle.TrussHandle
+#### load(truss_directory: str) -> truss.truss_handle.TrussHandle
 
 Get a handle to a Truss. A Truss is a build context designed to be built as a container locally or uploaded into a model serving environment.
 
@@ -31,7 +31,7 @@ Args:
 
 #### kill_all()
 
-#### mk_truss(model: Any, target_directory: str = None, data_files: List[str] = None, requirements_file: str = None) -> truss.truss_handle.TrussHandle
+#### create(model: Any, target_directory: str = None, data_files: List[str] = None, requirements_file: str = None) -> truss.truss_handle.TrussHandle
 
 Create a Truss with the given model. A Truss is a build context designed to
 be built as a container locally or uploaded into a model serving environment.

--- a/truss/__init__.py
+++ b/truss/__init__.py
@@ -11,10 +11,4 @@ def version():
     return __version__
 
 
-from truss.build import (
-    from_directory,
-    init,
-    kill_all,
-    mk_truss,
-    mk_truss_from_mlflow_uri,
-)
+from truss.build import create, create_from_mlflow_uri, init, kill_all, load

--- a/truss/build.py
+++ b/truss/build.py
@@ -54,7 +54,7 @@ def populate_target_directory(
     return target_directory_path
 
 
-def mk_truss_from_model(
+def create_from_model(
     model: Any,
     target_directory: str = None,
     data_files: List[str] = None,
@@ -102,7 +102,7 @@ def mk_truss_from_model(
     return scaf
 
 
-def mk_truss_from_pipeline(
+def create_from_pipeline(
     pipeline: Callable,
     target_directory: str = None,
     data_files: List[str] = None,
@@ -146,7 +146,7 @@ def mk_truss_from_pipeline(
         click.echo(
             click.style(
                 """WARNING: Truss identified objects in GPU memory. When serializing a
-                function via mk_truss, objects in GPU memory must be moved to
+                function via create, objects in GPU memory must be moved to
                 CPU to be serialized correctly.""",
                 fg="yellow",
             )
@@ -162,7 +162,7 @@ def mk_truss_from_pipeline(
     return scaf
 
 
-def mk_truss_from_mlflow_uri(
+def create_from_mlflow_uri(
     model_uri: str,
     target_directory: str = None,
     data_files: List[str] = None,
@@ -197,10 +197,10 @@ def mk_truss_from_mlflow_uri(
     return truss
 
 
-def mk_truss_from_model_with_exception_handler(*args):
+def create_from_model_with_exception_handler(*args):
     # returns None if framework not supported, otherwise the Truss
     try:
-        return mk_truss_from_model(*args)
+        return create_from_model(*args)
     except FrameworkNotSupportedError:
         return None
 
@@ -236,7 +236,7 @@ def init(
     return scaf
 
 
-def from_directory(truss_directory: str) -> TrussHandle:
+def load(truss_directory: str) -> TrussHandle:
     """Get a handle to a Truss. A Truss is a build context designed to be built
     as a container locally or uploaded into a model serving environment.
 
@@ -248,7 +248,18 @@ def from_directory(truss_directory: str) -> TrussHandle:
     return TrussHandle(Path(truss_directory))
 
 
-def mk_truss(
+def from_directory(**kwargs):
+    """DEPRECATED, use truss.load() instead.
+
+    Args:
+        truss_directory (str): The local directory of an existing Truss
+    Returns:
+        TrussHandle
+    """
+    return load(kwargs)
+
+
+def create(
     model: Any,
     target_directory: str = None,
     data_files: List[str] = None,
@@ -258,20 +269,31 @@ def mk_truss(
     # Some model objects can are callable (like Keras models)
     # so we first attempt to make Truss via a model object
 
-    model_scaffold = mk_truss_from_model_with_exception_handler(
+    model_scaffold = create_from_model_with_exception_handler(
         model, target_directory, data_files, requirements_file, bundled_packages
     )
     if model_scaffold:
         return model_scaffold
     else:
         if callable(model):
-            return mk_truss_from_pipeline(
+            return create_from_pipeline(
                 model, target_directory, data_files, requirements_file, bundled_packages
             )
 
     raise ValueError(
         "Invalid input to make Truss. Truss expects a supported framework or callable function."
     )
+
+
+def mk_truss(**kwargs):
+    """DEPRECATED, use truss.create() instead
+
+    Args:
+        model (Any): An in-memory model object
+    Returns:
+        TrussHandle
+    """
+    return create(kwargs)
 
 
 def cleanup():

--- a/truss/cli.py
+++ b/truss/cli.py
@@ -89,7 +89,7 @@ def build_context(build_dir, target_directory) -> None:
 
     TARGET DIRECTORY: A Truss directory. If none, use current directory.
     """
-    tr = _get_truss_from_directory(target_directory=target_directory)
+    tr = _load_truss_from_directory(target_directory=target_directory)
     tr.docker_build_setup(build_dir=Path(build_dir))
 
 
@@ -106,7 +106,7 @@ def build_image(target_directory, build_dir, tag):
 
     BUILD_DIR: Image context. If none, a temp directory is created.
     """
-    tr = _get_truss_from_directory(target_directory=target_directory)
+    tr = _load_truss_from_directory(target_directory=target_directory)
     if build_dir:
         build_dir = Path(build_dir)
     tr.build_docker_image(build_dir=build_dir, tag=tag)
@@ -129,7 +129,7 @@ def run_image(target_directory, build_dir, tag, port, attach):
 
     BUILD_DIR: Image context. If none, a temp directory is created.
     """
-    tr = _get_truss_from_directory(target_directory=target_directory)
+    tr = _load_truss_from_directory(target_directory=target_directory)
     if build_dir:
         build_dir = Path(build_dir)
     urls = tr.get_urls_from_truss()
@@ -176,7 +176,7 @@ def predict(target_directory, request, build_dir, tag, port, run_local, request_
     else:
         raise ValueError("At least one of request or request-file must be supplied.")
 
-    tr = _get_truss_from_directory(target_directory=target_directory)
+    tr = _load_truss_from_directory(target_directory=target_directory)
     if run_local:
         return tr.server_predict(request_data)
     else:
@@ -199,7 +199,7 @@ def run_example(target_directory, name, local):
 
     TARGET DIRECTORY: A Truss directory. If none, use current directory.
     """
-    tr = _get_truss_from_directory(target_directory=target_directory)
+    tr = _load_truss_from_directory(target_directory=target_directory)
     predict_fn = tr.docker_predict
     if local:
         predict_fn = tr.server_predict
@@ -225,7 +225,7 @@ def get_container_logs(target_directory):
 
     TARGET DIRECTORY: A Truss directory. If none, use current directory.
     """
-    for log in _get_truss_from_directory(
+    for log in _load_truss_from_directory(
         target_directory=target_directory
     ).container_logs():
         click.echo(log)
@@ -239,7 +239,7 @@ def kill(target_directory):
 
     TARGET DIRECTORY: A Truss directory. If none, use current directory.
     """
-    tr = _get_truss_from_directory(target_directory=target_directory)
+    tr = _load_truss_from_directory(target_directory=target_directory)
     tr.kill_container()
 
 
@@ -262,7 +262,7 @@ def cleanup() -> None:
     truss.build.cleanup()
 
 
-def _get_truss_from_directory(target_directory: str = None):
+def _load_truss_from_directory(target_directory: str = None):
     """Gets Truss from directory. If none, use the current directory"""
     if target_directory is None:
         target_directory = os.getcwd()

--- a/truss/test_data/happy.ipynb
+++ b/truss/test_data/happy.ipynb
@@ -24,9 +24,9 @@
     "    lr.fit(df.values, df.iloc[:, 0])\n",
     "    \n",
     "    with tempfile.TemporaryDirectory() as tmp:\n",
-    "        tr = truss.mk_truss(lr, target_directory=tmp)\n",
+    "        tr = truss.create(lr, target_directory=tmp)\n",
     "        \n",
-    "        assert truss.from_directory(tmp).spec.yaml_string == tr.spec.yaml_string"
+    "        assert truss.load(tmp).spec.yaml_string == tr.spec.yaml_string"
    ]
   }
  ],

--- a/truss/tests/environments_inference/test_requirements_inference.py
+++ b/truss/tests/environments_inference/test_requirements_inference.py
@@ -1,14 +1,14 @@
 from typing import List
 
 import pandas as pd  # noqa
-from truss.build import mk_truss
+from truss.build import create
 
 
-def test_infer_deps_through_mk_truss_local_import(sklearn_rfc_model, tmp_path):
+def test_infer_deps_through_create_local_import(sklearn_rfc_model, tmp_path):
     dir_path = tmp_path / "truss"
     import requests  # noqa
 
-    tr = mk_truss(
+    tr = create(
         sklearn_rfc_model,
         target_directory=dir_path,
     )
@@ -16,11 +16,9 @@ def test_infer_deps_through_mk_truss_local_import(sklearn_rfc_model, tmp_path):
     _validate_that_package_is_in_requirements(spec.requirements, "requests")
 
 
-def test_infer_deps_through_mk_truss_top_of_the_file_import(
-    sklearn_rfc_model, tmp_path
-):
+def test_infer_deps_through_create_top_of_the_file_import(sklearn_rfc_model, tmp_path):
     dir_path = tmp_path / "truss"
-    tr = mk_truss(
+    tr = create(
         sklearn_rfc_model,
         target_directory=dir_path,
     )

--- a/truss/tests/samples.py
+++ b/truss/tests/samples.py
@@ -24,7 +24,7 @@ from tensorflow.keras.layers.experimental import preprocessing
 
 # Create a fake dataset to include with the deployment
 from test_folder.utils.embedding_util import create_reference_embeddings
-from truss.build import mk_truss, scaffold, scaffold_custom
+from truss.build import create, scaffold, scaffold_custom
 from truss.constants import HUGGINGFACE_TRANSFORMER
 from truss.definitions.base import build_scaffold_directory
 from truss.definitions.huggingface_transformer import (
@@ -78,11 +78,11 @@ os.chdir(current_dir)
 
 
 # You can take a whole directory
-ms = mk_truss(
+ms = create(
     model, model_files=["pytorch_eg/"], data_files=[], target_directory="test_pytorch"
 )
 # You can also take single files or globs
-ms2 = mk_truss(
+ms2 = create(
     model,
     model_files=["pytorch_eg/utils/*.py", "pytorch_eg/my_pytorch_model.py"],
     data_files=[],
@@ -104,7 +104,7 @@ data_y = iris["target"]
 data_x = pd.DataFrame(data_x, columns=feature_names)
 rfc.fit(data_x, data_y)
 
-ms = mk_truss(rfc, model_files=[], data_files=[])
+ms = create(rfc, model_files=[], data_files=[])
 ms.docker_build_string
 ms.predict([[0, 0, 0, 0]])
 
@@ -189,14 +189,14 @@ with open("test_folder/embedding_reqs.txt", "w") as f:
 
 create_reference_embeddings()
 
-mk_truss = scaffold_custom(
+create = scaffold_custom(
     model_files=["test_folder", "test_folder/utils/*.py", "embeddings.npy"],
     target_directory="test_custom",
     requirements_file="test_folder/embedding_reqs.txt",
     model_class="MyEmbeddingModel",
 )
-mk_truss.docker_build_string
-mk_truss.predict(["hello world", "bar baz"])
+create.docker_build_string
+create.predict(["hello world", "bar baz"])
 
 
 url = "http://archive.ics.uci.edu/ml/machine-learning-databases/auto-mpg/auto-mpg.data"
@@ -255,7 +255,7 @@ history = linear_model.fit(
 linear_model.predict(train_features[:10])
 
 
-scaff = mk_truss(model=linear_model)
+scaff = create(model=linear_model)
 scaff.docker_build_string
 scaff.predict([[0, 0, 0, 0, 0, 0, 0, 0, 0]])
 
@@ -263,10 +263,10 @@ scaff.predict([[0, 0, 0, 0, 0, 0, 0, 0, 0]])
 
 
 built_scaffold_dir = build_scaffold_directory(HUGGINGFACE_TRANSFORMER)
-mk_truss = HuggingFaceTransformerPipelineScaffold(
+create = HuggingFaceTransformerPipelineScaffold(
     model_type="text-generation", path_to_scaffold=built_scaffold_dir
 )
-mk_truss.predict([{"text_inputs": "hello world"}])
+create.predict([{"text_inputs": "hello world"}])
 
 
 PYTORCH_MODEL_CODE = """
@@ -308,7 +308,7 @@ model = MyModelWithArgs(**MODEL_INIT_ARGS)
 os.chdir(current_dir)
 
 
-ms = mk_truss(
+ms = create(
     model,
     model_files=[PYTORCH_WITH_ARGS_PATH],
     data_files=[],

--- a/truss/tests/test_build.py
+++ b/truss/tests/test_build.py
@@ -3,7 +3,7 @@ from contextlib import contextmanager
 from pathlib import Path
 
 import numpy as np
-from truss.build import cleanup, init, mk_truss
+from truss.build import cleanup, create, init
 from truss.truss_spec import TrussSpec
 
 
@@ -66,7 +66,7 @@ def test_truss_init_with_data_file_and_requirements_file_and_bundled_packages(
     assert (spec.bundled_packages_dir / "dep_pkg" / "file.py").exists()
 
 
-def test_mk_truss(sklearn_rfc_model, tmp_path):
+def test_create(sklearn_rfc_model, tmp_path):
     dir_path = tmp_path / "truss"
     data_file_path = tmp_path / "data.txt"
     with data_file_path.open("w") as data_file:
@@ -79,7 +79,7 @@ def test_mk_truss(sklearn_rfc_model, tmp_path):
     with req_file_path.open("w") as req_file:
         for req in requirements:
             req_file.write(f"{req}\n")
-    scaf = mk_truss(
+    scaf = create(
         sklearn_rfc_model,
         target_directory=dir_path,
         data_files=[str(data_file_path)],
@@ -94,7 +94,7 @@ def test_mk_truss(sklearn_rfc_model, tmp_path):
     assert spec.requirements == requirements
 
 
-def test_mk_truss_pipeline(sklearn_rfc_model, tmp_path):
+def test_create_pipeline(sklearn_rfc_model, tmp_path):
     def inference(request: dict):
         inputs = request["inputs"]
         response = sklearn_rfc_model.predict([inputs])[0]
@@ -112,7 +112,7 @@ def test_mk_truss_pipeline(sklearn_rfc_model, tmp_path):
     with req_file_path.open("w") as req_file:
         for req in requirements:
             req_file.write(f"{req}\n")
-    scaf = mk_truss(
+    scaf = create(
         inference,
         target_directory=dir_path,
         data_files=[str(data_file_path)],
@@ -207,7 +207,7 @@ def test_cleanup(sklearn_rfc_model, tmp_path):
     with req_file_path.open("w") as req_file:
         for req in requirements:
             req_file.write(f"{req}\n")
-    _ = mk_truss(
+    _ = create(
         sklearn_rfc_model,
         data_files=[str(data_file_path)],
         requirements_file=str(req_file_path),
@@ -254,13 +254,13 @@ def test_truss_via_t5_mk_pipeline(
 @contextmanager
 def _model_server_predict(model, model_input):
     with tempfile.TemporaryDirectory() as dir_name:
-        sc = mk_truss(model, target_directory=dir_name)
+        sc = create(model, target_directory=dir_name)
         result = sc.server_predict(model_input)
         yield result
 
 
 @contextmanager
 def _model_server_predict_pipeline(pipeline, model_input):
-    sc = mk_truss(pipeline)
+    sc = create(pipeline)
     result = sc.server_predict(model_input)
     yield result


### PR DESCRIPTION
This PR proposes new names for two primary functions.

Truss has two functions that every user will call often: `mk_truss()` and `from_directory()`. This PR improves Truss' developer experience by renaming these functions to more descriptive names: `create()` and `load()`.

Here's some code after this PR:

```python
import truss

truss.create(my_model, "my_model_dir")

# Elsewhere
handle = truss.load("my_model_dir")
```

The original function names are preserved as deprecated aliases and can be removed in a future major version.

Thoughts?