### PR TITLE
For live reload, retry if model is not ready

### DIFF
--- a/truss/templates/control/control/helpers/errors.py
+++ b/truss/templates/control/control/helpers/errors.py
@@ -34,3 +34,9 @@ class InadmissiblePatch(PatchApplicatonError):
     """Patch does not apply to current state of Truss."""
 
     pass
+
+
+class ModelNotReady(Error):
+    """Model has started running, but not ready yet."""
+
+    pass

--- a/truss/test_data/truss_container_fs/app/common/logging.py
+++ b/truss/test_data/truss_container_fs/app/common/logging.py
@@ -1,0 +1,47 @@
+import logging
+import sys
+
+from pythonjsonlogger import jsonlogger
+
+LEVEL = logging.INFO
+
+JSON_LOG_HANDLER = logging.StreamHandler(stream=sys.stderr)
+JSON_LOG_HANDLER.set_name("json_logger_handler")
+JSON_LOG_HANDLER.setLevel(LEVEL)
+JSON_LOG_HANDLER.setFormatter(
+    jsonlogger.JsonFormatter("%(asctime)s %(levelname)s %(message)s")
+)
+
+
+class HealthCheckFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        # for any health check endpoints, lets skip logging
+        return (
+            record.getMessage().find("GET / ") == -1
+            and record.getMessage().find("GET /v1/models/model ") == -1
+        )
+
+
+def setup_logging():
+    loggers = [logging.getLogger()] + [
+        logging.getLogger(name) for name in logging.root.manager.loggerDict
+    ]
+
+    for logger in loggers:
+        logger.setLevel(LEVEL)
+        logger.propagate = False
+
+        setup = False
+
+        # let's not thrash the handlers unnecessarily
+        for handler in logger.handlers:
+            if handler.name == JSON_LOG_HANDLER.name:
+                setup = True
+
+        if not setup:
+            logger.handlers.clear()
+            logger.addHandler(JSON_LOG_HANDLER)
+
+        # some special handling for request logging
+        if logger.name == "uvicorn.access":
+            logger.addFilter(HealthCheckFilter())

--- a/truss/test_data/truss_container_fs/app/common/serialization.py
+++ b/truss/test_data/truss_container_fs/app/common/serialization.py
@@ -3,10 +3,6 @@ import decimal
 import json
 import uuid
 
-import msgpack
-import msgpack_numpy as mp_np
-import numpy as np
-
 
 # mostly cribbed from django.core.serializer.DjangoJSONEncoder
 def truss_msgpack_encoder(obj, chain=None):
@@ -61,6 +57,8 @@ def truss_msgpack_decoder(obj, chain=None):
 
 # this json object is JSONType + np.array + datetime
 def is_truss_serializable(obj):
+    import numpy as np
+
     # basic JSON types
     if isinstance(obj, (str, int, float, bool, type(None), dict, list)):
         return True
@@ -75,12 +73,18 @@ def is_truss_serializable(obj):
 
 
 def truss_msgpack_serialize(obj):
+    import msgpack
+    import msgpack_numpy as mp_np
+
     return msgpack.packb(
         obj, default=lambda x: truss_msgpack_encoder(x, chain=mp_np.encode)
     )
 
 
 def truss_msgpack_deserialize(obj):
+    import msgpack
+    import msgpack_numpy as mp_np
+
     return msgpack.unpackb(
         obj, object_hook=lambda x: truss_msgpack_decoder(x, chain=mp_np.decode)
     )
@@ -88,6 +92,8 @@ def truss_msgpack_deserialize(obj):
 
 class DeepNumpyEncoder(json.JSONEncoder):
     def default(self, obj):
+        import numpy as np
+
         if isinstance(obj, np.integer):
             return int(obj)
         elif isinstance(obj, np.floating):

--- a/truss/test_data/truss_container_fs/app/common/truss_server.py
+++ b/truss/test_data/truss_container_fs/app/common/truss_server.py
@@ -1,248 +1,169 @@
-import json  # noqa: E402
-import logging  # noqa: E402
-import os
-import sys
-from http import HTTPStatus  # noqa: E402
-from threading import Thread
-from typing import List
+import asyncio
+import json
+from typing import Dict, Optional, Union
 
-import numpy as np  # noqa: E402
-import tornado.web  # noqa: E402
-from common.lib_support import ensure_kfserving_installed
-from common.serialization import DeepNumpyEncoder  # noqa: E402
-from common.serialization import (  # noqa: E402
+import kserve
+import kserve.errors as errors
+from common.logging import setup_logging
+from common.serialization import (
+    DeepNumpyEncoder,
     truss_msgpack_deserialize,
     truss_msgpack_serialize,
 )
-from common.util import (  # noqa: E402
-    assign_request_to_inputs_instances_after_validation,
-)
-from kfserving import KFModel
-from kfserving.handlers.http import HTTPHandler  # noqa: E402
-from kfserving.kfserver import HealthHandler, KFServer, ListHandler, LivenessHandler
+from fastapi import Depends, FastAPI, Request
+from fastapi.responses import ORJSONResponse
+from fastapi.routing import APIRoute as FastAPIRoute
+from kserve.handlers import DataPlane, ModelRepositoryExtension, V1Endpoints
 from model_wrapper import ModelWrapper
-from pythonjsonlogger import jsonlogger  # noqa: E402
-from tornado.httpserver import HTTPServer
-from tornado.ioloop import IOLoop
-
-ensure_kfserving_installed()
-
-logger = logging.getLogger(__name__)
+from starlette.responses import Response
 
 
-def _configure_logging():
-    json_log_handler = logging.StreamHandler()
-    json_log_handler.setFormatter(
-        jsonlogger.JsonFormatter("%(asctime)s %(levelname)s %(message)s")
-    )
-    logger = logging.getLogger()
-    for handler in logger.handlers:
-        logger.removeHandler(handler)
-    logger.addHandler(json_log_handler)
+async def parse_body(request: Request) -> bytes:
+    """
+    Used by FastAPI to read body in an asynchronous manner
+    """
+    return await request.body()
 
 
-class TrussHTTPBinaryHandler(HTTPHandler):
-    def validate(self, request):
-        if (
-            "instances" in request
-            and not isinstance(request["instances"], (list, np.ndarray))
-        ) or (
-            "inputs" in request
-            and not isinstance(request["inputs"], (list, np.ndarray))
-        ):
-            raise tornado.web.HTTPError(
-                status_code=HTTPStatus.BAD_REQUEST,
-                reason='Expected "instances" or "inputs" to be a list or NumPy ndarray',
+class BasetenEndpoints(V1Endpoints):
+    def __init__(
+        self,
+        dataplane: DataPlane,
+        model_repository_extension: Optional[ModelRepositoryExtension] = None,
+    ):
+        super().__init__(dataplane, model_repository_extension)
+
+    @staticmethod
+    def check_healthy(model: ModelWrapper):
+        if model.load_failed():
+            raise errors.InferenceError("Model load failed")
+
+        if not model.ready:
+            raise errors.ModelNotReady(model.name)
+
+    async def model_ready(self, model_name: str) -> Dict[str, Union[str, bool]]:
+        model: ModelWrapper = self.dataplane.get_model_from_registry(model_name)
+
+        self.check_healthy(model)
+
+        return {}
+
+    def predict(
+        self, model_name: str, request: Request, body_raw: bytes = Depends(parse_body)
+    ) -> Response:
+        """
+        This method is called by FastAPI, which introspects that it's not async, and schedules it on a thread
+        """
+        model: ModelWrapper = self.dataplane.get_model_from_registry(model_name)
+
+        self.check_healthy(model)
+
+        body: dict
+        if self.is_binary(request):
+            body = truss_msgpack_deserialize(body_raw)
+        else:
+            body = json.loads(body_raw)
+
+        # calls kserve.model.Model.__call__, which runs validate, preprocess, predict, and postprocess
+        response: dict = asyncio.run(model(body, headers=dict(request.headers.items())))
+
+        response_headers = {}
+        if self.is_binary(request):
+            response_headers["Content-Type"] = "application/octet-stream"
+            return Response(
+                content=truss_msgpack_serialize(response), headers=response_headers
             )
-        return assign_request_to_inputs_instances_after_validation(request)
-
-
-class TrussHTTPHandler(HTTPHandler):
-    def validate(self, request):
-        if ("instances" in request and not isinstance(request["instances"], list)) or (
-            "inputs" in request and not isinstance(request["inputs"], list)
-        ):
-            raise tornado.web.HTTPError(
-                status_code=HTTPStatus.BAD_REQUEST,
-                reason='Expected "instances" or "inputs" to be a list',
-            )
-        return assign_request_to_inputs_instances_after_validation(request)
-
-
-class TrussPredictHandler(TrussHTTPBinaryHandler):
-    def post(self, name: str):
-        model = self.get_model(name)
-        try:
-            body = truss_msgpack_deserialize(self.request.body)
-        except Exception as e:
-            raise tornado.web.HTTPError(
-                status_code=HTTPStatus.BAD_REQUEST,
-                reason="Unrecognized request format: %s" % e,
-            )
-        request = self.validate(body)
-        request = model.preprocess(request)
-        response = model.predict(request)
-        response = model.postprocess(response)
-        try:
-            final_response = truss_msgpack_serialize(response)
-        except Exception as e:
-            raise tornado.web.HTTPError(
-                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
-                reason="Unable to serialize model prediction to response: %s" % e,
-            )
-        self.write(final_response)
-
-
-class TrussExplainHandler(TrussHTTPBinaryHandler):
-    def post(self, name: str):
-        model = self.get_model(name)
-        try:
-            body = truss_msgpack_deserialize(self.request.body)
-        except Exception as e:
-            raise tornado.web.HTTPError(
-                status_code=HTTPStatus.BAD_REQUEST,
-                reason="Unrecognized request format: %s" % e,
-            )
-        request = self.validate(body)
-        request = model.preprocess(request)
-        response = model.explain(request)
-        response = model.postprocess(response)
-        try:
-            final_response = truss_msgpack_serialize(response)
-        except Exception as e:
-            raise tornado.web.HTTPError(
-                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
-                reason="Unable to serialize model prediction to response: %s" % e,
-            )
-        self.write(final_response)
-
-
-class PredictHandler(TrussHTTPHandler):
-    def post(self, name: str):
-        model = self.get_model(name)
-        try:
-            body = json.loads(self.request.body)
-        except json.decoder.JSONDecodeError as e:
-            raise tornado.web.HTTPError(
-                status_code=HTTPStatus.BAD_REQUEST,
-                reason="Unrecognized request format: %s" % e,
-            )
-        request = self.validate(body)
-        request = model.preprocess(request)
-        response = model.predict(request)
-        response = model.postprocess(response)
-        try:
-            final_response = json.dumps(response, cls=DeepNumpyEncoder)
-        except Exception as e:
-            raise tornado.web.HTTPError(
-                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
-                reason="Unable to serialize model prediction to response: %s" % e,
-            )
-        self.write(final_response)
-
-
-class ExplainHandler(TrussHTTPHandler):
-    def post(self, name: str):
-        model = self.get_model(name)
-        try:
-            body = json.loads(self.request.body)
-        except json.decoder.JSONDecodeError as e:
-            raise tornado.web.HTTPError(
-                status_code=HTTPStatus.BAD_REQUEST,
-                reason="Unrecognized request format: %s" % e,
-            )
-        request = self.validate(body)
-        request = model.preprocess(request)
-        response = model.explain(request)
-        response = model.postprocess(response)
-        try:
-            final_response = json.dumps(response, cls=DeepNumpyEncoder)
-        except Exception as e:
-            raise tornado.web.HTTPError(
-                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
-                reason="Unable to serialize model prediction to response: %s" % e,
-            )
-        self.write(final_response)
-
-
-class TrussServer(KFServer):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        _configure_logging()
-
-    def load_all(self, main_loop: IOLoop):
-        try:
-            for model in self.registered_models.get_models():
-                model.load()
-        except Exception as e:
-            logging.error(f"Error loading model: {e}")
-
-            # fixme(zack) for live reload, we don't want to kill the process?
-            if not os.environ.get("CONTROL_SERVER_PORT"):
-                self._http_server.stop()
-                main_loop.stop()
-                sys.exit(1)
-
-    def start(self, models: List[KFModel], nest_asyncio: bool = False):
-        if len(models) != 1:
-            raise RuntimeError("TrussServer only supports one model")
-
-        if not isinstance(models[0], ModelWrapper):
-            raise ValueError(
-                "TrussServer only accepts ModelWrapper instances instead of KFServer instances"
+        else:
+            response_headers["Content-Type"] = "application/json"
+            return Response(
+                content=json.dumps(response, cls=DeepNumpyEncoder),
+                headers=response_headers,
             )
 
-        for model in models:
-            self.register_model(model)
-
-        self._http_server = HTTPServer(
-            self.create_application(), max_buffer_size=self.max_buffer_size
+    @staticmethod
+    def is_binary(request: Request):
+        return (
+            "Content-Type" in request.headers
+            and request.headers["Content-Type"] == "application/octet-stream"
         )
 
-        logging.info("Listening on port %s", self.http_port)
-        self._http_server.bind(self.http_port)
 
-        logging.info("Will fork %d workers", self.workers)
-        self._http_server.start(self.workers)
+class TrussServer(kserve.ModelServer):
 
-        Thread(
-            target=self.load_all,
-            args=[IOLoop.current()],
-        ).start()
+    _endpoints: BasetenEndpoints
+    _model: ModelWrapper
+    _config: dict
 
-        IOLoop.current().start()
+    def __init__(self, http_port: int, config: dict):
+        super().__init__(
+            http_port=http_port,
+            enable_grpc=False,
+            workers=1,
+            enable_docs_url=False,
+            enable_latency_logging=False,
+        )
+
+        self._config = config
+        self._endpoints = BasetenEndpoints(
+            self.dataplane, self.model_repository_extension
+        )
+
+    def start_model(self) -> None:
+        """
+        Overloaded version of super().start to use instance model in TrussServer
+        """
+        super().start([])
+
+    def on_startup(self):
+        """
+        This method will be started inside the main process, so here is where we want to setup our logging and model
+        """
+        setup_logging()
+
+        self._model = ModelWrapper(self._config)
+        self.register_model(self._model)
+
+        self._model.start_load()
 
     def create_application(self):
-        return tornado.web.Application(
-            [
-                # Server Liveness API returns 200 if server is alive.
-                (r"/", LivenessHandler),
-                (r"/v1/models", ListHandler, dict(models=self.registered_models)),
-                # Model Health API returns 200 if model is ready to serve.
-                (
-                    r"/v1/models/([a-zA-Z0-9_-]+)",
-                    HealthHandler,
-                    dict(models=self.registered_models),
+        return FastAPI(
+            title="Baseten Inference Server",
+            docs_url=None,
+            redoc_url=None,
+            default_response_class=ORJSONResponse,
+            on_startup=[self.on_startup],
+            routes=[
+                # liveness endpoint
+                FastAPIRoute(r"/", self.dataplane.live),
+                # readiness endpoint
+                FastAPIRoute(
+                    r"/v1/models/{model_name}", self._endpoints.model_ready, tags=["V1"]
                 ),
-                (
-                    r"/v1/models/([a-zA-Z0-9_-]+):predict",
-                    PredictHandler,
-                    dict(models=self.registered_models),
+                FastAPIRoute(
+                    r"/v1/models/{model_name}:predict",
+                    self._endpoints.predict,
+                    methods=["POST"],
+                    tags=["V1"],
                 ),
-                (
-                    r"/v1/models/([a-zA-Z0-9_-]+):predict_binary",
-                    TrussPredictHandler,
-                    dict(models=self.registered_models),
+                FastAPIRoute(
+                    r"/v1/models/{model_name}:predict_binary",
+                    self._endpoints.predict,
+                    methods=["POST"],
+                    tags=["V1"],
                 ),
-                (
-                    r"/v1/models/([a-zA-Z0-9_-]+):explain",
-                    ExplainHandler,
-                    dict(models=self.registered_models),
+                FastAPIRoute(
+                    r"/v1/models/{model_name}:explain",
+                    self._endpoints.explain,
+                    methods=["POST"],
+                    tags=["V1"],
                 ),
-                (
-                    r"/v1/models/([a-zA-Z0-9_-]+):explain_binary",
-                    TrussExplainHandler,
-                    dict(models=self.registered_models),
-                ),
-            ]
+            ],
+            exception_handlers={
+                errors.InvalidInput: errors.invalid_input_handler,
+                errors.InferenceError: errors.inference_error_handler,
+                errors.ModelNotFound: errors.model_not_found_handler,
+                errors.ModelNotReady: errors.model_not_ready_handler,
+                NotImplementedError: errors.not_implemented_error_handler,
+                Exception: errors.generic_exception_handler,
+            },
         )

--- a/truss/test_data/truss_container_fs/app/common/util.py
+++ b/truss/test_data/truss_container_fs/app/common/util.py
@@ -1,4 +1,4 @@
-def model_supports_predict_proba(model):
+def model_supports_predict_proba(model: object) -> bool:
     if not hasattr(model, "predict_proba"):
         return False
     if hasattr(
@@ -12,10 +12,10 @@ def model_supports_predict_proba(model):
     return True
 
 
-def assign_request_to_inputs_instances_after_validation(request):
+def assign_request_to_inputs_instances_after_validation(body: dict) -> dict:
     # we will treat "instances" and "inputs" the same
-    if "instances" in request and "inputs" not in request:
-        request["inputs"] = request["instances"]
-    elif "inputs" in request and "instances" not in request:
-        request["instances"] = request["inputs"]
-    return request
+    if "instances" in body and "inputs" not in body:
+        body["inputs"] = body["instances"]
+    elif "inputs" in body and "instances" not in body:
+        body["instances"] = body["inputs"]
+    return body

--- a/truss/test_data/truss_container_fs/app/inference_server.py
+++ b/truss/test_data/truss_container_fs/app/inference_server.py
@@ -1,10 +1,12 @@
 import os
 
 import yaml
-from common.truss_server import TrussServer
-from model_wrapper import ModelWrapper
+from common.logging import setup_logging
+from common.truss_server import TrussServer  # noqa: E402
 
 CONFIG_FILE = "config.yaml"
+
+setup_logging()
 
 
 class ConfiguredTrussServer:
@@ -17,9 +19,8 @@ class ConfiguredTrussServer:
             self._config = yaml.safe_load(config_file)
 
     def start(self):
-        server = TrussServer(workers=1, http_port=self._port)
-        model = ModelWrapper(self._config)
-        server.start([model])
+        server = TrussServer(http_port=self._port, config=self._config)
+        server.start_model()
 
 
 if __name__ == "__main__":

--- a/truss/test_data/truss_container_fs/app/model_wrapper.py
+++ b/truss/test_data/truss_container_fs/app/model_wrapper.py
@@ -3,22 +3,86 @@ import inspect
 import logging
 import sys
 import traceback
+from enum import Enum
 from pathlib import Path
-from typing import Dict, List
+from threading import Lock, Thread
+from typing import Dict, Union
 
-import kfserving
+import kserve
+import numpy as np
+from cloudevents.http import CloudEvent
+from common.util import assign_request_to_inputs_instances_after_validation
+from kserve.errors import InvalidInput
+from kserve.grpc.grpc_predict_v2_pb2 import ModelInferRequest, ModelInferResponse
 from shared.secrets_resolver import SecretsResolver
 
 MODEL_BASENAME = "model"
 
 
-class ModelWrapper(kfserving.KFModel):
+class ModelWrapper(kserve.Model):
+    class Status(Enum):
+        NOT_READY = 0
+        LOADING = 1
+        READY = 2
+        FAILED = 3
+
+    _config: dict
+    _model: object
+    _load_lock: Lock = Lock()
+    _predict_lock: Lock = Lock()
+    _status: Status = Status.NOT_READY
+    _logger: logging.Logger
+
     def __init__(self, config: dict):
         super().__init__(MODEL_BASENAME)
         self._config = config
-        self._model = None
+        self.logger = logging.getLogger(__name__)
 
-    def load(self):
+    def load(self) -> bool:
+        if self.ready:
+            return self.ready
+
+        # if we are already loading, just pass; our container will return 503 while we're loading
+        if not self._load_lock.acquire(blocking=False):
+            return False
+
+        self._status = ModelWrapper.Status.LOADING
+
+        self.logger.info("Executing model.load()...")
+
+        try:
+            self.try_load()
+            self.ready = True
+            self._status = ModelWrapper.Status.READY
+
+            self.logger.info("Completed model.load() execution")
+
+            return self.ready
+        except Exception:
+            self.logger.exception("Exception while loading model")
+            self._status = ModelWrapper.Status.FAILED
+        finally:
+            self._load_lock.release()
+
+        return self.ready
+
+    def start_load(self):
+        if self.should_load():
+            thread = Thread(target=self.load)
+            thread.start()
+
+    def load_failed(self) -> bool:
+        return self._status == ModelWrapper.Status.FAILED
+
+    def should_load(self) -> bool:
+        # don't retry failed loads
+        return (
+            not self._load_lock.locked()
+            and not self._status == ModelWrapper.Status.FAILED
+            and not self.ready
+        )
+
+    def try_load(self):
         if "bundled_packages_dir" in self._config:
             bundled_packages_path = Path("/packages")
             if bundled_packages_path.exists():
@@ -39,28 +103,52 @@ class ModelWrapper(kfserving.KFModel):
         if _signature_accepts_keyword_arg(model_class_signature, "secrets"):
             model_init_params["secrets"] = SecretsResolver.get_secrets(self._config)
         self._model = model_class(**model_init_params)
+
         if hasattr(self._model, "load"):
             self._model.load()
-        self.ready = True
 
-    def preprocess(self, request: Dict) -> Dict:
+    def validate(self, payload):
+        if (
+            "instances" in payload
+            and not isinstance(payload["instances"], (list, np.ndarray))
+            or "inputs" in payload
+            and not isinstance(payload["inputs"], (list, np.ndarray))
+        ):
+            raise InvalidInput(
+                'Expected "instances" or "inputs" to be a list or NumPy ndarray'
+            )
+
+        return assign_request_to_inputs_instances_after_validation(payload)
+
+    def preprocess(
+        self,
+        payload: Union[Dict, CloudEvent, ModelInferRequest],
+        headers: Dict[str, str] = None,
+    ) -> Union[Dict, ModelInferRequest]:
         if not hasattr(self._model, "preprocess"):
-            return request
-        return self._model.preprocess(request)
+            return payload
+        return self._model.preprocess(payload)
 
-    def postprocess(self, request: Dict) -> Dict:
+    def postprocess(
+        self, response: Union[Dict, ModelInferResponse], headers: Dict[str, str] = None
+    ) -> Dict:
         if not hasattr(self._model, "postprocess"):
-            return request
-        return self._model.postprocess(request)
+            return response
+        return self._model.postprocess(response)
 
-    def predict(self, request: Dict) -> Dict[str, List]:
-        response = {}
+    def predict(
+        self, payload: Union[Dict, ModelInferRequest], headers: Dict[str, str] = None
+    ) -> Union[Dict, ModelInferResponse]:
         try:
-            return self._model.predict(request)
+            self._predict_lock.acquire()
+            return self._model.predict(payload)
         except Exception:
-            logging.error(traceback.format_exc())
+            response = {}
+            logging.exception("Exception while running predict")
             response["error"] = {"traceback": traceback.format_exc()}
             return response
+        finally:
+            self._predict_lock.release()
 
 
 def _signature_accepts_keyword_arg(signature: inspect.Signature, kwarg: str) -> bool:

--- a/truss/test_data/truss_container_fs/app/requirements.txt
+++ b/truss/test_data/truss_container_fs/app/requirements.txt
@@ -3,7 +3,7 @@
 argparse==1.4.0
 aiocontextvars==0.2.2
 cython==0.29.23
-kfserving==0.5.0
+kserve==0.10.0rc1
 msgpack-numpy==0.4.8
 msgpack==1.0.2
 python-json-logger==2.0.2


### PR DESCRIPTION
We were retrying if we couldn't connect to the inference server, but not when we could connect but the model wasn't ready. We do that now. The effect of this issue was that if model took a long time to load, then the requests until then would fail. This leads to a bad user experience when calling predict right after applying a patch for a slow loading model. This retry behavior is consistent with non-reloadable models, where, if the model is deploy via kserve or knative, the request would wait until the model is ready.

Please note that all files under `truss_container_fs` are auto-generated and can be ignored for this review. Added a test for this case as well.