### PR TITLE
Put inference server overseer thread creation behind a flag to stop tests from hanging

### DIFF
--- a/truss/templates/control/control/application.py
+++ b/truss/templates/control/control/application.py
@@ -24,7 +24,10 @@ def create_app(base_config: dict):
     )
     patch_applier = PatchApplier(Path(app.config["inference_server_home"]), app.logger)
     app.config["inference_server_controller"] = InferenceServerController(
-        app.config["inference_server_process_controller"], patch_applier, app.logger
+        app.config["inference_server_process_controller"],
+        patch_applier,
+        app.logger,
+        app.config.get("oversee_inference_server", True),
     )
     app.register_blueprint(control_app)
 

--- a/truss/templates/control/control/helpers/inference_server_controller.py
+++ b/truss/templates/control/control/helpers/inference_server_controller.py
@@ -21,16 +21,18 @@ class InferenceServerController:
         process_controller: InferenceServerProcessController,
         patch_applier: PatchApplier,
         app_logger,
+        oversee_inference_server: bool = True,
     ):
         self._lock = threading.Lock()
         self._process_controller = process_controller
         self._patch_applier = patch_applier
         self._current_running_hash = os.environ.get("HASH_TRUSS", None)
         self._app_logger = app_logger
-        self._inference_server_overseer_thread = threading.Thread(
-            target=self._check_and_recover_inference_server
-        )
-        self._inference_server_overseer_thread.start()
+        if oversee_inference_server:
+            self._inference_server_overseer_thread = threading.Thread(
+                target=self._check_and_recover_inference_server
+            )
+            self._inference_server_overseer_thread.start()
 
     def apply_patch(self, patch_request):
         with self._lock:

--- a/truss/tests/templates/control/control/test_server.py
+++ b/truss/tests/templates/control/control/test_server.py
@@ -41,6 +41,7 @@ def app(truss_container_fs, truss_original_hash):
                 "control_server_host": "0.0.0.0",
                 "control_server_port": 8081,
                 "inference_server_port": 8082,
+                "oversee_inference_server": False,
             }
         )
         yield control_app

--- a/truss/tests/test_truss_handle.py
+++ b/truss/tests/test_truss_handle.py
@@ -582,6 +582,7 @@ def test_container_oom_caught_during_waiting(container_state_mock):
 
 
 @patch("truss.truss_handle.get_container_state")
+@pytest.mark.integration
 def test_container_stuck_in_created(container_state_mock):
     container_state_mock.return_value = DockerStates.CREATED
     with pytest.raises(ContainerIsDownError):


### PR DESCRIPTION
Otherwise, the overseer thread was never closed and test would hang after finishing.

Also marked a slow test as integration.