### PR TITLE
Ignore baseten package during model inference

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.1.9"
+version = "0.1.10"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/environment_inference/requirements_inference.py
+++ b/truss/environment_inference/requirements_inference.py
@@ -14,7 +14,7 @@ from pkg_resources import WorkingSet
 POORLY_NAMED_PACKAGES = {"PIL": "Pillow", "sklearn": "scikit-learn"}
 
 # We don't want a few foundation packages
-IGNORED_PACKAGES = {"pip", "truss", "pluggy", "pytest", "py"}
+IGNORED_PACKAGES = {"baseten", "pip", "truss", "pluggy", "pytest", "py"}
 
 TOP_LEVEL_NAMESPACES_TO_DROP_FOR_INFERENCE = ["truss", "baseten"]
 


### PR DESCRIPTION
Baseten client tends to get bundled because inference is common triggered via baseten.deploy. It's very unlikely that the packaged model also needs baseten at runtime.