### PR TITLE
Controlling supervisord retries

### DIFF
--- a/docs/develop/deploying-your-truss.md
+++ b/docs/develop/deploying-your-truss.md
@@ -1,0 +1,3 @@
+# Overview
+
+To

--- a/examples/flan-t5-xl/README.md
+++ b/examples/flan-t5-xl/README.md
@@ -4,7 +4,7 @@ This is a [Truss](https://truss.baseten.co/) for Flan-T5 XL using `T5Tokenizer` 
 
 ## Truss
 
-Truss is an open-source model serving framework developed by Baseten. It allows you to develop and deploy machine learning models onto Baseten (and other platforms like [AWS](https://truss.baseten.co/deploy/aws) or [GCP](https://truss.baseten.co/deploy/gcp)). Using Truss, you can develop a GPU model using [live-reload](https://baseten.co/blog/technical-deep-dive-truss-live-reload), package models and their associated code, create Docker containers and deploy models on Baseten.
+Truss is an open-source model serving framework developed by Baseten. It allows you to develop and deploy machine learning models onto Baseten (and other platforms like [Sagemaker](https://truss.baseten.co/deploy/sagemaker). Using Truss, you can develop a GPU model using [live-reload](https://baseten.co/blog/technical-deep-dive-truss-live-reload), package models and their associated code, create Docker containers and deploy models on Baseten.
 
 ## Deploying Flan-T5 XL
 

--- a/truss/templates/tgi/supervisord.conf.jinja
+++ b/truss/templates/tgi/supervisord.conf.jinja
@@ -7,6 +7,7 @@ logfile_maxbytes=0
 [program:text-generation-launcher]
 command=text-generation-launcher --max-concurrent-requests=128 --hostname=0.0.0.0 --port=8081 {{extra_args}}
 startsecs=0
+startretries=1
 autostart=true
 autorestart=true
 stdout_logfile=/dev/fd/1
@@ -16,6 +17,7 @@ redirect_stderr=true
 [program:nginx]
 command=nginx -g "daemon off;"
 startsecs=0
+startretries=1
 autostart=true
 autorestart=true
 stdout_logfile=/dev/fd/1


### PR DESCRIPTION
Supervisord continually restarts failed services which is not ideal when there are other retries built into the system later on. This PR updates supervisord to only retry once before failing. 