### PR TITLE
Filter out healthcheck endpoints from access logging

### DIFF
--- a/truss/templates/server/common/logging.py
+++ b/truss/templates/server/common/logging.py
@@ -17,8 +17,8 @@ class HealthCheckFilter(logging.Filter):
     def filter(self, record: logging.LogRecord) -> bool:
         # for any health check endpoints, lets skip logging
         return (
-            record.getMessage().find("/") == -1
-            and record.getMessage().find("/v1/models/model") == -1
+            record.getMessage().find("GET / ") == -1
+            and record.getMessage().find("GET /v1/models/model ") == -1
         )
 
 

--- a/truss/templates/server/common/logging.py
+++ b/truss/templates/server/common/logging.py
@@ -13,6 +13,15 @@ JSON_LOG_HANDLER.setFormatter(
 )
 
 
+class HealthCheckFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        # for any health check endpoints, lets skip logging
+        return (
+            record.getMessage().find("/") == -1
+            and record.getMessage().find("/v1/models/model") == -1
+        )
+
+
 def setup_logging():
     loggers = [logging.getLogger()] + [
         logging.getLogger(name) for name in logging.root.manager.loggerDict
@@ -32,3 +41,7 @@ def setup_logging():
         if not setup:
             logger.handlers.clear()
             logger.addHandler(JSON_LOG_HANDLER)
+
+        # some special handling for request logging
+        if logger.name == "uvicorn.access":
+            logger.addFilter(HealthCheckFilter())


### PR DESCRIPTION
## What
We don't want to display access logging by default for healthcheck endpoints

## How
Adding a logging filter for the `uvicorn.access` logger to filter out by endpoint