### PR TITLE
Rework deployment workflow to build baseimage based on version changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,6 +83,7 @@ jobs:
       - shell: bash
         run: |
           poetry run bin/generate_base_images.py \
+            --live-reload both \
             --use-gpu ${{ matrix.use_gpu }}  \
             --python-version ${{ matrix.python_version }} \
             --job-type ${{ matrix.job_type }} \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,9 @@ jobs:
     outputs:
       version_changed: ${{ steps.versions.outputs.version_changed }}
       new_version: ${{ steps.versions.outputs.new_version }}
+      new_base_image_version: ${{ steps.versions.outputs.new_base_image_version }}
       dev_version: ${{ steps.versions.outputs.dev_version }}
+      build_base_images: ${{ steps.versions.outputs.build_base_images }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -27,14 +29,17 @@ jobs:
       - id: versions
         run: |
           NEW_VERSION=$(poetry version | awk '{print $2}')
+          NEW_BASE_IMAGE_VERSION=$(poetry run python -c "from truss.contexts.image_builder.util import TRUSS_BASE_IMAGE_VERSION_TAG; print(TRUSS_BASE_IMAGE_VERSION_TAG)")
 
-          git checkout HEAD^1 -- pyproject.toml
+          git checkout HEAD^1 -- pyproject.toml truss/contexts/image_builder/util.py
           OLD_VERSION=$(poetry version | awk '{print $2}')
+          OLD_BASE_IMAGE_VERSION=$(poetry run python -c "from truss.contexts.image_builder.util import TRUSS_BASE_IMAGE_VERSION_TAG; print(TRUSS_BASE_IMAGE_VERSION_TAG)")
 
           # Put back things into place
-          git checkout HEAD -- pyproject.toml
+          git checkout HEAD -- pyproject.toml truss/contexts/image_builder/util.py
 
           echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "new_base_image_version=$NEW_BASE_IMAGE_VERSION" >> $GITHUB_OUTPUT
 
           if [[ "$NEW_VERSION" != "$OLD_VERSION" ]]; then
             echo "version_changed=true" >> $GITHUB_OUTPUT
@@ -48,19 +53,14 @@ jobs:
             echo "dev_version=false" >> $GITHUB_OUTPUT
           fi
 
-  integration-tests:
-    needs: [detect-version-changed]
-    if: needs.detect-version-changed.outputs.dev_version == 'false'
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/setup-python/
-      - run: poetry install
-      - run: poetry run pytest truss/tests  -m 'integration'
-
+          if [[ "$NEW_BASE_IMAGE_VERSION" != "$OLD_BASE_IMAGE_VERSION" ]]; then
+            echo "build_base_images=true" >> $GITHUB_OUTPUT
+          else
+            echo "build_base_images=false" >> $GITHUB_OUTPUT
+          fi
   build-and-push-truss-base-images-if-needed:
-    needs: [integration-tests, detect-version-changed]
-    if: always() && needs.detect-version-changed.outputs.version_changed == 'true' && (needs.integration-tests.result == 'success' || needs.integration-tests.result == 'skipped')
+    needs: [detect-version-changed]
+    if: needs.detect-version-changed.outputs.build_base_images == 'true'
     runs-on: ubuntu-20.04
     steps:
       - name: Set up Docker Buildx
@@ -77,8 +77,19 @@ jobs:
       - run: poetry install
       - shell: bash
         run: |
-          poetry run bin/generate_base_images.py --version-tag v${{ needs.detect-version-changed.outputs.new_version }} \
+          poetry run bin/generate_base_images.py --version-tag ${{ needs.detect-version-changed.outputs.new_vernew_base_image_versionsion }} \
             --skip-login --push
+
+  integration-tests:
+    needs: [detect-version-changed]
+    if: needs.detect-version-changed.outputs.dev_version == 'false'
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/setup-python/
+      - run: poetry install
+      - run: poetry run pytest truss/tests  -m 'integration'
+
 
   git-tag-if-version-changed:
     needs: [integration-tests, detect-version-changed]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,6 +62,11 @@ jobs:
     needs: [detect-version-changed]
     if: needs.detect-version-changed.outputs.build_base_images == 'true'
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python_version: ["3.8", "3.9", "3.10", "3.11"]
+        use_gpu: ['y', 'n']
+        job_type: ['server', 'training']
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -77,7 +82,11 @@ jobs:
       - run: poetry install
       - shell: bash
         run: |
-          poetry run bin/generate_base_images.py --version-tag ${{ needs.detect-version-changed.outputs.new_vernew_base_image_versionsion }} \
+          poetry run bin/generate_base_images.py \
+            --use-gpu ${{ matrix.use_gpu }}  \
+            --python-version ${{ matrix.python_version }} \
+            --job-type ${{ matrix.job_type }} \
+            --version-tag ${{ needs.detect-version-changed.outputs.new_vernew_base_image_versionsion }} \
             --skip-login --push
 
   integration-tests:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,8 +81,8 @@ jobs:
             --skip-login --push
 
   integration-tests:
-    needs: [detect-version-changed]
-    if: needs.detect-version-changed.outputs.dev_version == 'false'
+    needs: [detect-version-changed, build-and-push-truss-base-images-if-needed]
+    if: always() && needs.detect-version-changed.outputs.dev_version == 'false' && (needs.build-and-push-truss-base-images-if-needed.result == 'success' || needs.build-and-push-truss-base-images-if-needed.result == 'skipped')
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Based on our discussion, I have updated the Github action to detect if the `TRUSS_BASE_IMAGE_VERSION_TAG` changes. 

If it does, then we build all the bae images that are needed before running the integration tests using that tag (it doesn't make sense to build based on the pyproject.toml version since it won't be picked up if it does not match `TRUSS_BASE_IMAGE_VERSION_TAG`).

This effectively makes `TRUSS_BASE_IMAGE_VERSION_TAG` a separate version for Base Images that managed separately