### PR TITLE
Use uvloop for uvicorn

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.4.9rc1"
+version = "0.4.9"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/contexts/image_builder/util.py
+++ b/truss/contexts/image_builder/util.py
@@ -11,7 +11,7 @@ from truss import __version__
 # [IMPORTANT] Make sure all images for this version are published to dockerhub
 # before change to this value lands. This value is used to look for base images
 # when building docker image for a truss.
-TRUSS_BASE_IMAGE_VERSION_TAG = "v0.4.8"
+TRUSS_BASE_IMAGE_VERSION_TAG = "v0.4.9"
 
 
 def file_is_empty(path: Path, ignore_hash_style_comments: bool = True) -> bool:

--- a/truss/templates/server/common/truss_server.py
+++ b/truss/templates/server/common/truss_server.py
@@ -262,6 +262,8 @@ class TrussServer:
 
         max_asyncio_workers = min(32, utils.cpu_count() + 4)
         logging.info(f"Setting max asyncio worker threads as {max_asyncio_workers}")
+        # Call this so uvloop gets used
+        cfg.setup_event_loop()
         asyncio.get_event_loop().set_default_executor(
             concurrent.futures.ThreadPoolExecutor(max_workers=max_asyncio_workers)
         )

--- a/truss/templates/server/requirements.txt
+++ b/truss/templates/server/requirements.txt
@@ -9,6 +9,7 @@ python-json-logger==2.0.2
 pyyaml==6.0.0
 fastapi==0.95.0
 uvicorn==0.21.1
+uvloop==0.17.0
 psutil==5.9.4
 joblib==1.2.0
 requests==2.31.0


### PR DESCRIPTION
Use uvloop for model server event loop. uvloop is much more efficient and it doesn't have the issue where response on requests reusing keep-alive connections have an added delay.