### PR TITLE
Enable an empty `config.yml`

### DIFF
--- a/truss/tests/test_config.py
+++ b/truss/tests/test_config.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 import yaml
 from truss.truss_config import (
@@ -286,3 +288,32 @@ def test_empty_config():
     new_config = generate_default_config()
 
     assert new_config == config.to_dict(verbose=False)
+
+
+def test_from_yaml():
+    yaml_path = Path("test.yaml")
+    data = {"description": "this is a test"}
+    with yaml_path.open("w") as yaml_file:
+        yaml.safe_dump(data, yaml_file)
+
+    result = TrussConfig.from_yaml(yaml_path)
+
+    assert result.description == "this is a test"
+
+    yaml_path.unlink()
+
+
+def test_from_yaml_empty():
+    yaml_path = Path("test.yaml")
+    data = {}
+    with yaml_path.open("w") as yaml_file:
+        yaml.safe_dump(data, yaml_file)
+
+    result = TrussConfig.from_yaml(yaml_path)
+
+    # test some attributes (should be default)
+    assert result.description is None
+    assert result.spec_version == "2.0"
+    assert result.bundled_packages_dir == "packages"
+
+    yaml_path.unlink()

--- a/truss/tests/test_config.py
+++ b/truss/tests/test_config.py
@@ -279,3 +279,10 @@ def test_huggingface_cache_multiple_models_mixed_revision():
     assert new_config == config.to_dict(verbose=False)
     assert config.to_dict(verbose=True)["hf_cache"][0].get("revision") is None
     assert config.to_dict(verbose=True)["hf_cache"][1].get("revision") == "not-main2"
+
+
+def test_empty_config():
+    config = TrussConfig()
+    new_config = generate_default_config()
+
+    assert new_config == config.to_dict(verbose=False)

--- a/truss/truss_config.py
+++ b/truss/truss_config.py
@@ -352,7 +352,10 @@ class TrussConfig:
     @staticmethod
     def from_yaml(yaml_path: Path):
         with yaml_path.open() as yaml_file:
-            return TrussConfig.from_dict(yaml.safe_load(yaml_file))
+            yaml_data = yaml.safe_load(yaml_file)
+            if yaml_data is None:
+                return TrussConfig.from_dict({})
+            return TrussConfig.from_dict(yaml_data)
 
     def write_to_yaml_file(self, path: Path):
         with path.open("w") as config_file:

--- a/truss/truss_config.py
+++ b/truss/truss_config.py
@@ -352,10 +352,8 @@ class TrussConfig:
     @staticmethod
     def from_yaml(yaml_path: Path):
         with yaml_path.open() as yaml_file:
-            yaml_data = yaml.safe_load(yaml_file)
-            if yaml_data is None:
-                return TrussConfig.from_dict({})
-            return TrussConfig.from_dict(yaml_data)
+            raw_data = yaml.safe_load(yaml_file) or {}
+            return TrussConfig.from_dict(raw_data)
 
     def write_to_yaml_file(self, path: Path):
         with path.open("w") as config_file:


### PR DESCRIPTION
This pull request refactors the `from_yaml` method in the `TrussConfig` class to improve handling of scenarios where a YAML file is empty or contains no valid data.

In the original version, the `yaml.safe_load `method would return `None` if the YAML file was empty. This would cause `TrussConfig.from_dict(None)` to execute, which would result in a `'NoneType' object has no attribute 'get'` error. In this case, we should just be using an entirely default config file.

With the changes in this PR, if the loaded YAML data is `None`, we pass an empty dictionary to the `TrussConfig.from_dict` method, ensuring it always receives a dictionary. This way, no key from the config file is _required_; we always have defaults.