### PR TITLE
Install tar for the truss-context-builder

### DIFF
--- a/context_builder.Dockerfile
+++ b/context_builder.Dockerfile
@@ -4,7 +4,7 @@
 # docker buildx build . -f context_builder.Dockerfile --platform=linux/amd64 -t baseten/truss-context-builder
 FROM python:3.9-alpine
 
-RUN apk add curl bash --no-cache
+RUN apk add curl bash tar --no-cache
 
 RUN curl -sSL https://install.python-poetry.org | python -
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.4.1"
+version = "0.4.2"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION
we realised that the version of tar that is packaged with python3.9-alpine doesn’t automatically pick up all types of compression, adding the gnu tar does