### PR TITLE
Restart inference server on crash when on live reload

### DIFF
--- a/truss/templates/control/control/application.py
+++ b/truss/templates/control/control/application.py
@@ -20,6 +20,7 @@ def create_app(base_config: dict):
         app.config["inference_server_home"],
         app.config["inference_server_process_args"],
         app.config["inference_server_port"],
+        app_logger=app.logger,
     )
     patch_applier = PatchApplier(Path(app.config["inference_server_home"]), app.logger)
     app.config["inference_server_controller"] = InferenceServerController(

--- a/truss/templates/control/control/helpers/inference_server_process_controller.py
+++ b/truss/templates/control/control/helpers/inference_server_process_controller.py
@@ -10,12 +10,14 @@ class InferenceServerProcessController:
         inference_server_home,
         inference_server_process_args,
         inference_server_port,
+        app_logger,
     ) -> None:
         self._inference_server_process = None
         self._inference_server_home = inference_server_home
         self._inference_server_process_args = inference_server_process_args
         self._inference_server_port = inference_server_port
         self._inference_server_started = False
+        self._app_logger = app_logger
 
     def start(self):
         with current_directory(self._inference_server_home):
@@ -47,3 +49,10 @@ class InferenceServerProcessController:
             return False
 
         return self._inference_server_process.poll() is None
+
+    def check_and_recover_inference_server(self):
+        if self.inference_server_started() and not self.is_inference_server_running():
+            self._app_logger.warning(
+                "Inference server seems to have crashed, restarting"
+            )
+            self.start()

--- a/truss/tests/conftest.py
+++ b/truss/tests/conftest.py
@@ -294,57 +294,57 @@ def pytorch_model_with_init_args(tmp_path, pytorch_model_init_args):
 
 @pytest.fixture
 def custom_model_truss_dir(tmp_path) -> Path:
-    dir_path = tmp_path / "custom_truss"
-    handle = init(str(dir_path))
-    with handle.spec.model_class_filepath.open("w") as file:
-        file.write(CUSTOM_MODEL_CODE)
-    return dir_path
+    yield _custom_model_from_code(
+        tmp_path,
+        "custom_truss",
+        CUSTOM_MODEL_CODE,
+    )
 
 
 @pytest.fixture
 def no_preprocess_custom_model(tmp_path):
-    dir_path = tmp_path / "my_no_preprocess_model"
-    handle = init(str(dir_path))
-    with handle.spec.model_class_filepath.open("w") as file:
-        file.write(NO_PREPROCESS_CUSTOM_MODEL_CODE)
-    yield dir_path
+    yield _custom_model_from_code(
+        tmp_path,
+        "my_no_preprocess_model",
+        NO_PREPROCESS_CUSTOM_MODEL_CODE,
+    )
 
 
 @pytest.fixture
 def custom_model_control(tmp_path):
-    dir_path = tmp_path / "control_truss"
-    handle = init(str(dir_path))
-    handle.live_reload()
-    with handle.spec.model_class_filepath.open("w") as file:
-        file.write(CUSTOM_MODEL_CODE)
-    yield dir_path
+    yield _custom_model_from_code(
+        tmp_path,
+        "control_truss",
+        CUSTOM_MODEL_CODE,
+        handle_ops=lambda handle: handle.live_reload(),
+    )
 
 
 @pytest.fixture
 def no_postprocess_custom_model(tmp_path):
-    dir_path = tmp_path / "my_no_postprocess_model"
-    handle = init(str(dir_path))
-    with handle.spec.model_class_filepath.open("w") as file:
-        file.write(NO_POSTPROCESS_CUSTOM_MODEL_CODE)
-    yield dir_path
+    yield _custom_model_from_code(
+        tmp_path,
+        "my_no_postprocess_model",
+        NO_POSTPROCESS_CUSTOM_MODEL_CODE,
+    )
 
 
 @pytest.fixture
 def no_load_custom_model(tmp_path):
-    dir_path = tmp_path / "my_no_load_model"
-    handle = init(str(dir_path))
-    with handle.spec.model_class_filepath.open("w") as file:
-        file.write(NO_LOAD_CUSTOM_MODEL_CODE)
-    yield dir_path
+    yield _custom_model_from_code(
+        tmp_path,
+        "my_no_load_model",
+        NO_LOAD_CUSTOM_MODEL_CODE,
+    )
 
 
 @pytest.fixture
 def no_params_init_custom_model(tmp_path):
-    dir_path = tmp_path / "my_no_params_init_load_model"
-    handle = init(str(dir_path))
-    with handle.spec.model_class_filepath.open("w") as file:
-        file.write(NO_PARAMS_INIT_CUSTOM_MODEL_CODE)
-    yield dir_path
+    yield _custom_model_from_code(
+        tmp_path,
+        "my_no_params_init_load_model",
+        NO_PARAMS_INIT_CUSTOM_MODEL_CODE,
+    )
 
 
 @pytest.fixture
@@ -663,3 +663,18 @@ def _pytorch_model_from_content(
     sys.path.append(str(path))
     model_class = getattr(importlib.import_module(model_module_name), model_class_name)
     return model_class(), f
+
+
+def _custom_model_from_code(
+    where_dir: Path,
+    truss_name: str,
+    model_code: str,
+    handle_ops: callable = None,
+) -> Path:
+    dir_path = where_dir / truss_name
+    handle = init(str(dir_path))
+    if handle_ops is not None:
+        handle_ops(handle)
+    with handle.spec.model_class_filepath.open("w") as file:
+        file.write(model_code)
+    return dir_path


### PR DESCRIPTION
Fix for https://github.com/basetenlabs/truss/issues/143 
We check in background every few seconds if inference server process has died where it should have been running, and if so we start the inference server again. 

Normally, any errors in loading the model or calling predict would result in exceptions which will be caught and error printed out. In these sceranios, for reload capable trusses, we don't want to retry but let the user debug issue based on error messages. But there are certain (rare) cases where the python process may immediately crash, without a chance for printing out any error message. In such scenarios it's worth restarting the process. Apart from the chance of the restarted inference server continuing successfully, e.g. if the crash was triggered via a runtime interaction such as specific input, the restart loop can also serve as useful information for debugging.

I tested this manually, writing an integration test for this scenario is quite tricky, let me create an issue for that for now.