### PR TITLE
Update patch ping protocol

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.1.8rc2"
+version = "0.1.9"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/templates/control/control/helpers/inference_server_controller.py
+++ b/truss/templates/control/control/helpers/inference_server_controller.py
@@ -59,13 +59,18 @@ class InferenceServerController:
             self._process_controller.start()
             self._current_running_hash = req_hash
 
-    def truss_hash(self):
+    def truss_hash(self) -> str:
         return self._current_running_hash
 
     def restart(self):
         with self._lock:
             self._process_controller.stop()
             self._process_controller.start()
+
+    def start(self):
+        # For now, start just does restart, this alias allows for better
+        # readability in certain scenarios where the intention is to start.
+        self.restart()
 
     def stop(self):
         with self._lock:

--- a/truss/templates/control/control/helpers/inference_server_starter.py
+++ b/truss/templates/control/control/helpers/inference_server_starter.py
@@ -49,6 +49,9 @@ def inference_server_startup_flow(application):
                 # If hash is current start inference server, otherwise delay that
                 # for when patch is applied.
                 if "is_current" in resp_body and resp_body["is_current"] is True:
+                    application.logger.info(
+                        "Hash is current, starting inference server"
+                    )
                     inference_server_controller.start()
             except Exception as exc:  # noqa
                 application.logger.warning(

--- a/truss/templates/control/control/helpers/inference_server_starter.py
+++ b/truss/templates/control/control/helpers/inference_server_starter.py
@@ -1,0 +1,51 @@
+import os
+
+import requests
+from tenacity import Retrying, stop_after_attempt, wait_exponential
+
+
+def inference_server_startup_flow(application):
+    """
+    Perform the inference server startup flow
+
+    Inference server startup flow supports checking for patches. If a patch ping
+    url is provided then we hit that url to start the sync mechanism. The ping
+    calls with current truss hash. The patch ping endpoint should return a
+    response indicating, either that the supplied hash is current or that the
+    request has been accepted. Acceptance of request means that a patch will be
+    supplied soon to the truss (by calling of /control/patch endpoint).
+
+    If we find that our hash is current, we start the inference server
+    immediately. Otherwise, we delay the start to when the patch is supplied.
+
+    The goal is to start the inference server as soon as we have the latest
+    code, but not before.
+    Example responses:
+    {"is_current": true}
+    {"accepted": true}
+    """
+    inference_server_controller = application.config["inference_server_controller"]
+    patch_ping_url = os.environ.get("PATCH_PING_URL_TRUSS")
+    if patch_ping_url is None:
+        inference_server_controller.start()
+        return
+
+    truss_hash = inference_server_controller.truss_hash()
+    payload = {"truss_hash": truss_hash}
+
+    for attempt in Retrying(
+        stop=stop_after_attempt(15),
+        wait=wait_exponential(multiplier=2, min=1, max=4),
+    ):
+        with attempt:
+            application.logger.info(
+                f"Pinging {patch_ping_url} for patch with hash {truss_hash}"
+            )
+            resp = requests.post(patch_ping_url, timeout=1, json=payload)
+            resp.raise_for_status()
+            resp_body = resp.json()
+
+            # If hash is current start inference server, otherwise delay that
+            # for when patch is applied.
+            if "is_current" in resp_body and resp_body["is_current"] is True:
+                inference_server_controller.start()

--- a/truss/test_data/patch_ping_test_server/app.py
+++ b/truss/test_data/patch_ping_test_server/app.py
@@ -1,0 +1,59 @@
+import inspect
+from collections import Counter
+
+from flask import Flask
+
+# This webserver is meant for testing the patch ping flow in truss
+# Some of the end points can be used for patch ping, the names indicate
+# the behavior they simulate.
+# The stats endpoint can be used to collect stats for verification.
+
+app = Flask(__name__)
+
+_stats = Counter()
+
+
+def _inc_fn_call_stat():
+    global _stats
+    fn_name = inspect.stack()[1][3]
+    _stats[f"{fn_name}_called_count"] += 1
+
+
+@app.route("/hash_is_current", methods=["POST"])
+def hash_is_current():
+    _inc_fn_call_stat()
+    return {
+        "is_current": True,
+    }
+
+
+@app.route("/hash_is_current_but_only_every_third_call_succeeds", methods=["POST"])
+def hash_is_current_but_only_every_third_call_succeeds():
+    _inc_fn_call_stat()
+    global _stats
+    fn_name = inspect.stack()[0][3]
+    if _stats[f"{fn_name}_called_count"] % 3 == 0:
+        return {
+            "is_current": True,
+        }
+    return "simulated failure", 500
+
+
+@app.route("/accepted", methods=["POST"])
+def accepted():
+    _inc_fn_call_stat()
+    return {
+        "accepted": True,
+    }
+
+
+@app.route("/health")
+def health():
+    _inc_fn_call_stat()
+    return {}
+
+
+@app.route("/stats")
+def stats():
+    global _stats
+    return _stats


### PR DESCRIPTION
Patch ping mechanism now allows for the ping endpoint to return an is_current flag in response, using which the inference server can be started immediately. Previously, the live reload capable truss had to necessarily wait for the patch endpoint to be called for starting the inference server. There were two issue with this for the initial truss deploy:
1. It wasted time, the truss is always current on initial deploy and waiting for the patch endpoint to be called wastes time and delay inference server startup. This time can be many seconds, see the point below.
2. The truss control server usually starts up quickly, but it may take a few seconds for it to be callable, the registration of the service hosting it may take a few seconds to be available to the cluster DNS. If the external service that provides patches, doesn't retry long enough then the startup can actually fail. We ran into this.

Tests have been added to test this mechanism. In fact, a lot of this PR is about that testing. A couple changes were needed to be able to test this flow:
1. A patch_ping_url param has been added to docker_run and docker_predict functions
2. A host entry has been added to the docker run command to start the truss container, to allow it to hit the local test server.