### PR TITLE
Better secret error handling.

### DIFF
--- a/truss/templates/shared/secrets_resolver.py
+++ b/truss/templates/shared/secrets_resolver.py
@@ -39,7 +39,8 @@ class Secrets(Mapping):
 
     def __getitem__(self, key: str) -> str:
         if key not in self._base_secrets:
-            # Note this is the case where the secrets are not
+            # Note this is the case where the secrets are not specified in
+            # config.yaml
             raise SecretNotFound(f"Secret '{key}' not specified in the config.")
 
         found_secret = SecretsResolver._resolve_secret(key, self._base_secrets[key])


### PR DESCRIPTION
TODO: Write integration tests

# Summary

Currently, if you are missing secrets from your config file, you get this error:

```

Aug 09 2:11:07pm
Exception while loading model

Traceback (most recent call last):
  File "/app/model_wrapper.py", line 101, in load
    self.try_load()
  File "/app/model_wrapper.py", line 163, in try_load
    retry(
  File "/app/common/retry.py", line 20, in retry
    raise exc
  File "/app/common/retry.py", line 15, in retry
    fn()
  File "/app/model/model.py", line 21, in load
    "pyannote/speaker-diarization@2.1", use_auth_token=self._secrets["hf_access_token"]
  File "/app/shared/secrets_resolver.py", line 37, in __getitem__
    return SecretsResolver._resolve_secret(key, self._base_secrets[key])
KeyError: 'hf_access_token'
```

Similarly, if your secrets are not mounted, you will just get a silent failure and a `None` returned from secrets.get().

# Fix

I propose fixing this by returning a new exception type with more information.

