### PR TITLE
Ignore irrelevant changes for live-reload

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.4.2"
+version = "0.4.3"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION
Focus on changes relevant to serving the Truss; ignore the rest. Earlier strategy was too aggressive, we would only allow live-reload if there were explicit support for patching a change. This meant that additions of anything at the root level, such as `README.md`, changes under `.git` and such will result in a full deploy.

We now identify the places that we know can affect Truss serving. For those places, we check if can patch or not. Any changes outside of those places are assumed to have no effect on serving and are ignored. Effectively, we're saying that those changes are patchable, it's just that the patch is a no-op from the point of view of serving, and ignoring them serves the purpose.