### PR TITLE
Drop custom base image venv patch for now

### DIFF
--- a/truss/templates/server.Dockerfile.jinja
+++ b/truss/templates/server.Dockerfile.jinja
@@ -21,12 +21,6 @@ COPY ./base_server_requirements.txt base_server_requirements.txt
 RUN pip install -r base_server_requirements.txt --no-cache-dir && rm -rf /root/.cache/pip
 
     {%- if config.live_reload %}
-RUN pythonVersion=$(echo $($PYTHON_EXECUTABLE --version) | cut -d" " -f2 | cut -d"." -f1,2) \
-    && add-apt-repository -y ppa:deadsnakes/ppa && \
-    apt update -y && apt install -y --no-install-recommends python$pythonVersion-venv \
-    && apt-get autoremove -y \
-    && apt-get clean -y \
-    && rm -rf /var/lib/apt/lists/*
 # Create symlink for control server to start inference server process with correct python executable
 RUN readlink {{config.base_image.python_executable_path}} &>/dev/null \
     && echo "WARNING: Overwriting existing link at /usr/local/bin/python"

--- a/truss/tests/test_truss_handle.py
+++ b/truss/tests/test_truss_handle.py
@@ -98,7 +98,7 @@ def test_build_docker_image(custom_model_truss_dir_with_pre_and_post):
 @pytest.mark.parametrize(
     "base_image, path, expected_fail",
     [
-        ("baseten/truss-server-base:3.9-v0.4.3", "/usr/local/bin/python3", False),
+        ("baseten/truss-server-base:3.9-v0.4.8rc4", "/usr/local/bin/python3", False),
         ("python:3.8", "/usr/local/bin/python3", False),
         ("python:3.11", "/usr/local/bin/python3", False),
         ("python:alpine", "/usr/local/bin/python3", True),


### PR DESCRIPTION
Integration tests are failing because it's not possible to apply the venv patch to our base images. 

I think that's okay for now. Just going to drop this to unblock the release and we can revisit this edge case as needed for specific custom base images (most of them will have venv anyways so it's okay).