### PR TITLE
Late bind external data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.4.3"
+version = "0.4.4dev3"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/templates/base.Dockerfile.jinja
+++ b/truss/templates/base.Dockerfile.jinja
@@ -31,6 +31,9 @@ RUN pip install -r requirements.txt --no-cache-dir && rm -rf /root/.cache/pip
     {%- endif %}
 {% endblock %}
 
+{% block b10cp %}
+{% endblock %}
+
 
 ENV APP_HOME /app
 WORKDIR $APP_HOME

--- a/truss/templates/server.Dockerfile.jinja
+++ b/truss/templates/server.Dockerfile.jinja
@@ -8,6 +8,12 @@ RUN pip install -r server_requirements.txt --no-cache-dir && rm -rf /root/.cache
 {{ super() }}
 {% endblock %}
 
+{% block b10cp %}
+RUN mkdir -p /app/bin \
+    && curl https://baseten-public.s3.us-west-2.amazonaws.com/bin/b10cp-0.0.2-linux-amd64 -o /app/bin/b10cp \
+    && chmod +x /app/bin/b10cp
+{% endblock %}
+
 {% block app_copy %}
 COPY ./server /app
 COPY ./{{ config.model_module_dir }} /app/model

--- a/truss/templates/server/common/external_data_resolver.py
+++ b/truss/templates/server/common/external_data_resolver.py
@@ -25,5 +25,6 @@ def _download(URL: str, download_to: Path):
         timeout=BLOB_DOWNLOAD_TIMEOUT_SECS,
     )
     resp.raise_for_status()
+    download_to.parent.mkdir(exist_ok=True, parents=True)
     with download_to.open("wb") as file:
         shutil.copyfileobj(resp.raw, file)

--- a/truss/templates/server/common/external_data_resolver.py
+++ b/truss/templates/server/common/external_data_resolver.py
@@ -1,0 +1,29 @@
+import shutil
+from pathlib import Path
+
+import requests
+
+BLOB_DOWNLOAD_TIMEOUT_SECS = 600  # 10 minutes
+
+
+def download_external_data(data_dir: Path, config: dict):
+    for item in config["external_data"]:
+        backend = item["backend"]
+        item_url = item["url"]
+        local_data_path = item["local_data_path"]
+        if backend != "http_public":
+            raise ValueError(f"Unknown backend {backend}")
+        _download(item_url, data_dir / local_data_path)
+
+
+def _download(URL: str, download_to: Path):
+    # Streaming download to keep memory usage low
+    resp = requests.get(
+        URL,
+        allow_redirects=True,
+        stream=True,
+        timeout=BLOB_DOWNLOAD_TIMEOUT_SECS,
+    )
+    resp.raise_for_status()
+    with download_to.open("wb") as file:
+        shutil.copyfileobj(resp.raw, file)

--- a/truss/templates/server/common/external_data_resolver.py
+++ b/truss/templates/server/common/external_data_resolver.py
@@ -1,9 +1,11 @@
 import shutil
+import subprocess
 from pathlib import Path
 
 import requests
 
 BLOB_DOWNLOAD_TIMEOUT_SECS = 600  # 10 minutes
+B10CP_PATH = "/app/bin/b10cp"
 
 
 def download_external_data(data_dir: Path, config: dict):
@@ -17,6 +19,13 @@ def download_external_data(data_dir: Path, config: dict):
 
 
 def _download(URL: str, download_to: Path):
+    download_to.parent.mkdir(exist_ok=True, parents=True)
+
+    b10cp_success = _try_b10cp(URL, download_to)
+    if b10cp_success:
+        return
+
+    # Fallback if b10cp can't handle the url
     # Streaming download to keep memory usage low
     resp = requests.get(
         URL,
@@ -25,6 +34,22 @@ def _download(URL: str, download_to: Path):
         timeout=BLOB_DOWNLOAD_TIMEOUT_SECS,
     )
     resp.raise_for_status()
-    download_to.parent.mkdir(exist_ok=True, parents=True)
     with download_to.open("wb") as file:
         shutil.copyfileobj(resp.raw, file)
+
+
+def _try_b10cp(URL: str, download_to: Path) -> bool:
+    if not Path(B10CP_PATH).exists():
+        return False
+
+    proc = subprocess.run(
+        [
+            B10CP_PATH,
+            "-source",
+            URL,  # Add quotes to work with any special characters.
+            "-target",
+            str(download_to),
+        ],
+        check=False,
+    )
+    return proc.returncode == 0

--- a/truss/templates/server/common/external_data_resolver.py
+++ b/truss/templates/server/common/external_data_resolver.py
@@ -9,8 +9,11 @@ B10CP_PATH = "/app/bin/b10cp"
 
 
 def download_external_data(data_dir: Path, config: dict):
+    if "external_data" not in config:
+        return
+
     for item in config["external_data"]:
-        backend = item["backend"]
+        backend = item.get("backend", "http_public")
         item_url = item["url"]
         local_data_path = item["local_data_path"]
         if backend != "http_public":

--- a/truss/templates/server/model_wrapper.py
+++ b/truss/templates/server/model_wrapper.py
@@ -86,6 +86,7 @@ class ModelWrapper(kserve.Model):
 
     def try_load(self):
         data_dir = Path("data")
+        data_dir.mkdir(exist_ok=True)
         download_external_data(data_dir, self._config)
 
         if "bundled_packages_dir" in self._config:

--- a/truss/tests/conftest.py
+++ b/truss/tests/conftest.py
@@ -355,11 +355,11 @@ def custom_model_external_data_access_tuple_fixture(tmp_path: Path):
     (tmp_path / filename).write_text(content)
     port = 9089
     proc = subprocess.Popen(
-        ["python", "-m", "http.server", str(port)],
+        ["python", "-m", "http.server", str(port), "--bind", "0.0.0.0"],
         cwd=tmp_path,
     )
     try:
-        url = f"http://localhost:{port}/{filename}"
+        url = f"http://host.docker.internal:{port}/{filename}"
         yield (
             _custom_model_from_code(
                 tmp_path,

--- a/truss/tests/conftest.py
+++ b/truss/tests/conftest.py
@@ -360,13 +360,17 @@ def custom_model_external_data_access_tuple_fixture(tmp_path: Path):
     )
     try:
         url = f"http://host.docker.internal:{port}/{filename}"
+        # Add arbitrary get params to get that they don't cause issues, the
+        # server above ignores them.
+        # url_with_get_params = f"{url}?foo=bar&baz=bla"
+        url_with_get_params = f"{url}?foo=bar&baz=bla"
         yield (
             _custom_model_from_code(
                 tmp_path,
                 "external_data_access",
                 EXTERNAL_DATA_ACCESS,
                 handle_ops=lambda handle: handle.add_external_data_item(
-                    url=url, local_data_path="test.txt"
+                    url=url_with_get_params, local_data_path="test.txt"
                 ),
             ),
             content,

--- a/truss/tests/templates/server/common/test_external_resolver.py
+++ b/truss/tests/templates/server/common/test_external_resolver.py
@@ -1,0 +1,73 @@
+from unittest.mock import patch
+
+import pytest
+from truss.templates.server.common.external_data_resolver import (
+    _external_data_items,
+    download_external_data,
+)
+from truss.truss_config import ExternalData, ExternalDataItem, TrussConfig
+
+
+def test_external_data_items(tmp_path):
+    url1 = "http://dummy1"
+    url2 = "http://dummy2"
+    data_dir = tmp_path
+    config = TrussConfig(
+        external_data=ExternalData(
+            items=[
+                ExternalDataItem(url=url1, local_data_path="dummy1"),
+                ExternalDataItem(url=url2, local_data_path="dir/dummy2"),
+            ]
+        )
+    )
+
+    items = _external_data_items(data_dir, config.to_dict())
+    assert items == [
+        (url1, tmp_path / "dummy1"),
+        (url2, tmp_path / "dir" / "dummy2"),
+    ]
+
+
+def test_external_data_items_unsupported_backend(tmp_path):
+    url = "http://dummy1"
+    data_dir = tmp_path
+    config = TrussConfig(
+        external_data=ExternalData(
+            items=[
+                ExternalDataItem(
+                    url=url, local_data_path="dummy1", backend="unsupported"
+                ),
+            ]
+        )
+    )
+
+    with pytest.raises(ValueError):
+        _external_data_items(data_dir, config.to_dict())
+
+
+def test_external_data_items_empty(tmp_path):
+    data_dir = tmp_path
+    config = TrussConfig()
+
+    items = _external_data_items(data_dir, config.to_dict())
+    assert items == []
+
+
+@patch("truss.templates.server.common.external_data_resolver._try_b10cp")
+@patch("truss.templates.server.common.external_data_resolver._download_using_requests")
+def test_download_external_data(
+    _try_b10cp_mock, _download_using_requests_mock, tmp_path
+):
+    _try_b10cp_mock.return_value = False
+    url = "http://dummy1"
+    data_dir = tmp_path
+    config = TrussConfig(
+        external_data=ExternalData(
+            items=[
+                ExternalDataItem(url=url, local_data_path="dummy1"),
+            ]
+        )
+    )
+    download_external_data(data_dir, config.to_dict())
+    assert _try_b10cp_mock.called_with(url, tmp_path / "dummy1")
+    assert _download_using_requests_mock.called_with(url, tmp_path / "dummy1")


### PR DESCRIPTION
Instead of bundling external data into the docker image, download it at model load time using b10cp. b10cp download is very fast and we avoid the decompression step that comes with bundling into docker image. We also avoid the longer build times by bundling weights into docker image.

With https://github.com/basetenlabs/flan-t5-xl-truss/tree/ext-data Downloading the weights, which total around 11 GB, takes 40 seconds compared to 2 minutes when downloading from HuggingFace directly. This is significant improvement in startup time.