### PR TITLE
Update base image to 20.04 to support more python versions

### DIFF
--- a/docker/base_images/base_image.Dockerfile.jinja
+++ b/docker/base_images/base_image.Dockerfile.jinja
@@ -1,10 +1,10 @@
 {% if use_gpu %}
-FROM nvidia/cuda:11.2.1-base-ubuntu18.04
+FROM nvidia/cuda:11.2.1-base-ubuntu20.04
 ENV CUDNN_VERSION=8.1.0.77
 ENV CUDA=11.2
 ENV LD_LIBRARY_PATH /usr/local/cuda/extras/CUPTI/lib64:$LD_LIBRARY_PATH
 
-RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub && \
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub && \
     apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \
         cuda-command-line-tools-11-2 \
@@ -36,6 +36,7 @@ RUN apt update && \
     apt install -y python{{python_version}} && \
     apt install -y python{{python_version}}-distutils && \
     apt install -y python{{python_version}}-venv && \
+    apt install -y python{{python_version}}-dev && \
     rm -rf /var/lib/apt/lists
 
 RUN ln -sf /usr/bin/python{{python_version}} /usr/bin/python3 && \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.4.8rc2"
+version = "0.4.8rc3"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.4.8rc3"
+version = "0.4.8rc4"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/contexts/image_builder/util.py
+++ b/truss/contexts/image_builder/util.py
@@ -11,7 +11,7 @@ from truss import __version__
 # [IMPORTANT] Make sure all images for this version are published to dockerhub
 # before change to this value lands. This value is used to look for base images
 # when building docker image for a truss.
-TRUSS_BASE_IMAGE_VERSION_TAG = "v0.4.8rc2"
+TRUSS_BASE_IMAGE_VERSION_TAG = "v0.4.8rc3"
 
 
 def file_is_empty(path: Path, ignore_hash_style_comments: bool = True) -> bool:

--- a/truss/contexts/image_builder/util.py
+++ b/truss/contexts/image_builder/util.py
@@ -11,7 +11,7 @@ from truss import __version__
 # [IMPORTANT] Make sure all images for this version are published to dockerhub
 # before change to this value lands. This value is used to look for base images
 # when building docker image for a truss.
-TRUSS_BASE_IMAGE_VERSION_TAG = "v0.4.8rc3"
+TRUSS_BASE_IMAGE_VERSION_TAG = "v0.4.8rc4"
 
 
 def file_is_empty(path: Path, ignore_hash_style_comments: bool = True) -> bool:


### PR DESCRIPTION
The dead-snakes package repo did not support the new python versions that we introduced on the old 18.04 base image so we needed to upgrade the base image to add support for the python versions we need.

```
Supported Ubuntu and Python Versions
====================================

- Ubuntu 20.04 (focal) Python3.5 - Python3.7, Python3.9 - Python3.11
- Ubuntu 22.04 (jammy) Python3.7 - Python3.9, Python3.11
- Note: Python2.7 (all), Python 3.8 (focal), Python 3.10 (jammy) are not provided by deadsnakes as upstream ubuntu provides those packages.

Why some packages aren't built:
- Note: for focal, older python versions require libssl<1.1 so they are not currently built
- Note: for jammy, older python versions requre libssl<3 so they are not currently built
- If you need these, reach out to asottile to set up a private ppa

The packages may also work on other versions of Ubuntu or Debian, but that is not tested or supported.

Packages
========

The packages provided here are loosely based on the debian upstream packages with some modifications to make them more usable as non-default pythons and on ubuntu. As such, the packages follow debian's patterns and often do not include a full python distribution with just `apt install python#.#`. Here is a list of packages that may be useful along with the default install:

- `python#.#-dev`: includes development headers for building C extensions
- `python#.#-venv`: provides the standard library `venv` module
- `python#.#-distutils`: provides the standard library `distutils` module
- `python#.#-lib2to3`: provides the `2to3-#.#` utility as well as the standard library `lib2to3` module
- `python#.#-gdbm`: provides the standard library `dbm.gnu` module
- `python#.#-tk`: provides the standard library `tkinter` module


```