### PR TITLE
Always run integration tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,6 @@ jobs:
       version_changed: ${{ steps.versions.outputs.version_changed }}
       new_version: ${{ steps.versions.outputs.new_version }}
       new_base_image_version: ${{ steps.versions.outputs.new_base_image_version }}
-      dev_version: ${{ steps.versions.outputs.dev_version }}
       build_base_images: ${{ steps.versions.outputs.build_base_images }}
     steps:
       - uses: actions/checkout@v3
@@ -45,12 +44,6 @@ jobs:
             echo "version_changed=true" >> $GITHUB_OUTPUT
           else
             echo "version_changed=false" >> $GITHUB_OUTPUT
-          fi
-
-          if [[ "$NEW_VERSION" == *"dev"* ]]; then
-            echo "dev_version=true" >> $GITHUB_OUTPUT
-          else
-            echo "dev_version=false" >> $GITHUB_OUTPUT
           fi
 
           if [[ "$NEW_BASE_IMAGE_VERSION" != "$OLD_BASE_IMAGE_VERSION" ]]; then
@@ -91,7 +84,7 @@ jobs:
 
   integration-tests:
     needs: [detect-version-changed, build-and-push-truss-base-images-if-needed]
-    if: ${{ !failure() && !cancelled() &&  needs.detect-version-changed.outputs.dev_version == 'false' && (needs.build-and-push-truss-base-images-if-needed.result == 'success' || needs.build-and-push-truss-base-images-if-needed.result == 'skipped') }}
+    if: ${{ !failure() && !cancelled() && (needs.build-and-push-truss-base-images-if-needed.result == 'success' || needs.build-and-push-truss-base-images-if-needed.result == 'skipped') }}
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false


### PR DESCRIPTION
Since we enabled a Workflow to build dev context builder versions from PR via workflow_dispatch, we can drop this skip and always run integration tests on `main` branch pushes for now.

Ideally we will move to a separate release branch at some point, but this is okay for now.