### PR TITLE
Clean up logging for control server

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.4.9dev44"
+version = "0.4.9dev45"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.4.9rc0"
+version = "0.4.9dev44"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/templates/control/control/application.py
+++ b/truss/templates/control/control/application.py
@@ -9,6 +9,7 @@ from fastapi.responses import JSONResponse
 from helpers.errors import ModelLoadFailed, PatchApplicatonError
 from helpers.inference_server_controller import InferenceServerController
 from helpers.inference_server_process_controller import InferenceServerProcessController
+from helpers.logging import setup_logging
 from helpers.patch_applier import PatchApplier
 
 
@@ -50,9 +51,9 @@ def create_app(base_config: Dict):
         },
     )
 
+    setup_logging()
+
     app_logger = logging.getLogger(__name__)
-    # TODO(pankaj): change this back to info once things are stable
-    app_logger.setLevel(logging.DEBUG)
 
     app.state.logger = app_logger
 

--- a/truss/templates/control/control/helpers/logging.py
+++ b/truss/templates/control/control/helpers/logging.py
@@ -1,0 +1,47 @@
+import logging
+import sys
+
+from pythonjsonlogger import jsonlogger
+
+LEVEL: int = logging.INFO
+
+JSON_LOG_HANDLER = logging.StreamHandler(stream=sys.stdout)
+JSON_LOG_HANDLER.set_name("json_logger_handler")
+JSON_LOG_HANDLER.setLevel(LEVEL)
+JSON_LOG_HANDLER.setFormatter(
+    jsonlogger.JsonFormatter("%(asctime)s %(levelname)s %(message)s")
+)
+
+
+class HealthCheckFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        # for any health check endpoints, lets skip logging
+        return (
+            record.getMessage().find("GET / ") == -1
+            and record.getMessage().find("GET /v1/models/model ") == -1
+        )
+
+
+def setup_logging() -> None:
+    loggers = [logging.getLogger()] + [
+        logging.getLogger(name) for name in logging.root.manager.loggerDict
+    ]
+
+    for logger in loggers:
+        logger.setLevel(LEVEL)
+        logger.propagate = False
+
+        setup = False
+
+        # let's not thrash the handlers unnecessarily
+        for handler in logger.handlers:
+            if handler.name == JSON_LOG_HANDLER.name:
+                setup = True
+
+        if not setup:
+            logger.handlers.clear()
+            logger.addHandler(JSON_LOG_HANDLER)
+
+        # some special handling for request logging
+        if logger.name == "uvicorn.access":
+            logger.addFilter(HealthCheckFilter())

--- a/truss/templates/control/requirements.txt
+++ b/truss/templates/control/requirements.txt
@@ -4,3 +4,4 @@ fastapi==0.95.0
 uvicorn==0.21.1
 uvloop==0.17.0
 tenacity==8.1.0
+python-json-logger==2.0.2


### PR DESCRIPTION
# Problem

Right now, the control server does not put out logs in a JSON format, leading the server logs to look odd, with a lot of repeated content.

We fix it by using the right logger for it.


# Before
<img width="564" alt="BT-8025_Remove_timestamps_from_Truss_logs" src="https://github.com/basetenlabs/truss/assets/850115/6309a739-77ea-431b-b338-1be89a9e1442">


# After

<img width="1824" alt="Cursor_and_Model___test-with-log-levels-fixed-9" src="https://github.com/basetenlabs/truss/assets/850115/313ba13b-36de-49d5-9931-b0702a07a454">


# Testing

Ran this via this action: https://github.com/basetenlabs/truss/actions/runs/5249489220, and then tested in development.

