### PR TITLE
Refactor huggingface support to allow live_reload support

### DIFF
--- a/truss/templates/base.Dockerfile.jinja
+++ b/truss/templates/base.Dockerfile.jinja
@@ -1,14 +1,6 @@
 ARG PYVERSION={{config.python_version}}
 
-{% if config.model_framework.value == 'huggingface_transformer' %}
-    {% if config.resources.use_gpu %}
-FROM baseten/baseten-huggingface-transformer-server-gpu-base:latest
-    {% else %}
-# TODO(pankaj): Use baseten wrapper, to be consistent with gpu case
-FROM huggingface/transformers-cpu:4.18.0
-    {% endif %}
-{% else %}
-    {% if config.resources.use_gpu %}
+{% if config.resources.use_gpu %}
 # TODO(pankaj): Replace with baseten/baseten-server-gpu-base-$PYVERSION:latest
 FROM nvidia/cuda:11.2.1-base-ubuntu18.04
 ENV CUDNN_VERSION=8.1.0.77
@@ -55,9 +47,8 @@ RUN ln -sf /usr/bin/python3.9 /usr/bin/python3 && \
 
 RUN python3 -m pip install --no-cache-dir --upgrade pip
 
-    {% else %}
+{% else %}
 FROM baseten/baseten-server-base-$PYVERSION:latest
-    {% endif %}
 {% endif %}
 
 
@@ -71,7 +62,12 @@ RUN apt-get update && apt-get install --yes --no-install-recommends $(cat system
 
 
 RUN pip install --upgrade pip
-
+{% if config.model_framework.value == 'huggingface_transformer' %}
+    {% if config.resources.use_gpu %}
+# HuggingFace pytorch gpu support needs mkl
+RUN pip install mkl
+    {% endif %}
+{% endif%}
 
 {% block install_requirements %}
 COPY ./requirements.txt requirements.txt

--- a/truss/templates/control/requirements.txt
+++ b/truss/templates/control/requirements.txt
@@ -1,5 +1,5 @@
 dataclasses-json==0.5.7
 Flask==2.0.3
 waitress==2.1.2
-truss==0.1.1
+truss==0.1.6
 tenacity==8.1.0

--- a/truss/templates/control/requirements.txt
+++ b/truss/templates/control/requirements.txt
@@ -1,5 +1,5 @@
 dataclasses-json==0.5.7
 Flask==2.0.3
 waitress==2.1.2
-truss==0.1.6
+truss==0.1.7
 tenacity==8.1.0

--- a/truss/templates/huggingface_transformer/requirements.txt
+++ b/truss/templates/huggingface_transformer/requirements.txt
@@ -7,3 +7,5 @@ kfserving==0.5.0
 msgpack-numpy==0.4.7.1
 msgpack==1.0.2
 python-json-logger==2.0.2
+transformers
+torch


### PR DESCRIPTION
I inspected our huggingface support and it seems to be based on the huggingface transformers state of early last year. We only support pytorch, e.g. tensorflow is explicitly uninstalled from one of the base images. 
Based the transformers [CPU](https://github.com/huggingface/transformers/blob/71c87119708b6466574eb2cb11097c6b38b86fc9/docker/transformers-pytorch-cpu/Dockerfile)  and [GPU](https://github.com/huggingface/transformers/blob/71c87119708b6466574eb2cb11097c6b38b86fc9/docker/transformers-pytorch-gpu/Dockerfile) images I feel we can simply support that in our general images, and avoid the need for special images.

I haven't tested the GPU images. Our GPU base image has slightly newer cuda version and is set up a bit differently, but hopefully our GPU image set up works well with transformers library and we can avoid maintaining a separate base image.

Apart from ease of maintenance we get a quick benefit of live_reload starting to work for huggingface framework, it's broken currently.

For the CPU part I tested manually, and we have an integration test as well in `test_huggingface_transformer_framework.py`