### PR TITLE
Add None checks to try fix #170

### DIFF
--- a/truss/environment_inference/requirements_inference.py
+++ b/truss/environment_inference/requirements_inference.py
@@ -90,11 +90,11 @@ def _extract_packages_from_frame(frame) -> Set[str]:
         if name.startswith("__"):
             continue
 
-        if isinstance(val, types.ModuleType):
+        if isinstance(val, types.ModuleType) and val.__name__ is not None:
             # Split ensures you get root package,
             # not just imported function
             pkg_name = val.__name__.split(".")[0]
-        elif hasattr(val, "__module__"):
+        elif hasattr(val, "__module__") and val.__module__ is not None:
             pkg_name = val.__module__.split(".")[0]
         else:
             continue


### PR DESCRIPTION
There are many possibilities in how __module__ and __name__ and set in python across different environments, adding some checks here to try and fix the issue in question. We may want to add more checks in future, e.g. if __module__ is a string. I didn't want to overkill so didn't add that in this change.