### PR TITLE
Keeping `config.yml` simple after `truss push`

### DIFF
--- a/truss/cli.py
+++ b/truss/cli.py
@@ -339,7 +339,7 @@ def push(
     # Write model name to config if it's not already there
     if model_name != tr.spec.config.model_name:
         tr.spec.config.model_name = model_name
-        tr.spec.config.write_to_yaml_file(tr.spec.config_path)
+        tr.spec.config.write_to_yaml_file(tr.spec.config_path, verbose=False)
 
     # TODO(Abu): This needs to be refactored to be more generic
     service = remote_provider.push(tr, model_name, publish=publish)  # type: ignore

--- a/truss/truss_config.py
+++ b/truss/truss_config.py
@@ -354,9 +354,9 @@ class TrussConfig:
         with yaml_path.open() as yaml_file:
             return TrussConfig.from_dict(yaml.safe_load(yaml_file))
 
-    def write_to_yaml_file(self, path: Path):
+    def write_to_yaml_file(self, path: Path, verbose: bool = True):
         with path.open("w") as config_file:
-            yaml.dump(self.to_dict(verbose=True), config_file)
+            yaml.dump(self.to_dict(verbose=verbose), config_file)
 
     def to_dict(self, verbose: bool = True):
         return obj_to_dict(self, verbose=verbose)


### PR DESCRIPTION
When users would specify a `model_name` in `truss push` from the cli, a verbose version of the config would be rewritten into the .yml file. This PR prevents this from happening.