### PR TITLE
Only kill process on failed load if not live_reload

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.1.12"
+version = "0.1.13"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/templates/server/common/truss_server.py
+++ b/truss/templates/server/common/truss_server.py
@@ -176,7 +176,8 @@ class TrussServer(KFServer):
             logging.error(f"Error loading model: {e}")
             self._http_server.stop()
             main_loop.stop()
-            raise e
+            import sys
+            sys.exit(1, e)
 
     def start(self, models: List[KFModel], nest_asyncio: bool = False):
         if len(models) != 1:

--- a/truss/templates/server/common/truss_server.py
+++ b/truss/templates/server/common/truss_server.py
@@ -1,5 +1,6 @@
 import json  # noqa: E402
 import logging  # noqa: E402
+import sys
 from http import HTTPStatus  # noqa: E402
 from threading import Thread
 from typing import List
@@ -176,7 +177,6 @@ class TrussServer(KFServer):
             logging.error(f"Error loading model: {e}")
             self._http_server.stop()
             main_loop.stop()
-            import sys
             sys.exit(1)
 
     def start(self, models: List[KFModel], nest_asyncio: bool = False):

--- a/truss/templates/server/common/truss_server.py
+++ b/truss/templates/server/common/truss_server.py
@@ -177,7 +177,7 @@ class TrussServer(KFServer):
             self._http_server.stop()
             main_loop.stop()
             import sys
-            sys.exit(1, e)
+            sys.exit(1)
 
     def start(self, models: List[KFModel], nest_asyncio: bool = False):
         if len(models) != 1:


### PR DESCRIPTION
# What
We rely on the process being up for live reload so can't kill when load fails.  This is exercised in the `test_control_truss_local_update_that_crashes_inference_server` test.

# How
Using the CONTROL_SERVER_PORT env variable to determine live_reload, we just let a failing `load()` log and move on

# Testing
Integration tests passing