### PR TITLE
Extend config.yaml patch support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.4.10rc1"
+version = "0.4.10rc3"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/contexts/image_builder/serving_image_builder.py
+++ b/truss/contexts/image_builder/serving_image_builder.py
@@ -1,10 +1,6 @@
-import os
-import shutil
-import subprocess
 from pathlib import Path
 from typing import Optional
 
-import requests
 from truss.constants import (
     BASE_SERVER_REQUIREMENTS_TXT_FILENAME,
     CONTROL_SERVER_CODE_DIR,
@@ -28,8 +24,8 @@ from truss.contexts.image_builder.util import (
 )
 from truss.contexts.truss_context import TrussContext
 from truss.patch.hash import directory_content_hash
-from truss.truss_config import ExternalData
 from truss.truss_spec import TrussSpec
+from truss.util.download import download_external_data
 from truss.util.jinja import read_template_from_fs
 from truss.util.path import (
     build_truss_target_directory,
@@ -39,9 +35,6 @@ from truss.util.path import (
 
 BUILD_SERVER_DIR_NAME = "server"
 BUILD_CONTROL_SERVER_DIR_NAME = "control"
-B10CP_EXECUTABLE_NAME = "b10cp"
-BLOB_DOWNLOAD_TIMEOUT_SECS = 600  # 10 minutes
-B10CP_PATH_TRUSS_ENV_VAR_NAME = "B10CP_PATH_TRUSS"
 
 
 class ServingImageBuilderContext(TrussContext):
@@ -80,7 +73,7 @@ class ServingImageBuilder(ImageBuilder):
         copy_tree_path(truss_dir, build_dir)
 
         # Download external data
-        self._download_external_data(data_dir)
+        download_external_data(self._spec.external_data, data_dir)
 
         # Copy inference server code
         copy_into_build_dir(SERVER_CODE_DIR, BUILD_SERVER_DIR_NAME)
@@ -157,83 +150,3 @@ class ServingImageBuilder(ImageBuilder):
         )
         docker_file_path = build_dir / MODEL_DOCKERFILE_NAME
         docker_file_path.write_text(dockerfile_contents)
-
-    def _download_external_data(self, data_dir: Path):
-        external_data = self._spec.external_data
-        if external_data is None:
-            return
-        data_dir.mkdir(exist_ok=True)
-        b10cp_path = _b10cp_path()
-
-        # ensure parent directories exist
-        for item in external_data.items:
-            path = data_dir / item.local_data_path
-            if data_dir not in path.parents:
-                raise ValueError(
-                    "Local data path of external data cannot point to outside data directory"
-                )
-            path.parent.mkdir(exist_ok=True)
-
-        if b10cp_path is not None:
-            print("b10cp found, using it to download external data")
-            _download_external_data_using_b10cp(b10cp_path, data_dir, external_data)
-            return
-
-        # slow path
-        _download_external_data_using_requests(data_dir, external_data)
-
-
-def _b10cp_path() -> Optional[str]:
-    return os.environ.get(B10CP_PATH_TRUSS_ENV_VAR_NAME)
-
-
-def _download_external_data_using_b10cp(
-    b10cp_path: str,
-    data_dir: Path,
-    external_data: ExternalData,
-):
-    procs = []
-    # TODO(pankaj) Limit concurrency here
-    for item in external_data.items:
-        path = (data_dir / item.local_data_path).resolve()
-        proc = _download_from_url_using_b10cp(b10cp_path, item.url, path)
-        procs.append(proc)
-
-    for proc in procs:
-        proc.wait()
-
-
-def _download_from_url_using_b10cp(
-    b10cp_path: str,
-    url: str,
-    download_to: Path,
-):
-    return subprocess.Popen(
-        [
-            b10cp_path,
-            "-source",
-            url,  # Add quotes to work with any special characters.
-            "-target",
-            str(download_to),
-        ]
-    )
-
-
-def _download_external_data_using_requests(data_dir: Path, external_data: ExternalData):
-    for item in external_data.items:
-        _download_from_url_using_requests(
-            item.url, (data_dir / item.local_data_path).resolve()
-        )
-
-
-def _download_from_url_using_requests(URL: str, download_to: Path):
-    # Streaming download to keep memory usage low
-    resp = requests.get(
-        URL,
-        allow_redirects=True,
-        stream=True,
-        timeout=BLOB_DOWNLOAD_TIMEOUT_SECS,
-    )
-    resp.raise_for_status()
-    with download_to.open("wb") as file:
-        shutil.copyfileobj(resp.raw, file)

--- a/truss/patch/local_truss_patch_applier.py
+++ b/truss/patch/local_truss_patch_applier.py
@@ -4,6 +4,9 @@ from pathlib import Path
 from typing import List
 
 from truss.templates.control.control.helpers.errors import UnsupportedPatch
+from truss.templates.control.control.helpers.truss_patch.model_code_patch_applier import (
+    apply_model_code_patch,
+)
 from truss.templates.control.control.helpers.types import (
     Action,
     ModelCodePatch,
@@ -25,10 +28,6 @@ class LocalTrussPatchApplier:
         self._logger = logger
 
     def __call__(self, patches: List[Patch]):
-        from truss.templates.control.control.helpers.truss_patch.model_code_patch_applier import (
-            apply_model_code_patch,
-        )
-
         for patch in patches:
             self._logger.debug(f"Applying patch {patch.to_dict()}")
             if isinstance(patch.body, ModelCodePatch):

--- a/truss/patch/local_truss_patch_applier.py
+++ b/truss/patch/local_truss_patch_applier.py
@@ -4,9 +4,6 @@ from pathlib import Path
 from typing import List
 
 from truss.templates.control.control.helpers.errors import UnsupportedPatch
-from truss.templates.control.control.helpers.truss_patch.model_code_patch_applier import (
-    apply_model_code_patch,
-)
 from truss.templates.control.control.helpers.types import (
     Action,
     ModelCodePatch,
@@ -28,6 +25,10 @@ class LocalTrussPatchApplier:
         self._logger = logger
 
     def __call__(self, patches: List[Patch]):
+        from truss.templates.control.control.helpers.truss_patch.model_code_patch_applier import (
+            apply_model_code_patch,
+        )
+
         for patch in patches:
             self._logger.debug(f"Applying patch {patch.to_dict()}")
             if isinstance(patch.body, ModelCodePatch):

--- a/truss/templates/control/control/helpers/inference_server_controller.py
+++ b/truss/templates/control/control/helpers/inference_server_controller.py
@@ -150,10 +150,10 @@ def _patch_sort_key_fn(patch: Patch) -> int:
     PATCH_ORDER = [
         PatchType.SYSTEM_PACKAGE,
         PatchType.PYTHON_REQUIREMENT,
-        PatchType.ENVIRONMENT_VARIABLE,
         PatchType.EXTERNAL_DATA,
-        PatchType.CONFIG,
         PatchType.MODEL_CODE,
+        PatchType.CONFIG,
+        PatchType.ENVIRONMENT_VARIABLE,
     ]
     if patch.type not in PATCH_ORDER:
         raise ValueError(f"Unexpected patch type {patch.type}")

--- a/truss/templates/control/control/helpers/inference_server_controller.py
+++ b/truss/templates/control/control/helpers/inference_server_controller.py
@@ -28,6 +28,7 @@ class InferenceServerController:
     _patch_applier: ModelContainerPatchApplier
     _app_logger: logging.Logger
     _oversee_inference_server: bool
+    _inf_env: dict
 
     def __init__(
         self,
@@ -47,6 +48,7 @@ class InferenceServerController:
                 target=self._check_and_recover_inference_server
             )
             self._inference_server_overseer_thread.start()
+        self._inf_env = os.environ.copy()
 
     def apply_patch(self, patch_request):
         with self._lock:
@@ -63,7 +65,7 @@ class InferenceServerController:
                 # We are in sync, ok to start running inference server now, if
                 # it's not running.
                 if not self._process_controller.inference_server_started():
-                    self._process_controller.start()
+                    self._process_controller.start(self._inf_env)
                 self._app_logger.info("Request hash same as current hash, skipping.")
                 return
 
@@ -86,7 +88,7 @@ class InferenceServerController:
             try:
                 patches_executed = 0
                 for patch in patches:
-                    self._patch_applier(patch)
+                    self._patch_applier(patch, self._inf_env)
                     patches_executed += 1
             except Exception as exc:
                 if patches_executed > 0:
@@ -100,10 +102,10 @@ class InferenceServerController:
                 # Theoretically, a single patch application may leave
                 # side-effects, but that's not the case with currently
                 # supported patches.
-                self._process_controller.start()
+                self._process_controller.start(self._inf_env)
                 raise PatchFailedRecoverable(str(exc)) from exc
 
-            self._process_controller.start()
+            self._process_controller.start(self._inf_env)
             self._current_running_hash = req_hash
 
     def truss_hash(self) -> Optional[str]:
@@ -112,7 +114,7 @@ class InferenceServerController:
     def restart(self):
         with self._lock:
             self._process_controller.stop()
-            self._process_controller.start()
+            self._process_controller.start(self._inf_env)
 
     def start(self):
         # For now, start just does restart, this alias allows for better
@@ -131,7 +133,9 @@ class InferenceServerController:
         self._app_logger.info("Inference server overseer thread started")
         while True:
             with self._lock:
-                self._process_controller.check_and_recover_inference_server()
+                self._process_controller.check_and_recover_inference_server(
+                    self._inf_env
+                )
             time.sleep(INFERENCE_SERVER_CHECK_INTERVAL_SECS)
 
 
@@ -142,13 +146,15 @@ def _patch_sort_key_fn(patch: Patch) -> int:
     # model code patches, so it's better to apply model code patches last to
     # avoid ending up with partially applied patches which currently triggers
     # full deploy.
-    if patch.type == PatchType.SYSTEM_PACKAGE:
-        return 0
 
-    if patch.type == PatchType.PYTHON_REQUIREMENT:
-        return 1
-
-    if patch.type == PatchType.MODEL_CODE:
-        return 2
-
-    raise ValueError(f"Unexpected patch type {patch.type}")
+    PATCH_ORDER = [
+        PatchType.SYSTEM_PACKAGE,
+        PatchType.PYTHON_REQUIREMENT,
+        PatchType.ENVIRONMENT_VARIABLE,
+        PatchType.EXTERNAL_DATA,
+        PatchType.CONFIG,
+        PatchType.MODEL_CODE,
+    ]
+    if patch.type not in PATCH_ORDER:
+        raise ValueError(f"Unexpected patch type {patch.type}")
+    return PATCH_ORDER.index(patch.type)

--- a/truss/templates/control/control/helpers/inference_server_process_controller.py
+++ b/truss/templates/control/control/helpers/inference_server_process_controller.py
@@ -31,9 +31,8 @@ class InferenceServerProcessController:
         self._inference_server_ever_started = False
         self._app_logger = app_logger
 
-    def start(self):
+    def start(self, inf_env: dict):
         with current_directory(self._inference_server_home):
-            inf_env = os.environ.copy()
             inf_env["INFERENCE_SERVER_PORT"] = str(self._inference_server_port)
             self._inference_server_process = subprocess.Popen(
                 self._inference_server_process_args,
@@ -72,12 +71,12 @@ class InferenceServerProcessController:
     def is_inference_server_intentionally_stopped(self) -> bool:
         return INFERENCE_SERVER_FAILED_FILE.exists()
 
-    def check_and_recover_inference_server(self):
+    def check_and_recover_inference_server(self, inf_env: dict):
         if self.inference_server_started() and not self.is_inference_server_running():
             if not self.is_inference_server_intentionally_stopped():
                 self._app_logger.warning(
                     "Inference server seems to have crashed, restarting"
                 )
-                self.start()
+                self.start(inf_env)
             else:
                 self._app_logger.warning("Inference server unrecoverable. Try patching")

--- a/truss/templates/control/control/helpers/truss_patch/model_code_patch_applier.py
+++ b/truss/templates/control/control/helpers/truss_patch/model_code_patch_applier.py
@@ -4,7 +4,8 @@ from pathlib import Path
 # TODO(pankaj) In desparate need of refactoring into separate library
 try:
     from helpers.types import Action, ModelCodePatch
-except ModuleNotFoundError:
+except ModuleNotFoundError as exc:
+    logging.debug(f"Importing helpers from truss core: {exc}")
     from truss.templates.control.control.helpers.types import Action, ModelCodePatch
 
 
@@ -14,8 +15,9 @@ def apply_model_code_patch(
     logger: logging.Logger,
 ):
     logger.debug(f"Applying model code patch {patch.to_dict()}")
-    action = patch.action
     filepath: Path = model_code_dir / patch.path
+    action = patch.action
+
     if action in [Action.ADD, Action.UPDATE]:
         filepath.parent.mkdir(parents=True, exist_ok=True)
         logger.info(f"Updating file {filepath}")
@@ -23,7 +25,7 @@ def apply_model_code_patch(
             content = patch.content
             if content is None:
                 raise ValueError(
-                    "Invalid patch: content of a model code update patch should not be None."
+                    "Invalid patch: content of a file update patch should not be None."
                 )
             file.write(content)
 
@@ -34,4 +36,4 @@ def apply_model_code_patch(
             logger.info(f"Deleting file {filepath}")
             filepath.unlink()
     else:
-        raise ValueError(f"Unknown model code patch action {action}")
+        raise ValueError(f"Unknown patch action {action}")

--- a/truss/templates/control/control/helpers/types.py
+++ b/truss/templates/control/control/helpers/types.py
@@ -10,6 +10,11 @@ class PatchType(Enum):
     MODEL_CODE = "model_code"
     PYTHON_REQUIREMENT = "python_requirement"
     SYSTEM_PACKAGE = "system_package"
+    CONFIG = "config"
+    PACKAGE = "package"
+    DATA = "data"
+    ENVIRONMENT_VARIABLE = "environment_variable"
+    EXTERNAL_DATA = "external_data"
 
 
 class Action(Enum):
@@ -95,13 +100,133 @@ class SystemPackagePatch(PatchBody):
         )
 
 
+@dataclass
+class ConfigPatch(PatchBody):
+    config: dict
+    path: str = "config.yaml"
+
+    def to_dict(self):
+        return {
+            "action": self.action.value,
+            "config": self.config,
+            "path": self.path,
+        }
+
+    @staticmethod
+    def from_dict(patch_dict: Dict):
+        action_str = patch_dict["action"]
+        return ConfigPatch(
+            action=Action[action_str],
+            config=patch_dict["config"],
+            path=patch_dict["path"],
+        )
+
+
+@dataclass
+class DataPatch(PatchBody):
+    content: dict
+    path: str
+
+    def to_dict(self):
+        return {
+            "action": self.action.value,
+            "content": self.content,
+            "path": self.path,
+        }
+
+    @staticmethod
+    def from_dict(patch_dict: Dict):
+        action_str = patch_dict["action"]
+        return DataPatch(
+            action=Action[action_str],
+            content=patch_dict["content"],
+            path=patch_dict["path"],
+        )
+
+
+@dataclass
+class PackagePatch(PatchBody):
+    content: dict
+    path: str
+
+    def to_dict(self):
+        return {
+            "action": self.action.value,
+            "content": self.content,
+            "path": self.path,
+        }
+
+    @staticmethod
+    def from_dict(patch_dict: Dict):
+        action_str = patch_dict["action"]
+        return PackagePatch(
+            action=Action[action_str],
+            content=patch_dict["content"],
+            path=patch_dict["path"],
+        )
+
+
+@dataclass
+class EnvVarPatch(PatchBody):
+    item: dict
+
+    def to_dict(self):
+        return {
+            "action": self.action.value,
+            "item": self.item,
+        }
+
+    @staticmethod
+    def from_dict(patch_dict: Dict):
+        action_str = patch_dict["action"]
+        return EnvVarPatch(
+            action=Action[action_str],
+            item=patch_dict["item"],
+        )
+
+
+@dataclass
+class ExternalDataPatch(PatchBody):
+    item: Dict[str, str]
+
+    def to_dict(self):
+        return {
+            "action": self.action.value,
+            "item": self.item,
+        }
+
+    @staticmethod
+    def from_dict(patch_dict: Dict):
+        action_str = patch_dict["action"]
+        return ExternalDataPatch(
+            action=Action[action_str],
+            item=patch_dict["item"],
+        )
+
+
 PATCH_BODY_BY_TYPE: Dict[
     PatchType,
-    Type[Union[ModelCodePatch, PythonRequirementPatch, SystemPackagePatch]],
+    Type[
+        Union[
+            ModelCodePatch,
+            PythonRequirementPatch,
+            SystemPackagePatch,
+            ConfigPatch,
+            DataPatch,
+            PackagePatch,
+            EnvVarPatch,
+            ExternalDataPatch,
+        ]
+    ],
 ] = {
     PatchType.MODEL_CODE: ModelCodePatch,
     PatchType.PYTHON_REQUIREMENT: PythonRequirementPatch,
     PatchType.SYSTEM_PACKAGE: SystemPackagePatch,
+    PatchType.CONFIG: ConfigPatch,
+    PatchType.DATA: DataPatch,
+    PatchType.PACKAGE: PackagePatch,
+    PatchType.ENVIRONMENT_VARIABLE: EnvVarPatch,
+    PatchType.EXTERNAL_DATA: ExternalDataPatch,
 }
 
 

--- a/truss/templates/control/requirements.txt
+++ b/truss/templates/control/requirements.txt
@@ -1,5 +1,5 @@
 dataclasses-json==0.5.7
-truss==0.4.8
+truss==0.4.10rc2
 Flask==2.0.3
 waitress==2.1.2
 tenacity==8.1.0

--- a/truss/tests/patch/test_calc_patch.py
+++ b/truss/tests/patch/test_calc_patch.py
@@ -1,10 +1,14 @@
 from pathlib import Path
 from typing import Any, Callable, List, Optional
 
+import yaml
 from truss.patch.calc_patch import calc_truss_patch
 from truss.patch.signature import calc_truss_signature
 from truss.templates.control.control.helpers.types import (
     Action,
+    ConfigPatch,
+    EnvVarPatch,
+    ExternalDataPatch,
     ModelCodePatch,
     Patch,
     PatchType,
@@ -12,6 +16,7 @@ from truss.templates.control.control.helpers.types import (
     SystemPackagePatch,
 )
 from truss.truss_config import TrussConfig
+from truss.truss_handle import TrussHandle
 
 
 def test_calc_truss_patch_unsupported(custom_model_truss_dir: Path):
@@ -168,15 +173,23 @@ def test_calc_config_patches_add_python_requirement(custom_model_truss_dir: Path
         custom_model_truss_dir,
         lambda config: config.requirements.append("requests==1.0.0"),
     )
-    assert len(patches) == 1
-    patch = patches[0]
-    assert patch == Patch(
-        type=PatchType.PYTHON_REQUIREMENT,
-        body=PythonRequirementPatch(
-            action=Action.ADD,
-            requirement="requests==1.0.0",
+    assert len(patches) == 2
+    assert patches == [
+        Patch(
+            type=PatchType.CONFIG,
+            body=ConfigPatch(
+                action=Action.UPDATE,
+                config=yaml.safe_load((custom_model_truss_dir / "config.yaml").open()),
+            ),
         ),
-    )
+        Patch(
+            type=PatchType.PYTHON_REQUIREMENT,
+            body=PythonRequirementPatch(
+                action=Action.ADD,
+                requirement="requests==1.0.0",
+            ),
+        ),
+    ]
 
 
 def test_calc_config_patches_remove_python_requirement(custom_model_truss_dir: Path):
@@ -185,15 +198,23 @@ def test_calc_config_patches_remove_python_requirement(custom_model_truss_dir: P
         config_pre_op=lambda config: config.requirements.append("requests==1.0.0"),
         config_op=lambda config: config.requirements.clear(),
     )
-    assert len(patches) == 1
-    patch = patches[0]
-    assert patch == Patch(
-        type=PatchType.PYTHON_REQUIREMENT,
-        body=PythonRequirementPatch(
-            action=Action.REMOVE,
-            requirement="requests",
+    assert len(patches) == 2
+    assert patches == [
+        Patch(
+            type=PatchType.CONFIG,
+            body=ConfigPatch(
+                action=Action.UPDATE,
+                config=yaml.safe_load((custom_model_truss_dir / "config.yaml").open()),
+            ),
         ),
-    )
+        Patch(
+            type=PatchType.PYTHON_REQUIREMENT,
+            body=PythonRequirementPatch(
+                action=Action.REMOVE,
+                requirement="requests",
+            ),
+        ),
+    ]
 
 
 def test_calc_config_patches_update_python_requirement(custom_model_truss_dir: Path):
@@ -205,15 +226,23 @@ def test_calc_config_patches_update_python_requirement(custom_model_truss_dir: P
         config_pre_op=lambda config: config.requirements.append("requests==1.0.0"),
         config_op=update_requests_version,
     )
-    assert len(patches) == 1
-    patch = patches[0]
-    assert patch == Patch(
-        type=PatchType.PYTHON_REQUIREMENT,
-        body=PythonRequirementPatch(
-            action=Action.UPDATE,
-            requirement="requests==2.0.0",
+    assert len(patches) == 2
+    assert patches == [
+        Patch(
+            type=PatchType.CONFIG,
+            body=ConfigPatch(
+                action=Action.UPDATE,
+                config=yaml.safe_load((custom_model_truss_dir / "config.yaml").open()),
+            ),
         ),
-    )
+        Patch(
+            type=PatchType.PYTHON_REQUIREMENT,
+            body=PythonRequirementPatch(
+                action=Action.UPDATE,
+                requirement="requests==2.0.0",
+            ),
+        ),
+    ]
 
 
 def test_calc_config_patches_add_remove_and_update_python_requirement(
@@ -236,7 +265,15 @@ def test_calc_config_patches_add_remove_and_update_python_requirement(
         config_pre_op=config_pre_op,
         config_op=config_op,
     )
-    assert len(patches) == 3
+    assert len(patches) == 4
+    assert patches[0] == Patch(
+        type=PatchType.CONFIG,
+        body=ConfigPatch(
+            action=Action.UPDATE,
+            config=yaml.safe_load((custom_model_truss_dir / "config.yaml").open()),
+        ),
+    )
+    patches = patches[1:]
     patches.sort(key=lambda patch: patch.body.requirement)
     assert patches == [
         Patch(
@@ -263,14 +300,59 @@ def test_calc_config_patches_add_remove_and_update_python_requirement(
     ]
 
 
-def test_calc_config_patches_non_python_or_system_requirement_change(
+def test_calc_config_patches_add_env_var(
     custom_model_truss_dir: Path,
 ):
     patches = _apply_config_change_and_calc_patches(
         custom_model_truss_dir,
         config_op=lambda config: config.environment_variables.update({"foo": "bar"}),
     )
-    assert patches is None
+    assert len(patches) == 2
+    assert patches == [
+        Patch(
+            type=PatchType.CONFIG,
+            body=ConfigPatch(
+                action=Action.UPDATE,
+                config=yaml.safe_load((custom_model_truss_dir / "config.yaml").open()),
+            ),
+        ),
+        Patch(
+            type=PatchType.ENVIRONMENT_VARIABLE,
+            body=EnvVarPatch(
+                action=Action.ADD,
+                item={"foo": "bar"},
+            ),
+        ),
+    ]
+
+
+def test_calc_config_patches_add_remove_env_var(
+    custom_model_truss_dir: Path,
+):
+    patches = _apply_config_change_and_calc_patches(
+        custom_model_truss_dir,
+        config_pre_op=lambda config: config.environment_variables.update(
+            {"foo": "bar"}
+        ),
+        config_op=lambda config: config.environment_variables.clear(),
+    )
+    assert len(patches) == 2
+    assert patches == [
+        Patch(
+            type=PatchType.CONFIG,
+            body=ConfigPatch(
+                action=Action.UPDATE,
+                config=yaml.safe_load((custom_model_truss_dir / "config.yaml").open()),
+            ),
+        ),
+        Patch(
+            type=PatchType.ENVIRONMENT_VARIABLE,
+            body=EnvVarPatch(
+                action=Action.REMOVE,
+                item={"foo": "bar"},
+            ),
+        ),
+    ]
 
 
 def test_calc_config_patches_add_system_package(custom_model_truss_dir: Path):
@@ -278,15 +360,23 @@ def test_calc_config_patches_add_system_package(custom_model_truss_dir: Path):
         custom_model_truss_dir,
         lambda config: config.system_packages.append("curl"),
     )
-    assert len(patches) == 1
-    patch = patches[0]
-    assert patch == Patch(
-        type=PatchType.SYSTEM_PACKAGE,
-        body=SystemPackagePatch(
-            action=Action.ADD,
-            package="curl",
+    assert len(patches) == 2
+    assert patches == [
+        Patch(
+            type=PatchType.CONFIG,
+            body=ConfigPatch(
+                action=Action.UPDATE,
+                config=yaml.safe_load((custom_model_truss_dir / "config.yaml").open()),
+            ),
         ),
-    )
+        Patch(
+            type=PatchType.SYSTEM_PACKAGE,
+            body=SystemPackagePatch(
+                action=Action.ADD,
+                package="curl",
+            ),
+        ),
+    ]
 
 
 def test_calc_config_patches_remove_system_package(custom_model_truss_dir: Path):
@@ -295,15 +385,23 @@ def test_calc_config_patches_remove_system_package(custom_model_truss_dir: Path)
         config_pre_op=lambda config: config.system_packages.append("curl"),
         config_op=lambda config: config.system_packages.clear(),
     )
-    assert len(patches) == 1
-    patch = patches[0]
-    assert patch == Patch(
-        type=PatchType.SYSTEM_PACKAGE,
-        body=SystemPackagePatch(
-            action=Action.REMOVE,
-            package="curl",
+    assert len(patches) == 2
+    assert patches == [
+        Patch(
+            type=PatchType.CONFIG,
+            body=ConfigPatch(
+                action=Action.UPDATE,
+                config=yaml.safe_load((custom_model_truss_dir / "config.yaml").open()),
+            ),
         ),
-    )
+        Patch(
+            type=PatchType.SYSTEM_PACKAGE,
+            body=SystemPackagePatch(
+                action=Action.REMOVE,
+                package="curl",
+            ),
+        ),
+    ]
 
 
 def test_calc_config_patches_add_and_remove_system_package(
@@ -326,6 +424,15 @@ def test_calc_config_patches_add_and_remove_system_package(
         config_pre_op=config_pre_op,
         config_op=config_op,
     )
+    assert len(patches) == 3
+    assert patches[0] == Patch(
+        type=PatchType.CONFIG,
+        body=ConfigPatch(
+            action=Action.UPDATE,
+            config=yaml.safe_load((custom_model_truss_dir / "config.yaml").open()),
+        ),
+    )
+    patches = patches[1:]
     patches.sort(key=lambda patch: patch.body.package)
     assert patches == [
         Patch(
@@ -340,6 +447,88 @@ def test_calc_config_patches_add_and_remove_system_package(
             body=SystemPackagePatch(
                 action=Action.ADD,
                 package="libsnd",
+            ),
+        ),
+    ]
+
+
+def test_calc_config_patches_toggle_apply_library_patches(custom_model_truss_dir: Path):
+    def config_op(config: TrussConfig):
+        config.apply_library_patches = False
+
+    patches = _apply_config_change_and_calc_patches(custom_model_truss_dir, config_op)
+    assert len(patches) == 1
+    patch = patches[0]
+    assert patch == Patch(
+        type=PatchType.CONFIG,
+        body=ConfigPatch(
+            action=Action.UPDATE,
+            config=yaml.safe_load((custom_model_truss_dir / "config.yaml").open()),
+        ),
+    )
+
+
+def test_calc_config_patches_add_external_data(
+    custom_model_external_data_access_tuple_fixture: Path,
+):
+    path, _ = custom_model_external_data_access_tuple_fixture
+    th = TrussHandle(path)
+    external_data = th.spec.config.external_data
+
+    def config_op(config: TrussConfig):
+        config.external_data = external_data
+
+    def config_pre_op(config: TrussConfig):
+        config.external_data = None
+
+    patches = _apply_config_change_and_calc_patches(
+        path,
+        config_pre_op=config_pre_op,
+        config_op=config_op,
+    )
+    assert len(patches) == 2
+    assert patches == [
+        Patch(
+            type=PatchType.CONFIG,
+            body=ConfigPatch(
+                action=Action.UPDATE,
+                config=yaml.safe_load((path / "config.yaml").open()),
+            ),
+        ),
+        Patch(
+            type=PatchType.EXTERNAL_DATA,
+            body=ExternalDataPatch(action=Action.ADD, item=external_data.to_list()[0]),
+        ),
+    ]
+
+
+def test_calc_config_patches_remove_external_data(
+    custom_model_external_data_access_tuple_fixture: Path,
+):
+    path, _ = custom_model_external_data_access_tuple_fixture
+    th = TrussHandle(path)
+    external_data = th.spec.config.external_data
+
+    def config_op(config: TrussConfig):
+        config.external_data = None
+
+    patches = _apply_config_change_and_calc_patches(
+        path,
+        config_op=config_op,
+    )
+    assert len(patches) == 2
+    assert patches == [
+        Patch(
+            type=PatchType.CONFIG,
+            body=ConfigPatch(
+                action=Action.UPDATE,
+                config=yaml.safe_load((path / "config.yaml").open()),
+            ),
+        ),
+        Patch(
+            type=PatchType.EXTERNAL_DATA,
+            body=ExternalDataPatch(
+                action=Action.REMOVE, item=external_data.to_list()[0]
             ),
         ),
     ]

--- a/truss/tests/templates/control/control/helpers/test_model_container_patch_applier.py
+++ b/truss/tests/templates/control/control/helpers/test_model_container_patch_applier.py
@@ -1,8 +1,10 @@
+import os
 import sys
 from pathlib import Path
-from unittest.mock import Mock
+from unittest import mock
 
 import pytest
+from truss.truss_config import TrussConfig
 
 # Needed to simulate the set up on the model docker container
 sys.path.append(
@@ -18,15 +20,23 @@ sys.path.append(
 from helpers.truss_patch.model_container_patch_applier import (  # noqa
     ModelContainerPatchApplier,
 )
-from helpers.types import Action, ModelCodePatch, Patch, PatchType  # noqa
+from helpers.types import (  # noqa
+    Action,
+    ConfigPatch,
+    EnvVarPatch,
+    ExternalDataPatch,
+    ModelCodePatch,
+    Patch,
+    PatchType,
+)
 
 
 @pytest.fixture
 def patch_applier(truss_container_fs):
-    return ModelContainerPatchApplier(truss_container_fs / "app", Mock())
+    return ModelContainerPatchApplier(truss_container_fs / "app", mock.Mock())
 
 
-def test_patch_applier_add(
+def test_patch_applier_model_code_patch_add(
     patch_applier: ModelContainerPatchApplier, truss_container_fs
 ):
     patch = Patch(
@@ -37,11 +47,11 @@ def test_patch_applier_add(
             content="",
         ),
     )
-    patch_applier(patch)
+    patch_applier(patch, os.environ.copy())
     assert (truss_container_fs / "app" / "model" / "dummy").exists()
 
 
-def test_patch_applier_remove(
+def test_patch_applier_model_code_patch_remove(
     patch_applier: ModelContainerPatchApplier, truss_container_fs
 ):
     patch = Patch(
@@ -52,11 +62,11 @@ def test_patch_applier_remove(
         ),
     )
     assert (truss_container_fs / "app" / "model" / "model.py").exists()
-    patch_applier(patch)
+    patch_applier(patch, os.environ.copy())
     assert not (truss_container_fs / "app" / "model" / "model.py").exists()
 
 
-def test_patch_applier_update(
+def test_patch_applier_model_code_patch_update(
     patch_applier: ModelContainerPatchApplier, truss_container_fs
 ):
     new_model_file_content = """
@@ -71,6 +81,87 @@ def test_patch_applier_update(
             content=new_model_file_content,
         ),
     )
-    patch_applier(patch)
+    patch_applier(patch, os.environ.copy())
     with (truss_container_fs / "app" / "model" / "model.py").open() as model_file:
         assert model_file.read() == new_model_file_content
+
+
+def test_patch_applier_config_patch_update(
+    patch_applier: ModelContainerPatchApplier, truss_container_fs
+):
+    new_config_dict = {"model_name": "foobar"}
+    patch = Patch(
+        type=PatchType.CONFIG,
+        body=ConfigPatch(
+            action=Action.UPDATE,
+            config=new_config_dict,
+        ),
+    )
+    patch_applier(patch, os.environ.copy())
+    new_config = TrussConfig.from_yaml(truss_container_fs / "app" / "config.yaml")
+    assert new_config.model_name == "foobar"
+
+
+def test_patch_applier_env_var_patch_update(
+    patch_applier: ModelContainerPatchApplier,
+):
+    env_var_dict = {"FOO": "BAR"}
+    patch = Patch(
+        type=PatchType.ENVIRONMENT_VARIABLE,
+        body=EnvVarPatch(
+            action=Action.UPDATE,
+            item={"FOO": "BAR-PATCHED"},
+        ),
+    )
+    patch_applier(patch, env_var_dict)
+    assert env_var_dict["FOO"] == "BAR-PATCHED"
+
+
+def test_patch_applier_env_var_patch_add(
+    patch_applier: ModelContainerPatchApplier,
+):
+    env_var_dict = {"FOO": "BAR"}
+    patch = Patch(
+        type=PatchType.ENVIRONMENT_VARIABLE,
+        body=EnvVarPatch(
+            action=Action.ADD,
+            item={"BAR": "FOO"},
+        ),
+    )
+    patch_applier(patch, env_var_dict)
+    assert env_var_dict["FOO"] == "BAR"
+    assert env_var_dict["BAR"] == "FOO"
+
+
+def test_patch_applier_env_var_patch_remove(
+    patch_applier: ModelContainerPatchApplier,
+):
+    env_var_dict = {"FOO": "BAR"}
+    patch = Patch(
+        type=PatchType.ENVIRONMENT_VARIABLE,
+        body=EnvVarPatch(
+            action=Action.REMOVE,
+            item={"FOO": "BAR"},
+        ),
+    )
+    patch_applier(patch, env_var_dict)
+    with pytest.raises(KeyError):
+        _ = env_var_dict["FOO"]
+
+
+def test_patch_applier_external_data_patch_add(
+    patch_applier: ModelContainerPatchApplier,
+    truss_container_fs,
+):
+    patch = Patch(
+        type=PatchType.EXTERNAL_DATA,
+        body=ExternalDataPatch(
+            action=Action.ADD,
+            item={
+                "url": "https://raw.githubusercontent.com/basetenlabs/truss/main/docs/assets/truss_logo_horizontal.png",
+                "local_data_path": "truss_icon",
+            },
+        ),
+    )
+    patch_applier(patch, os.environ.copy())
+    assert (truss_container_fs / "app" / "data" / "truss_icon").exists()

--- a/truss/tests/test_control_truss_patching.py
+++ b/truss/tests/test_control_truss_patching.py
@@ -1,4 +1,4 @@
-import subprocess
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -6,12 +6,12 @@ from truss.constants import SUPPORTED_PYTHON_VERSIONS
 from truss.tests.conftest import CUSTOM_MODEL_USING_EXTERNAL_PACKAGE_CODE
 from truss.tests.test_testing_utilities_for_other_tests import ensure_kill_all
 from truss.tests.test_truss_handle import (
-    verify_environment_variable_on_container,
     verify_python_requirement_installed_on_container,
     verify_python_requirement_not_installed_on_container,
     verify_system_package_installed_on_container,
     verify_system_requirement_not_installed_on_container,
 )
+from truss.truss_config import ExternalDataItem
 from truss.truss_handle import TrussHandle
 
 
@@ -26,6 +26,12 @@ def control_model_handle_tag_tuple(
     th = TrussHandle(custom_model_control)
     tag = "test-docker-custom-model-control-tag:0.0.1"
     return (custom_model_control, th, tag)
+
+
+def update_model_code(path, new_model_code):
+    model_code_file_path = path / "model" / "model.py"
+    with model_code_file_path.open("w") as model_code_file:
+        model_code_file.write(new_model_code)
 
 
 @pytest.mark.integration
@@ -43,23 +49,18 @@ def test_control_truss_model_code_patch(
     custom_model_control, th, tag = control_model_handle_tag_tuple
     th.update_python_version(python_version)
 
-    def predict_with_updated_model_code():
-        new_model_code = """
+    new_model_code = """
 class Model:
     def predict(self, model_input):
         return [2 for i in model_input]
 """
-        model_code_file_path = custom_model_control / "model" / "model.py"
-        with model_code_file_path.open("w") as model_code_file:
-            model_code_file.write(new_model_code)
-        return th.docker_predict([1], tag=tag, binary=binary)
 
     with ensure_kill_all():
         result = th.docker_predict([1], tag=tag, binary=binary)
         assert result[0] == 1
         orig_num_truss_images = len(th.get_all_docker_images())
-
-        result = predict_with_updated_model_code()
+        update_model_code(custom_model_control, new_model_code)
+        result = th.docker_predict([1], tag=tag, binary=binary)
         assert result[0] == 2
         assert orig_num_truss_images == current_num_docker_images(th)
 
@@ -211,7 +212,6 @@ def test_control_truss_patch_ignored_changes(
         assert current_num_docker_images(th) == orig_num_truss_images
 
 
-@pytest.mark.skip(reason="Unsupported patch")
 @pytest.mark.integration
 def test_patch_added_model_dir(
     custom_model_control, tmp_path, control_model_handle_tag_tuple
@@ -231,7 +231,7 @@ def test_patch_added_model_dir(
 
         predict_with_added_model_dir_file()
         assert orig_num_truss_images == current_num_docker_images(th)
-        assert (tmp_path / "model" / "dir" / "foo.bar").exists()
+        assert (custom_model_control / "model" / "dir" / "foo.bar").exists()
 
 
 @pytest.mark.skip(reason="Unsupported patch")
@@ -257,33 +257,36 @@ def test_patch_data_dir(control_model_handle_tag_tuple):
         assert orig_num_truss_images == current_num_docker_images(th)
 
 
-@pytest.mark.skip(reason="Unsupported patch")
 @pytest.mark.integration
 def test_patch_env_var(control_model_handle_tag_tuple):
-    _, th, tag = control_model_handle_tag_tuple
+    truss_dir, th, tag = control_model_handle_tag_tuple
 
     def predict_with_environment_variables_change():
         th.add_environment_variable("foo", "bar")
-        th.docker_predict([1], tag=tag)
-        verify_environment_variable_on_container(
-            th.get_running_serving_container_ignore_hash(), "foo", "bar"
-        )
+        result = th.docker_predict([1], tag=tag)
+        assert result == "bar"
         th.add_environment_variable("foo", "bar2")
-        th.kill_container()
-        th.docker_predict([1], tag=tag)
-        verify_environment_variable_on_container(
-            th.get_running_serving_container_ignore_hash(), "foo", "bar2"
-        )
-        th.clear_environment_variables()
-        th.kill_container()
-        th.docker_predict([1], tag=tag)
-        with pytest.raises(AssertionError):
-            verify_environment_variable_on_container(
-                th.get_running_serving_container_ignore_hash(), "foo", "bar2"
-            )
+        result = th.docker_predict([1], tag=tag)
+        assert result == "bar2"
+        config_path = truss_dir / "config.yaml"
+        with config_path.open("w") as file:
+            file.write("{}")
+
+        assert th._serving_hash() != th.truss_hash_on_serving_container()
+        result = th.docker_predict([1], tag=tag)
+        assert result == "No foo :("
 
     with ensure_kill_all():
-        th.docker_predict([1], tag=tag)
+        new_model_code = """
+import os
+class Model:
+    def predict(self, model_input):
+        print(os.environ.copy())
+        return os.environ.get("foo", "No foo :(")
+"""
+        update_model_code(truss_dir, new_model_code)
+        result = th.docker_predict([1], tag=tag)
+        assert result == "No foo :("
         orig_num_truss_images = len(th.get_all_docker_images())
 
         predict_with_environment_variables_change()
@@ -303,16 +306,15 @@ class Model:
     def predict(self, model_input):
         return [2 for i in model_input]
         """
-        model_code_file_path = custom_model_with_external_package / "model" / "model.py"
-        with model_code_file_path.open("w") as model_code_file:
-            model_code_file.write(new_model_code)
+        update_model_code(custom_model_with_external_package, new_model_code)
         th.docker_predict([1], tag=tag)
         th.kill_container()
         orig_num_truss_images = len(th.get_all_docker_images())
         th.add_external_package("../ext_pkg")
         th.add_external_package("../ext_pkg2")
-        with model_code_file_path.open("w") as model_code_file:
-            model_code_file.write(CUSTOM_MODEL_USING_EXTERNAL_PACKAGE_CODE)
+        update_model_code(
+            custom_model_with_external_package, CUSTOM_MODEL_USING_EXTERNAL_PACKAGE_CODE
+        )
         th.docker_predict([1], tag=tag)
         assert orig_num_truss_images == current_num_docker_images(th)
         assert (custom_model_with_external_package / "ext_pkg").exists() and (
@@ -337,18 +339,19 @@ def test_patch_secrets(control_model_handle_tag_tuple):
         assert orig_num_truss_images == current_num_docker_images(th)
 
 
-@pytest.mark.skip(reason="Unsupported patch")
 @pytest.mark.integration
 def test_predict_with_external_data_change(
     custom_model_external_data_access_tuple_fixture, tmp_path
 ):
     truss_dir, _ = custom_model_external_data_access_tuple_fixture
     th = TrussHandle(truss_dir)
+    th.live_reload()
     tag = "test-external-data-access-tag:0.0.1"
     with ensure_kill_all():
         th.docker_predict([], tag=tag)
         orig_num_truss_images = len(th.get_all_docker_images())
         th.remove_all_external_data()
+        assert th._serving_hash() != th.truss_hash_on_serving_container()
         new_model_code = """
 class Model:
     def __init__(self, data_dir):
@@ -358,18 +361,11 @@ class Model:
     def predict(self, model_input):
         return None
 """
-        model_code_file_path = truss_dir / "model" / "model.py"
-        with model_code_file_path.open("w") as model_code_file:
-            model_code_file.write(new_model_code)
+        update_model_code(truss_dir, new_model_code)
         th.docker_predict([], tag=tag)
         content = "foobar"
         filename = "foobar.txt"
         (tmp_path / filename).write_text(content)
-        port = 9090
-        proc = subprocess.Popen(
-            ["python", "-m", "http.server", str(port), "--bind", "*"],
-            cwd=tmp_path,
-        )
         new_model_code = """
 class Model:
     def __init__(self, data_dir):
@@ -377,19 +373,34 @@ class Model:
         pass
 
     def predict(self, model_input):
-        with (self._data_dir / 'foobar.txt').open() as file:
-            return file.read()
+        return (self._data_dir / 'foobar.txt').read_text()
 """
-        model_code_file_path = truss_dir / "model" / "model.py"
-        with model_code_file_path.open("w") as model_code_file:
-            model_code_file.write(new_model_code)
-        try:
-            url = f"http://localhost:{port}/{filename}"
-            th.add_external_data_item(url, filename)
-            result = th.docker_predict([], tag=tag)
-            assert (
-                result == content
-                and orig_num_truss_images == current_num_docker_images(th)
+        update_model_code(truss_dir, new_model_code)
+        url = f"http://host.docker.internal:9089/{filename}"
+        th.add_external_data_item(url, filename)
+        result = th.docker_predict([], tag=tag)
+        assert result == content
+
+        content = "patched content"
+        new_filename = "foobar-patched.txt"
+        (tmp_path / new_filename).write_text(content)
+        current_external_data = th._spec.config.external_data
+        new_external_data = replace(
+            current_external_data,
+            items=[
+                ExternalDataItem(
+                    url=f"http://host.docker.internal:9089/{new_filename}",
+                    local_data_path=filename,
+                )
+            ],
+        )
+        th._update_config(
+            lambda conf: replace(
+                conf,
+                external_data=new_external_data,
             )
-        finally:
-            proc.kill()
+        )
+        result = th.docker_predict([], tag=tag)
+        assert result == content and orig_num_truss_images == current_num_docker_images(
+            th
+        )

--- a/truss/truss_handle.py
+++ b/truss/truss_handle.py
@@ -451,10 +451,6 @@ class TrussHandle:
             )
         )
 
-    def clear_environment_variables(self):
-        """Remove environment variables from truss model's config."""
-        self._update_config(lambda conf: replace(conf, environment_variables={}))
-
     def add_secret(self, secret_name: str, default_secret_value: str = ""):
         validate_secret_name(secret_name)
         self._update_config(

--- a/truss/util/download.py
+++ b/truss/util/download.py
@@ -1,0 +1,92 @@
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+import requests
+from truss.truss_config import ExternalData
+
+B10CP_EXECUTABLE_NAME = "b10cp"
+BLOB_DOWNLOAD_TIMEOUT_SECS = 600  # 10 minutes
+B10CP_PATH_TRUSS_ENV_VAR_NAME = "B10CP_PATH_TRUSS"
+
+
+def download_external_data(external_data: Optional[ExternalData], data_dir: Path):
+    if external_data is None:
+        return
+    data_dir.mkdir(exist_ok=True)
+    b10cp_path = _b10cp_path()
+
+    # ensure parent directories exist
+    for item in external_data.items:
+        path = data_dir / item.local_data_path
+        if data_dir not in path.parents:
+            raise ValueError(
+                "Local data path of external data cannot point to outside data directory"
+            )
+        path.parent.mkdir(exist_ok=True)
+
+    if b10cp_path is not None:
+        print("b10cp found, using it to download external data")
+        _download_external_data_using_b10cp(b10cp_path, data_dir, external_data)
+        return
+
+    # slow path
+    _download_external_data_using_requests(data_dir, external_data)
+
+
+def _b10cp_path() -> Optional[str]:
+    return os.environ.get(B10CP_PATH_TRUSS_ENV_VAR_NAME)
+
+
+def _download_external_data_using_b10cp(
+    b10cp_path: str,
+    data_dir: Path,
+    external_data: ExternalData,
+):
+    procs = []
+    # TODO(pankaj) Limit concurrency here
+    for item in external_data.items:
+        path = (data_dir / item.local_data_path).resolve()
+        proc = _download_from_url_using_b10cp(b10cp_path, item.url, path)
+        procs.append(proc)
+
+    for proc in procs:
+        proc.wait()
+
+
+def _download_from_url_using_b10cp(
+    b10cp_path: str,
+    url: str,
+    download_to: Path,
+):
+    return subprocess.Popen(
+        [
+            b10cp_path,
+            "-source",
+            url,  # Add quotes to work with any special characters.
+            "-target",
+            str(download_to),
+        ]
+    )
+
+
+def _download_external_data_using_requests(data_dir: Path, external_data: ExternalData):
+    for item in external_data.items:
+        _download_from_url_using_requests(
+            item.url, (data_dir / item.local_data_path).resolve()
+        )
+
+
+def _download_from_url_using_requests(URL: str, download_to: Path):
+    # Streaming download to keep memory usage low
+    resp = requests.get(
+        URL,
+        allow_redirects=True,
+        stream=True,
+        timeout=BLOB_DOWNLOAD_TIMEOUT_SECS,
+    )
+    resp.raise_for_status()
+    with download_to.open("wb") as file:
+        shutil.copyfileobj(resp.raw, file)


### PR DESCRIPTION
- Creates subclasses for patch support extension to config values (including external data and environment variables) data dir, packages. Package and Data patches are left unimplemented
- Add support for patch calculation of config beyond python and system requirements
- Moves external data download utils for reuse
- Introduces a shared handle to the inference server environment variables to be passed between patch applier and inference server controller