### PR TITLE
Reorder workflows to not waste time building images we don't need

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,10 +47,20 @@ jobs:
             echo "dev_version=false" >> $GITHUB_OUTPUT
           fi
 
-  build-and-push-truss-base-images-if-needed:
+  integration-tests:
     needs: [detect-version-changed]
+    if: needs.detect-version-changed.outputs.dev_version == 'false'
     runs-on: ubuntu-20.04
-    if: needs.detect-version-changed.outputs.version_changed == 'true'
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/setup-python/
+      - run: poetry install
+      - run: poetry run pytest truss/tests  -m 'integration'
+
+  build-and-push-truss-base-images-if-needed:
+    needs: [integration-tests, detect-version-changed]
+    if: needs.detect-version-changed.outputs.version_changed == 'true' && (needs.integration-tests.result == 'success' || needs.integration-tests.result == 'skipped')
+    runs-on: ubuntu-20.04
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -68,15 +78,6 @@ jobs:
         run: |
           poetry run bin/generate_base_images.py --version-tag v${{ needs.detect-version-changed.outputs.new_version }} \
             --skip-login --push
-  integration-tests:
-    needs: [build-and-push-truss-base-images-if-needed, detect-version-changed]
-    if: needs.detect-version-changed.outputs.dev_version == 'false'
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/setup-python/
-      - run: poetry install
-      - run: poetry run pytest truss/tests  -m 'integration'
 
   git-tag-if-version-changed:
     needs: [integration-tests, detect-version-changed]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,11 +36,11 @@ repos:
         exclude: ^examples/|^truss/test.+/|model.py$
         pass_filenames: true
   - repo: https://github.com/tcort/markdown-link-check
-    rev: "v3.11.2"
+    rev: "v3.10.3"
     hooks:
       - id: markdown-link-check
   - repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 22.10.0
     hooks:
       - id: black
         # It is recommended to specify the latest version of Python


### PR DESCRIPTION
Currently, we spend 20 minutes building base images before we spend 60 minutes running integration tests before we start building the context builder which we actually need.

This change allows us to skip the integration tests for dev version and run all of the build-and-publish sets in parallel to save time.