### PR TITLE
Implement Truss Accelerator Spec

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.3.4"
+version = "0.3.5rc1"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/tests/test_config.py
+++ b/truss/tests/test_config.py
@@ -1,0 +1,70 @@
+import pytest
+from truss.truss_config import (
+    DEFAULT_CPU,
+    DEFAULT_MEMORY,
+    DEFAULT_USE_GPU,
+    Accelerator,
+    AcceleratorSpec,
+    Resources,
+)
+
+
+@pytest.mark.parametrize(
+    "input_dict, expect_resources, output_dict",
+    [
+        (
+            {},
+            Resources(),
+            {
+                "cpu": DEFAULT_CPU,
+                "memory": DEFAULT_MEMORY,
+                "use_gpu": DEFAULT_USE_GPU,
+                "accelerator": None,
+            },
+        ),
+        (
+            {"accelerator": None},
+            Resources(),
+            {
+                "cpu": DEFAULT_CPU,
+                "memory": DEFAULT_MEMORY,
+                "use_gpu": DEFAULT_USE_GPU,
+                "accelerator": None,
+            },
+        ),
+        (
+            {"accelerator": "V100"},
+            Resources(accelerator=AcceleratorSpec(Accelerator.V100, 1), use_gpu=True),
+            {
+                "cpu": DEFAULT_CPU,
+                "memory": DEFAULT_MEMORY,
+                "use_gpu": True,
+                "accelerator": "V100",
+            },
+        ),
+        (
+            {"accelerator": "T4:1"},
+            Resources(accelerator=AcceleratorSpec(Accelerator.T4, 1), use_gpu=True),
+            {
+                "cpu": DEFAULT_CPU,
+                "memory": DEFAULT_MEMORY,
+                "use_gpu": True,
+                "accelerator": "T4",
+            },
+        ),
+        (
+            {"accelerator": "A10G:4"},
+            Resources(accelerator=AcceleratorSpec(Accelerator.A10G, 4), use_gpu=True),
+            {
+                "cpu": DEFAULT_CPU,
+                "memory": DEFAULT_MEMORY,
+                "use_gpu": True,
+                "accelerator": "A10G:4",
+            },
+        ),
+    ],
+)
+def test_parse_resources(input_dict, expect_resources, output_dict):
+    parsed_result = Resources.from_dict(input_dict)
+    assert parsed_result == expect_resources
+    assert parsed_result.to_dict() == output_dict

--- a/truss/truss_config.py
+++ b/truss/truss_config.py
@@ -1,8 +1,10 @@
 from dataclasses import dataclass, field
+from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import yaml
+from truss.errors import ValidationError
 from truss.types import ModelFrameworkType
 from truss.validation import (
     validate_cpu_spec,
@@ -33,11 +35,47 @@ DEFAULT_TRAINING_CLASS_NAME = "Train"
 DEFAULT_TRAINING_MODULE_DIR = "train"
 
 
+class Accelerator(Enum):
+    T4 = "T4"
+    A10G = "A10G"
+    V100 = "V100"
+
+
+@dataclass
+class AcceleratorSpec:
+    accelerator: Optional[Accelerator] = None
+    count: int = 0
+
+    def to_str(self) -> Optional[str]:
+        if self.accelerator is None or self.count == 0:
+            return None
+        if self.count > 1:
+            return f"{self.accelerator.value}:{self.count}"
+        return self.accelerator.value
+
+    @staticmethod
+    def from_str(acc_spec: Optional[str]):
+        if acc_spec is None:
+            return AcceleratorSpec()
+        parts = acc_spec.split(":")
+        count = 1
+        if len(parts) not in [1, 2]:
+            raise ValidationError("`accelerator` does not match parsing requirements.")
+        if len(parts) == 2:
+            count = int(parts[1])
+        try:
+            acc = Accelerator[parts[0]]
+        except KeyError as exc:
+            raise ValidationError(f"Accelerator {acc_spec} not supported") from exc
+        return AcceleratorSpec(accelerator=acc, count=count)
+
+
 @dataclass
 class Resources:
     cpu: str = DEFAULT_CPU
     memory: str = DEFAULT_MEMORY
     use_gpu: bool = DEFAULT_USE_GPU
+    accelerator: AcceleratorSpec = AcceleratorSpec()
 
     @staticmethod
     def from_dict(d):
@@ -45,11 +83,16 @@ class Resources:
         validate_cpu_spec(cpu)
         memory = d.get("memory", DEFAULT_MEMORY)
         validate_memory_spec(memory)
+        accelerator = AcceleratorSpec.from_str((d.get("accelerator", None)))
+        use_gpu = d.get("use_gpu", DEFAULT_USE_GPU)
+        if accelerator.accelerator is not None:
+            use_gpu = True
 
         return Resources(
             cpu=cpu,
             memory=memory,
-            use_gpu=d.get("use_gpu", DEFAULT_USE_GPU),
+            use_gpu=use_gpu,
+            accelerator=accelerator,
         )
 
     def to_dict(self):
@@ -57,6 +100,7 @@ class Resources:
             "cpu": self.cpu,
             "memory": self.memory,
             "use_gpu": self.use_gpu,
+            "accelerator": self.accelerator.to_str(),
         }
 
 

--- a/truss/truss_config.py
+++ b/truss/truss_config.py
@@ -39,6 +39,7 @@ class Accelerator(Enum):
     T4 = "T4"
     A10G = "A10G"
     V100 = "V100"
+    A100 = "A100"
 
 
 @dataclass


### PR DESCRIPTION
## What

Currently, in Truss, we allow our users to specify a set of resources that are required to either train or serve their models. We expect the cloud provider to respect these resources when serving or training the models. One of these resources specifications is `use_gpu` which allows us to build the Docker image with the appropriate drivers pre-built into the image.

However, as we all know, not all GPUs are created equal. In fact, your selection for GPU determines how much GPU RAM you have, how fast the GPU is, and in fact if your training and serving job might even succeed. 

To resolve this need, we are introducing an accelerator field to the resources section of the truss config, inspired by [SkyPilot](https://github.com/skypilot-org/skypilot).

## Spec

Additional field to `config.yaml`:

```
resources:
  accelerator: A10G  # 1x NVIDIA A10G GPU T4 GPU
train:
  resources:
    accelerator: V100:4  # 4x NVIDIA V100 GPU
```

The above snippet illustrates how one can specify an accelerator in truss config. It is the job of the backend deploying or running the truss to respect these resources (just like any other resources that are specified there)

### Allowed Accelerators:

The following accelerators from Nvidia are supported in the initial version of spec

- `T4`
- `A10G`
- `V100`
- `A100`

If the accelerator is included, the backend may infer that `use_gpu` is `True` and to build the appropriate Dockerfile image as needed.

The backend will choose the appropriate instance that it supports based on the combinations of accelerator cpus and memory as needed.

### Accelerator Count:

Each accelerator type can be followed by `:n` to specific that the node should have access to n of that accelerator. If it’s omitted, then the count is assumed to be 1