### PR TITLE
Implement system package live reload

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.2.1rc2"
+version = "0.2.1"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/contexts/image_builder/util.py
+++ b/truss/contexts/image_builder/util.py
@@ -10,7 +10,7 @@ from truss import __version__
 # [IMPORTANT] Make sure all images for this version are published to dockerhub
 # before change to this value lands. This value is used to look for base images
 # when building docker image for a truss.
-TRUSS_BASE_IMAGE_VERSION_TAG = "v0.2.1rc2"
+TRUSS_BASE_IMAGE_VERSION_TAG = "v0.2.1"
 
 
 def file_is_empty(path: Path, ignore_hash_style_comments: bool = True) -> bool:

--- a/truss/templates/control/control/helpers/types.py
+++ b/truss/templates/control/control/helpers/types.py
@@ -8,6 +8,7 @@ class PatchType(Enum):
 
     MODEL_CODE = "model_code"
     PYTHON_REQUIREMENT = "python_requirement"
+    SYSTEM_PACKAGE = "system_package"
 
 
 class Action(Enum):
@@ -71,9 +72,31 @@ class PythonRequirementPatch(PatchBody):
         )
 
 
+@dataclass
+class SystemPackagePatch(PatchBody):
+    # For uninstall this should just be the name of the package, but for update
+    # should be the full line in the requirements.txt format.
+    package: str
+
+    def to_dict(self):
+        return {
+            "action": self.action.value,
+            "package": self.package,
+        }
+
+    @staticmethod
+    def from_dict(patch_dict: dict):
+        action_str = patch_dict["action"]
+        return SystemPackagePatch(
+            action=Action[action_str],
+            package=patch_dict["package"],
+        )
+
+
 PATCH_BODY_BY_TYPE = {
     PatchType.MODEL_CODE: ModelCodePatch,
     PatchType.PYTHON_REQUIREMENT: PythonRequirementPatch,
+    PatchType.SYSTEM_PACKAGE: SystemPackagePatch,
 }
 
 

--- a/truss/tests/patch/test_patch.py
+++ b/truss/tests/patch/test_patch.py
@@ -193,12 +193,12 @@ def test_calc_config_patches_add_remove_and_update_python_requirement(
     ]
 
 
-def test_calc_config_patches_non_python_requirement_change(
+def test_calc_config_patches_non_python_or_system_requirement_change(
     custom_model_truss_dir: Path,
 ):
     patches = _apply_config_change_and_calc_patches(
         custom_model_truss_dir,
-        config_op=lambda config: config.system_packages.append("bla"),
+        config_op=lambda config: config.environment_variables.update({"foo": "bar"}),
     )
     assert patches is None
 

--- a/truss/tests/patch/test_patch.py
+++ b/truss/tests/patch/test_patch.py
@@ -9,6 +9,7 @@ from truss.templates.control.control.helpers.types import (
     Patch,
     PatchType,
     PythonRequirementPatch,
+    SystemPackagePatch,
 )
 from truss.truss_config import TrussConfig
 
@@ -201,6 +202,78 @@ def test_calc_config_patches_non_python_or_system_requirement_change(
         config_op=lambda config: config.environment_variables.update({"foo": "bar"}),
     )
     assert patches is None
+
+
+def test_calc_config_patches_add_system_package(custom_model_truss_dir: Path):
+    patches = _apply_config_change_and_calc_patches(
+        custom_model_truss_dir,
+        lambda config: config.system_packages.append("curl"),
+    )
+    assert len(patches) == 1
+    patch = patches[0]
+    assert patch == Patch(
+        type=PatchType.SYSTEM_PACKAGE,
+        body=SystemPackagePatch(
+            action=Action.UPDATE,
+            package="curl",
+        ),
+    )
+
+
+def test_calc_config_patches_remove_system_package(custom_model_truss_dir: Path):
+    patches = _apply_config_change_and_calc_patches(
+        custom_model_truss_dir,
+        config_pre_op=lambda config: config.system_packages.append("curl"),
+        config_op=lambda config: config.system_packages.clear(),
+    )
+    assert len(patches) == 1
+    patch = patches[0]
+    assert patch == Patch(
+        type=PatchType.SYSTEM_PACKAGE,
+        body=SystemPackagePatch(
+            action=Action.REMOVE,
+            package="curl",
+        ),
+    )
+
+
+def test_calc_config_patches_add_and_remove_system_package(
+    custom_model_truss_dir: Path,
+):
+    def config_pre_op(config: TrussConfig):
+        config.system_packages = [
+            "curl",
+            "jq",
+        ]
+
+    def config_op(config: TrussConfig):
+        config.system_packages = [
+            "curl",
+            "libsnd",
+        ]
+
+    patches = _apply_config_change_and_calc_patches(
+        custom_model_truss_dir,
+        config_pre_op=config_pre_op,
+        config_op=config_op,
+    )
+    patches.sort(key=lambda patch: patch.body.package)
+    assert patches == [
+        Patch(
+            type=PatchType.SYSTEM_PACKAGE,
+            body=SystemPackagePatch(
+                action=Action.REMOVE,
+                package="jq",
+            ),
+        ),
+        Patch(
+            type=PatchType.SYSTEM_PACKAGE,
+            body=SystemPackagePatch(
+                action=Action.UPDATE,
+                package="libsnd",
+            ),
+        ),
+    ]
 
 
 def _apply_config_change_and_calc_patches(


### PR DESCRIPTION
* On the same lines as python requirements reload, addition removals of system packages can be live reloaded now.
* System package changes are always applied before python requirements as new python requirement installation may depend on new system packages.


TODO: Add tests. I will write those before landing, but want to post the PR for early feedback.