### PR TITLE
non-rc version bump

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 Release notes for new versions of Truss, in reverse chronological order.
 
+### Version 0.4.0
+
+This release updates the model invocation interface in Truss templates, affecting **only newly created Trusses**.
+
+Until now, when creating a Truss, the `predict()` function expected a dictionary with the key `inputs` and a value to give the model as input. This default behavior was due to a legacy requirement in Baseten that was removed months ago.
+
+Now, the default behavior is to use the input of `predict()` directly, which can be anything JSON-serializable: string, number, list, dictionary, etc. If you want, you can modify the `predict()` function to expect a dictionary with `inputs` like the old spec.
+
+Before (sklearn iris):
+
+```python
+model.predict({"inputs": [[0, 0, 0, 0]]})
+```
+
+Now (sklearn iris):
+
+```python
+model.predict([[0, 0, 0, 0]])
+```
+
+**This change does not affect existing Trusses.** Only new Trusses created on this version (i.e. by running `truss.create()` or `truss init`) will use the updated templates.
+
+### Version 0.3.0
+
+This version was created to support [blueprint](https://blueprint.baseten.co).
+
 ### Version 0.2.0
 
 With this release, a minor version increment recognizes the overall progress made on Truss since its initial release in Summer 2022. And simplified naming for key functions improves Truss' developer experience, while carefully considered warnings and a long deprecation period ensure nothing breaks.

--- a/docs/develop/processing.md
+++ b/docs/develop/processing.md
@@ -41,7 +41,7 @@ Here is a post-processing function from the same [TensorFlow example](../create/
 ```python
 from scipy.special import softmax
 
-def postprocess(self, model_output: Dict, k=5) -> Dict:
+def postprocess(self, model_output: Any, k=5) -> Any:
     """Post process step for ResNet"""
     class_predictions = model_output["predictions"][0]
     LABELS = requests.get(

--- a/docs/notebooks/tensorflow_example.ipynb
+++ b/docs/notebooks/tensorflow_example.ipynb
@@ -93,7 +93,7 @@
         "Finally, update the post-processing function to:\n",
         "\n",
         "```python\n",
-        "def postprocess(self, model_output: Dict, k=5) -> Dict:\n",
+        "def postprocess(self, model_output: Any, k=5) -> Any:\n",
         "    \"\"\"Post process step for ResNet\"\"\"\n",
         "    class_predictions = model_output[\"predictions\"][0]\n",
         "    LABELS = requests.get(\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.4.0rc1"
+version = "0.4.0"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION
After testing on Friday afternoon, we are confident the changes in Truss 0.4.0 are supported on Baseten and are ready to start the release process.

This PR also includes a couple small docs updates with the version bump.