### PR TITLE
Updating liveness check 

### DIFF
--- a/truss/templates/server/common/errors.py
+++ b/truss/templates/server/common/errors.py
@@ -57,6 +57,17 @@ class ModelNotReady(RuntimeError):
         return self.error_msg
 
 
+class ModelNotLive(RuntimeError):
+    def __init__(self, model_name: str, detail: Optional[str] = None):
+        self.model_name = model_name
+        self.error_msg = f"Model with name {self.model_name} is not alive."
+        if detail:
+            self.error_msg = self.error_msg + " " + detail
+
+    def __str__(self):
+        return self.error_msg
+
+
 async def exception_handler(_, exc):
     return JSONResponse(
         status_code=HTTPStatus.INTERNAL_SERVER_ERROR, content={"error": str(exc)}
@@ -85,6 +96,12 @@ async def model_not_found_handler(_, exc):
 
 
 async def model_not_ready_handler(_, exc):
+    return JSONResponse(
+        status_code=HTTPStatus.SERVICE_UNAVAILABLE, content={"error": str(exc)}
+    )
+
+
+async def model_not_live_handler(_, exc):
     return JSONResponse(
         status_code=HTTPStatus.SERVICE_UNAVAILABLE, content={"error": str(exc)}
     )

--- a/truss/templates/server/common/truss_server.py
+++ b/truss/templates/server/common/truss_server.py
@@ -79,9 +79,11 @@ class BasetenEndpoints:
 
         return {}
 
-    async def model_live(self, model_name: str) -> Dict[str, Union[str, bool]]:
+    async def model_live(
+        self,
+    ) -> Dict[str, Union[str, bool]]:
         try:
-            self.check_healthy(self._safe_lookup_model(model_name))
+            self.check_healthy(self._model)
             return {}
         except Exception as e:
             # If the exception is errors.ModelNotLive, then we want to propogate the exception
@@ -170,7 +172,6 @@ class TrussServer:
             default_response_class=ORJSONResponse,
             on_startup=[self.on_startup],
             routes=[
-                # liveness endpoint
                 FastAPIRoute(r"/", self._endpoints.model_live),
                 # readiness endpoint
                 FastAPIRoute(


### PR DESCRIPTION
### Overview

Kubernetes uses the _liveness endpoint_ to determine if it should keep / restart a pod. Currently, we always return `True` for liveness even if the model needs to be restarted (i.e when the model `load` has failed after some number of retries). 

This PR updates the liveness endpoint such that it returns a 503 response when the model load has been set as failed. This only occurs after _n_ retries of the users `model.load` function. To do this, we 

1. Add a new exception `ModelNotLive` and associated exception handler that propogates a 503 status code
2. Add a liveness check that checks for failed model load (__if there are other scenarios where we should mark the model as not live, please comment__)

This PR was tested via the Docker image flow by testing Truss' that threw Exceptions during `model.load` as well as models that successfully loaded. 
