### PR TITLE
Fix context builder image build

### DIFF
--- a/context_builder.Dockerfile
+++ b/context_builder.Dockerfile
@@ -13,7 +13,10 @@ RUN apt-get update \
 RUN curl -sSL https://install.python-poetry.org | python -
 
 ENV PATH="/root/.local/bin:${PATH}"
-COPY . .
+COPY ./truss ./truss
+COPY ./pyproject.toml ./pyproject.toml
+COPY ./poetry.lock ./poetry.lock
+COPY ./README.md ./README.md
 
 # https://python-poetry.org/docs/configuration/#virtualenvsin-project
 # to write to project root .venv file to be used for context builder test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.4.9rc4"
+version = "0.4.9rc5"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION
Copy only the relevant content, not the whole truss gh root dir into the image.