### PR TITLE
Drop docker run from non-integration tests

### DIFF
--- a/truss/utils.py
+++ b/truss/utils.py
@@ -18,6 +18,13 @@ def copy_file_path(src: Path, dest: Path) -> Tuple[str, str]:
     return copy_file(str(src), str(dest))
 
 
+def copy_path(src: Path, dest: Path):
+    if src.is_file():
+        copy_file(src, dest)
+    else:
+        copy_tree_path(src, dest)
+
+
 def remove_tree_path(target: Path) -> None:
     return remove_tree(str(target))
 


### PR DESCRIPTION
Yesterday, we dropped `truss_container_fs`. Today, we do the same thing but much faster, by avoiding docker all together. 

We don't need to run the docker build since we're just copying files from the context (as opposed to downloaded requirements or effects of the RUN statements).

I tried to do this while testings as much code as possible by:
1. Using `ServingImageBuilder` to prepare the context and template out the Dockerfile
2. Extract the relevant COPY statements from the Dockerfil.e

Looking forward to your feedback!