### PR TITLE
Remove predict lock

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.5.0devsid1"
+version = "0.5.1rc1+devsid"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.5.1dev4"
+version = "0.5.1dev5"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.5.1rc1+devsid"
+version = "0.5.1dev3"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.5.1dev3"
+version = "0.5.1dev4"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.5.0a3"
+version = "0.5.0devsid1"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/templates/server/common/truss_server.py
+++ b/truss/templates/server/common/truss_server.py
@@ -33,7 +33,7 @@ from starlette.responses import Response
 # Please consider the following when increasing this:
 # 1. Self-termination on model load fail.
 # 2. Graceful termination.
-NUM_WORKERS = 1
+NUM_WORKERS = 2
 WORKER_TERMINATION_TIMEOUT_SECS = 120.0
 WORKER_TERMINATION_CHECK_INTERVAL_SECS = 0.5
 

--- a/truss/templates/server/common/truss_server.py
+++ b/truss/templates/server/common/truss_server.py
@@ -33,7 +33,7 @@ from starlette.responses import Response
 # Please consider the following when increasing this:
 # 1. Self-termination on model load fail.
 # 2. Graceful termination.
-NUM_WORKERS = 2
+NUM_WORKERS = 1
 WORKER_TERMINATION_TIMEOUT_SECS = 120.0
 WORKER_TERMINATION_CHECK_INTERVAL_SECS = 0.5
 


### PR DESCRIPTION
# What

Currently, there's a lock around the `predict` function in truss to prevent concurrency. This poses an issue for us on a couple dimensions:

1. The lock prevents us from benefitting from continuous batching
2. It  prevents us from fully utilizing the GPUs that users have paid for

Furthermore, it doesn't really solve any problems for us. As you will observe in the loom below, there is definitely a blow to the generation speed when more requests are run parallel, so there's a chance that users will want to control the amount of concurrency on their pods. However, we support controlling concurrency via the concurrency target on Baseten itself already, if this is a thing that users want to control.

# Risks

We don't know the full context behind the lock. Some of the thinking around it was that it could cause different model invocations running concurrently to clobber each other, or cause OOM issues. Testing with wizardlm, neither of these seem to be the case. All said, we will continue to let users  control the concurrency via the UI if they want to serialize their requests.

# Testing

Pushed this to dev environment, check out https://www.loom.com/share/84b013c1be294cdc84719f0159e83bf8 for how this works & some more details.