### PR TITLE
Better error resilience.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.5.7rc1"
+version = "0.5.7rc3"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/remote/baseten/service.py
+++ b/truss/remote/baseten/service.py
@@ -47,6 +47,14 @@ class BasetenService(TrussService):
 
             return decode_content()
 
+        parsed_response = response.json()
+
+        if "model_output" not in parsed_response:
+            # In the case that the model is in a non-ready state, the response
+            # will not contain a model_output. Instead, return the
+            # error as-is.
+            return parsed_response
+
         return response.json()["model_output"]
 
     def authenticate(self) -> dict:

--- a/truss/remote/baseten/service.py
+++ b/truss/remote/baseten/service.py
@@ -49,10 +49,9 @@ class BasetenService(TrussService):
 
         parsed_response = response.json()
 
-        if "model_output" not in parsed_response:
+        if "error" in parsed_response:
             # In the case that the model is in a non-ready state, the response
-            # will not contain a model_output. Instead, return the
-            # error as-is.
+            # will be a json with an `error` key.
             return parsed_response
 
         return response.json()["model_output"]


### PR DESCRIPTION
Right now, `truss predict` behaves weirdly if there are errors. This makes us more resilient to those errors. The change in this PR defends against this case:

```
$ [~]$ curl -X POST https://app.baseten.co/models/9P2boVP/predict \
  -H 'Authorization: Api-Key g9RlcBM6.JfudVBlNqMjTNbnprEQAWHoZtbUajWrh' \
  -d '{"a": "b", "c": true}'
{
	"error": "Model is not ready, it is still building or deploying"
}
``` 

specifically