### PR TITLE
Skip integration tests for dev versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,8 @@ jobs:
               --skip-login --push
           fi
   integration-tests:
-    needs: [build-and-push-truss-base-images-if-needed]
+    needs: [build-and-push-truss-base-images-if-needed, detect-version-changed]
+    if: ! contains( needs.detect-version-changed.outputs.new_version, "dev" )
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
@@ -72,7 +73,7 @@ jobs:
       - run: poetry run pytest truss/tests  -m 'integration'
 
   git-tag-if-version-changed:
-    needs: [integration-tests, detect-version-changed]
+    needs: [detect-version-changed]
     if: needs.detect-version-changed.outputs.version_changed == 'true'
     runs-on: ubuntu-20.04
     steps:
@@ -90,7 +91,7 @@ jobs:
 
   build-n-push-context-builder-image:
     needs: [integration-tests, detect-version-changed]
-    if: needs.detect-version-changed.outputs.version_changed == 'true'
+    if: needs.detect-version-changed.outputs.version_changed == 'true' && (needs.integration-tests.result == 'success' || needs.integration-tests.result == 'skipped')
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,8 +73,8 @@ jobs:
       - run: poetry run pytest truss/tests  -m 'integration'
 
   git-tag-if-version-changed:
-    needs: [detect-version-changed]
-    if: needs.detect-version-changed.outputs.version_changed == 'true'
+    needs: [integration-tests, detect-version-changed]
+    if: needs.detect-version-changed.outputs.version_changed == 'true' && (needs.integration-tests.result == 'success' || needs.integration-tests.result == 'skipped')
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Iteration time to test new context builder changes is heavily limited by intergration tests. This skips integration tests for dev images.