### PR TITLE
Update msgpack-numpy version to fix np array serialization issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.1.8rc1"
+version = "0.1.8rc2"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/templates/custom/requirements.txt
+++ b/truss/templates/custom/requirements.txt
@@ -4,6 +4,6 @@ argparse==1.4.0
 aiocontextvars==0.2.2
 cython==0.29.23
 kfserving==0.5.0
-msgpack-numpy==0.4.7.1
+msgpack-numpy==0.4.8
 msgpack==1.0.2
 python-json-logger==2.0.2

--- a/truss/templates/huggingface_transformer/requirements.txt
+++ b/truss/templates/huggingface_transformer/requirements.txt
@@ -4,7 +4,7 @@ argparse==1.4.0
 aiocontextvars==0.2.2
 cython==0.29.23
 kfserving==0.5.0
-msgpack-numpy==0.4.7.1
+msgpack-numpy==0.4.8
 msgpack==1.0.2
 python-json-logger==2.0.2
 transformers

--- a/truss/templates/keras/requirements.txt
+++ b/truss/templates/keras/requirements.txt
@@ -4,6 +4,6 @@ argparse==1.4.0
 aiocontextvars==0.2.2
 cython==0.29.23
 kfserving==0.5.0
-msgpack-numpy==0.4.7.1
+msgpack-numpy==0.4.8
 msgpack==1.0.2
 python-json-logger==2.0.2

--- a/truss/templates/lightgbm/requirements.txt
+++ b/truss/templates/lightgbm/requirements.txt
@@ -4,6 +4,6 @@ argparse==1.4.0
 aiocontextvars==0.2.2
 cython==0.29.23
 kfserving==0.5.0
-msgpack-numpy==0.4.7.1
+msgpack-numpy==0.4.8
 msgpack==1.0.2
 python-json-logger==2.0.2

--- a/truss/templates/mlflow/requirements.txt
+++ b/truss/templates/mlflow/requirements.txt
@@ -4,6 +4,6 @@ argparse==1.4.0
 aiocontextvars==0.2.2
 cython==0.29.23
 kfserving==0.5.0
-msgpack-numpy==0.4.7.1
+msgpack-numpy==0.4.8
 msgpack==1.0.2
 python-json-logger==2.0.2

--- a/truss/templates/pipeline/requirements.txt
+++ b/truss/templates/pipeline/requirements.txt
@@ -4,6 +4,6 @@ argparse==1.4.0
 aiocontextvars==0.2.2
 cython==0.29.23
 kfserving==0.5.0
-msgpack-numpy==0.4.7.1
+msgpack-numpy==0.4.8
 msgpack==1.0.2
 python-json-logger==2.0.2

--- a/truss/templates/pytorch/requirements.txt
+++ b/truss/templates/pytorch/requirements.txt
@@ -4,6 +4,6 @@ argparse==1.4.0
 aiocontextvars==0.2.2
 cython==0.29.23
 kfserving==0.5.0
-msgpack-numpy==0.4.7.1
+msgpack-numpy==0.4.8
 msgpack==1.0.2
 python-json-logger==2.0.2

--- a/truss/templates/sklearn/requirements.txt
+++ b/truss/templates/sklearn/requirements.txt
@@ -4,6 +4,6 @@ argparse==1.4.0
 aiocontextvars==0.2.2
 cython==0.29.23
 kfserving==0.5.0
-msgpack-numpy==0.4.7.1
+msgpack-numpy==0.4.8
 msgpack==1.0.2
 python-json-logger==2.0.2

--- a/truss/templates/xgboost/requirements.txt
+++ b/truss/templates/xgboost/requirements.txt
@@ -2,7 +2,7 @@ argparse==1.4.0
 aiocontextvars==0.2.2
 cython==0.29.23
 kfserving==0.5.0
-msgpack-numpy==0.4.7.1
+msgpack-numpy==0.4.8
 msgpack==1.0.2
 python-json-logger==2.0.2
 joblib==1.1.0


### PR DESCRIPTION
msgpack-numpy 0.4.7.1 does not support serializing np string arrays of dype 'object'. e.g. this fails

```
ln [28]: import msgpack_numpy as mp_np, numpy as np
In [29]: mp_np.decode(mp_np.encode(np.array(['foo'], dtype='object)))
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[29], line 1
----> 1 mp_np.decode(mp_np.encode(x))

File /usr/local/lib/python3.9/site-packages/msgpack_numpy.py:90, in decode(obj, chain)
     88     else:
     89         descr = obj[b'type']
---> 90     return np.frombuffer(obj[b'data'],
     91                 dtype=_unpack_dtype(descr)).reshape(obj[b'shape'])
     92 else:
     93     descr = obj[b'type']

ValueError: cannot create an OBJECT array from memory buffer
```

This means that deserializing a response for the binary prediction endpoint fails. Upgrading to 0.4.8 fixes that.