### PR TITLE
Change log when control server starts

### DIFF
--- a/truss/templates/control/control/server.py
+++ b/truss/templates/control/control/server.py
@@ -46,7 +46,7 @@ if __name__ == "__main__":
     # Perform inference server startup flow in background
     Thread(target=inference_server_startup_flow, args=(application,)).start()
 
-    application.logger.info(f"Starting control server on port {CONTROL_SERVER_PORT}")
+    application.logger.info(f"Starting live reload server on port {CONTROL_SERVER_PORT}")
     server: Union[BaseWSGIServer, MultiSocketServer] = create_server(
         application,
         host=application.config["control_server_host"],


### PR DESCRIPTION
Following a discussion about the different model states, it was decided to change the log when the control server start to indicate what functionality it brings instead of the generic "control server" term. 