### PR TITLE
Expand python lookup path for starting inference server

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.2.1"
+version = "0.2.2"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/contexts/image_builder/util.py
+++ b/truss/contexts/image_builder/util.py
@@ -10,7 +10,7 @@ from truss import __version__
 # [IMPORTANT] Make sure all images for this version are published to dockerhub
 # before change to this value lands. This value is used to look for base images
 # when building docker image for a truss.
-TRUSS_BASE_IMAGE_VERSION_TAG = "v0.2.1"
+TRUSS_BASE_IMAGE_VERSION_TAG = "v0.2.2"
 
 
 def file_is_empty(path: Path, ignore_hash_style_comments: bool = True) -> bool:

--- a/truss/templates/control/control/server.py
+++ b/truss/templates/control/control/server.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 from threading import Thread
 
 from application import create_app
@@ -6,17 +7,32 @@ from helpers.inference_server_starter import inference_server_startup_flow
 
 CONTROL_SERVER_PORT = int(os.environ.get("CONTROL_SERVER_PORT", "8080"))
 INFERENCE_SERVER_PORT = int(os.environ.get("INFERENCE_SERVER_PORT", "8090"))
+PYTHON_EXECUTABLE_LOOKUP_PATHS = [
+    "/usr/local/bin/python",
+    "/usr/local/bin/python3",
+    "/usr/bin/python",
+    "/usr/bin/python3",
+]
+
+
+def _identify_python_executable_path() -> str:
+    for path in PYTHON_EXECUTABLE_LOOKUP_PATHS:
+        if Path(path).exists():
+            return path
+
+    raise RuntimeError("Unable to find python, make sure it's installed.")
 
 
 if __name__ == "__main__":
     from waitress import create_server
 
     inf_serv_home = os.environ["APP_HOME"]
+    python_executable_path = _identify_python_executable_path()
     application = create_app(
         {
             "inference_server_home": inf_serv_home,
             "inference_server_process_args": [
-                "/usr/local/bin/python",
+                python_executable_path,
                 f"{inf_serv_home}/inference_server.py",
             ],
             "control_server_host": "0.0.0.0",


### PR DESCRIPTION
On gpu images python is available at `/usr/bin/python3`. Expand the python executable search path to allow for that.