### PR TITLE
Drop pre/post process from templates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.4.4"
+version = "0.4.5"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/templates/custom/model/model.py
+++ b/truss/templates/custom/model/model.py
@@ -12,20 +12,6 @@ class Model:
         # Load model here and assign to self._model.
         pass
 
-    def preprocess(self, model_input: Any) -> Any:
-        """
-        Incorporate pre-processing required by the model if desired here.
-
-        These might be feature transformations that are tightly coupled to the model.
-        """
-        return model_input
-
-    def postprocess(self, model_output: Any) -> Any:
-        """
-        Incorporate post-processing required by the model if desired here.
-        """
-        return model_output
-
     def predict(self, model_input: Any) -> Any:
         model_output = {}
         # Invoke model on model_input and calculate predictions here.

--- a/truss/templates/huggingface_transformer/model/model.py
+++ b/truss/templates/huggingface_transformer/model/model.py
@@ -27,20 +27,6 @@ class Model:
             **transformer_config,
         )
 
-    def preprocess(self, model_input: Any) -> Any:
-        """
-        Incorporate pre-processing required by the model if desired here.
-
-        These might be feature transformations that are tightly coupled to the model.
-        """
-        return model_input
-
-    def postprocess(self, model_output: Any) -> Any:
-        """
-        Incorporate post-processing required by the model if desired here.
-        """
-        return model_output
-
     def predict(self, model_input: Any) -> Any:
         model_output = {}
         instances = model_input

--- a/truss/templates/keras/model/model.py
+++ b/truss/templates/keras/model/model.py
@@ -17,20 +17,6 @@ class Model:
             str(self._data_dir / self._model_binary_dir)
         )
 
-    def preprocess(self, model_input: Any) -> Any:
-        """
-        Incorporate pre-processing required by the model if desired here.
-
-        These might be feature transformations that are tightly coupled to the model.
-        """
-        return model_input
-
-    def postprocess(self, model_output: Any) -> Any:
-        """
-        Incorporate post-processing required by the model if desired here.
-        """
-        return model_output
-
     def predict(self, model_input: Any) -> Any:
         model_output = {}
         inputs = np.array(model_input)

--- a/truss/templates/lightgbm/model/model.py
+++ b/truss/templates/lightgbm/model/model.py
@@ -25,20 +25,6 @@ class Model:
         model_file_path = next(path for path in paths if path.exists())
         self._model = joblib.load(model_file_path)
 
-    def preprocess(self, model_input: Any) -> Any:
-        """
-        Incorporate pre-processing required by the model if desired here.
-
-        These might be feature transformations that are tightly coupled to the model.
-        """
-        return model_input
-
-    def postprocess(self, model_output: Any) -> Any:
-        """
-        Incorporate post-processing required by the model if desired here.
-        """
-        return model_output
-
     def predict(self, model_input: Any) -> Any:
         model_output = {}
         result = self._model.predict(model_input)

--- a/truss/templates/mlflow/model/model.py
+++ b/truss/templates/mlflow/model/model.py
@@ -16,20 +16,6 @@ class Model:
         model_binary_dir_path = self._data_dir / self._model_binary_dir
         self._model = mlflow.pyfunc.load_model(model_binary_dir_path / "model")
 
-    def preprocess(self, model_input: Any) -> Any:
-        """
-        Incorporate pre-processing required by the model if desired here.
-
-        These might be feature transformations that are tightly coupled to the model.
-        """
-        return model_input
-
-    def postprocess(self, model_output: Any) -> Any:
-        """
-        Incorporate post-processing required by the model if desired here.
-        """
-        return model_output
-
     def predict(self, model_input: Any) -> Any:
         model_output = {}
         inputs = np.array(model_input)

--- a/truss/templates/pipeline/model/model.py
+++ b/truss/templates/pipeline/model/model.py
@@ -12,19 +12,5 @@ class Model:
         with open(self._data_dir / "pipeline.cpick", "rb") as f:
             self._pipeline = pickle.load(f)
 
-    def preprocess(self, model_input: Any) -> Any:
-        """
-        Incorporate pre-processing required by the model if desired here.
-
-        These might be feature transformations that are tightly coupled to the model.
-        """
-        return model_input
-
-    def postprocess(self, model_output: Any) -> Any:
-        """
-        Incorporate post-processing required by the model if desired here.
-        """
-        return model_output
-
     def predict(self, model_input: Any) -> Any:
         return self._pipeline(model_input)

--- a/truss/templates/pytorch/model/model.py
+++ b/truss/templates/pytorch/model/model.py
@@ -26,20 +26,6 @@ class Model:
         self._model = imp.load_pickle(package_name, model_pickle_filename)
         self._model_dtype = list(self._model.parameters())[0].dtype
 
-    def preprocess(self, model_input: Any) -> Any:
-        """
-        Incorporate pre-processing required by the model if desired here.
-
-        These might be feature transformations that are tightly coupled to the model.
-        """
-        return model_input
-
-    def postprocess(self, model_output: Any) -> Any:
-        """
-        Incorporate post-processing required by the model if desired here.
-        """
-        return model_output
-
     def predict(self, model_input: Any) -> Any:
         model_output = {}
         with torch.no_grad():

--- a/truss/templates/sklearn/model/model.py
+++ b/truss/templates/sklearn/model/model.py
@@ -24,20 +24,6 @@ class Model:
         model_file_path = next(path for path in paths if path.exists())
         self._model = joblib.load(model_file_path)
 
-    def preprocess(self, model_input: Any) -> Any:
-        """
-        Incorporate pre-processing required by the model if desired here.
-
-        These might be feature transformations that are tightly coupled to the model.
-        """
-        return model_input
-
-    def postprocess(self, model_output: Any) -> Any:
-        """
-        Incorporate post-processing required by the model if desired here.
-        """
-        return model_output
-
     def predict(self, model_input: Any) -> Any:
         model_output = {}
         result = self._model.predict(model_input)

--- a/truss/templates/xgboost/model/model.py
+++ b/truss/templates/xgboost/model/model.py
@@ -31,20 +31,6 @@ class Model:
         self._model = xgb.Booster()
         self._model.load_model(model_file_path)
 
-    def preprocess(self, model_input: Any) -> Any:
-        """
-        Incorporate pre-processing required by the model if desired here.
-
-        These might be feature transformations that are tightly coupled to the model.
-        """
-        return model_input
-
-    def postprocess(self, model_output: Any) -> Any:
-        """
-        Incorporate post-processing required by the model if desired here.
-        """
-        return model_output
-
     def predict(self, model_input: Any) -> Any:
         model_output = {}
         dmatrix_inputs = xgb.DMatrix(model_input)

--- a/truss/test_data/test_truss/model/model.py
+++ b/truss/test_data/test_truss/model/model.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import Any
 
 
 class Model:
@@ -12,21 +12,7 @@ class Model:
         # Load model here and assign to self._model.
         pass
 
-    def preprocess(self, model_input: Any) -> Any:
-        """
-        Incorporate pre-processing required by the model if desired here.
-
-        These might be feature transformations that are tightly coupled to the model.
-        """
-        return model_input
-
-    def postprocess(self, model_output: Dict) -> Dict:
-        """
-        Incorporate post-processing required by the model if desired here.
-        """
-        return model_output
-
-    def predict(self, model_input: Dict) -> Dict[str, List]:
+    def predict(self, model_input: Any) -> Any:
         model_output = {}
         # Invoke model on model_input and calculate predictions here.
         model_output["predictions"] = []


### PR DESCRIPTION
The pre and post process functions are an advanced feature that is confusing to see on all of the getting started templates. I think we should drop them in favor of simplicity in the getting started flow.