### PR TITLE
naming and consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,15 +68,15 @@ rfc = RandomForestClassifier()
 rfc.fit(data_x, data_y)
 
 # Create the Truss (serializing & packaging model)
-tr = truss.mk_truss(rfc, target_directory="iris_rfc_truss")
+tr = truss.create(rfc, target_directory="iris_rfc_truss")
 
 # Serve a prediction from the model
-tr.server_predict({"inputs": [[0, 0, 0, 0]]})
+tr.predict({"inputs": [[0, 0, 0, 0]]})
 ```
 
 ### Package your model
 
-The `truss.mk_truss()` command can be used with any supported framework:
+The `truss.create()` command can be used with any supported framework:
 
 * [Hugging Face](https://truss.baseten.co/create/huggingface)
 * [LightGBM](https://truss.baseten.co/create/lightgbm)

--- a/docs/create/huggingface.md
+++ b/docs/create/huggingface.md
@@ -29,12 +29,12 @@ model = pipeline('fill-mask', model='bert-base-uncased')
 
 ### Create a Truss
 
-Use the `mk_truss` command to package your model into a Truss.
+Use the `create` command to package your model into a Truss.
 
 ```python
-from truss import mk_truss
+from truss import create
 
-tr = mk_truss(model, target_directory="huggingface_truss")
+tr = create(model, target_directory="huggingface_truss")
 ```
 
 Check the target directory to see your new Truss!

--- a/docs/create/lightgbm.md
+++ b/docs/create/lightgbm.md
@@ -51,12 +51,12 @@ model = lgb.train(params=params, train_set=train, valid_sets=test)
 
 ### Create a Truss
 
-Use the `mk_truss` command to package your model into a Truss.
+Use the `create` command to package your model into a Truss.
 
 ```python
-from truss import mk_truss
+from truss import create
 
-tr = mk_truss(model, target_directory="lightgbm_truss")
+tr = create(model, target_directory="lightgbm_truss")
 ```
 
 Check the target directory to see your new Truss!

--- a/docs/create/manual.md
+++ b/docs/create/manual.md
@@ -16,7 +16,7 @@ To familiarize yourself with the structure of Truss, review the [structure refer
 
 ### Adding the model binary
 
-First, you'll need to add a model binary to your new Truss. On supported frameworks, this is provided automatically by the `mk_truss` command. For a custom Truss, it can come from many sources, such as:
+First, you'll need to add a model binary to your new Truss. On supported frameworks, this is provided automatically by the `create` command. For a custom Truss, it can come from many sources, such as:
 
 * Pickling your model
 * Serializing your model
@@ -46,7 +46,7 @@ Also, your model gets access to certain values, including the `config.yaml` file
 
 ## Example code
 
-While XGBoost is a supported framework — you can make a Truss from an XGBoost model with `mk_truss` — we'll use the manual method here for demonstration.
+While XGBoost is a supported framework — you can make a Truss from an XGBoost model with `create` — we'll use the manual method here for demonstration.
 
 If you haven't already, create a Truss by running:
 

--- a/docs/create/mlflow.md
+++ b/docs/create/mlflow.md
@@ -35,14 +35,14 @@ with mlflow.start_run():
 
 ### Create a Truss
 
-Truss uses MLflow's [pyfunc](https://www.mlflow.org/docs/latest/python_api/mlflow.pyfunc.html) module in the packaging process. Once you have loaded the model, use the `mk_truss` command to package your model into a Truss.
+Truss uses MLflow's [pyfunc](https://www.mlflow.org/docs/latest/python_api/mlflow.pyfunc.html) module in the packaging process. Once you have loaded the model, use the `create` command to package your model into a Truss.
 
 ```python
 import os
 import truss
 
 model = mlflow.pyfunc.load_model(MODEL_URI)
-tr = truss.mk_truss(model, target_directory="./mlflow_truss")
+tr = truss.create(model, target_directory="./mlflow_truss")
 ```
 
 Check the target directory to see your new Truss!
@@ -53,7 +53,7 @@ To get a prediction from the Truss, try running:
 
 ```python
 data = np.array([-4, 1, 0, 10, -2, 1]).reshape(-1, 1)
-predictions = tr.server_predict({"inputs": data})
+predictions = tr.predict({"inputs": data})
 print(predictions)
 ```
 

--- a/docs/create/pytorch.md
+++ b/docs/create/pytorch.md
@@ -143,12 +143,12 @@ model, _ , _ = train_the_model()
 
 ### Create a Truss
 
-Use the `mk_truss` command to package your model into a Truss.
+Use the `create` command to package your model into a Truss.
 
 ```python
-from truss import mk_truss
+from truss import create
 
-tr = mk_truss(model, target_directory="pytorch_truss")
+tr = create(model, target_directory="pytorch_truss")
 ```
 
 Check the target directory to see your new Truss!
@@ -165,7 +165,7 @@ inputs = datasets.MNIST("../data", train=False, transform=transform)
 dataset = torch.utils.data.DataLoader(inputs, batch_size=1)
 
 import numpy as np
-print(tr.server_predict({"inputs": np.array(next(iter(dataset))[0])}))
+print(tr.predict({"inputs": np.array(next(iter(dataset))[0])}))
 ```
 
 For information on running the Truss locally, see [local development](../develop/localhost.md).

--- a/docs/create/sklearn.md
+++ b/docs/create/sklearn.md
@@ -30,12 +30,12 @@ model.fit(data_x, data_y)
 
 ### Create a Truss
 
-Use the `mk_truss` command to package your model into a Truss.
+Use the `create` command to package your model into a Truss.
 
 ```python
-from truss import mk_truss
+from truss import create
 
-tr = mk_truss(model, target_directory="sklearn_truss")
+tr = create(model, target_directory="sklearn_truss")
 ```
 
 Check the target directory to see your new Truss!

--- a/docs/create/tensorflow.md
+++ b/docs/create/tensorflow.md
@@ -32,12 +32,12 @@ model = tf.keras.applications.ResNet50V2(
 
 ### Create a Truss
 
-Use the `mk_truss` command to package your model into a Truss.
+Use the `create` command to package your model into a Truss.
 
 ```python
-from truss import mk_truss
+from truss import create
 
-tr = mk_truss(model, target_directory="tensorflow_truss")
+tr = create(model, target_directory="tensorflow_truss")
 ```
 
 Check the target directory to see your new Truss!
@@ -80,7 +80,7 @@ def postprocess(predictions, k=5):
 With these functions in place, you can invoke the model and pass it a URL, as in:
 
 ```python
-tr.server_predict({"inputs": "https://github.com/pytorch/hub/raw/master/images/dog.jpg"})
+tr.predict({"inputs": "https://github.com/pytorch/hub/raw/master/images/dog.jpg"})
 ```
 
 For information on running the Truss locally, see [local development](../develop/localhost.md).

--- a/docs/create/xgboost.md
+++ b/docs/create/xgboost.md
@@ -46,12 +46,12 @@ model = xgb.train(params,
 
 ### Create a Truss
 
-Use the `mk_truss` command to package your model into a Truss.
+Use the `create` command to package your model into a Truss.
 
 ```python
-from truss import mk_truss
+from truss import create
 
-tr = mk_truss(model, target_directory="xgboost_truss")
+tr = create(model, target_directory="xgboost_truss")
 ```
 
 Check the target directory to see your new Truss!

--- a/docs/deploy/baseten.md
+++ b/docs/deploy/baseten.md
@@ -15,7 +15,7 @@ pip install --upgrade baseten
 
 {% hint style="info" %}
 
-If your model is already in memory (you created it with `mk_truss`), you can skip loading it into memory from the directory.
+If your model is already in memory (you created it with `create`), you can skip loading it into memory from the directory.
 
 {% endhint %}
 
@@ -24,7 +24,7 @@ Before deploying your Truss, you may need to load it into memory in a Jupyter no
 ```python
 import truss
 
-my_truss = truss.from_directory("my_truss_lives_here")
+my_truss = truss.load("my_truss_lives_here")
 ```
 
 Once your Truss is in memory, simply run the following:

--- a/docs/develop/localhost.md
+++ b/docs/develop/localhost.md
@@ -21,7 +21,7 @@ There are two ways to interface with a Truss locally. The first is via [the Pyth
 When interacting with your Truss via the Python client, the first thing is to make sure it is in-memory. If you just created the Truss, it'll be in memory already, but if not, you'll need to load it with the following command:
 
 ```python
-tr = truss.from_directory("path_to_my_truss")
+tr = truss.load("path_to_my_truss")
 ```
 
 From there, you can invoke the Truss to serve the model in your Python environment. Just run:
@@ -112,7 +112,7 @@ Unlike Docker image, this mechanism requires that you already have the right Pyt
 In the Python environment, get a prediction without Docker by running:
 
 ```python
-tr.server_predict({"inputs": [[0, 0, 0, 0]]})
+tr.predict({"inputs": [[0, 0, 0, 0]]})
 ```
 
 Or in the command line, run:

--- a/docs/e2e.md
+++ b/docs/e2e.md
@@ -22,14 +22,14 @@ If you want to follow this tutorial for a particular framework and don't have a 
 
 ## Step 1: Create a Truss
 
-Truss works across model frameworks, and the most common model frameworks are supported with the one-line `mk_truss` command. Click the framework you built your model in to see specific packaging instructions for that format.
+Truss works across model frameworks, and the most common model frameworks are supported with the one-line `create` command. Click the framework you built your model in to see specific packaging instructions for that format.
 
 For the following formats, if you have an in-memory trained model object `model`, just call the following:
 
 ```python
-from truss import mk_truss
+from truss import create
 
-mk_truss(model, target_directory="my_truss")
+create(model, target_directory="my_truss")
 ```
 
 Supported frameworks:

--- a/docs/notebooks/aws_example.ipynb
+++ b/docs/notebooks/aws_example.ipynb
@@ -49,7 +49,7 @@
    "outputs": [],
    "source": [
     "# Make scaffold \n",
-    "scaffold = truss.mk_truss(rfc_model, target_directory='test_rfc_1')\n",
+    "scaffold = truss.create(rfc_model, target_directory='test_rfc_1')\n",
     "# This will produce a folder `test_rfc_1/` relative to your current directory. \n",
     "# Now we'll use Truss to build a Docker image on our local system\n",
     "scaffold.build_docker_image()"

--- a/docs/notebooks/huggingface_example.ipynb
+++ b/docs/notebooks/huggingface_example.ipynb
@@ -44,9 +44,9 @@
       },
       "outputs": [],
       "source": [
-        "from truss import mk_truss\n",
+        "from truss import create\n",
         "\n",
-        "tr = mk_truss(model, target_directory=\"huggingface_truss\")"
+        "tr = create(model, target_directory=\"huggingface_truss\")"
       ]
     },
     {
@@ -58,7 +58,7 @@
       "outputs": [],
       "source": [
         "# Serve a prediction from the model\n",
-        "tr.server_predict({\"inputs\": [\"Donatello is a teenage mutant [MASK] turtle\"]})"
+        "tr.predict({\"inputs\": [\"Donatello is a teenage mutant [MASK] turtle\"]})"
       ]
     }
   ],

--- a/docs/notebooks/lightgbm_example.ipynb
+++ b/docs/notebooks/lightgbm_example.ipynb
@@ -68,9 +68,9 @@
       },
       "outputs": [],
       "source": [
-        "from truss import mk_truss\n",
+        "from truss import create\n",
         "\n",
-        "tr = mk_truss(model, target_directory=\"lightgbm_truss\")"
+        "tr = create(model, target_directory=\"lightgbm_truss\")"
       ]
     },
     {
@@ -81,7 +81,7 @@
       },
       "outputs": [],
       "source": [
-        "tr.server_predict({\"inputs\": [[0, 0, 0, 0, 0, 0]]})"
+        "tr.predict({\"inputs\": [[0, 0, 0, 0, 0, 0]]})"
       ]
     }
   ],

--- a/docs/notebooks/mlflow_example.ipynb
+++ b/docs/notebooks/mlflow_example.ipynb
@@ -85,7 +85,7 @@
         "import truss\n",
         "\n",
         "model = mlflow.pyfunc.load_model(MODEL_URI)\n",
-        "tr = truss.mk_truss(model, target_directory=\"./mlflow_truss\")"
+        "tr = truss.create(model, target_directory=\"./mlflow_truss\")"
       ]
     },
     {
@@ -99,7 +99,7 @@
         "# Invoke the MLflow model\n",
         "\n",
         "data = np.array([-4, 1, 0, 10, -2, 1]).reshape(-1, 1)\n",
-        "predictions = tr.server_predict({\"inputs\": data})\n",
+        "predictions = tr.predict({\"inputs\": data})\n",
         "print(predictions)"
       ]
     }

--- a/docs/notebooks/sklearn_example.ipynb
+++ b/docs/notebooks/sklearn_example.ipynb
@@ -60,7 +60,7 @@
       "outputs": [],
       "source": [
         "# Create the Truss (serializing & packaging model)\n",
-        "tr = truss.mk_truss(rfc, \"iris-rfc\")"
+        "tr = truss.create(rfc, \"iris-rfc\")"
       ]
     },
     {
@@ -72,7 +72,7 @@
       "outputs": [],
       "source": [
         "# Serve a prediction from the model\n",
-        "tr.server_predict({\"inputs\": [[0, 0, 0, 0]]})"
+        "tr.predict({\"inputs\": [[0, 0, 0, 0]]})"
       ]
     }
   ],

--- a/docs/notebooks/tensorflow_example.ipynb
+++ b/docs/notebooks/tensorflow_example.ipynb
@@ -49,10 +49,10 @@
       },
       "outputs": [],
       "source": [
-        "from truss import mk_truss\n",
+        "from truss import create\n",
         "\n",
         "# Create the Truss (serializing & packaging model)\n",
-        "tr = mk_truss(model, target_directory=\"tensorflow_truss\")"
+        "tr = create(model, target_directory=\"tensorflow_truss\")"
       ]
     },
     {
@@ -102,7 +102,7 @@
       "outputs": [],
       "source": [
         "image = preprocess(\"https://github.com/pytorch/hub/raw/master/images/dog.jpg\")\n",
-        "results = tr.server_predict({\"inputs\": image})\n",
+        "results = tr.predict({\"inputs\": image})\n",
         "postprocess(results[\"predictions\"])"
       ]
     }

--- a/docs/notebooks/xgboost_example.ipynb
+++ b/docs/notebooks/xgboost_example.ipynb
@@ -63,9 +63,9 @@
       },
       "outputs": [],
       "source": [
-        "from truss import mk_truss\n",
+        "from truss import create\n",
         "\n",
-        "tr = mk_truss(model, target_directory=\"xgboost_truss\")"
+        "tr = create(model, target_directory=\"xgboost_truss\")"
       ]
     },
     {
@@ -76,7 +76,7 @@
       },
       "outputs": [],
       "source": [
-        "tr.server_predict({\"inputs\": [[0, 0, 0, 0, 0, 0]]})"
+        "tr.predict({\"inputs\": [[0, 0, 0, 0, 0, 0]]})"
       ]
     }
   ],

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -79,10 +79,10 @@ Invokes the packaged model, either locally or in a Docker container.
 * `target_directory`: A Truss directory. If none, use current directory.
 * `request`: String formatted as json that represents request
 * `build_dir`: Directory where context is built. If none, a temp directory is created.
-* `tag`: Docker build image tag
-* `port`: Local port used to run image
-* `run_local`: Flag to run prediction locally (instead of on Docker)
-* `request_file`: Path to json file containing the request
+* `tag`: Docker build image tag.
+* `port`: Local port used to run image.
+* `use_docker`: Flag to run prediction on Docker, defaults to `False`.
+* `request_file`: Path to json file containing the request.
 
 ### `run-example`
 

--- a/docs/reference/client.md
+++ b/docs/reference/client.md
@@ -8,7 +8,7 @@ A list of the functions available with `import truss` and their arguments and pr
 
 Cleans up `.truss` directory.
 
-#### `from_directory(truss_directory: str) -> truss.truss_handle.TrussHandle`
+#### `load(truss_directory: str) -> truss.truss_handle.TrussHandle`
 
 Get a handle to a Truss. A Truss is a build context designed to be built as a container locally or uploaded into a model serving environment.
 
@@ -30,7 +30,7 @@ Initialize an empty placeholder Truss. A Truss is a build context designed to be
 
 #### `kill_all()`
 
-#### mk_truss(model: Any, target_directory: str = None, data_files: List[str] = None, requirements_file: str = None) -> truss.truss_handle.TrussHandle
+#### create(model: Any, target_directory: str = None, data_files: List[str] = None, requirements_file: str = None) -> truss.truss_handle.TrussHandle
 
 Create a Truss with the given model. A Truss is a build context designed to
 be built as a container locally or uploaded into a model serving environment.
@@ -136,7 +136,7 @@ Examples are a simple `name to input` dictionary.
 
 #### `kill_container(self)`
 
-#### `server_predict(self, request: dict)`
+#### `predict(self, request: dict)`
 
 Run the prediction flow locally.
 

--- a/docs/reference/client.md
+++ b/docs/reference/client.md
@@ -46,7 +46,7 @@ be built as a container locally or uploaded into a model serving environment.
 
 * `TrussHandle`: A handle to the generated Truss that provides easy access to content inside.
 
-### Truss Use
+### Truss use (Truss handle reference)
 
 #### `bundled_package(self, file_dir_or_glob: str)`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.2.0"
+version = "0.2.0rc0"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.1.13rc2"
+version = "0.2.0"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/__init__.py
+++ b/truss/__init__.py
@@ -11,10 +11,4 @@ def version():
     return __version__
 
 
-from truss.build import (
-    from_directory,
-    init,
-    kill_all,
-    mk_truss,
-    mk_truss_from_mlflow_uri,
-)
+from truss.build import create, create_from_mlflow_uri, init, kill_all, load

--- a/truss/__init__.py
+++ b/truss/__init__.py
@@ -11,4 +11,12 @@ def version():
     return __version__
 
 
-from truss.build import create, create_from_mlflow_uri, init, kill_all, load
+from truss.build import (
+    create,
+    create_from_mlflow_uri,
+    from_directory,
+    init,
+    kill_all,
+    load,
+    mk_truss,
+)

--- a/truss/build.py
+++ b/truss/build.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import sys
 from pathlib import Path
 from typing import Any, Callable, List
 

--- a/truss/cli.py
+++ b/truss/cli.py
@@ -176,7 +176,7 @@ def run_image(target_directory, build_dir, tag, port, attach):
 )
 @error_handling
 @echo_output
-def predict(target_directory, request, build_dir, tag, port, run_local, request_file):
+def predict(target_directory, request, build_dir, tag, port, use_docker, request_file):
     """
     Invokes the packaged model, either locally or in a Docker container.
 
@@ -190,7 +190,7 @@ def predict(target_directory, request, build_dir, tag, port, run_local, request_
 
     PORT: Local port used to run image
 
-    RUN_LOCAL: Flag to run prediction locally
+    USE_DOCKER: Flag to run prediction with a docker container
 
     REQUEST_FILE: Path to json file containing the request
     """
@@ -203,12 +203,12 @@ def predict(target_directory, request, build_dir, tag, port, run_local, request_
         raise ValueError("At least one of request or request-file must be supplied.")
 
     tr = _get_truss_from_directory(target_directory=target_directory)
-    if run_local:
-        return tr.server_predict(request_data)
-    else:
+    if use_docker:
         return tr.docker_predict(
             request_data, build_dir=build_dir, tag=tag, local_port=port, detach=True
         )
+    else:
+        return tr.server_predict(request_data)
 
 
 @cli_group.command()
@@ -334,7 +334,7 @@ def _get_truss_from_directory(target_directory: str = None):
     """Gets Truss from directory. If none, use the current directory"""
     if target_directory is None:
         target_directory = os.getcwd()
-    return truss.from_directory(target_directory)
+    return truss.load(target_directory)
 
 
 def _variables_dict_from_option(variables_list: List[str]) -> dict:

--- a/truss/test_data/happy.ipynb
+++ b/truss/test_data/happy.ipynb
@@ -24,9 +24,9 @@
     "    lr.fit(df.values, df.iloc[:, 0])\n",
     "    \n",
     "    with tempfile.TemporaryDirectory() as tmp:\n",
-    "        tr = truss.mk_truss(lr, target_directory=tmp)\n",
+    "        tr = truss.create(lr, target_directory=tmp)\n",
     "        \n",
-    "        assert truss.from_directory(tmp).spec.yaml_string == tr.spec.yaml_string"
+    "        assert truss.load(tmp).spec.yaml_string == tr.spec.yaml_string"
    ]
   }
  ],

--- a/truss/tests/conftest.py
+++ b/truss/tests/conftest.py
@@ -18,7 +18,7 @@ from sklearn.ensemble import RandomForestClassifier
 from tensorflow.keras import layers
 from tensorflow.keras.layers.experimental import preprocessing
 from transformers import AutoModelWithLMHead, AutoTokenizer, pipeline
-from truss.build import init, mk_truss
+from truss.build import create, init
 from truss.truss_config import DEFAULT_BUNDLED_PACKAGES_DIR
 from truss.types import Example
 from xgboost import XGBClassifier
@@ -517,7 +517,7 @@ def huggingface_truss_handle_small_model(
 ):
     dir_path = tmp_path / "huggingface_truss_small_model"
     dir_path.mkdir()
-    mk_truss(huggingface_transformer_t5_small_pipeline, target_directory=str(dir_path))
+    create(huggingface_transformer_t5_small_pipeline, target_directory=str(dir_path))
     return dir_path
 
 

--- a/truss/tests/environments_inference/test_requirements_inference.py
+++ b/truss/tests/environments_inference/test_requirements_inference.py
@@ -1,14 +1,14 @@
 from typing import List
 
 import pandas as pd  # noqa
-from truss.build import mk_truss
+from truss.build import create
 
 
-def test_infer_deps_through_mk_truss_local_import(sklearn_rfc_model, tmp_path):
+def test_infer_deps_through_create_local_import(sklearn_rfc_model, tmp_path):
     dir_path = tmp_path / "truss"
     import requests  # noqa
 
-    tr = mk_truss(
+    tr = create(
         sklearn_rfc_model,
         target_directory=dir_path,
     )
@@ -16,11 +16,9 @@ def test_infer_deps_through_mk_truss_local_import(sklearn_rfc_model, tmp_path):
     _validate_that_package_is_in_requirements(spec.requirements, "requests")
 
 
-def test_infer_deps_through_mk_truss_top_of_the_file_import(
-    sklearn_rfc_model, tmp_path
-):
+def test_infer_deps_through_create_top_of_the_file_import(sklearn_rfc_model, tmp_path):
     dir_path = tmp_path / "truss"
-    tr = mk_truss(
+    tr = create(
         sklearn_rfc_model,
         target_directory=dir_path,
     )

--- a/truss/tests/samples.py
+++ b/truss/tests/samples.py
@@ -24,7 +24,7 @@ from tensorflow.keras.layers.experimental import preprocessing
 
 # Create a fake dataset to include with the deployment
 from test_folder.utils.embedding_util import create_reference_embeddings
-from truss.build import mk_truss, scaffold, scaffold_custom
+from truss.build import create, scaffold, scaffold_custom
 from truss.constants import HUGGINGFACE_TRANSFORMER
 from truss.definitions.base import build_scaffold_directory
 from truss.definitions.huggingface_transformer import (
@@ -78,11 +78,11 @@ os.chdir(current_dir)
 
 
 # You can take a whole directory
-ms = mk_truss(
+ms = create(
     model, model_files=["pytorch_eg/"], data_files=[], target_directory="test_pytorch"
 )
 # You can also take single files or globs
-ms2 = mk_truss(
+ms2 = create(
     model,
     model_files=["pytorch_eg/utils/*.py", "pytorch_eg/my_pytorch_model.py"],
     data_files=[],
@@ -104,7 +104,7 @@ data_y = iris["target"]
 data_x = pd.DataFrame(data_x, columns=feature_names)
 rfc.fit(data_x, data_y)
 
-ms = mk_truss(rfc, model_files=[], data_files=[])
+ms = create(rfc, model_files=[], data_files=[])
 ms.docker_build_string
 ms.predict([[0, 0, 0, 0]])
 
@@ -189,14 +189,14 @@ with open("test_folder/embedding_reqs.txt", "w") as f:
 
 create_reference_embeddings()
 
-mk_truss = scaffold_custom(
+create = scaffold_custom(
     model_files=["test_folder", "test_folder/utils/*.py", "embeddings.npy"],
     target_directory="test_custom",
     requirements_file="test_folder/embedding_reqs.txt",
     model_class="MyEmbeddingModel",
 )
-mk_truss.docker_build_string
-mk_truss.predict(["hello world", "bar baz"])
+create.docker_build_string
+create.predict(["hello world", "bar baz"])
 
 
 url = "http://archive.ics.uci.edu/ml/machine-learning-databases/auto-mpg/auto-mpg.data"
@@ -255,7 +255,7 @@ history = linear_model.fit(
 linear_model.predict(train_features[:10])
 
 
-scaff = mk_truss(model=linear_model)
+scaff = create(model=linear_model)
 scaff.docker_build_string
 scaff.predict([[0, 0, 0, 0, 0, 0, 0, 0, 0]])
 
@@ -263,10 +263,10 @@ scaff.predict([[0, 0, 0, 0, 0, 0, 0, 0, 0]])
 
 
 built_scaffold_dir = build_scaffold_directory(HUGGINGFACE_TRANSFORMER)
-mk_truss = HuggingFaceTransformerPipelineScaffold(
+create = HuggingFaceTransformerPipelineScaffold(
     model_type="text-generation", path_to_scaffold=built_scaffold_dir
 )
-mk_truss.predict([{"text_inputs": "hello world"}])
+create.predict([{"text_inputs": "hello world"}])
 
 
 PYTORCH_MODEL_CODE = """
@@ -308,7 +308,7 @@ model = MyModelWithArgs(**MODEL_INIT_ARGS)
 os.chdir(current_dir)
 
 
-ms = mk_truss(
+ms = create(
     model,
     model_files=[PYTORCH_WITH_ARGS_PATH],
     data_files=[],

--- a/truss/tests/samples.py
+++ b/truss/tests/samples.py
@@ -189,14 +189,14 @@ with open("test_folder/embedding_reqs.txt", "w") as f:
 
 create_reference_embeddings()
 
-create = scaffold_custom(
+sc = scaffold_custom(
     model_files=["test_folder", "test_folder/utils/*.py", "embeddings.npy"],
     target_directory="test_custom",
     requirements_file="test_folder/embedding_reqs.txt",
     model_class="MyEmbeddingModel",
 )
-create.docker_build_string
-create.predict(["hello world", "bar baz"])
+sc.docker_build_string
+sc.predict(["hello world", "bar baz"])
 
 
 url = "http://archive.ics.uci.edu/ml/machine-learning-databases/auto-mpg/auto-mpg.data"
@@ -263,10 +263,10 @@ scaff.predict([[0, 0, 0, 0, 0, 0, 0, 0, 0]])
 
 
 built_scaffold_dir = build_scaffold_directory(HUGGINGFACE_TRANSFORMER)
-create = HuggingFaceTransformerPipelineScaffold(
+hf_sc = HuggingFaceTransformerPipelineScaffold(
     model_type="text-generation", path_to_scaffold=built_scaffold_dir
 )
-create.predict([{"text_inputs": "hello world"}])
+hf_sc.predict([{"text_inputs": "hello world"}])
 
 
 PYTORCH_MODEL_CODE = """

--- a/truss/tests/test_backward.py
+++ b/truss/tests/test_backward.py
@@ -1,0 +1,58 @@
+from truss.build import from_directory, mk_truss
+
+
+def test_mk_truss_passthrough(sklearn_rfc_model, tmp_path):
+    dir_path = tmp_path / "truss"
+    data_file_path = tmp_path / "data.txt"
+    with data_file_path.open("w") as data_file:
+        data_file.write("test")
+    req_file_path = tmp_path / "requirements.txt"
+    requirements = [
+        "tensorflow==2.3.1",
+        "uvicorn==0.12.2",
+    ]
+    with req_file_path.open("w") as req_file:
+        for req in requirements:
+            req_file.write(f"{req}\n")
+    scaf = mk_truss(
+        sklearn_rfc_model,
+        target_directory=dir_path,
+        data_files=[str(data_file_path)],
+        requirements_file=str(req_file_path),
+    )
+    spec = scaf.spec
+    assert spec.model_module_dir.exists()
+    assert spec.truss_dir == dir_path
+    assert spec.config_path.exists()
+    assert spec.data_dir.exists()
+    assert (spec.data_dir / "data.txt").exists()
+    assert spec.requirements == requirements
+
+
+def test_from_directory_passthrough(sklearn_rfc_model, tmp_path):
+    dir_path = tmp_path / "truss"
+    data_file_path = tmp_path / "data.txt"
+    with data_file_path.open("w") as data_file:
+        data_file.write("test")
+    req_file_path = tmp_path / "requirements.txt"
+    requirements = [
+        "tensorflow==2.3.1",
+        "uvicorn==0.12.2",
+    ]
+    with req_file_path.open("w") as req_file:
+        for req in requirements:
+            req_file.write(f"{req}\n")
+    mk_truss(
+        sklearn_rfc_model,
+        target_directory=dir_path,
+        data_files=[str(data_file_path)],
+        requirements_file=str(req_file_path),
+    )
+    scaf = from_directory(dir_path)
+    spec = scaf.spec
+    assert spec.model_module_dir.exists()
+    assert spec.truss_dir == dir_path
+    assert spec.config_path.exists()
+    assert spec.data_dir.exists()
+    assert (spec.data_dir / "data.txt").exists()
+    assert spec.requirements == requirements

--- a/truss/tests/test_build.py
+++ b/truss/tests/test_build.py
@@ -3,7 +3,7 @@ from contextlib import contextmanager
 from pathlib import Path
 
 import numpy as np
-from truss.build import cleanup, init, mk_truss
+from truss.build import cleanup, create, init
 from truss.truss_spec import TrussSpec
 
 
@@ -66,7 +66,7 @@ def test_truss_init_with_data_file_and_requirements_file_and_bundled_packages(
     assert (spec.bundled_packages_dir / "dep_pkg" / "file.py").exists()
 
 
-def test_mk_truss(sklearn_rfc_model, tmp_path):
+def test_create(sklearn_rfc_model, tmp_path):
     dir_path = tmp_path / "truss"
     data_file_path = tmp_path / "data.txt"
     with data_file_path.open("w") as data_file:
@@ -79,7 +79,7 @@ def test_mk_truss(sklearn_rfc_model, tmp_path):
     with req_file_path.open("w") as req_file:
         for req in requirements:
             req_file.write(f"{req}\n")
-    scaf = mk_truss(
+    scaf = create(
         sklearn_rfc_model,
         target_directory=dir_path,
         data_files=[str(data_file_path)],
@@ -94,7 +94,7 @@ def test_mk_truss(sklearn_rfc_model, tmp_path):
     assert spec.requirements == requirements
 
 
-def test_mk_truss_pipeline(sklearn_rfc_model, tmp_path):
+def test_create_pipeline(sklearn_rfc_model, tmp_path):
     def inference(request: dict):
         inputs = request["inputs"]
         response = sklearn_rfc_model.predict([inputs])[0]
@@ -112,7 +112,7 @@ def test_mk_truss_pipeline(sklearn_rfc_model, tmp_path):
     with req_file_path.open("w") as req_file:
         for req in requirements:
             req_file.write(f"{req}\n")
-    scaf = mk_truss(
+    scaf = create(
         inference,
         target_directory=dir_path,
         data_files=[str(data_file_path)],
@@ -207,7 +207,7 @@ def test_cleanup(sklearn_rfc_model, tmp_path):
     with req_file_path.open("w") as req_file:
         for req in requirements:
             req_file.write(f"{req}\n")
-    _ = mk_truss(
+    _ = create(
         sklearn_rfc_model,
         data_files=[str(data_file_path)],
         requirements_file=str(req_file_path),
@@ -254,13 +254,13 @@ def test_truss_via_t5_mk_pipeline(
 @contextmanager
 def _model_server_predict(model, model_input):
     with tempfile.TemporaryDirectory() as dir_name:
-        sc = mk_truss(model, target_directory=dir_name)
+        sc = create(model, target_directory=dir_name)
         result = sc.server_predict(model_input)
         yield result
 
 
 @contextmanager
 def _model_server_predict_pipeline(pipeline, model_input):
-    sc = mk_truss(pipeline)
+    sc = create(pipeline)
     result = sc.server_predict(model_input)
     yield result

--- a/truss/tests/test_truss_handle.py
+++ b/truss/tests/test_truss_handle.py
@@ -37,6 +37,16 @@ def test_description(custom_model_truss_dir_with_pre_and_post_description):
     assert spec.description == "This model adds 3 to all inputs"
 
 
+def test_predict(custom_model_truss_dir_with_pre_and_post):
+    th = TrussHandle(custom_model_truss_dir_with_pre_and_post)
+    resp = th.predict(
+        {
+            "inputs": [1, 2, 3, 4],
+        }
+    )
+    assert resp == {"predictions": [4, 5, 6, 7]}
+
+
 def test_server_predict(custom_model_truss_dir_with_pre_and_post):
     th = TrussHandle(custom_model_truss_dir_with_pre_and_post)
     resp = th.server_predict(
@@ -148,6 +158,15 @@ def get_docker_containers_from_labels(custom_model_truss_dir_with_pre_and_post):
         assert len(t1.get_serving_docker_containers_from_labels()) == 2
         t1.kill_container()
         assert len(t1.get_serving_docker_containers_from_labels()) == 0
+
+
+@pytest.mark.integration
+def test_predict_use_docker(custom_model_truss_dir_with_pre_and_post):
+    th = TrussHandle(custom_model_truss_dir_with_pre_and_post)
+    tag = "test-docker-predict-tag:0.0.1"
+    with ensure_kill_all():
+        result = th.predict({"inputs": [1, 2]}, tag=tag, use_docker=True)
+        assert result == {"predictions": [4, 5]}
 
 
 @pytest.mark.integration

--- a/truss/truss_config.py
+++ b/truss/truss_config.py
@@ -22,7 +22,7 @@ DEFAULT_PYTHON_VERSION = "py39"
 DEFAULT_DATA_DIRECTORY = "data"
 DEFAULT_EXAMPLES_FILENAME = "examples.yaml"
 DEFAULT_SPEC_VERSION = "2.0"
-DEFAULT_SPEC_VERSION_FROM_DIRECTORY = "1.0"
+DEFAULT_SPEC_VERSION_ON_LOAD = "1.0"
 
 DEFAULT_CPU = "500m"
 DEFAULT_MEMORY = "512Mi"
@@ -134,10 +134,10 @@ class TrussConfig:
     @staticmethod
     def from_dict(d):
         config = TrussConfig(
-            # Users that are calling `from_directory` on an existing Truss
+            # Users that are calling `load` on an existing Truss
             # should default to 1.0 whereas users creating a new Truss
             # should default to 2.0.
-            spec_version=d.get("spec_version", DEFAULT_SPEC_VERSION_FROM_DIRECTORY),
+            spec_version=d.get("spec_version", DEFAULT_SPEC_VERSION_ON_LOAD),
             model_type=d.get("model_type", DEFAULT_MODEL_TYPE),
             model_framework=ModelFrameworkType(
                 d.get("model_framework", DEFAULT_MODEL_FRAMEWORK_TYPE.value)

--- a/truss/truss_handle.py
+++ b/truss/truss_handle.py
@@ -82,11 +82,6 @@ class TrussHandle:
     def spec(self) -> TrussSpec:
         return self._spec
 
-    def server_predict(self, request: dict):
-        """Run the prediction flow locally."""
-        model = LoadModelLocal.run(self._truss_dir)
-        return _prediction_flow(model, request)
-
     def build_docker_build_context(self, build_dir: Path = None):
         build_dir_path = Path(build_dir) if build_dir is not None else None
         image_builder = ServingImageBuilderContext.run(self._truss_dir)
@@ -188,6 +183,33 @@ class TrussHandle:
             raise err
 
         return container
+
+    def predict(
+        self,
+        request: dict,
+        use_docker: bool = False,
+        build_dir: Path = None,
+        tag: str = None,
+        local_port: int = INFERENCE_SERVER_PORT,
+        detach: bool = True,
+        patch_ping_url: str = None,
+    ):
+        if use_docker:
+            return self.docker_predict(
+                request,
+                build_dir=build_dir,
+                tag=tag,
+                local_port=local_port,
+                detach=detach,
+                patch_ping_url=patch_ping_url,
+            )
+        else:
+            return self.server_predict(request)
+
+    def server_predict(self, request: dict):
+        """Run the prediction flow locally."""
+        model = LoadModelLocal.run(self._truss_dir)
+        return _prediction_flow(model, request)
 
     def docker_predict(
         self,


### PR DESCRIPTION
(This PR supersedes https://github.com/basetenlabs/truss/pull/124)

This PR proposes unifies the developer experience for Truss around three simple, evocative function names: `create()`, `load()`, and `predict()`.

Packaging a model as a Truss involves functions that every user will call often: `mk_truss()` and `from_directory()`. This PR improves Truss' developer experience by renaming these functions to more descriptive names: `create()` and `load()`.

For local development, we also have predictions, which can run with or without docker. In the CLI, there is a predict function that takes an argument for whether or not to use docker, but the Truss handle only has `server_predict()` and `docker_predict()`. This PR adds `predict()`, which defaults to server predict[^1] and has a `use_docker` option to enable docker predict. It also updates the CLI predict function to use the same argument name and default value for consistency.

Here's some code after this PR:

```python
import truss

truss.create(my_model, "my_model_dir")

# Elsewhere
handle = truss.load("my_model_dir")
handle.predict(my_data)
```

The original function names are preserved as deprecated aliases and can be removed in a future major version. Deprecation warnings are logged when the original functions are invoked.

This change also affects everything Baseten-related that uses Truss. Here are the associated PRs:

- Client: https://github.com/basetenlabs/baseten_client/pull/237 
- Docs: https://github.com/basetenlabs/docs.baseten.co/pull/88
- App: https://github.com/basetenlabs/baseten/pull/5251

[^1]: I was conflicted on whether server predict or docker predict should be default. I was leaning toward server predict because it works on colab (makes docs look nicer) and also requires less setup. However, I believed docker predict would be more reliable. But a couple of weeks ago Bola and I were working on the Riffusion Truss and constantly trying to get it to work with docker predict, but it ended up being server predict that we could get working. That experience gave the the confidence to go with my original choice: no docker by default.