### PR TITLE
FIX: Switch `python` with `$PYTHON_EXECUTABLE`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.5.0a1"
+version = "0.5.0a2"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/templates/server.Dockerfile.jinja
+++ b/truss/templates/server.Dockerfile.jinja
@@ -51,9 +51,9 @@ COPY ./cache_warmer.py /cache_warmer.py
         {% for repo, data in models.items() %}
             {% for file in data.files %}
                 {%- if data.revision != None %}
-RUN python /cache_warmer.py {{file}} {{repo}} {{data.revision}}
+RUN $PYTHON_EXECUTABLE /cache_warmer.py {{file}} {{repo}} {{data.revision}}
                 {%- else %}
-RUN python /cache_warmer.py {{file}} {{repo}}
+RUN $PYTHON_EXECUTABLE /cache_warmer.py {{file}} {{repo}}
                 {%- endif %}
             {% endfor %}
         {% endfor %}

--- a/truss/truss_config.py
+++ b/truss/truss_config.py
@@ -352,8 +352,7 @@ class TrussConfig:
     @staticmethod
     def from_yaml(yaml_path: Path):
         with yaml_path.open() as yaml_file:
-            raw_data = yaml.safe_load(yaml_file) or {}
-            return TrussConfig.from_dict(raw_data)
+            return TrussConfig.from_dict(yaml.safe_load(yaml_file))
 
     def write_to_yaml_file(self, path: Path):
         with path.open("w") as config_file:

--- a/truss/truss_config.py
+++ b/truss/truss_config.py
@@ -352,7 +352,8 @@ class TrussConfig:
     @staticmethod
     def from_yaml(yaml_path: Path):
         with yaml_path.open() as yaml_file:
-            return TrussConfig.from_dict(yaml.safe_load(yaml_file))
+            raw_data = yaml.safe_load(yaml_file) or {}
+            return TrussConfig.from_dict(raw_data)
 
     def write_to_yaml_file(self, path: Path):
         with path.open("w") as config_file:


### PR DESCRIPTION
Use the `$PYTHON_EXECUTABLE` variable defined earlier in the dockerfile instead of naively using `python` in the caching mechanism for Hugging Face weights.