### PR TITLE
Adding `allow_patterns` and `ignore_patterns` to the Hugging Face cache.

### DIFF
--- a/truss/contexts/image_builder/serving_image_builder.py
+++ b/truss/contexts/image_builder/serving_image_builder.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, Optional
 
 import yaml
 from huggingface_hub import list_repo_files
+from huggingface_hub.utils import filter_repo_objects
 from truss.constants import (
     BASE_SERVER_REQUIREMENTS_TXT_FILENAME,
     CONTROL_SERVER_CODE_DIR,
@@ -91,8 +92,19 @@ class ServingImageBuilder(ImageBuilder):
             for model in config.hf_cache.models:
                 repo_id = model.repo_id
                 revision = model.revision
+
+                allow_patterns = model.allow_patterns
+                ignore_patterns = model.ignore_patterns
+
+                filtered_repo_files = list(
+                    filter_repo_objects(
+                        items=list_repo_files(repo_id, revision=revision),
+                        allow_patterns=allow_patterns,
+                        ignore_patterns=ignore_patterns,
+                    )
+                )
                 model_files[repo_id] = {
-                    "files": list_repo_files(repo_id, revision=revision),
+                    "files": filtered_repo_files,
                     "revision": revision,
                 }
 

--- a/truss/truss_config.py
+++ b/truss/truss_config.py
@@ -79,6 +79,8 @@ class AcceleratorSpec:
 class HuggingFaceModel:
     repo_id: str = ""
     revision: Optional[str] = None
+    allow_patterns: Optional[str] = None
+    ignore_patterns: Optional[str] = None
 
     @staticmethod
     def from_dict(d):
@@ -87,12 +89,29 @@ class HuggingFaceModel:
             raise ValueError("Repo ID for Hugging Face model cannot be empty.")
         revision = d.get("revision", None)
 
-        return HuggingFaceModel(repo_id=repo_id, revision=revision)
+        allow_patterns = d.get("allow_patterns", None)
+        ignore_pattenrs = d.get("ignore_patterns", None)
+
+        return HuggingFaceModel(
+            repo_id=repo_id,
+            revision=revision,
+            allow_patterns=allow_patterns,
+            ignore_patterns=ignore_pattenrs,
+        )
 
     def to_dict(self, verbose=False):
-        if verbose or self.revision is not None:
-            return {"repo_id": self.repo_id, "revision": self.revision}
-        return {"repo_id": self.repo_id}
+        data = {
+            "repo_id": self.repo_id,
+            "revision": self.revision,
+            "allow_patterns": self.allow_patterns,
+            "ignore_patterns": self.ignore_patterns,
+        }
+
+        if not verbose:
+            # only show changed values
+            data = {k: v for k, v in data.items() if v != self.__dict__.get(k, None)}
+
+        return data
 
 
 @dataclass

--- a/truss/truss_config.py
+++ b/truss/truss_config.py
@@ -79,8 +79,8 @@ class AcceleratorSpec:
 class HuggingFaceModel:
     repo_id: str = ""
     revision: Optional[str] = None
-    allow_patterns: Optional[str] = None
-    ignore_patterns: Optional[str] = None
+    allow_patterns: Optional[List[str]] = None
+    ignore_patterns: Optional[List[str]] = None
 
     @staticmethod
     def from_dict(d):

--- a/truss/truss_config.py
+++ b/truss/truss_config.py
@@ -110,7 +110,6 @@ class HuggingFaceModel:
         if not verbose:
             # only show changed values
             data = {k: v for k, v in data.items() if v is not None}
-            print(data)
 
         return data
 

--- a/truss/truss_config.py
+++ b/truss/truss_config.py
@@ -109,7 +109,8 @@ class HuggingFaceModel:
 
         if not verbose:
             # only show changed values
-            data = {k: v for k, v in data.items() if v != self.__dict__.get(k, None)}
+            data = {k: v for k, v in data.items() if v is not None}
+            print(data)
 
         return data
 


### PR DESCRIPTION
Introduces `allow_patterns` and `ignore_patterns` in the config file to prevent users from downloading the same weights multiple times. Often, HF repos include model weights in different formats in the same revision, such as `.bin`, `.h5`, `.fp16.safetensors`, `.safetensors`, etc. 

Both allow_patterns and ignore_patterns follow [fnmatch](https://docs.python.org/3/library/fnmatch.html) conventions. 

Also -- this PR swaps `repo_id` and `file_name` on cache copying to have cleaner logs.

TODO: adding tests.