### PR TITLE
Bump truss version in control server

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.4.8"
+version = "0.4.8rc8"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/templates/control/requirements.txt
+++ b/truss/templates/control/requirements.txt
@@ -1,5 +1,5 @@
 dataclasses-json==0.5.7
 Flask==2.0.3
 waitress==2.1.2
-truss==0.4.6dev2
+truss==0.4.8rc7
 tenacity==8.1.0


### PR DESCRIPTION
The issue we're seeing with control server was resolved wtih https://github.com/basetenlabs/truss/pull/340 
This PR updates the control server deps after that change has been released in rc7