### PR TITLE
Fix loading external packages in local

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.2.5rc1"
+version = "0.2.5"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.2.4"
+version = "0.2.5rc1"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/contexts/local_loader/load_model_local.py
+++ b/truss/contexts/local_loader/load_model_local.py
@@ -25,7 +25,7 @@ class LoadModelLocal(TrussContext):
             str(truss_dir),
             spec.model_module_fullname,
             spec.bundled_packages_dir.name,
-            [str(path) for path in spec.external_package_dirs_paths],
+            [str(path.resolve()) for path in spec.external_package_dirs_paths],
         ) as module:
             model_class = getattr(module, spec.model_class_name)
             model_class_signature = inspect.signature(model_class)

--- a/truss/contexts/local_loader/train_local.py
+++ b/truss/contexts/local_loader/train_local.py
@@ -21,7 +21,7 @@ class LocalTrainer(TrussContext):
                 str(truss_dir),
                 spec.train_module_fullname,
                 spec.bundled_packages_dir.name,
-                [str(path) for path in spec.external_package_dirs_paths],
+                [str(path.resolve()) for path in spec.external_package_dirs_paths],
             ) as module:
                 train_class = getattr(module, spec.train_class_name)
                 train_class_signature = inspect.signature(train_class)

--- a/truss/truss_spec.py
+++ b/truss/truss_spec.py
@@ -50,7 +50,7 @@ class TrussSpec:
             if path.is_absolute():
                 paths.append(path)
             else:
-                paths.append(self._truss_dir.resolve() / path)
+                paths.append(self._truss_dir / path)
         return paths
 
     @property

--- a/truss/truss_spec.py
+++ b/truss/truss_spec.py
@@ -50,7 +50,7 @@ class TrussSpec:
             if path.is_absolute():
                 paths.append(path)
             else:
-                paths.append(self._truss_dir / path)
+                paths.append(self._truss_dir.resolve() / path)
         return paths
 
     @property


### PR DESCRIPTION
Truss module loader can't handle relative of relative paths very well. In this case if truss_dir is already relative and if external packages dir is also relative then there's a problem. Pass absolute paths to TrussModuleLoader to avoid this.