### PR TITLE
Drop legacy Kserve input validation

### DIFF
--- a/truss/templates/server/common/truss_server.py
+++ b/truss/templates/server/common/truss_server.py
@@ -159,7 +159,6 @@ class TrussServer(kserve.ModelServer):
                 ),
             ],
             exception_handlers={
-                errors.InvalidInput: errors.invalid_input_handler,
                 errors.InferenceError: errors.inference_error_handler,
                 errors.ModelNotFound: errors.model_not_found_handler,
                 errors.ModelNotReady: errors.model_not_ready_handler,

--- a/truss/templates/server/common/util.py
+++ b/truss/templates/server/common/util.py
@@ -1,6 +1,3 @@
-from typing import Dict
-
-
 def model_supports_predict_proba(model: object) -> bool:
     if not hasattr(model, "predict_proba"):
         return False
@@ -13,12 +10,3 @@ def model_supports_predict_proba(model: object) -> bool:
         except AttributeError:
             return False
     return True
-
-
-def assign_request_to_inputs_instances_after_validation(body: Dict) -> dict:
-    # we will treat "instances" and "inputs" the same
-    if "instances" in body and "inputs" not in body:
-        body["inputs"] = body["instances"]
-    elif "inputs" in body and "instances" not in body:
-        body["instances"] = body["inputs"]
-    return body

--- a/truss/templates/server/model_wrapper.py
+++ b/truss/templates/server/model_wrapper.py
@@ -10,7 +10,6 @@ from typing import Dict, Optional, Union
 
 import kserve
 from cloudevents.http import CloudEvent
-from common.util import assign_request_to_inputs_instances_after_validation
 from kserve.grpc.grpc_predict_v2_pb2 import ModelInferRequest, ModelInferResponse
 from shared.secrets_resolver import SecretsResolver
 

--- a/truss/templates/server/model_wrapper.py
+++ b/truss/templates/server/model_wrapper.py
@@ -111,9 +111,6 @@ class ModelWrapper(kserve.Model):
         payload: Union[Dict, CloudEvent, ModelInferRequest],
         headers: Optional[Dict[str, str]] = None,
     ) -> Union[Dict, ModelInferRequest]:
-        # Do kserve validation pre-processing for backwards compatibility
-        payload = assign_request_to_inputs_instances_after_validation(payload)
-
         if not hasattr(self._model, "preprocess"):
             return payload
         return self._model.preprocess(payload)  # type: ignore

--- a/truss/test_data/truss_container_fs/app/common/truss_server.py
+++ b/truss/test_data/truss_container_fs/app/common/truss_server.py
@@ -159,7 +159,6 @@ class TrussServer(kserve.ModelServer):
                 ),
             ],
             exception_handlers={
-                errors.InvalidInput: errors.invalid_input_handler,
                 errors.InferenceError: errors.inference_error_handler,
                 errors.ModelNotFound: errors.model_not_found_handler,
                 errors.ModelNotReady: errors.model_not_ready_handler,

--- a/truss/test_data/truss_container_fs/app/common/util.py
+++ b/truss/test_data/truss_container_fs/app/common/util.py
@@ -10,12 +10,3 @@ def model_supports_predict_proba(model: object) -> bool:
         except AttributeError:
             return False
     return True
-
-
-def assign_request_to_inputs_instances_after_validation(body: dict) -> dict:
-    # we will treat "instances" and "inputs" the same
-    if "instances" in body and "inputs" not in body:
-        body["inputs"] = body["instances"]
-    elif "inputs" in body and "instances" not in body:
-        body["instances"] = body["inputs"]
-    return body

--- a/truss/test_data/truss_container_fs/app/model_wrapper.py
+++ b/truss/test_data/truss_container_fs/app/model_wrapper.py
@@ -10,7 +10,6 @@ from typing import Dict, Optional, Union
 
 import kserve
 from cloudevents.http import CloudEvent
-from common.util import assign_request_to_inputs_instances_after_validation
 from kserve.grpc.grpc_predict_v2_pb2 import ModelInferRequest, ModelInferResponse
 from shared.secrets_resolver import SecretsResolver
 

--- a/truss/test_data/truss_container_fs/app/model_wrapper.py
+++ b/truss/test_data/truss_container_fs/app/model_wrapper.py
@@ -111,9 +111,6 @@ class ModelWrapper(kserve.Model):
         payload: Union[Dict, CloudEvent, ModelInferRequest],
         headers: Optional[Dict[str, str]] = None,
     ) -> Union[Dict, ModelInferRequest]:
-        # Do kserve validation pre-processing for backwards compatibility
-        payload = assign_request_to_inputs_instances_after_validation(payload)
-
         if not hasattr(self._model, "preprocess"):
             return payload
         return self._model.preprocess(payload)  # type: ignore

--- a/truss/test_data/truss_container_fs/app/model_wrapper.py
+++ b/truss/test_data/truss_container_fs/app/model_wrapper.py
@@ -6,13 +6,11 @@ import traceback
 from enum import Enum
 from pathlib import Path
 from threading import Lock, Thread
-from typing import Dict, Union
+from typing import Dict, Optional, Union
 
 import kserve
-import numpy as np
 from cloudevents.http import CloudEvent
 from common.util import assign_request_to_inputs_instances_after_validation
-from kserve.errors import InvalidInput
 from kserve.grpc.grpc_predict_v2_pb2 import ModelInferRequest, ModelInferResponse
 from shared.secrets_resolver import SecretsResolver
 
@@ -26,14 +24,15 @@ class ModelWrapper(kserve.Model):
         READY = 2
         FAILED = 3
 
-    _config: dict
+    _config: Dict
     _model: object
     _load_lock: Lock = Lock()
     _predict_lock: Lock = Lock()
     _status: Status = Status.NOT_READY
     _logger: logging.Logger
+    ready: bool
 
-    def __init__(self, config: dict):
+    def __init__(self, config: Dict):
         super().__init__(MODEL_BASENAME)
         self._config = config
         self.logger = logging.getLogger(__name__)
@@ -107,41 +106,35 @@ class ModelWrapper(kserve.Model):
         if hasattr(self._model, "load"):
             self._model.load()
 
-    def validate(self, payload):
-        if (
-            "instances" in payload
-            and not isinstance(payload["instances"], (list, np.ndarray))
-            or "inputs" in payload
-            and not isinstance(payload["inputs"], (list, np.ndarray))
-        ):
-            raise InvalidInput(
-                'Expected "instances" or "inputs" to be a list or NumPy ndarray'
-            )
-
-        return assign_request_to_inputs_instances_after_validation(payload)
-
     def preprocess(
         self,
         payload: Union[Dict, CloudEvent, ModelInferRequest],
-        headers: Dict[str, str] = None,
+        headers: Optional[Dict[str, str]] = None,
     ) -> Union[Dict, ModelInferRequest]:
+        # Do kserve validation pre-processing for backwards compatibility
+        payload = assign_request_to_inputs_instances_after_validation(payload)
+
         if not hasattr(self._model, "preprocess"):
             return payload
-        return self._model.preprocess(payload)
+        return self._model.preprocess(payload)  # type: ignore
 
     def postprocess(
-        self, response: Union[Dict, ModelInferResponse], headers: Dict[str, str] = None
+        self,
+        response: Union[Dict, ModelInferResponse],
+        headers: Optional[Dict[str, str]] = None,
     ) -> Dict:
         if not hasattr(self._model, "postprocess"):
             return response
-        return self._model.postprocess(response)
+        return self._model.postprocess(response)  # type: ignore
 
     def predict(
-        self, payload: Union[Dict, ModelInferRequest], headers: Dict[str, str] = None
+        self,
+        payload: Union[Dict, ModelInferRequest],
+        headers: Optional[Dict[str, str]] = None,
     ) -> Union[Dict, ModelInferResponse]:
         try:
             self._predict_lock.acquire()
-            return self._model.predict(payload)
+            return self._model.predict(payload)  # type: ignore
         except Exception:
             response = {}
             logging.exception("Exception while running predict")

--- a/truss/tests/templates/core/server/common/test_util.py
+++ b/truss/tests/templates/core/server/common/test_util.py
@@ -1,28 +1,5 @@
 from unittest import mock
 
-from truss.templates.server.common.util import (
-    assign_request_to_inputs_instances_after_validation,
-)
-
-
-def test_assign_request_to_inputs_instances_after_validation():
-    inputs_input = [1, 2, 3, 4]
-    inputs_dict = {"inputs": inputs_input}
-    instances_input = [5, 6, 7, 8]
-    instances_dict = {"instances": instances_input}
-
-    processed_inputs = assign_request_to_inputs_instances_after_validation(inputs_dict)
-    processed_instances = assign_request_to_inputs_instances_after_validation(
-        instances_dict
-    )
-
-    assert processed_inputs["instances"] == processed_inputs["inputs"] == inputs_input
-    assert (
-        processed_instances["instances"]
-        == processed_instances["inputs"]
-        == instances_input
-    )
-
 
 def model_supports_predict_proba():
     mock_not_predict_proba = mock.Mock(name="mock_not_predict_proba")

--- a/truss/tests/test_truss_handle.py
+++ b/truss/tests/test_truss_handle.py
@@ -287,7 +287,7 @@ def test_docker_predict_secrets(custom_model_truss_dir_for_secrets):
     LocalConfigHandler.set_secret("secret_name", "secret_value")
     with ensure_kill_all():
         try:
-            result = th.docker_predict({"inputs": ["secret_name"]}, tag=tag)
+            result = th.docker_predict({"instances": ["secret_name"]}, tag=tag)
             assert result["predictions"][0] == "secret_value"
         finally:
             LocalConfigHandler.remove_secret("secret_name")


### PR DESCRIPTION
## What
Kserve expects that inputs with the `inputs` or `instances` keyword to match up to being either a list or a numpy array. However, since we have moved to allow truss users to specify the input type to their predict function in a very flexible way, this legacy kserve behavior is incompatible and gets in the user's way by returning opaque 400 errors.

This PR drops that input validation from kserve and passes the decoded input to the model's predict function directly. Any user errors are expected to return a 500 and to show the stacktrace in the logs of the service.