### PR TITLE
Fix an issue with pycache ignore for live reload

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.4.4dev4"
+version = "0.4.4"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/patch/calc_patch.py
+++ b/truss/patch/calc_patch.py
@@ -141,15 +141,15 @@ def _calc_changed_paths(
         root, root_relative_new_paths, ignore_patterns
     )
     previous_root_relative_paths = set(previous_root_path_content_hashes.keys())
-    new_uningored_path = _calc_unignored_paths(
+    unignored_prev_paths = _calc_unignored_paths(
         root, previous_root_relative_paths, ignore_patterns
     )
 
-    added_paths = unignored_new_paths - new_uningored_path
-    removed_paths = new_uningored_path - unignored_new_paths
+    added_paths = unignored_new_paths - unignored_prev_paths
+    removed_paths = unignored_prev_paths - unignored_new_paths
 
     updated_paths = set()
-    common_paths = unignored_new_paths.intersection(previous_root_relative_paths)
+    common_paths = unignored_new_paths.intersection(unignored_prev_paths)
     for path in common_paths:
         full_path: Path = root / path
         if full_path.is_file():

--- a/truss/tests/patch/test_calc_patch.py
+++ b/truss/tests/patch/test_calc_patch.py
@@ -119,6 +119,23 @@ def test_calc_truss_ignore_pycache(custom_model_truss_dir: Path):
     assert len(patches) == 0
 
 
+def test_calc_truss_ignore_pycache_existing(custom_model_truss_dir: Path):
+    # If __pycache__ existed before and there are no changes, there should be no
+    # patches.
+    top_pycache_path = custom_model_truss_dir / "__pycache__"
+    top_pycache_path.mkdir()
+    (top_pycache_path / "bla.pyc").touch()
+    model_pycache_path = custom_model_truss_dir / "model" / "__pycache__"
+    model_pycache_path.mkdir()
+    (model_pycache_path / "foo.pyo").touch()
+    sign = calc_truss_signature(custom_model_truss_dir)
+    patches = calc_truss_patch(
+        custom_model_truss_dir,
+        sign,
+    )
+    assert len(patches) == 0
+
+
 def test_calc_truss_ignore_changes_outside_patch_relevant_dirs(
     custom_model_truss_dir: Path,
 ):


### PR DESCRIPTION
The issue was that we ignored the file in Truss based on the ignore pattern, but we were not ignoring using the pattern the files in the previous signature. This resulted in the appearing as if the ignore files were being removed. Now we apply the ignore pattern to both.