### PR TITLE
Change default stream to stdout for truss logs.

### DIFF
--- a/truss/templates/server/common/logging.py
+++ b/truss/templates/server/common/logging.py
@@ -5,7 +5,7 @@ from pythonjsonlogger import jsonlogger
 
 LEVEL: int = logging.INFO
 
-JSON_LOG_HANDLER = logging.StreamHandler(stream=sys.stderr)
+JSON_LOG_HANDLER = logging.StreamHandler(stream=sys.stdout)
 JSON_LOG_HANDLER.set_name("json_logger_handler")
 JSON_LOG_HANDLER.setLevel(LEVEL)
 JSON_LOG_HANDLER.setFormatter(


### PR DESCRIPTION
Log truss logs to stdout instead of stderr

# Testing

Tested with this command:

```
$ poetry run truss predict --target_directory examples/truss-public-gh-repo-test --request '{"inputs": [1]}' 
```

Using the truss in this repo: 

This command spins up a docker containerBefore change, output all goes to stderr

```
$ docker logs 94837b306b92 > /dev/null
{"asctime": "2023-06-06 00:43:12,755", "levelname": "INFO", "message": "Setting max asyncio worker threads as 6"}
{"asctime": "2023-06-06 00:43:12,756", "levelname": "INFO", "message": "starting uvicorn with 1 workers"}
{"asctime": "2023-06-06 00:43:12,801", "levelname": "INFO", "message": "Executing model.load()..."}
{"asctime": "2023-06-06 00:43:12,802", "levelname": "INFO", "message": "Application startup complete."}
{"asctime": "2023-06-06 00:43:12,804", "levelname": "INFO", "message": "Completed model.load() execution in 3 ms"}
{"asctime": "2023-06-06 00:43:13,715", "levelname": "INFO", "message": "172.17.0.1:53630 - \"POST /v1/models/model%3Apredict HTTP/1.1\" 200"}
```

After change, now goes to stdout, nad gets eaten by /dev/null

```
$ docker logs 30f32f99b63f > /dev/null
$
```