### PR TITLE
Drop b10cp from docker build

### DIFF
--- a/truss/templates/base.Dockerfile.jinja
+++ b/truss/templates/base.Dockerfile.jinja
@@ -43,9 +43,6 @@ RUN pip install -r requirements.txt --no-cache-dir && rm -rf /root/.cache/pip
     {%- endif %}
 {% endblock %}
 
-{% block b10cp %}
-{% endblock %}
-
 
 ENV APP_HOME /app
 WORKDIR $APP_HOME

--- a/truss/templates/server.Dockerfile.jinja
+++ b/truss/templates/server.Dockerfile.jinja
@@ -44,12 +44,6 @@ RUN pip install -r server_requirements.txt --no-cache-dir && rm -rf /root/.cache
 {{ super() }}
 {% endblock %}
 
-{% block b10cp %}
-RUN mkdir -p /app/bin \
-    && curl https://baseten-public.s3.us-west-2.amazonaws.com/bin/b10cp-0.0.2-linux-amd64 -o /app/bin/b10cp \
-    && chmod +x /app/bin/b10cp
-{% endblock %}
-
 {% block app_copy %}
 # Copy data before code for better caching
 {%- if data_dir_exists %}

--- a/truss/test_data/server.Dockerfile
+++ b/truss/test_data/server.Dockerfile
@@ -28,10 +28,6 @@ RUN apt update && \
 COPY ./base_server_requirements.txt base_server_requirements.txt
 RUN pip install -r base_server_requirements.txt --no-cache-dir && rm -rf /root/.cache/pip
 
-RUN mkdir -p /app/bin \
-    && curl https://baseten-public.s3.us-west-2.amazonaws.com/bin/b10cp-0.0.2-linux-amd64 -o /app/bin/b10cp \
-    && chmod +x /app/bin/b10cp
-
 ENV APP_HOME /app
 WORKDIR $APP_HOME
 


### PR DESCRIPTION
After moving external data to happen at the build step, we no longer need to package this binary with truss images.