### PR TITLE
make invocation backwards compatible

### DIFF
--- a/truss/templates/huggingface_transformer/model/model.py
+++ b/truss/templates/huggingface_transformer/model/model.py
@@ -43,7 +43,10 @@ class Model:
 
     def predict(self, model_input: Any) -> Any:
         model_output = {}
-        instances = model_input
+        if isinstance(model_input, dict) and "inputs" in model_input:
+            instances = model_input["inputs"]  # For backward compatability
+        else:
+            instances = model_input
 
         with torch.no_grad():
             if self._has_named_args:

--- a/truss/templates/keras/model/model.py
+++ b/truss/templates/keras/model/model.py
@@ -33,7 +33,10 @@ class Model:
 
     def predict(self, model_input: Any) -> Any:
         model_output = {}
-        inputs = np.array(model_input)
+        if isinstance(model_input, dict) and "inputs" in model_input:
+            inputs = np.array(model_input["inputs"])  # For backward compatability
+        else:
+            inputs = np.array(model_input)
         result = self._model.predict(inputs).tolist()
         model_output["predictions"] = result
         return model_output

--- a/truss/templates/lightgbm/model/model.py
+++ b/truss/templates/lightgbm/model/model.py
@@ -41,6 +41,8 @@ class Model:
 
     def predict(self, model_input: Any) -> Any:
         model_output = {}
+        if isinstance(model_input, dict) and "inputs" in model_input:
+            model_input = model_input["inputs"]  # For backward compatability
         result = self._model.predict(model_input)
         model_output["predictions"] = result
         if self._supports_predict_proba:

--- a/truss/templates/mlflow/model/model.py
+++ b/truss/templates/mlflow/model/model.py
@@ -32,7 +32,10 @@ class Model:
 
     def predict(self, model_input: Any) -> Any:
         model_output = {}
-        inputs = np.array(model_input)
+        if isinstance(model_input, dict) and "inputs" in model_input:
+            inputs = np.array(model_input["inputs"])  # For backward compatability
+        else:
+            inputs = np.array(model_input)
         result = self._model.predict(inputs).tolist()
         model_output["predictions"] = result
         return model_output

--- a/truss/templates/pytorch/model/model.py
+++ b/truss/templates/pytorch/model/model.py
@@ -42,6 +42,8 @@ class Model:
 
     def predict(self, model_input: Any) -> Any:
         model_output = {}
+        if isinstance(model_input, dict) and "inputs" in model_input:
+            model_input = model_input["inputs"]  # For backward compatability
         with torch.no_grad():
             inputs = torch.tensor(
                 model_input, dtype=self._model_dtype, device=self._device

--- a/truss/templates/sklearn/model/model.py
+++ b/truss/templates/sklearn/model/model.py
@@ -40,6 +40,8 @@ class Model:
 
     def predict(self, model_input: Any) -> Any:
         model_output = {}
+        if isinstance(model_input, dict) and "inputs" in model_input:
+            model_input = model_input["inputs"]  # For backward compatability
         result = self._model.predict(model_input)
         model_output["predictions"] = result
         if self._supports_predict_proba:

--- a/truss/templates/xgboost/model/model.py
+++ b/truss/templates/xgboost/model/model.py
@@ -47,6 +47,8 @@ class Model:
 
     def predict(self, model_input: Any) -> Any:
         model_output = {}
+        if isinstance(model_input, dict) and "inputs" in model_input:
+            model_input = model_input["inputs"]  # For backward compatability
         dmatrix_inputs = xgb.DMatrix(model_input)
         result = self._model.predict(dmatrix_inputs)
         model_output["predictions"] = result

--- a/truss/tests/conftest.py
+++ b/truss/tests/conftest.py
@@ -217,6 +217,26 @@ class Model:
         }
 """
 
+# Backward compatible pre 0.4.0
+COMPATIBLE_040_CUSTOM_MODEL_CODE = """
+class Model:
+     def load(*args, **kwargs):
+        pass
+
+     def postprocess(self, request):
+        # Adds 1 to all
+        return {
+            'predictions': [value + 1 for value in request['predictions']],
+        }
+
+     def predict(self, model_input):
+        if isinstance(model_input, dict) and "inputs" in model_input:
+            model_input = model_input["inputs"] # For backward compatability
+        return {
+            'predictions': model_input,
+        }
+"""
+
 
 # Doesn't implement postprocess
 NO_POSTPROCESS_CUSTOM_MODEL_CODE = """
@@ -325,6 +345,15 @@ def no_preprocess_custom_model(tmp_path):
         tmp_path,
         "my_no_preprocess_model",
         NO_PREPROCESS_CUSTOM_MODEL_CODE,
+    )
+
+
+@pytest.fixture
+def compatible_040_custom_model(tmp_path):
+    yield _custom_model_from_code(
+        tmp_path,
+        "compatible_040_model",
+        COMPATIBLE_040_CUSTOM_MODEL_CODE,
     )
 
 

--- a/truss/tests/test_truss_handle.py
+++ b/truss/tests/test_truss_handle.py
@@ -44,6 +44,18 @@ def test_predict(custom_model_truss_dir_with_pre_and_post):
     assert resp == {"predictions": [4, 5, 6, 7]}
 
 
+def test_predict_with_inputs_key(compatible_040_custom_model):
+    th = TrussHandle(compatible_040_custom_model)
+    result = th.server_predict({"inputs": [1]})
+    assert result["predictions"][0] == 2
+
+
+def test_predict_with_instances_key(compatible_040_custom_model):
+    th = TrussHandle(compatible_040_custom_model)
+    result = th.server_predict({"instances": [1]})
+    assert result["predictions"][0] == 2
+
+
 def test_predict_with_external_packages(custom_model_with_external_package):
     th = TrussHandle(custom_model_with_external_package)
     resp = th.predict([1, 2, 3, 4])


### PR DESCRIPTION
Just to take a look at if we wanted to make this inputs change backwards-compatible by making the inputs key optional.

This could serve as a kind of deprecation period before removing it entirely? I just worry that to a new truss user, this makes what was otherwise a straightforward template have a confusion point.