### PR TITLE
Fix context builder image integration test

### DIFF
--- a/truss/tests/test_data/context_builder_image_test/Dockerfile
+++ b/truss/tests/test_data/context_builder_image_test/Dockerfile
@@ -2,4 +2,8 @@ from baseten/truss-context-builder:test
 
 COPY test.py test.py
 
+# This seems to be present on github actions execution environt and interferes.
+# So, get rid of it.
+RUN rm -rf /.venv
+
 RUN poetry run python test.py


### PR DESCRIPTION
A .venv folder that is present on the github actions environment gets packaged into the image and interferes the poetry environment for the test. Remove that folder to fix the test.