### PR TITLE
Fix ctrl server streaming, no buffer.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.5.0a1"
+version = "0.5.0rc3"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/templates/control/control/application.py
+++ b/truss/templates/control/control/application.py
@@ -63,7 +63,13 @@ def create_app(base_config: Dict):
 
     limits = httpx.Limits(max_keepalive_connections=8, max_connections=32)
     app_state.proxy_client = httpx.AsyncClient(
-        base_url=f"http://localhost:{app_state.inference_server_port}", limits=limits
+        base_url=f"http://localhost:{app_state.inference_server_port}",
+        limits=limits,
+        # We set trust_env to False so that the control server ignores the http_proxy
+        # environment variable set on the model pod. This environment variable causes
+        # requests to be routed through nginx, which is not necessary for calls to the
+        # inference server. Going through the proxy causes some unexpected behavior.
+        trust_env=False,
     )
 
     pip_path = getattr(app_state, "pip_path", None)

--- a/truss/templates/control/control/endpoints.py
+++ b/truss/templates/control/control/endpoints.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter
 from fastapi.responses import JSONResponse, StreamingResponse
 from helpers.errors import ModelLoadFailed, ModelNotReady
 from httpx import URL, ConnectError
+from starlette.background import BackgroundTask
 from starlette.requests import Request
 from starlette.responses import Response
 from tenacity import Retrying, retry_if_exception_type, stop_after_attempt, wait_fixed
@@ -75,7 +76,9 @@ async def proxy(request: Request):
 
     if _is_streaming_response(resp):
         return StreamingResponse(
-            resp.aiter_bytes(), media_type="application/octet-stream"
+            resp.aiter_raw(),
+            media_type="application/octet-stream",
+            background=BackgroundTask(resp.aclose),
         )
 
     await resp.aread()


### PR DESCRIPTION
**TODO:** Testing

# Problem

`aiter_bytes` seems to attempt to decode the content & as a result does some buffering. (see [code](https://github.com/encode/httpx/blob/6a1841b924ab5d318d771e1a04ffb55662bf458b/httpx/_models.py#L912)). To prevent this, we should instead use the lower level `aiter_raw`, since anyway we don't really do anything w/ the content in this block (we just proxy it).

I also took one of the suggestions from the httpx doc, and added closing the response as a background task.