### PR TITLE
Add missing dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,10 @@ blake3 = "^0.3.3"
 fastapi = "^0.95.0"
 uvicorn = "^0.21.1"
 psutil = "^5.9.4"
+dockerfile = "^3.2.0"
+virtualenv = "^20.23.0"
+watchfiles = "^0.19.0"
+yaspin = "^2.3.0"
 
 [tool.poetry.dev-dependencies]
 torch = "^1.9.0"


### PR DESCRIPTION
The context builder is missing some packages from the live reload change. This PR adds those dependencies. 