### PR TITLE
Added documentation for HF caching

### DIFF
--- a/docs/develop/configuration.md
+++ b/docs/develop/configuration.md
@@ -273,8 +273,7 @@ running on Docker locally, Truss allows specifying secrets in
 
 ### hf_cache
 
-Truss supports the caching of models pulled from Hugging Face. By saving your machine learning model's weights into your image during buildtime instead of runtime, you can considerably improve cold start performance. "Cold start" refers to the period when an application is launched for the first time and has to perform all initial setup operations. In this context, having the weights preloaded means your application can start using the machine learning model faster since it no longer has to wait for the weights to download during the runtime.
-
+Truss supports caching models pulled from Hugging Face. By saving your model's weights into your image during buildtime instead of runtime, you can considerably reduce cold start times (the time between the first call to a model server and it reaching a ready state). In this context, having the weights preloaded means your application can start using the model faster since it doesn't have to wait for the weights to download at runtime.
 
 The `hf_cache` key in the configuration file is used to manage model caching. This section contains several subkeys:
 - `repo_id` (required): The identifier of the Hugging Face repository where the model is located.

--- a/docs/develop/configuration.md
+++ b/docs/develop/configuration.md
@@ -303,4 +303,4 @@ hf_cache:
 In this configuration:
 
 - `stabilityai/stable-diffusion-xl-base-1.0` is the `repo_id`, pointing to the exact model to cache.
-- Some patterns are specified under `ignore_patterns``, ensuring that any files following these patterns won't be included in the cache. Here, we aim to cache only `fp16.safetensors`` in order to run Stable Diffusion XL in half-precision mode, allowing us to disregard many files that would otherwise consume valuable caching time.
+- Some patterns are specified under `ignore_patterns`, ensuring that any files following these patterns won't be included in the cache. Here, we aim to cache only `fp16.safetensors` in order to run Stable Diffusion XL in half-precision mode, allowing us to disregard many files that would otherwise consume valuable caching time.


### PR DESCRIPTION
- Truss supports caching of Hugging Face models to optimize project workflows. By embedding model weights during build time instead of runtime, it enhances cold start performance.

- The caching process leverages the `hf_cache` key in the configuration file with four child keys, namely `repo_id` (required), `revision`, `allow_patterns`, and `ignore_patterns` for precise cache control. Notably, `allow_patterns` and `ignore_patterns` follow Unix shell-style wildcards.

- It's possible to cache multiple Hugging Face models in a single Truss, improving efficiency. An example is given for caching the weights of the Stable Diffusion XL model, demonstrating how to ignore specific file patterns.