### PR TITLE
Live reload scale up from zero fix

### DIFF
--- a/truss/contexts/image_builder/util.py
+++ b/truss/contexts/image_builder/util.py
@@ -10,7 +10,7 @@ from truss import __version__
 # [IMPORTANT] Make sure all images for this version are published to dockerhub
 # before change to this value lands. This value is used to look for base images
 # when building docker image for a truss.
-TRUSS_BASE_IMAGE_VERSION_TAG = "test"
+TRUSS_BASE_IMAGE_VERSION_TAG = "v0.2.1rc2"
 
 
 def file_is_empty(path: Path, ignore_hash_style_comments: bool = True) -> bool:

--- a/truss/contexts/image_builder/util.py
+++ b/truss/contexts/image_builder/util.py
@@ -10,7 +10,7 @@ from truss import __version__
 # [IMPORTANT] Make sure all images for this version are published to dockerhub
 # before change to this value lands. This value is used to look for base images
 # when building docker image for a truss.
-TRUSS_BASE_IMAGE_VERSION_TAG = "v0.2.1rc2"
+TRUSS_BASE_IMAGE_VERSION_TAG = "test"
 
 
 def file_is_empty(path: Path, ignore_hash_style_comments: bool = True) -> bool:

--- a/truss/templates/control/control/endpoints.py
+++ b/truss/templates/control/control/endpoints.py
@@ -41,7 +41,8 @@ def proxy(path):
                 # process is running then we continue waiting for it to start (by retrying),
                 # otherwise we bail.
                 if (
-                    not inference_server_process_controller.is_inference_server_running()
+                    inference_server_process_controller.inference_server_ever_started()
+                    and not inference_server_process_controller.is_inference_server_running()
                 ):
                     error_msg = "It appears your model has stopped running. This often means' \
                         ' it crashed and may need a fix to get it running again."

--- a/truss/templates/control/control/helpers/inference_server_process_controller.py
+++ b/truss/templates/control/control/helpers/inference_server_process_controller.py
@@ -17,6 +17,7 @@ class InferenceServerProcessController:
         self._inference_server_process_args = inference_server_process_args
         self._inference_server_port = inference_server_port
         self._inference_server_started = False
+        self._inference_server_ever_started = False
         self._app_logger = app_logger
 
     def start(self):
@@ -28,6 +29,7 @@ class InferenceServerProcessController:
                 env=inf_env,
             )
             self._inference_server_started = True
+            self._inference_server_ever_started = True
 
     def stop(self):
         if self._inference_server_process is not None:
@@ -39,6 +41,9 @@ class InferenceServerProcessController:
 
     def inference_server_started(self) -> bool:
         return self._inference_server_started
+
+    def inference_server_ever_started(self) -> bool:
+        return self._inference_server_ever_started
 
     def is_inference_server_running(self) -> bool:
         # Explicitly check if inference server process is up, this is a bit expensive.


### PR DESCRIPTION
For the live-reloadable truss, if a prediction request is received at startup, the inference server may not have started up by that time. We have a retry logic for the case where inference server process is taking long to startup, but we weren't handling the case where inference server hadn't even been started. This can happen e.g. when patches are being applied on startup. We check for this condition now. 

We still bail out immediately if we know that inference server was started in the past but isn't running anymore. In this case the inference server process may have crashed due to an error and we don't want user to wait unnecessarily.