### PR TITLE
Ignore pycache files for live reload patching

### DIFF
--- a/truss/tests/patch/test_patch.py
+++ b/truss/tests/patch/test_patch.py
@@ -94,6 +94,22 @@ def test_calc_truss_patch_update_file(custom_model_truss_dir: Path):
     )
 
 
+def test_calc_truss_ignore_pycache(custom_model_truss_dir: Path):
+    prev_sign = calc_truss_signature(custom_model_truss_dir)
+    top_pycache_path = custom_model_truss_dir / "__pycache__"
+    top_pycache_path.mkdir()
+    (top_pycache_path / "bla.pyc").touch()
+    model_pycache_path = custom_model_truss_dir / "model" / "__pycache__"
+    model_pycache_path.mkdir()
+    (model_pycache_path / "foo.pyo").touch()
+
+    patches = calc_truss_patch(
+        custom_model_truss_dir,
+        prev_sign,
+    )
+    assert len(patches) == 0
+
+
 def test_calc_config_patches_add_python_requirement(custom_model_truss_dir: Path):
     patches = _apply_config_change_and_calc_patches(
         custom_model_truss_dir,

--- a/truss/tests/test_truss_handle.py
+++ b/truss/tests/test_truss_handle.py
@@ -691,6 +691,15 @@ class Model:
         th.remove_system_package(pkg)
         return th.docker_predict([1], tag=tag, binary=binary)
 
+    def predict_with_ignored_changes():
+        top_pycache_path = custom_model_control / "__pycache__"
+        top_pycache_path.mkdir()
+        (top_pycache_path / "bla.pyc").touch()
+        model_pycache_path = custom_model_control / "model" / "__pycache__"
+        model_pycache_path.mkdir()
+        (model_pycache_path / "foo.pyc").touch()
+        return th.docker_predict([1], tag=tag, binary=binary)
+
     def current_num_docker_images() -> int:
         return len(th.get_all_docker_images())
 
@@ -732,6 +741,10 @@ class Model:
         _verify_system_requirement_not_installed_on_container(container, system_pkg)
 
         result = predict_with_unpatchable_change()
+        assert result[0] == 2
+        assert current_num_docker_images() == orig_num_truss_images + 1
+
+        result = predict_with_ignored_changes()
         assert result[0] == 2
         assert current_num_docker_images() == orig_num_truss_images + 1
 


### PR DESCRIPTION
Pycache files have been very problematic with live reload as their creation makes the Truss change in a way that we don't allow patching. We ignore them now, as we should.
We ignore pycache files at any level. I had to use two patterns to match pycache directories as well as files inside of them. Open to ideas on how to achieve this with a single glob pattern, the few things I tried didn't work.