### PR TITLE
Make --publish a flag.

### DIFF
--- a/truss/cli.py
+++ b/truss/cli.py
@@ -305,6 +305,7 @@ def train(target_directory: str, build_dir, tag, var: List[str], vars_yaml_file,
 @click.option(
     "--publish",
     type=bool,
+    is_flag=True,
     required=False,
     default=False,
     help="Publish truss as production deployment.",


### PR DESCRIPTION
If you leave --publish out, it deploys a draft, if you add it it deploys a non-draft


# Testing

Ran

```
$ poetry run truss push --remote sid-dev --publish
```

successfully