### PR TITLE
Add support for local train

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.1.10"
+version = "0.1.11rc1"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/cli.py
+++ b/truss/cli.py
@@ -215,9 +215,15 @@ def predict(target_directory, request, build_dir, tag, port, run_local, request_
     required=False,
     help="Training variables from a yaml file",
 )
+@click.option(
+    "--local",
+    is_flag=True,
+    default=False,
+    help="Flag to run training locally (not on docker)",
+)
 @error_handling
 @echo_output
-def train(target_directory, build_dir, tag, var, vars_yaml_file):
+def train(target_directory, build_dir, tag, var, vars_yaml_file, local):
     """Runs prediction for a Truss in a docker image or locally"""
     tr = _get_truss_from_directory(target_directory=target_directory)
     if vars_yaml_file is not None:
@@ -225,32 +231,10 @@ def train(target_directory, build_dir, tag, var, vars_yaml_file):
             variables = yaml.safe_load(vars_file)
     else:
         variables = _variables_dict_from_option(var)
+    if local:
+        return tr.local_train(variables=variables)
+
     return tr.docker_train(build_dir=build_dir, tag=tag, variables=variables)
-
-
-@cli_group.command()
-@click.option(
-    "--var",
-    multiple=True,
-    help="""Training variables in key=value form where value is string.
-    For more complex values use vars_yaml_file""",
-)
-@click.option(
-    "--vars_yaml_file",
-    required=False,
-    help="Training variables from a yaml file",
-)
-@error_handling
-@echo_output
-def local_train(target_directory, build_dir, tag, var, vars_yaml_file):
-    """Runs prediction for a Truss in a docker image or locally"""
-    tr = _get_truss_from_directory(target_directory=target_directory)
-    if vars_yaml_file is not None:
-        with Path(vars_yaml_file).open() as vars_file:
-            variables = yaml.safe_load(vars_file)
-    else:
-        variables = _variables_dict_from_option(var)
-    return tr.local_train(variables=variables)
 
 
 @cli_group.command()

--- a/truss/cli.py
+++ b/truss/cli.py
@@ -229,6 +229,31 @@ def train(target_directory, build_dir, tag, var, vars_yaml_file):
 
 
 @cli_group.command()
+@click.option(
+    "--var",
+    multiple=True,
+    help="""Training variables in key=value form where value is string.
+    For more complex values use vars_yaml_file""",
+)
+@click.option(
+    "--vars_yaml_file",
+    required=False,
+    help="Training variables from a yaml file",
+)
+@error_handling
+@echo_output
+def local_train(target_directory, build_dir, tag, var, vars_yaml_file):
+    """Runs prediction for a Truss in a docker image or locally"""
+    tr = _get_truss_from_directory(target_directory=target_directory)
+    if vars_yaml_file is not None:
+        with Path(vars_yaml_file).open() as vars_file:
+            variables = yaml.safe_load(vars_file)
+    else:
+        variables = _variables_dict_from_option(var)
+    return tr.local_train(variables=variables)
+
+
+@cli_group.command()
 @click.argument("target_directory", required=False)
 @click.option("--name", type=str, required=False, help="Name of example to run")
 @click.option(

--- a/truss/contexts/local_loader/load_model_local.py
+++ b/truss/contexts/local_loader/load_model_local.py
@@ -3,13 +3,13 @@ import inspect
 from pathlib import Path
 from typing import Dict
 
-from truss.contexts.local_loader.model_module_loader import model_class_module_loaded
+from truss.contexts.local_loader.truss_module_loader import truss_module_loaded
 from truss.contexts.truss_context import TrussContext
 from truss.local.local_config_handler import LocalConfigHandler
 from truss.truss_spec import TrussSpec
 
 
-class LoadLocal(TrussContext):
+class LoadModelLocal(TrussContext):
     """Loads a Truss model locally.
 
     The loaded model can be used to make predictions for quick testing.
@@ -20,7 +20,7 @@ class LoadLocal(TrussContext):
     @staticmethod
     def run(truss_dir: Path):
         spec = TrussSpec(truss_dir)
-        with model_class_module_loaded(
+        with truss_module_loaded(
             str(truss_dir),
             spec.model_module_fullname,
             spec.bundled_packages_dir.name,

--- a/truss/contexts/local_loader/load_model_local.py
+++ b/truss/contexts/local_loader/load_model_local.py
@@ -1,11 +1,12 @@
-import copy
 import inspect
 from pathlib import Path
-from typing import Dict
 
 from truss.contexts.local_loader.truss_module_loader import truss_module_loaded
+from truss.contexts.local_loader.utils import (
+    prepare_secrets,
+    signature_accepts_keyword_arg,
+)
 from truss.contexts.truss_context import TrussContext
-from truss.local.local_config_handler import LocalConfigHandler
 from truss.truss_spec import TrussSpec
 
 
@@ -28,33 +29,13 @@ class LoadModelLocal(TrussContext):
             model_class = getattr(module, spec.model_class_name)
             model_class_signature = inspect.signature(model_class)
             model_init_params = {}
-            if _signature_accepts_keyword_arg(model_class_signature, "config"):
+            if signature_accepts_keyword_arg(model_class_signature, "config"):
                 model_init_params["config"] = spec.config.to_dict()
-            if _signature_accepts_keyword_arg(model_class_signature, "data_dir"):
+            if signature_accepts_keyword_arg(model_class_signature, "data_dir"):
                 model_init_params["data_dir"] = truss_dir / "data"
-            if _signature_accepts_keyword_arg(model_class_signature, "secrets"):
-                model_init_params["secrets"] = _prepare_secrets(spec)
+            if signature_accepts_keyword_arg(model_class_signature, "secrets"):
+                model_init_params["secrets"] = prepare_secrets(spec)
             model = model_class(**model_init_params)
             if hasattr(model, "load"):
                 model.load()
             return model
-
-
-def _signature_accepts_keyword_arg(signature: inspect.Signature, kwarg: str) -> bool:
-    return kwarg in signature.parameters or _signature_accepts_kwargs(signature)
-
-
-def _signature_accepts_kwargs(signature: inspect.Signature) -> bool:
-    for param in signature.parameters.values():
-        if param.kind == inspect.Parameter.VAR_KEYWORD:
-            return True
-    return False
-
-
-def _prepare_secrets(spec: TrussSpec) -> Dict[str, str]:
-    secrets = copy.deepcopy(spec.secrets)
-    local_secerts = LocalConfigHandler.get_config().secrets
-    for secret_name in secrets:
-        if secret_name in local_secerts:
-            secrets[secret_name] = local_secerts[secret_name]
-    return secrets

--- a/truss/contexts/local_loader/train_local.py
+++ b/truss/contexts/local_loader/train_local.py
@@ -1,0 +1,53 @@
+import inspect
+from pathlib import Path
+
+from truss.contexts.local_loader.truss_module_loader import truss_module_loaded
+from truss.contexts.local_loader.utils import (
+    prepare_secrets,
+    signature_accepts_keyword_arg,
+)
+from truss.contexts.truss_context import TrussContext
+from truss.truss_spec import TrussSpec
+
+
+class LocalTrainer(TrussContext):
+    """Allows training a truss locally."""
+
+    @staticmethod
+    def run(truss_dir: Path):
+        def train(variables: dict = None):
+            spec = TrussSpec(truss_dir)
+            with truss_module_loaded(
+                str(truss_dir),
+                spec.train_module_fullname,
+                spec.bundled_packages_dir.name,
+            ) as module:
+                train_class = getattr(module, spec.train_class_name)
+                train_class_signature = inspect.signature(train_class)
+                train_init_params = {}
+                config = spec.config
+                if signature_accepts_keyword_arg(train_class_signature, "config"):
+                    train_init_params["config"] = config.to_dict()
+                if signature_accepts_keyword_arg(train_class_signature, "output_dir"):
+                    train_init_params["output_dir"] = truss_dir / "data"
+                if signature_accepts_keyword_arg(train_class_signature, "secrets"):
+                    train_init_params["secrets"] = prepare_secrets(spec)
+
+                # Wire up variables
+                if signature_accepts_keyword_arg(train_class_signature, "variables"):
+                    runtime_variables = {}
+                    runtime_variables.update(config.train.variables)
+                    if variables is not None:
+                        runtime_variables.update(variables)
+                    train_init_params["variables"] = runtime_variables
+                trainer = train_class(**train_init_params)
+
+                if hasattr(trainer, "pre_train"):
+                    trainer.pre_train()
+
+                trainer.train()
+
+                if hasattr(trainer, "post_train"):
+                    trainer.post_train()
+
+        return train

--- a/truss/contexts/local_loader/utils.py
+++ b/truss/contexts/local_loader/utils.py
@@ -1,0 +1,26 @@
+import copy
+import inspect
+from typing import Dict
+
+from truss.local.local_config_handler import LocalConfigHandler
+from truss.truss_spec import TrussSpec
+
+
+def prepare_secrets(spec: TrussSpec) -> Dict[str, str]:
+    secrets = copy.deepcopy(spec.secrets)
+    local_secerts = LocalConfigHandler.get_config().secrets
+    for secret_name in secrets:
+        if secret_name in local_secerts:
+            secrets[secret_name] = local_secerts[secret_name]
+    return secrets
+
+
+def signature_accepts_keyword_arg(signature: inspect.Signature, kwarg: str) -> bool:
+    return kwarg in signature.parameters or _signature_accepts_kwargs(signature)
+
+
+def _signature_accepts_kwargs(signature: inspect.Signature) -> bool:
+    for param in signature.parameters.values():
+        if param.kind == inspect.Parameter.VAR_KEYWORD:
+            return True
+    return False

--- a/truss/tests/contexts/local_loader/test_load_local.py
+++ b/truss/tests/contexts/local_loader/test_load_local.py
@@ -1,4 +1,4 @@
-from truss.contexts.local_loader.load_model_local import _prepare_secrets
+from truss.contexts.local_loader.utils import prepare_secrets
 from truss.local.local_config_handler import LocalConfigHandler
 from truss.truss_handle import TrussHandle
 from truss.truss_spec import TrussSpec
@@ -12,7 +12,7 @@ def test_prepare_secrets(custom_model_truss_dir, tmp_path):
         handle = TrussHandle(custom_model_truss_dir)
         handle.add_secret("secret_name")
         spec = TrussSpec(custom_model_truss_dir)
-        secrets = _prepare_secrets(spec)
+        secrets = prepare_secrets(spec)
         assert secrets["secret_name"] == "secret_value"
     finally:
         LocalConfigHandler.TRUSS_CONFIG_DIR = orig_truss_config_dir

--- a/truss/tests/contexts/local_loader/test_load_local.py
+++ b/truss/tests/contexts/local_loader/test_load_local.py
@@ -1,4 +1,4 @@
-from truss.contexts.local_loader.load_local import _prepare_secrets
+from truss.contexts.local_loader.load_model_local import _prepare_secrets
 from truss.local.local_config_handler import LocalConfigHandler
 from truss.truss_handle import TrussHandle
 from truss.truss_spec import TrussSpec

--- a/truss/tests/contexts/local_loader/test_truss_module_finder.py
+++ b/truss/tests/contexts/local_loader/test_truss_module_finder.py
@@ -1,7 +1,7 @@
 import tempfile
 from pathlib import Path
 
-from truss.contexts.local_loader.model_module_loader import model_class_module_loaded
+from truss.contexts.local_loader.truss_module_loader import truss_module_loaded
 from truss.truss_config import DEFAULT_BUNDLED_PACKAGES_DIR
 
 ORIG_MODEL_CLASS_CONTENT = """
@@ -58,7 +58,7 @@ A = 2
 def test_model_module_finder():
     with tempfile.TemporaryDirectory() as temp_dir:
         _write_model_module_files(temp_dir, ORIG_MODEL_CLASS_CONTENT)
-        with model_class_module_loaded(temp_dir, "model.model") as model_module:
+        with truss_module_loaded(temp_dir, "model.model") as model_module:
             model_class = getattr(model_module, "Model")
             assert model_class.x == 1
 
@@ -66,12 +66,12 @@ def test_model_module_finder():
 def test_model_module_finder_reload():
     with tempfile.TemporaryDirectory() as temp_dir:
         _write_model_module_files(temp_dir, ORIG_MODEL_CLASS_CONTENT)
-        with model_class_module_loaded(temp_dir, "model.model") as model_module:
+        with truss_module_loaded(temp_dir, "model.model") as model_module:
             model_class = getattr(model_module, "Model")
             assert model_class.x == 1
     with tempfile.TemporaryDirectory() as temp_dir:
         _write_model_module_files(temp_dir, NEW_MODEL_CLASS_CONTENT)
-        with model_class_module_loaded(temp_dir, "model.model") as model_module:
+        with truss_module_loaded(temp_dir, "model.model") as model_module:
             model_class = getattr(model_module, "Model")
             assert model_class.x == 2
 
@@ -83,7 +83,7 @@ def test_model_module_finder_additional_modules():
             ORIG_MODEL_CLASS_USING_ADDITIONAL_MODULE_CONTENT,
             additional_module_file_content=ORIG_ADDITIONAL_MODULE_CONTENT,
         )
-        with model_class_module_loaded(
+        with truss_module_loaded(
             temp_dir, "model.model", DEFAULT_BUNDLED_PACKAGES_DIR
         ) as model_module:
             model_class = getattr(model_module, "Model")
@@ -97,7 +97,7 @@ def test_model_module_finder_additional_modules_reload():
             ORIG_MODEL_CLASS_USING_ADDITIONAL_MODULE_CONTENT,
             additional_module_file_content=ORIG_ADDITIONAL_MODULE_CONTENT,
         )
-        with model_class_module_loaded(
+        with truss_module_loaded(
             temp_dir, "model.model", DEFAULT_BUNDLED_PACKAGES_DIR
         ) as model_module:
             model_class = getattr(model_module, "Model")
@@ -109,7 +109,7 @@ def test_model_module_finder_additional_modules_reload():
             ORIG_MODEL_CLASS_USING_ADDITIONAL_MODULE_CONTENT,
             additional_module_file_content=NEW_ADDITIONAL_MODULE_CONTENT,
         )
-        with model_class_module_loaded(
+        with truss_module_loaded(
             temp_dir, "model.model", DEFAULT_BUNDLED_PACKAGES_DIR
         ) as model_module:
             model_class = getattr(model_module, "Model")
@@ -124,7 +124,7 @@ def test_model_module_finder_reload_non_model_file_updated():
             UTIL_FILE_CONTENT,
             SUBMODULE_FILE_CONTENT,
         )
-        with model_class_module_loaded(temp_dir, "model.model") as model_module:
+        with truss_module_loaded(temp_dir, "model.model") as model_module:
             model_class = getattr(model_module, "Model")
             assert model_class.x == 1
             assert model_class.y == 3
@@ -135,7 +135,7 @@ def test_model_module_finder_reload_non_model_file_updated():
             NEW_UTIL_FILE_CONTENT,
             NEW_SUBMODULE_FILE_CONTENT,
         )
-        with model_class_module_loaded(temp_dir, "model.model") as model_module:
+        with truss_module_loaded(temp_dir, "model.model") as model_module:
             model_class = getattr(model_module, "Model")
             assert model_class.x == 2
             assert model_class.y == 4

--- a/truss/tests/model_frameworks/test_huggingface_transformer_framework.py
+++ b/truss/tests/model_frameworks/test_huggingface_transformer_framework.py
@@ -9,7 +9,7 @@ from truss.constants import CONFIG_FILE
 from truss.contexts.image_builder.serving_image_builder import (
     ServingImageBuilderContext,
 )
-from truss.contexts.local_loader.load_local import LoadLocal
+from truss.contexts.local_loader.load_model_local import LoadModelLocal
 from truss.model_frameworks.huggingface_transformer import HuggingfaceTransformer
 from truss.tests.test_testing_utilities_for_other_tests import ensure_kill_all
 from truss.truss_config import TrussConfig
@@ -45,7 +45,7 @@ def test_run_truss(huggingface_transformer_t5_small_pipeline):
         truss_dir = Path(tmp_work_dir, "truss")
         framework = HuggingfaceTransformer()
         framework.to_truss(model, truss_dir)
-        model = LoadLocal.run(truss_dir)
+        model = LoadModelLocal.run(truss_dir)
         result = model.predict({"inputs": "My name is Sarah and I live in London"})
         predictions = result["predictions"]
         assert len(predictions) == 1

--- a/truss/tests/model_frameworks/test_keras_framework.py
+++ b/truss/tests/model_frameworks/test_keras_framework.py
@@ -9,7 +9,7 @@ from truss.constants import CONFIG_FILE
 from truss.contexts.image_builder.serving_image_builder import (
     ServingImageBuilderContext,
 )
-from truss.contexts.local_loader.load_local import LoadLocal
+from truss.contexts.local_loader.load_model_local import LoadModelLocal
 from truss.model_frameworks.keras import Keras
 from truss.truss_config import TrussConfig
 
@@ -41,7 +41,7 @@ def test_run_truss(keras_mpg_model):
         truss_dir = Path(tmp_work_dir, "truss")
         sklearn_framework = Keras()
         sklearn_framework.to_truss(keras_mpg_model, truss_dir)
-        model = LoadLocal.run(truss_dir)
+        model = LoadModelLocal.run(truss_dir)
         result = model.predict({"inputs": [0, 0, 0, 0, 0, 0, 0, 0, 0]})
         predictions = result["predictions"]
         assert len(predictions) == 1

--- a/truss/tests/model_frameworks/test_lightgbm_framework.py
+++ b/truss/tests/model_frameworks/test_lightgbm_framework.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 from truss.constants import CONFIG_FILE
-from truss.contexts.local_loader.load_local import LoadLocal
+from truss.contexts.local_loader.load_model_local import LoadModelLocal
 from truss.model_frameworks.lightgbm import LightGBM
 from truss.tests.test_testing_utilities_for_other_tests import ensure_kill_all
 from truss.truss_config import TrussConfig
@@ -40,7 +40,7 @@ def test_run_truss(lgb_pima_model):
         truss_dir = Path(tmp_work_dir, "truss")
         lgb_framework = LightGBM()
         lgb_framework.to_truss(lgb_pima_model, truss_dir)
-        model = LoadLocal.run(truss_dir)
+        model = LoadModelLocal.run(truss_dir)
         predictions = model.predict({"inputs": [[0, 0, 0, 0, 0, 0, 0, 0]]})
         assert len(predictions["predictions"]) == 1
         assert len(predictions["predictions"][0]) == 2

--- a/truss/tests/model_frameworks/test_sklearn_framework.py
+++ b/truss/tests/model_frameworks/test_sklearn_framework.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 from truss.constants import CONFIG_FILE
-from truss.contexts.local_loader.load_local import LoadLocal
+from truss.contexts.local_loader.load_model_local import LoadModelLocal
 from truss.model_frameworks.sklearn import SKLearn
 from truss.tests.test_testing_utilities_for_other_tests import ensure_kill_all
 from truss.truss_config import TrussConfig
@@ -40,7 +40,7 @@ def test_run_truss(sklearn_rfc_model):
         truss_dir = Path(tmp_work_dir, "truss")
         sklearn_framework = SKLearn()
         sklearn_framework.to_truss(sklearn_rfc_model, truss_dir)
-        model = LoadLocal.run(truss_dir)
+        model = LoadModelLocal.run(truss_dir)
         predictions = model.predict({"inputs": [[0, 0, 0, 0]]})
         assert len(predictions["probabilities"]) == 1
         assert len(predictions["probabilities"][0]) == 3

--- a/truss/tests/model_frameworks/test_xgboost_framework.py
+++ b/truss/tests/model_frameworks/test_xgboost_framework.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 from truss.constants import CONFIG_FILE
-from truss.contexts.local_loader.load_local import LoadLocal
+from truss.contexts.local_loader.load_model_local import LoadModelLocal
 from truss.model_frameworks.xgboost import XGBoost
 from truss.tests.test_testing_utilities_for_other_tests import ensure_kill_all
 from truss.truss_config import TrussConfig
@@ -40,7 +40,7 @@ def test_run_truss(xgboost_pima_model):
         truss_dir = Path(tmp_work_dir, "truss")
         xgboost_framework = XGBoost()
         xgboost_framework.to_truss(xgboost_pima_model, truss_dir)
-        model = LoadLocal.run(truss_dir)
+        model = LoadModelLocal.run(truss_dir)
         predictions = model.predict({"inputs": [[0, 0, 0, 0, 0, 0, 0, 0]]})
         assert "predictions" in predictions
         assert len(predictions["predictions"]) == 1

--- a/truss/tests/test_truss_handle.py
+++ b/truss/tests/test_truss_handle.py
@@ -177,6 +177,21 @@ def test_docker_train(variables_to_artifacts_training_truss):
             }
 
 
+def test_local_train(variables_to_artifacts_training_truss):
+    th = TrussHandle(variables_to_artifacts_training_truss)
+    th.add_training_variable("x", "y")
+    th.add_training_variable("a", "b")
+    input_vars = {"x": "z"}
+    th.local_train(variables=input_vars)
+    vars_artifact = th.spec.data_dir / "variables.json"
+    with vars_artifact.open() as vars_file:
+        vars_from_artifact = json.load(vars_file)
+        assert vars_from_artifact == {
+            "x": "z",
+            "a": "b",
+        }
+
+
 @pytest.mark.integration
 def test_docker_predict_with_bundled_packages(
     custom_model_truss_dir_with_bundled_packages,

--- a/truss/truss_handle.py
+++ b/truss/truss_handle.py
@@ -39,7 +39,8 @@ from truss.contexts.image_builder.serving_image_builder import (
 from truss.contexts.image_builder.training_image_builder import (
     TrainingImageBuilderContext,
 )
-from truss.contexts.local_loader.load_local import LoadLocal
+from truss.contexts.local_loader.load_model_local import LoadModelLocal
+from truss.contexts.local_loader.train_local import LocalTrainer
 from truss.docker import (
     Docker,
     DockerStates,
@@ -83,7 +84,7 @@ class TrussHandle:
 
     def server_predict(self, request: dict):
         """Run the prediction flow locally."""
-        model = LoadLocal.run(self._truss_dir)
+        model = LoadModelLocal.run(self._truss_dir)
         return _prediction_flow(model, request)
 
     def build_docker_build_context(self, build_dir: Path = None):
@@ -294,6 +295,9 @@ class TrussHandle:
         copy_tree_path(output_dir, self._spec.data_dir)
         rmtree(str(output_dir))
         rmtree(str(variables_dir))
+
+    def local_train(self, variables: dict = None):
+        LocalTrainer.run(self._truss_dir)(variables)
 
     def docker_build_setup(self, build_dir: Path = None):
         """

--- a/truss/truss_spec.py
+++ b/truss/truss_spec.py
@@ -53,6 +53,18 @@ class TrussSpec:
         return self.training_module_dir / conf.train.training_class_filename
 
     @property
+    def train_module_name(self) -> str:
+        return str(Path(self._config.train.training_class_filename).with_suffix(""))
+
+    @property
+    def train_module_fullname(self) -> str:
+        return f"{self._config.train.training_module_dir}.{self.train_module_name}"
+
+    @property
+    def train_class_name(self) -> str:
+        return self._config.train.training_class_name
+
+    @property
     def config(self) -> TrussConfig:
         return self._config
 


### PR DESCRIPTION
Main change is in `train_local.py`. Lot of other stuff is just rename, unfortunately that makes these PRs look complex. At the same time it's important to rename as we extend functionality, e.g. load_local has been renamed to load_model_local, because now there's model as well as training.

Usage:
`truss local_train --target-directory /truss/path`
>>> truss_handle.local_train(variables)
