### PR TITLE
Support streaming in truss predict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.5.6"
+version = "0.5.7rc1"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -287,6 +287,7 @@ def predict(
     if inspect.isgenerator(result):
         for chunk in result:
             rich.print(chunk, end="")
+        return
     rich.print_json(data=result)
 
 

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -1,3 +1,4 @@
+import inspect
 import json
 import logging
 import os
@@ -283,6 +284,9 @@ def predict(
 
     service = remote_provider.get_baseten_service(model_name, published)  # type: ignore
     result = service.predict(request_data)
+    if inspect.isgenerator(result):
+        for chunk in result:
+            rich.print(chunk, end="")
     rich.print_json(data=result)
 
 

--- a/truss/remote/baseten/service.py
+++ b/truss/remote/baseten/service.py
@@ -4,6 +4,8 @@ from truss.remote.baseten.auth import AuthService
 from truss.remote.truss_remote import TrussService
 from truss.truss_handle import TrussHandle
 
+DEFAULT_STREAM_ENCODING = "utf-8"
+
 
 class BasetenService(TrussService):
     def __init__(
@@ -30,7 +32,21 @@ class BasetenService(TrussService):
 
     def predict(self, model_request_body: Dict):
         invocation_url = f"{self._service_url}/predict"
-        response = self._send_request(invocation_url, "POST", data=model_request_body)
+        response = self._send_request(
+            invocation_url, "POST", data=model_request_body, stream=True
+        )
+
+        if response.headers.get("transfer-encoding") == "chunked":
+            # Case of streaming response, the backend does not set an encoding, so
+            # manually decode to the contents to utf-8 here.
+            def decode_content():
+                for chunk in response.iter_content(
+                    chunk_size=8192, decode_unicode=True
+                ):
+                    yield chunk.decode(response.encoding or DEFAULT_STREAM_ENCODING)
+
+            return decode_content()
+
         return response.json()["model_output"]
 
     def authenticate(self) -> dict:

--- a/truss/remote/truss_remote.py
+++ b/truss/remote/truss_remote.py
@@ -33,6 +33,7 @@ class TrussService(ABC):
         method: str,
         headers: Optional[Dict] = None,
         data: Optional[Dict] = None,
+        stream: Optional[bool] = False,
     ):
         """
         Send a HTTP request.
@@ -56,11 +57,13 @@ class TrussService(ABC):
         auth_header = self.authenticate()
         headers = {**headers, **auth_header}
         if method == "GET":
-            response = requests.request(method, url, headers=headers)
+            response = requests.request(method, url, headers=headers, stream=stream)
         elif method == "POST":
             if not data:
                 raise ValueError("POST request must have data")
-            response = requests.request(method, url, json=data, headers=headers)
+            response = requests.request(
+                method, url, json=data, headers=headers, stream=stream
+            )
         else:
             raise ValueError(f"Unsupported method: {method}")
 


### PR DESCRIPTION
# Summary

Support streaming in the `truss predict` command. Similarly to the `baseten` client, we solve this here by checking to see if chunked transfer-encoding has been set, and if so, returning a generator from the baseten predict function, and in the CLI, printing out the results.

# Testing

```
@squidarth ➜ .../truss/truss/test_data/test_streaming_truss (sshanker/support-streaming-in-truss-predict) $ poetry run truss predict -d '{"a": "b"}'
? 🎮 Which remote do you want to connect to? sid-prod
01234
```