### PR TITLE
hack: use root logger for model_wrapper load logs

### DIFF
--- a/truss/templates/server/model_wrapper.py
+++ b/truss/templates/server/model_wrapper.py
@@ -28,7 +28,7 @@ class ModelWrapper:
 
     def __init__(self, config: Dict):
         self._config = config
-        self._logger = logging.getLogger(__name__)
+        self._logger = logging.getLogger()
         self.name = MODEL_BASENAME
         self.ready = False
         self._load_lock = Lock()


### PR DESCRIPTION
Uses the root logger object in the `model_wrapper` module to pick up the logs from the model load operation – I've checked the actual object in the load thread and it seems to be getting set up correctly according to `logging.py:setup_logging` but fails to log these messages. Hoping to merge this hack in order to unblock the release for custom base images.