### PR TITLE
Bump version for release testing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.4.10rc10"
+version = "0.5.0a0"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION
Bumping version using `poetry version preminor`. Will try to stick with peotry to automatically bump these versions for us.