### PR TITLE
Fix issue with dataclasses for python3.11

### DIFF
--- a/truss/truss_config.py
+++ b/truss/truss_config.py
@@ -81,7 +81,7 @@ class Resources:
     cpu: str = DEFAULT_CPU
     memory: str = DEFAULT_MEMORY
     use_gpu: bool = DEFAULT_USE_GPU
-    accelerator: AcceleratorSpec = AcceleratorSpec()
+    accelerator: AcceleratorSpec = field(default_factory=AcceleratorSpec)
 
     @staticmethod
     def from_dict(d):


### PR DESCRIPTION
Uncovered the following issue when testing python3.11

```
ValueError: mutable default <class 'truss.truss_config.AcceleratorSpec'> for field accelerator is not allowed: use default_factory
```