### PR TITLE
"control_server_host" now binds to both IPV4 & IPV6

### DIFF
--- a/truss/templates/control/control/server.py
+++ b/truss/templates/control/control/server.py
@@ -37,7 +37,7 @@ if __name__ == "__main__":
                 python_executable_path,
                 f"{inf_serv_home}/inference_server.py",
             ],
-            "control_server_host": "0.0.0.0",
+            "control_server_host": "*",
             "control_server_port": CONTROL_SERVER_PORT,
             "inference_server_port": INFERENCE_SERVER_PORT,
         }

--- a/truss/tests/conftest.py
+++ b/truss/tests/conftest.py
@@ -355,7 +355,7 @@ def custom_model_external_data_access_tuple_fixture(tmp_path: Path):
     (tmp_path / filename).write_text(content)
     port = 9089
     proc = subprocess.Popen(
-        ["python", "-m", "http.server", str(port), "--bind", "0.0.0.0"],
+        ["python", "-m", "http.server", str(port), "--bind", "*"],
         cwd=tmp_path,
     )
     try:

--- a/truss/tests/templates/control/control/test_server.py
+++ b/truss/tests/templates/control/control/test_server.py
@@ -39,7 +39,7 @@ def app(truss_container_fs, truss_original_hash):
             {
                 "inference_server_home": inf_serv_home,
                 "inference_server_process_args": ["python", "inference_server.py"],
-                "control_server_host": "0.0.0.0",
+                "control_server_host": "*",
                 "control_server_port": 8081,
                 "inference_server_port": 8082,
                 "oversee_inference_server": False,


### PR DESCRIPTION
The `control_server_host` is currently set to `0.0.0.0` which forces waitress to only bind to the IPV4 address. According to the [waitress docs](https://github.com/Pylons/waitress/blob/455f2a5fd38cafab95893ca170c7504e4239d985/docs/usage.rst) by changing from `0.0.0.0` to `*` will cause it to bind to both.