### PR TITLE
extend patch support for truss dir patch applier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.5.8"
+version = "0.5.8rc1"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.5.8rc1"
+version = "0.5.9rc1"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/patch/truss_dir_patch_applier.py
+++ b/truss/patch/truss_dir_patch_applier.py
@@ -1,5 +1,4 @@
 import logging
-from dataclasses import replace
 from pathlib import Path
 from typing import List
 
@@ -81,11 +80,5 @@ class TrussDirPatchApplier:
                 new_config = TrussConfig.from_dict(patch.body.config)
                 continue
             raise UnsupportedPatch(f"Unknown patch type {patch.type}")
-
-        new_config = replace(
-            new_config,
-            requirements=list(reqs.values()),
-            system_packages=list(pkgs),
-        )
 
         new_config.write_to_yaml_file(self._truss_config_path)

--- a/truss/patch/truss_dir_patch_applier.py
+++ b/truss/patch/truss_dir_patch_applier.py
@@ -79,6 +79,7 @@ class TrussDirPatchApplier:
                 continue
             if isinstance(patch.body, ConfigPatch):
                 last_config = TrussConfig.from_dict(patch.body.config)
+                continue
             raise UnsupportedPatch(f"Unknown patch type {patch.type}")
 
         self._truss_config = replace(

--- a/truss/patch/truss_dir_patch_applier.py
+++ b/truss/patch/truss_dir_patch_applier.py
@@ -43,7 +43,7 @@ class TrussDirPatchApplier:
         # Aggregate config patches and apply at end
         reqs = reqs_by_name(self._truss_config.requirements)
         pkgs = system_packages_set(self._truss_config.system_packages)
-        last_config = self._truss_config
+        new_config = self._truss_config
         for patch in patches:
             self._logger.debug(f"Applying patch {patch.to_dict()}")
             action = patch.body.action
@@ -78,16 +78,14 @@ class TrussDirPatchApplier:
             if isinstance(patch.body, ExternalDataPatch):
                 continue
             if isinstance(patch.body, ConfigPatch):
-                last_config = TrussConfig.from_dict(patch.body.config)
+                new_config = TrussConfig.from_dict(patch.body.config)
                 continue
             raise UnsupportedPatch(f"Unknown patch type {patch.type}")
 
-        self._truss_config = replace(
-            self._truss_config,
+        new_config = replace(
+            new_config,
             requirements=list(reqs.values()),
             system_packages=list(pkgs),
         )
-        self._truss_config.write_to_yaml_file(self._truss_config_path)
 
-        if last_config != self._truss_config:
-            self._truss_config.write_to_yaml_file(self._truss_config_path)
+        new_config.write_to_yaml_file(self._truss_config_path)


### PR DESCRIPTION
- extends the truss dir patch applier to support newer patch types for publish from draft flow