### PR TITLE
Serialize errors as bytes when necessary

### DIFF
--- a/truss/templates/control/control/application.py
+++ b/truss/templates/control/control/application.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Dict
 
 from endpoints import control_app
-from flask import Flask, jsonify, request
+from flask import Flask, request
 from helpers.errors import PatchApplicatonError
 from helpers.inference_server_controller import InferenceServerController
 from helpers.inference_server_process_controller import InferenceServerProcessController
@@ -75,8 +75,7 @@ def _camel_to_snake_case(camel_cased: str) -> str:
 def _create_error_response(content):
     if (
         "Content-Type" in request.headers
-        and request.headers["Content-Type"] == "application/json"
+        and request.headers["Content-Type"] == "application/octet-stream"
     ):
-        return jsonify(content)
-    else:
         return truss_msgpack_serialize(content)
+    return content

--- a/truss/tests/templates/control/control/test_server.py
+++ b/truss/tests/templates/control/control/test_server.py
@@ -122,6 +122,7 @@ class Model:
     assert resp.json == {"prediction": [1]}
 
 
+@pytest.mark.integration
 def test_patch_model_code_update_predict_model_not_ready(app, client):
     mock_model_file_content = """
 class Model:
@@ -149,6 +150,7 @@ class Model:
     assert "ModelNotReady" in resp.json["error"]["msg"]
 
 
+@pytest.mark.integration
 def test_patch_model_code_update_predict_binary_model_not_ready(app, client):
     mock_model_file_content = """
 class Model:
@@ -169,7 +171,9 @@ class Model:
     )
     _verify_apply_patch_success(client, patch)
     resp = client.post(
-        "/v1/models/model:predict_binary", data=truss_msgpack_serialize({})
+        "/v1/models/model:predict_binary",
+        data=truss_msgpack_serialize({}),
+        headers={"Content-type": "application/octet-stream"},
     )
     resp.status_code == 200
     assert type(resp.data) == bytes
@@ -210,7 +214,7 @@ def test_patch_model_code_create_in_new_dir(app, client):
 
 
 def test_404(client):
-    resp = client.post("/control/nonexitant")
+    resp = client.post("/control/nonexistant")
     assert resp.status_code == 404
 
 


### PR DESCRIPTION
We saw a couple of `unpack(b)` errors that came from the `proxy` endpoint when either a model isn't ready by `INFERENCE_SERVER_START_WAIT_SECS` or the inference server stopped running. This PR ensures that we serialize the error outputs correctly, based on the `request`'s headers.

this is what the error response from `predict_binary` used to look like:
```
In [27]: requests.post(url=binary, data=truss_msgpack_serialize(model_input), headers={"Conten
    ...: t-type": "application/octet-stream"}).__dict__
Out[27]: 
{'_content': b'{"error":{"msg":"<class \'tenacity.RetryError\'>: RetryError[<Future at 0x7ff4257f4b50 state=finished raised ModelNotReady>]","type":"unknown"}}\n',
 '_content_consumed': True,
 '_next': None,
 'status_code': 200,
 'headers': {'Content-Length': '143', 'Content-Type': 'application/json', 'Date': 'Thu, 01 Jun 2023 22:09:28 GMT', 'Server': 'waitress'},
 'raw': <urllib3.response.HTTPResponse at 0x7f7969ce3460>,
 'url': 'http://127.0.0.1:8080/v1/models/model:predict_binary',
 'encoding': 'utf-8',
 'history': [],
 'reason': 'OK',
 'cookies': <RequestsCookieJar[]>,
 'elapsed': datetime.timedelta(seconds=59, microseconds=338927),
 'request': <PreparedRequest [POST]>,
 'connection': <requests.adapters.HTTPAdapter at 0x7f7969ccfd00>}
```
this is what the error response from `predict_binary` looks like now:
```
In [29]: requests.post(url=binary, data=truss_msgpack_serialize(model_input), headers={"Conten
    ...: t-type": "application/octet-stream"}).__dict__
Out[29]: 
{'_content': b'\x82\xabpredictions\x85\xc4\x02nd\xc3\xc4\x04type\xa3<i8\xc4\x04kind\xc4\x00\xc4\x05shape\x91\x01\xc4\x04data\xc4\x08\x00\x00\x00\x00\x00\x00\x00\x00\xadprobabilities\x91\x93\xcb?\xef\xae\x14z\xe1G\xae\xcb?\x84z\xe1G\xae\x14{\xcb\x00\x00\x00\x00\x00\x00\x00\x00',
 '_content_consumed': True,
 '_next': None,
 'status_code': 200,
 'headers': {'Content-Length': '105', 'Content-Type': 'application/octet-stream', 'Date': 'Thu, 01 Jun 2023 22:14:02 GMT', 'Server': 'uvicorn', 'Via': 'waitress'},
 'raw': <urllib3.response.HTTPResponse at 0x7f7969c15c10>,
 'url': 'http://127.0.0.1:8080/v1/models/model:predict_binary',
 'encoding': None,
 'history': [],
 'reason': 'OK',
 'cookies': <RequestsCookieJar[]>,
 'elapsed': datetime.timedelta(seconds=31, microseconds=213163),
 'request': <PreparedRequest [POST]>,
 'connection': <requests.adapters.HTTPAdapter at 0x7f7969cb9910>}
```