### PR TITLE
make init safe and default

### DIFF
--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -84,14 +84,6 @@ def image():
 @truss_cli.command()
 @click.argument("target_directory", required=True)
 @click.option(
-    "-s",
-    "--skip-confirm",
-    is_flag=True,
-    show_default=True,
-    default=True,
-    help="Skip confirmation prompt.",
-)
-@click.option(
     "-t",
     "--trainable",
     is_flag=True,
@@ -100,7 +92,7 @@ def image():
     help="Create a trainable truss.",
 )
 @error_handling
-def init(target_directory, skip_confirm, trainable) -> None:
+def init(target_directory, trainable) -> None:
     """Create a new truss.
 
     TARGET_DIRECTORY: A Truss is created in this directory
@@ -111,13 +103,12 @@ def init(target_directory, skip_confirm, trainable) -> None:
         )
     tr_path = Path(target_directory)
     build_config = select_server_backend()
-    if skip_confirm or click.confirm(f"A Truss will be created at {tr_path}"):
-        truss.init(
-            target_directory=target_directory,
-            trainable=trainable,
-            build_config=build_config,
-        )
-        click.echo(f"Truss was created in {tr_path}")
+    truss.init(
+        target_directory=target_directory,
+        trainable=trainable,
+        build_config=build_config,
+    )
+    click.echo(f"Truss was created in {tr_path}")
 
 
 @image.command()  # type: ignore


### PR DESCRIPTION
This PR:

* Prevents a Truss from being created via CLI in an existing folder
* Removes the confirmation step on truss init

As Truss init is now safe (won't overwrite existing info) and easily reversible (just `rm -r` the created folder), there's no need to confirm before creation.