### PR TITLE
Adding requests to server requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.4.8rc0"
+version = "0.4.8rc1"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/templates/server/requirements.txt
+++ b/truss/templates/server/requirements.txt
@@ -11,3 +11,4 @@ fastapi==0.95.0
 uvicorn==0.21.1
 psutil==5.9.4
 joblib==1.2.0
+requests==2.31.0


### PR DESCRIPTION
Trusses (Both control server and published server cases) error out with the following when deployed. This PR adds the lib to the server requirements. @squidarth has tested this and confirmed it works. 

```
Traceback (most recent call last):
  File "/app/inference_server.py", line 6, in <module>
    from common.truss_server import TrussServer  # noqa: E402
  File "/app/common/truss_server.py", line 24, in <module>
    from model_wrapper import ModelWrapper
  File "/app/model_wrapper.py", line 13, in <module>
    from common.external_data_resolver import download_external_data
  File "/app/common/external_data_resolver.py", line 6, in <module>
    import requests
ModuleNotFoundError: No module named 'requests'
````
