### PR TITLE
Add PR Coverage comment to pull requests

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -42,8 +42,10 @@ jobs:
       - run: poetry install
       - name: run tests (poetry run pytest...)
         run: poetry run pytest -v --cov=truss -m 'not integration' > pytest-coverage.txt
-      - name: Comment coverage
-        uses: coroo/pytest-coverage-commentator@v1.0.2
+      - name: Pytest coverage comment
+        uses: MishaKav/pytest-coverage-comment@main
+        with:
+          pytest-coverage-path: ./pytest-coverage.txt
 
   markdown-link-check:
     runs-on: ubuntu-20.04

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -41,11 +41,12 @@ jobs:
       - uses: ./.github/actions/setup-python/
       - run: poetry install
       - name: run tests (poetry run pytest...)
-        run: poetry run pytest -v --cov=truss -m 'not integration' > pytest-coverage.txt
+        run: poetry run pytest --junitxml=pytest.xml --cov-report=term-missing:skip-covered  -v --cov=truss -m 'not integration' | tee pytest-coverage.txt
       - name: Pytest coverage comment
         uses: MishaKav/pytest-coverage-comment@main
         with:
           pytest-coverage-path: ./pytest-coverage.txt
+          junitxml-path: ./pytest.xml
 
   markdown-link-check:
     runs-on: ubuntu-20.04

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -41,12 +41,9 @@ jobs:
       - uses: ./.github/actions/setup-python/
       - run: poetry install
       - name: run tests (poetry run pytest...)
-        run: poetry run pytest -v --cov=truss -m 'not integration'
-      - name: Coverage comment
-        id: coverage_comment
-        uses: py-cov-action/python-coverage-comment-action@v3
-        with:
-          GITHUB_TOKEN: ${{ github.token }}
+        run: poetry run pytest -v --cov=truss -m 'not integration' > pytest-coverage.txt
+      - name: Comment coverage
+        uses: coroo/pytest-coverage-commentator@v1.0.2
 
   markdown-link-check:
     runs-on: ubuntu-20.04

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -41,12 +41,18 @@ jobs:
       - uses: ./.github/actions/setup-python/
       - run: poetry install
       - name: run tests (poetry run pytest...)
-        run: poetry run pytest --junitxml=pytest.xml --cov-report=term-missing:skip-covered  -v --cov=truss -m 'not integration' | tee pytest-coverage.txt
-      - name: Pytest coverage comment
-        uses: MishaKav/pytest-coverage-comment@main
+        run: poetry run pytest --junitxml=pytest.xml --cov-report xml:./cov.xml  -v --cov=truss -m 'not integration'
+      # - name: Pytest coverage comment
+      #   uses: MishaKav/pytest-coverage-comment@main
+      #   with:
+      #     pytest-coverage-path: ./pytest-coverage.txt
+      #     junitxml-path: ./pytest.xml
+
+      - name: Post coverage diff
+        uses: orgoro/coverage@v3
         with:
-          pytest-coverage-path: ./pytest-coverage.txt
-          junitxml-path: ./pytest.xml
+            coverageFile: ./cov.xml
+            token: ${{ secrets.GITHUB_TOKEN }}
 
   markdown-link-check:
     runs-on: ubuntu-20.04

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
     paths:
       - poetry.lock
-      - pyproject.yaml
+      - pyproject.toml
       - "truss/**"
       - "docs/**"
       - .github/workflows/pr.yml
@@ -42,6 +42,11 @@ jobs:
       - run: poetry install
       - name: run tests (poetry run pytest...)
         run: poetry run pytest -v --cov=truss -m 'not integration'
+      - name: Coverage comment
+        id: coverage_comment
+        uses: py-cov-action/python-coverage-comment-action@v3
+        with:
+          GITHUB_TOKEN: ${{ github.token }}
 
   markdown-link-check:
     runs-on: ubuntu-20.04

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,8 +56,6 @@ kserve = "0.10.0rc1"
 isort = "^5.10.1"
 flake8 = "^4.0.1"
 ipdb = "^0.13.9"
-coverage = "^6.4.1"
-pytest-cov = "^3.0.0"
 xgboost = "^1.6.1"
 lightgbm = "^3.3.2"
 transformers = "^4.20.1"
@@ -73,6 +71,8 @@ truss = 'truss.cli:cli_group'
 [tool.poetry.group.dev.dependencies]
 mlflow = "^1.29.0"
 mypy = "^1.0.0"
+coverage = {extras = ["toml"], version = "^7.2.2"}
+pytest-cov = "^4.0.0"
 
 [build-system]
 requires = ["poetry-core>=1.2.1"]
@@ -85,3 +85,6 @@ src_paths = ["isort", "test"]
 [tool.mypy]
 python_version = 3.8
 ignore_missing_imports = true
+
+[tool.coverage.run]
+relative_files = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,8 @@ kserve = "0.10.0rc1"
 isort = "^5.10.1"
 flake8 = "^4.0.1"
 ipdb = "^0.13.9"
+coverage = "^6.4.1"
+pytest-cov = "^3.0.0"
 xgboost = "^1.6.1"
 lightgbm = "^3.3.2"
 transformers = "^4.20.1"
@@ -71,8 +73,6 @@ truss = 'truss.cli:cli_group'
 [tool.poetry.group.dev.dependencies]
 mlflow = "^1.29.0"
 mypy = "^1.0.0"
-coverage = {extras = ["toml"], version = "^7.2.2"}
-pytest-cov = "^4.0.0"
 
 [build-system]
 requires = ["poetry-core>=1.2.1"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,3 @@ src_paths = ["isort", "test"]
 [tool.mypy]
 python_version = 3.8
 ignore_missing_imports = true
-
-[tool.coverage.run]
-relative_files = true


### PR DESCRIPTION
We already have coverage reports through `pytest-cov`. This PR simply reports that to the user so that they know where they stand.

First message is using [this action](https://github.com/marketplace/actions/pytest-coverage-comment). There are a few configs worth playing with:
- `report-only-changed-files`: default false. 
- `hide-report`: default false (is too verbose?)
- `hide-badge`

Second message is using [this one](https://github.com/marketplace/actions/python-coverage)