### PR TITLE
initialize inference environment before starting overseer thread

### DIFF
--- a/truss/templates/control/control/helpers/inference_server_controller.py
+++ b/truss/templates/control/control/helpers/inference_server_controller.py
@@ -43,12 +43,12 @@ class InferenceServerController:
         self._current_running_hash = os.environ.get("HASH_TRUSS", None)
         self._app_logger = app_logger
         self._has_partially_applied_patch = False
+        self._inf_env = os.environ.copy()
         if oversee_inference_server:
             self._inference_server_overseer_thread = threading.Thread(
                 target=self._check_and_recover_inference_server
             )
             self._inference_server_overseer_thread.start()
-        self._inf_env = os.environ.copy()
 
     def apply_patch(self, patch_request):
         with self._lock:

--- a/truss/templates/control/control/helpers/inference_server_controller.py
+++ b/truss/templates/control/control/helpers/inference_server_controller.py
@@ -43,7 +43,9 @@ class InferenceServerController:
         self._current_running_hash = os.environ.get("HASH_TRUSS", None)
         self._app_logger = app_logger
         self._has_partially_applied_patch = False
-        self._inf_env = os.environ.copy()
+        self._inf_env = (
+            os.environ.copy()
+        )  # this must be initialized before overseer is started
         if oversee_inference_server:
             self._inference_server_overseer_thread = threading.Thread(
                 target=self._check_and_recover_inference_server


### PR DESCRIPTION
- We observed issues with the inference server overseer thread throwing an exception because of a missing attribute on the `InferenceServerController`
- Change the order of attribute initialization to be properly defined before the overseer thread is started