### PR TITLE
Don't run PR workflow on main branch

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,9 +1,6 @@
 name: PR
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     paths:
       - poetry.lock


### PR DESCRIPTION
It's unnecessary to run these after merging since they are run on PRs before merging and are required to pass.