### PR TITLE
custom base image support

### DIFF
--- a/bin/generate_base_images.py
+++ b/bin/generate_base_images.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import List, Optional, Set
 
 from jinja2 import Environment, FileSystemLoader
+from truss.constants import TRUSS_BUILD_DOCKERFILE_TEMPLATE_NAME
 from truss.contexts.image_builder.util import (
     truss_base_image_name,
     truss_base_image_tag,
@@ -54,12 +55,14 @@ def _render_dockerfile(
     jinja_env = Environment(
         loader=FileSystemLoader(str(base_path / "docker" / "base_images")),
     )
+    truss_build_template_path = TRUSS_BUILD_DOCKERFILE_TEMPLATE_NAME
     template = jinja_env.get_template("base_image.Dockerfile.jinja")
     return template.render(
         use_gpu=use_gpu,
         live_reload=live_reload,
         job_type=job_type,
         python_version=python_version,
+        truss_build_template_path=truss_build_template_path,
     )
 
 

--- a/docker/base_images/base_image.Dockerfile.jinja
+++ b/docker/base_images/base_image.Dockerfile.jinja
@@ -1,74 +1,26 @@
 {% if use_gpu %}
-FROM nvidia/cuda:11.2.1-base-ubuntu18.04
-ENV CUDNN_VERSION=8.1.0.77
-ENV CUDA=11.2
-ENV LD_LIBRARY_PATH /usr/local/cuda/extras/CUPTI/lib64:$LD_LIBRARY_PATH
+    FROM nvidia/cuda:11.2.1-base-ubuntu18.04
+    ENV CUDNN_VERSION=8.1.0.77
+    ENV CUDA=11.2
+    ENV LD_LIBRARY_PATH /usr/local/cuda/extras/CUPTI/lib64:$LD_LIBRARY_PATH
 
-RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub && \
-    apt-get update && apt-get install -y --no-install-recommends \
-        ca-certificates \
-        cuda-command-line-tools-11-2 \
-        libcublas-11-2 \
-        libcublas-dev-11-2 \
-        libcufft-11-2 \
-        libcurand-11-2 \
-        libcusolver-11-2 \
-        libcusparse-11-2 \
-        libcudnn8=${CUDNN_VERSION}-1+cuda${CUDA} \
-        libgomp1 \
-        && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
-# Allow statements and log messages to immediately appear in the Knative logs
-ENV PYTHONUNBUFFERED True
-ENV DEBIAN_FRONTEND=noninteractive
-
-RUN apt update && \
-    apt install -y bash \
-                   build-essential \
-                   git \
-                   curl \
-                   ca-certificates \
-                   software-properties-common && \
-    add-apt-repository -y ppa:deadsnakes/ppa && \
-    apt update -y && \
-    apt install -y python{{python_version}} && \
-    apt install -y python{{python_version}}-distutils && \
-    apt install -y python{{python_version}}-venv && \
-    rm -rf /var/lib/apt/lists
-
-RUN ln -sf /usr/bin/python{{python_version}} /usr/bin/python3 && \
-    curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
-    python3 get-pip.py
-
-RUN python3 -m pip install --no-cache-dir --upgrade pip
-
+    RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub && \
+        apt-get update && apt-get install -y --no-install-recommends \
+            ca-certificates \
+            cuda-command-line-tools-11-2 \
+            libcublas-11-2 \
+            libcublas-dev-11-2 \
+            libcufft-11-2 \
+            libcurand-11-2 \
+            libcusolver-11-2 \
+            libcusparse-11-2 \
+            libcudnn8=${CUDNN_VERSION}-1+cuda${CUDA} \
+            libgomp1 \
+            && \
+        apt-get clean && \
+        rm -rf /var/lib/apt/lists/*
 {% else %}
-FROM python:{{python_version}}
-RUN apt update && apt install -y
-
-# Allow statements and log messages to immediately appear in the Knative logs
-ENV PYTHONUNBUFFERED True
+    FROM python:{{python_version}}
 {% endif %}
 
-
-RUN pip install --no-cache-dir --upgrade pip \
-    && rm -rf /root/.cache/pip
-
-COPY ./requirements.txt requirements.txt
-RUN pip install --no-cache-dir -r requirements.txt \
-    && rm -rf /root/.cache/pip
-
-# This is a hack, kfserving uses table_logger, which doesn't work well with
-# numpy 1.24 onwards, where np.float and np.int have been remove.
-# https://github.com/AleksTk/table-logger/blob/v0.3.6/table_logger/table_logger.py#L80
-# Monkey patch table_logger here. Ultimately we should move away from kfserving,
-# perhaps to kserve.
-RUN find /usr/local/lib/ -name table_logger.py -exec sed -i '/np\.int:/d;/np\.float:/d' {} \;
-
-{% if live_reload %}
-COPY ./control /control
-RUN python3 -m venv /control/.env \
-    && /control/.env/bin/pip3 install -r /control/requirements.txt
-{% endif %}
+{% include truss_build_template_path %}

--- a/truss/constants.py
+++ b/truss/constants.py
@@ -35,6 +35,7 @@ SERVER_REQUIREMENTS_TXT_FILENAME = "server_requirements.txt"
 TRAINING_REQUIREMENTS_TXT_FILENAME = "training_requirements.txt"
 SYSTEM_PACKAGES_TXT_FILENAME = "system_packages.txt"
 
+TRUSS_BUILD_DOCKERFILE_TEMPLATE_NAME = "_truss_build.Dockerfile.jinja"
 SERVER_DOCKERFILE_TEMPLATE_NAME = "server.Dockerfile.jinja"
 TRAINING_DOCKERFILE_TEMPLATE_NAME = "training.Dockerfile.jinja"
 MODEL_DOCKERFILE_NAME = "Dockerfile"

--- a/truss/contexts/image_builder/image_builder.py
+++ b/truss/contexts/image_builder/image_builder.py
@@ -12,6 +12,7 @@ class ImageBuilder(ABC):
         build_dir: Optional[Path] = None,
         tag: Optional[str] = None,
         labels: Optional[dict] = None,
+        cache: bool = True,
     ):
         """Build image.
 
@@ -27,6 +28,7 @@ class ImageBuilder(ABC):
                 str(build_dir_path),
                 labels=labels if labels else {},
                 tags=tag or self.default_tag,
+                cache=cache,
             )
 
     @property

--- a/truss/contexts/image_builder/serving_image_builder.py
+++ b/truss/contexts/image_builder/serving_image_builder.py
@@ -110,15 +110,18 @@ class ServingImageBuilder(ImageBuilder):
         dockerfile_template = read_template_from_fs(
             TEMPLATES_DIR, SERVER_DOCKERFILE_TEMPLATE_NAME
         )
-        base_image_name = truss_base_image_name(job_type="server")
         python_version = to_dotted_python_version(config.python_version)
-        tag = truss_base_image_tag(
-            python_version=python_version,
-            use_gpu=config.resources.use_gpu,
-            live_reload=config.live_reload,
-            version_tag=TRUSS_BASE_IMAGE_VERSION_TAG,
-        )
-        base_image_name_and_tag = f"{base_image_name}:{tag}"
+        if config.base_image:
+            base_image_name_and_tag = config.base_image
+        else:
+            base_image_name = truss_base_image_name(job_type="server")
+            tag = truss_base_image_tag(
+                python_version=python_version,
+                use_gpu=config.resources.use_gpu,
+                live_reload=config.live_reload,
+                version_tag=TRUSS_BASE_IMAGE_VERSION_TAG,
+            )
+            base_image_name_and_tag = f"{base_image_name}:{tag}"
         should_install_system_requirements = file_is_not_empty(
             build_dir / SYSTEM_PACKAGES_TXT_FILENAME
         )
@@ -131,6 +134,8 @@ class ServingImageBuilder(ImageBuilder):
             should_install_system_requirements=should_install_system_requirements,
             should_install_requirements=should_install_python_requirements,
             config=config,
+            python_version=python_version,
+            live_reload=config.live_reload,
             data_dir_exists=data_dir.exists(),
             bundled_packages_dir_exists=bundled_packages_dir.exists(),
             truss_hash=directory_content_hash(self._truss_dir),

--- a/truss/contexts/image_builder/serving_image_builder.py
+++ b/truss/contexts/image_builder/serving_image_builder.py
@@ -13,6 +13,7 @@ from truss.constants import (
     SHARED_SERVING_AND_TRAINING_CODE_DIR_NAME,
     SYSTEM_PACKAGES_TXT_FILENAME,
     TEMPLATES_DIR,
+    TRUSS_BUILD_DOCKERFILE_TEMPLATE_NAME,
 )
 from truss.contexts.image_builder.image_builder import ImageBuilder
 from truss.contexts.image_builder.util import (
@@ -110,6 +111,7 @@ class ServingImageBuilder(ImageBuilder):
         dockerfile_template = read_template_from_fs(
             TEMPLATES_DIR, SERVER_DOCKERFILE_TEMPLATE_NAME
         )
+        truss_build_template_path = TRUSS_BUILD_DOCKERFILE_TEMPLATE_NAME
         python_version = to_dotted_python_version(config.python_version)
         if config.base_image:
             base_image_name_and_tag = config.base_image
@@ -134,6 +136,7 @@ class ServingImageBuilder(ImageBuilder):
             should_install_system_requirements=should_install_system_requirements,
             should_install_requirements=should_install_python_requirements,
             config=config,
+            truss_build_template_path=truss_build_template_path,
             python_version=python_version,
             live_reload=config.live_reload,
             data_dir_exists=data_dir.exists(),

--- a/truss/contexts/image_builder/training_image_builder.py
+++ b/truss/contexts/image_builder/training_image_builder.py
@@ -13,6 +13,7 @@ from truss.constants import (
     TRAINING_JOB_WRAPPER_CODE_DIR,
     TRAINING_JOB_WRAPPER_CODE_DIR_NAME,
     TRAINING_REQUIREMENTS_TXT_FILENAME,
+    TRUSS_BUILD_DOCKERFILE_TEMPLATE_NAME,
 )
 from truss.contexts.image_builder.image_builder import ImageBuilder
 from truss.contexts.image_builder.util import (
@@ -92,6 +93,7 @@ class TrainingImageBuilder(ImageBuilder):
         dockerfile_template = template_env.get_template(
             TRAINING_DOCKERFILE_TEMPLATE_NAME
         )
+        truss_build_template_path = TRUSS_BUILD_DOCKERFILE_TEMPLATE_NAME
         should_install_system_requirements = file_is_not_empty(
             build_dir / SYSTEM_PACKAGES_TXT_FILENAME
         )
@@ -114,6 +116,7 @@ class TrainingImageBuilder(ImageBuilder):
         dockerfile_contents = dockerfile_template.render(
             base_image_name_and_tag=base_image_name_and_tag,
             config=self._spec.config,
+            truss_build_template_path=truss_build_template_path,
             python_version=python_version,
             live_reload=config.live_reload,
             bundled_packages_dir_exists=bundled_packages_dir_exists,

--- a/truss/contexts/image_builder/training_image_builder.py
+++ b/truss/contexts/image_builder/training_image_builder.py
@@ -99,17 +99,23 @@ class TrainingImageBuilder(ImageBuilder):
             build_dir / REQUIREMENTS_TXT_FILENAME
         )
         config = self._spec.config
-        base_image_name = truss_base_image_name(job_type="training")
-        tag = truss_base_image_tag(
-            python_version=to_dotted_python_version(config.python_version),
-            use_gpu=config.resources.use_gpu,
-            live_reload=config.live_reload,
-            version_tag=TRUSS_BASE_IMAGE_VERSION_TAG,
-        )
-        base_image_name_and_tag = f"{base_image_name}:{tag}"
+        python_version = to_dotted_python_version(config.python_version)
+        if config.base_image:
+            base_image_name_and_tag = config.base_image
+        else:
+            base_image_name = truss_base_image_name(job_type="training")
+            tag = truss_base_image_tag(
+                python_version=python_version,
+                use_gpu=config.resources.use_gpu,
+                live_reload=config.live_reload,
+                version_tag=TRUSS_BASE_IMAGE_VERSION_TAG,
+            )
+            base_image_name_and_tag = f"{base_image_name}:{tag}"
         dockerfile_contents = dockerfile_template.render(
             base_image_name_and_tag=base_image_name_and_tag,
             config=self._spec.config,
+            python_version=python_version,
+            live_reload=config.live_reload,
             bundled_packages_dir_exists=bundled_packages_dir_exists,
             should_install_system_requirements=should_install_system_requirements,
             should_install_requirements=should_install_requirements,

--- a/truss/templates/_truss_build.Dockerfile.jinja
+++ b/truss/templates/_truss_build.Dockerfile.jinja
@@ -1,0 +1,50 @@
+{% if use_gpu %}
+    # Allow statements and log messages to immediately appear in the Knative logs
+    ENV PYTHONUNBUFFERED True
+    ENV DEBIAN_FRONTEND=noninteractive
+
+    RUN apt update && \
+        apt install -y bash \
+                    build-essential \
+                    git \
+                    curl \
+                    ca-certificates \
+                    software-properties-common && \
+        add-apt-repository -y ppa:deadsnakes/ppa && \
+        apt update -y && \
+        apt install -y python{{python_version}} && \
+        apt install -y python{{python_version}}-distutils && \
+        apt install -y python{{python_version}}-venv && \
+        rm -rf /var/lib/apt/lists
+
+    RUN ln -sf /usr/bin/python{{python_version}} /usr/bin/python3 && \
+        curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
+        python3 get-pip.py
+
+    RUN python3 -m pip install --no-cache-dir --upgrade pip
+{% else %}
+    RUN apt update && apt install -y
+
+    # Allow statements and log messages to immediately appear in the Knative logs
+    ENV PYTHONUNBUFFERED True
+{% endif %}
+
+RUN pip install --no-cache-dir --upgrade pip \
+    && rm -rf /root/.cache/pip
+
+COPY ./requirements.txt requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt \
+    && rm -rf /root/.cache/pip
+
+# This is a hack, kfserving uses table_logger, which doesn't work well with
+# numpy 1.24 onwards, where np.float and np.int have been remove.
+# https://github.com/AleksTk/table-logger/blob/v0.3.6/table_logger/table_logger.py#L80
+# Monkey patch table_logger here. Ultimately we should move away from kfserving,
+# perhaps to kserve.
+RUN find /usr/local/lib/ -name table_logger.py -exec sed -i '/np\.int:/d;/np\.float:/d' {} \;
+
+{% if live_reload %}
+COPY ./control /control
+RUN python3 -m venv /control/.env \
+    && /control/.env/bin/pip3 install -r /control/requirements.txt
+{% endif %}

--- a/truss/templates/base.Dockerfile.jinja
+++ b/truss/templates/base.Dockerfile.jinja
@@ -1,6 +1,7 @@
 ARG PYVERSION={{config.python_version}}
 FROM {{base_image_name_and_tag}}
 
+{% if config.base_image %}
 {% block rebuild_base %}
 {% if use_gpu %}
 # Allow statements and log messages to immediately appear in the Knative logs
@@ -60,6 +61,7 @@ RUN major=$(python -c"import sys; print(sys.version_info.major)") && [ $major -e
 RUN minor=$(python -c"import sys; print(sys.version_info.minor)") && [ $minor -ge 8 && $minor -le 10 ] || { echo "WARNING: Supplied base image does not have 3.8 <= python <= 3.10"; unset minor; }
 {% endblock %}
 {% endblock %}
+{% endif %}
 
 RUN pip install --upgrade pip --no-cache-dir \
     && rm -rf /root/.cache/pip

--- a/truss/templates/base.Dockerfile.jinja
+++ b/truss/templates/base.Dockerfile.jinja
@@ -2,9 +2,10 @@ ARG PYVERSION={{config.python_version}}
 FROM {{base_image_name_and_tag}}
 
 {% block fail_fast %}
-        RUN grep -w ID=debian /etc/os-release || { echo "Supplied base image is not a debian image"; exit 1; }
-        RUN major=$(python -c"import sys; print(sys.version_info.major)") &&  [ $major = 3 ]  || { echo "ERROR: Supplied base image does not have python3"; unset major; exit 1; }
-        RUN minor=$(python -c"import sys; print(sys.version_info.minor)") && [ $minor >= 8] && [ $minor <= 10 ] || { echo "WARNING: Supplied base image does not have 3.8 <= python <= 3.10"; unset minor; }
+        RUN grep -w 'ID=debian\|ID_LIKE=debian' /etc/os-release || { echo "ERROR: Supplied base image is not a debian image"; exit 1; }
+        RUN which python && python --version | grep -E '3\.[0-9]|10\.[0-9][0-9]' || \
+            which python3 && python3 --version | grep -E '3\.[0-9]|10\.[0-9][0-9]' || \
+            { echo "ERROR: Supplied base image does not have 3.8 <= python <= 3.10"; exit 1; }
 {% endblock %}
 
 {% if config.base_image %}

--- a/truss/templates/base.Dockerfile.jinja
+++ b/truss/templates/base.Dockerfile.jinja
@@ -1,65 +1,14 @@
 ARG PYVERSION={{config.python_version}}
 FROM {{base_image_name_and_tag}}
 
-{% if config.base_image %}
-    {% block fail_fast %}
+{% block fail_fast %}
         RUN grep -w ID=debian /etc/os-release || { echo "Supplied base image is not a debian image"; exit 1; }
         RUN major=$(python -c"import sys; print(sys.version_info.major)") &&  [ $major = 3 ]  || { echo "ERROR: Supplied base image does not have python3"; unset major; exit 1; }
         RUN minor=$(python -c"import sys; print(sys.version_info.minor)") && [ $minor >= 8] && [ $minor <= 10 ] || { echo "WARNING: Supplied base image does not have 3.8 <= python <= 3.10"; unset minor; }
-    {% endblock %}
+{% endblock %}
 
-    {% block rebuild_base %}
-        {% if use_gpu %}
-            # Allow statements and log messages to immediately appear in the Knative logs
-            ENV PYTHONUNBUFFERED True
-            ENV DEBIAN_FRONTEND=noninteractive
-
-            RUN apt update && \
-                apt install -y bash \
-                            build-essential \
-                            git \
-                            curl \
-                            ca-certificates \
-                            software-properties-common && \
-                add-apt-repository -y ppa:deadsnakes/ppa && \
-                apt update -y && \
-                apt install -y python{{python_version}} && \
-                apt install -y python{{python_version}}-distutils && \
-                apt install -y python{{python_version}}-venv && \
-                rm -rf /var/lib/apt/lists
-
-            RUN ln -sf /usr/bin/python{{python_version}} /usr/bin/python3 && \
-                curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
-                python3 get-pip.py
-
-            RUN python3 -m pip install --no-cache-dir --upgrade pip
-        {% else %}
-            RUN apt update && apt install -y
-
-            # Allow statements and log messages to immediately appear in the Knative logs
-            ENV PYTHONUNBUFFERED True
-        {% endif %}
-
-        RUN pip install --no-cache-dir --upgrade pip \
-            && rm -rf /root/.cache/pip
-
-        COPY ./requirements.txt requirements.txt
-        RUN pip install --no-cache-dir -r requirements.txt \
-            && rm -rf /root/.cache/pip
-
-        # This is a hack, kfserving uses table_logger, which doesn't work well with
-        # numpy 1.24 onwards, where np.float and np.int have been remove.
-        # https://github.com/AleksTk/table-logger/blob/v0.3.6/table_logger/table_logger.py#L80
-        # Monkey patch table_logger here. Ultimately we should move away from kfserving,
-        # perhaps to kserve.
-        RUN find /usr/local/lib/ -name table_logger.py -exec sed -i '/np\.int:/d;/np\.float:/d' {} \;
-
-        {% if live_reload %}
-        COPY ./control /control
-        RUN python3 -m venv /control/.env \
-            && /control/.env/bin/pip3 install -r /control/requirements.txt
-        {% endif %}
-    {% endblock %}
+{% if config.base_image %}
+    {% include truss_build_template_path %}
 {% endif %}
 
 RUN pip install --upgrade pip --no-cache-dir \

--- a/truss/templates/base.Dockerfile.jinja
+++ b/truss/templates/base.Dockerfile.jinja
@@ -1,6 +1,66 @@
 ARG PYVERSION={{config.python_version}}
 FROM {{base_image_name_and_tag}}
 
+{% block rebuild_base %}
+{% if use_gpu %}
+# Allow statements and log messages to immediately appear in the Knative logs
+ENV PYTHONUNBUFFERED True
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt update && \
+    apt install -y bash \
+                   build-essential \
+                   git \
+                   curl \
+                   ca-certificates \
+                   software-properties-common && \
+    add-apt-repository -y ppa:deadsnakes/ppa && \
+    apt update -y && \
+    apt install -y python{{python_version}} && \
+    apt install -y python{{python_version}}-distutils && \
+    apt install -y python{{python_version}}-venv && \
+    rm -rf /var/lib/apt/lists
+
+RUN ln -sf /usr/bin/python{{python_version}} /usr/bin/python3 && \
+    curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
+    python3 get-pip.py
+
+RUN python3 -m pip install --no-cache-dir --upgrade pip
+{% else %}
+FROM python:{{python_version}}
+RUN apt update && apt install -y
+
+# Allow statements and log messages to immediately appear in the Knative logs
+ENV PYTHONUNBUFFERED True
+{% endif %}
+
+RUN pip install --no-cache-dir --upgrade pip \
+    && rm -rf /root/.cache/pip
+
+COPY ./requirements.txt requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt \
+    && rm -rf /root/.cache/pip
+
+# This is a hack, kfserving uses table_logger, which doesn't work well with
+# numpy 1.24 onwards, where np.float and np.int have been remove.
+# https://github.com/AleksTk/table-logger/blob/v0.3.6/table_logger/table_logger.py#L80
+# Monkey patch table_logger here. Ultimately we should move away from kfserving,
+# perhaps to kserve.
+RUN find /usr/local/lib/ -name table_logger.py -exec sed -i '/np\.int:/d;/np\.float:/d' {} \;
+
+{% if live_reload %}
+COPY ./control /control
+RUN python3 -m venv /control/.env \
+    && /control/.env/bin/pip3 install -r /control/requirements.txt
+{% endif %}
+
+{% block fail_fast %}
+RUN grep -w ID=debian /etc/os-release || { echo "Supplied base image is not a debian image"; exit 1; }
+RUN major=$(python -c"import sys; print(sys.version_info.major)") && [ $major -eq 3 ] || { echo "ERROR: Supplied base image does not have python3"; unset major; exit 1; }
+RUN minor=$(python -c"import sys; print(sys.version_info.minor)") && [ $minor -ge 8 && $minor -le 10 ] || { echo "WARNING: Supplied base image does not have 3.8 <= python <= 3.10"; unset minor; }
+{% endblock %}
+{% endblock %}
+
 RUN pip install --upgrade pip --no-cache-dir \
     && rm -rf /root/.cache/pip
 {% if config.model_framework.value == 'huggingface_transformer' %}

--- a/truss/templates/base.Dockerfile.jinja
+++ b/truss/templates/base.Dockerfile.jinja
@@ -2,65 +2,64 @@ ARG PYVERSION={{config.python_version}}
 FROM {{base_image_name_and_tag}}
 
 {% if config.base_image %}
-{% block rebuild_base %}
-{% if use_gpu %}
-# Allow statements and log messages to immediately appear in the Knative logs
-ENV PYTHONUNBUFFERED True
-ENV DEBIAN_FRONTEND=noninteractive
+    {% block fail_fast %}
+        RUN grep -w ID=debian /etc/os-release || { echo "Supplied base image is not a debian image"; exit 1; }
+        RUN major=$(python -c"import sys; print(sys.version_info.major)") &&  [ $major = 3 ]  || { echo "ERROR: Supplied base image does not have python3"; unset major; exit 1; }
+        RUN minor=$(python -c"import sys; print(sys.version_info.minor)") && [ $minor >= 8] && [ $minor <= 10 ] || { echo "WARNING: Supplied base image does not have 3.8 <= python <= 3.10"; unset minor; }
+    {% endblock %}
 
-RUN apt update && \
-    apt install -y bash \
-                   build-essential \
-                   git \
-                   curl \
-                   ca-certificates \
-                   software-properties-common && \
-    add-apt-repository -y ppa:deadsnakes/ppa && \
-    apt update -y && \
-    apt install -y python{{python_version}} && \
-    apt install -y python{{python_version}}-distutils && \
-    apt install -y python{{python_version}}-venv && \
-    rm -rf /var/lib/apt/lists
+    {% block rebuild_base %}
+        {% if use_gpu %}
+            # Allow statements and log messages to immediately appear in the Knative logs
+            ENV PYTHONUNBUFFERED True
+            ENV DEBIAN_FRONTEND=noninteractive
 
-RUN ln -sf /usr/bin/python{{python_version}} /usr/bin/python3 && \
-    curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
-    python3 get-pip.py
+            RUN apt update && \
+                apt install -y bash \
+                            build-essential \
+                            git \
+                            curl \
+                            ca-certificates \
+                            software-properties-common && \
+                add-apt-repository -y ppa:deadsnakes/ppa && \
+                apt update -y && \
+                apt install -y python{{python_version}} && \
+                apt install -y python{{python_version}}-distutils && \
+                apt install -y python{{python_version}}-venv && \
+                rm -rf /var/lib/apt/lists
 
-RUN python3 -m pip install --no-cache-dir --upgrade pip
-{% else %}
-FROM python:{{python_version}}
-RUN apt update && apt install -y
+            RUN ln -sf /usr/bin/python{{python_version}} /usr/bin/python3 && \
+                curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
+                python3 get-pip.py
 
-# Allow statements and log messages to immediately appear in the Knative logs
-ENV PYTHONUNBUFFERED True
-{% endif %}
+            RUN python3 -m pip install --no-cache-dir --upgrade pip
+        {% else %}
+            RUN apt update && apt install -y
 
-RUN pip install --no-cache-dir --upgrade pip \
-    && rm -rf /root/.cache/pip
+            # Allow statements and log messages to immediately appear in the Knative logs
+            ENV PYTHONUNBUFFERED True
+        {% endif %}
 
-COPY ./requirements.txt requirements.txt
-RUN pip install --no-cache-dir -r requirements.txt \
-    && rm -rf /root/.cache/pip
+        RUN pip install --no-cache-dir --upgrade pip \
+            && rm -rf /root/.cache/pip
 
-# This is a hack, kfserving uses table_logger, which doesn't work well with
-# numpy 1.24 onwards, where np.float and np.int have been remove.
-# https://github.com/AleksTk/table-logger/blob/v0.3.6/table_logger/table_logger.py#L80
-# Monkey patch table_logger here. Ultimately we should move away from kfserving,
-# perhaps to kserve.
-RUN find /usr/local/lib/ -name table_logger.py -exec sed -i '/np\.int:/d;/np\.float:/d' {} \;
+        COPY ./requirements.txt requirements.txt
+        RUN pip install --no-cache-dir -r requirements.txt \
+            && rm -rf /root/.cache/pip
 
-{% if live_reload %}
-COPY ./control /control
-RUN python3 -m venv /control/.env \
-    && /control/.env/bin/pip3 install -r /control/requirements.txt
-{% endif %}
+        # This is a hack, kfserving uses table_logger, which doesn't work well with
+        # numpy 1.24 onwards, where np.float and np.int have been remove.
+        # https://github.com/AleksTk/table-logger/blob/v0.3.6/table_logger/table_logger.py#L80
+        # Monkey patch table_logger here. Ultimately we should move away from kfserving,
+        # perhaps to kserve.
+        RUN find /usr/local/lib/ -name table_logger.py -exec sed -i '/np\.int:/d;/np\.float:/d' {} \;
 
-{% block fail_fast %}
-RUN grep -w ID=debian /etc/os-release || { echo "Supplied base image is not a debian image"; exit 1; }
-RUN major=$(python -c"import sys; print(sys.version_info.major)") && [ $major -eq 3 ] || { echo "ERROR: Supplied base image does not have python3"; unset major; exit 1; }
-RUN minor=$(python -c"import sys; print(sys.version_info.minor)") && [ $minor -ge 8 && $minor -le 10 ] || { echo "WARNING: Supplied base image does not have 3.8 <= python <= 3.10"; unset minor; }
-{% endblock %}
-{% endblock %}
+        {% if live_reload %}
+        COPY ./control /control
+        RUN python3 -m venv /control/.env \
+            && /control/.env/bin/pip3 install -r /control/requirements.txt
+        {% endif %}
+    {% endblock %}
 {% endif %}
 
 RUN pip install --upgrade pip --no-cache-dir \

--- a/truss/tests/test_truss_handle.py
+++ b/truss/tests/test_truss_handle.py
@@ -100,6 +100,7 @@ def test_build_docker_image(custom_model_truss_dir_with_pre_and_post):
     [
         ("baseten/truss-server-base:3.9-v0.4.3", False),
         ("baseten/truss-training-base:3.9-v0.4.3", False),
+        ("python:3.8.3", False),
         ("alpine", True),
         ("python:2.7-slim", True),
         ("python:3.5-slim", True),

--- a/truss/tests/test_truss_handle.py
+++ b/truss/tests/test_truss_handle.py
@@ -95,6 +95,38 @@ def test_build_docker_image(custom_model_truss_dir_with_pre_and_post):
 
 
 @pytest.mark.integration
+@pytest.mark.parametrize(
+    "base_image, expected_fail",
+    [
+        ("baseten/truss-server-base:3.9-v0.4.3", False),
+        ("baseten/truss-training-base:3.9-v0.4.3", False),
+        ("alpine", True),
+        ("python:2.7-slim", True),
+        ("python:3.5-slim", True),
+    ],
+)
+def test_build_docker_image_from_user_base_image(
+    custom_model_truss_dir, base_image, expected_fail
+):
+    th = TrussHandle(custom_model_truss_dir)
+    th.set_base_image(base_image)
+    try:
+        th.build_serving_docker_image(cache=False)
+    except DockerException as exc:
+        assert expected_fail is True
+        assert "It returned with code 1" in str(exc)
+
+
+@pytest.mark.integration
+def test_docker_predict_custom_base_image(custom_model_truss_dir_with_pre_and_post):
+    th = TrussHandle(custom_model_truss_dir_with_pre_and_post)
+    th.set_base_image("baseten/truss-server-base:3.9-v0.4.3")
+    with ensure_kill_all():
+        result = th.docker_predict([1, 2])
+        assert result == {"predictions": [4, 5]}
+
+
+@pytest.mark.integration
 def test_build_docker_image_gpu(custom_model_truss_dir_for_gpu, tmp_path):
     th = TrussHandle(custom_model_truss_dir_for_gpu)
     tag = "test-build-image-gpu-tag:0.0.1"

--- a/truss/truss_config.py
+++ b/truss/truss_config.py
@@ -244,6 +244,7 @@ class TrussConfig:
     # spec_version is a version string
     spec_version: str = DEFAULT_SPEC_VERSION
     train: Train = field(default_factory=Train)
+    base_image: Optional[str] = None
 
     @property
     def canonical_python_version(self) -> str:
@@ -290,6 +291,7 @@ class TrussConfig:
             external_data=transform_optional(
                 d.get("external_data"), ExternalData.from_list
             ),
+            base_image=d.get("base_image", None),
         )
         config.validate()
         return config
@@ -327,6 +329,7 @@ class TrussConfig:
             "live_reload": self.live_reload,
             "spec_version": self.spec_version,
             "train": self.train.to_dict(),
+            "base_image": self.base_image,
         }
         if self.external_data is not None:
             d["external_data"] = transform_optional(

--- a/truss/truss_handle.py
+++ b/truss/truss_handle.py
@@ -131,13 +131,17 @@ class TrussHandle:
 
     @proxy_to_shadow_if_scattered
     def build_serving_docker_image(
-        self, build_dir: Optional[Path] = None, tag: Optional[str] = None
+        self,
+        build_dir: Optional[Path] = None,
+        tag: Optional[str] = None,
+        cache: bool = True,
     ):
         image = self._build_image(
             builder_context=ServingImageBuilderContext,
             labels=self._get_serving_lookup_labels(),
             build_dir=build_dir,
             tag=tag,
+            cache=cache,
         )
         self._store_signature()
         return image
@@ -689,6 +693,10 @@ class TrussHandle:
 
         self._update_config(enable_gpu_fn)
 
+    def set_base_image(self, base_image: str):
+        """Set the base image for a given truss"""
+        self._update_config(lambda conf: replace(conf, base_image=base_image))
+
     @proxy_to_shadow_if_scattered
     def patch_container(self, patch_request: Dict):
         """Patch changes onto the container running this Truss.
@@ -920,6 +928,7 @@ class TrussHandle:
         labels: Dict[str, str],
         build_dir: Optional[Path] = None,
         tag: Optional[str] = None,
+        cache: bool = True,
     ):
         image = _docker_image_from_labels(labels=labels)
         if image is not None:
@@ -928,9 +937,7 @@ class TrussHandle:
         build_dir_path = Path(build_dir) if build_dir is not None else None
         image_builder = builder_context.run(self._truss_dir)
         build_image_result = image_builder.build_image(
-            build_dir_path,
-            tag,
-            labels=labels,
+            build_dir_path, tag, labels=labels, cache=cache
         )
         return build_image_result
 

--- a/truss/truss_spec.py
+++ b/truss/truss_spec.py
@@ -184,6 +184,10 @@ class TrussSpec:
     def live_reload(self) -> bool:
         return self._config.live_reload
 
+    @property
+    def base_image(self) -> Optional[str]:
+        return self._config.base_image
+
 
 def _join_lines(lines: List[str]) -> str:
     return "\n".join(lines) + "\n"


### PR DESCRIPTION
- Adds a new top level config `base_image` wherein a user can supply a base image for `base.Dockerfile`
- Implements fail fast mechanisms checking for the os and the python version
- Introduces `cache` argument to the image builder to invalidate cache of `RUN` instructions across subsequent builds. See end of [section](https://docs.docker.com/engine/reference/builder/#run)