### PR TITLE
Simplify truss init / push commands.

### DIFF
--- a/truss/build.py
+++ b/truss/build.py
@@ -218,6 +218,7 @@ def init(
     bundled_packages: Optional[List[str]] = None,
     trainable: bool = False,
     build_config: Optional[Build] = None,
+    model_name: Optional[str] = None,
 ) -> TrussHandle:
     """
     Initialize an empty placeholder Truss. A Truss is a build context designed
@@ -230,6 +231,7 @@ def init(
                           Truss in. The directory is created if it doesn't exist.
     """
     config = TrussConfig(
+        model_name=model_name,
         python_version=map_to_supported_python_version(infer_python_version()),
     )
 

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -99,7 +99,7 @@ def image():
     "--backend",
     show_default=True,
     default=ModelServer.TrussServer.value,
-    type=click.Choice(server.value for server in ModelServer),
+    type=click.Choice([server.value for server in ModelServer]),
 )
 @error_handling
 def init(target_directory, trainable, backend) -> None:

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -11,9 +11,10 @@ from typing import Callable, Optional, Union
 import rich
 import rich_click as click
 import truss
-from truss.cli.create import select_server_backend
+from truss.cli.create import ask_name, select_server_backend
 from truss.remote.remote_cli import inquire_model_name, inquire_remote_name
 from truss.remote.remote_factory import RemoteFactory
+from truss.truss_config import ModelServer
 
 logging.basicConfig(level=logging.INFO)
 
@@ -93,8 +94,15 @@ def image():
     default=False,
     help="Create a trainable truss.",
 )
+@click.option(
+    "-b",
+    "--backend",
+    show_default=True,
+    default=ModelServer.TrussServer.value,
+    type=click.Choice(server.value for server in ModelServer),
+)
 @error_handling
-def init(target_directory, trainable) -> None:
+def init(target_directory, trainable, backend) -> None:
     """Create a new truss.
 
     TARGET_DIRECTORY: A Truss is created in this directory
@@ -104,13 +112,15 @@ def init(target_directory, trainable) -> None:
             f'Error: Directory "{target_directory}" already exists and cannot be overwritten.'
         )
     tr_path = Path(target_directory)
-    build_config = select_server_backend()
+    build_config = select_server_backend(ModelServer[backend])
+    model_name = ask_name()
     truss.init(
         target_directory=target_directory,
         trainable=trainable,
         build_config=build_config,
+        model_name=model_name,
     )
-    click.echo(f"Truss was created in {tr_path}")
+    click.echo(f"Truss {model_name} was created in {tr_path.absolute()}")
 
 
 @image.command()  # type: ignore

--- a/truss/cli/create.py
+++ b/truss/cli/create.py
@@ -24,14 +24,7 @@ REQUIRED_ARGUMENTS = {
 }
 
 
-def select_server_backend() -> Build:
-    server_backend = ModelServer[
-        inquirer.select(
-            message="Select a server:",
-            choices=[s.value for s in ModelServer],
-            default=ModelServer.TrussServer.value,
-        ).execute()
-    ]
+def select_server_backend(server_backend: ModelServer) -> Build:
     follow_up_questions = REQUIRED_ARGUMENTS.get(server_backend)
     args = {}
     if follow_up_questions:
@@ -41,3 +34,7 @@ def select_server_backend() -> Build:
             ).execute()
 
     return Build(model_server=server_backend, arguments=args)
+
+
+def ask_name() -> str:
+    return inquirer.text(message="What's the name of your model?").execute()

--- a/truss/remote/remote_cli.py
+++ b/truss/remote/remote_cli.py
@@ -9,11 +9,9 @@ from truss.remote.truss_remote import RemoteConfig
 def inquire_remote_config() -> RemoteConfig:
     # TODO(bola): extract questions from remote
     rich.print("💻 Let's add a Baseten remote!")
-    remote_url = inquirer.text(
-        message="🌐 Baseten remote url:",
-        default="https://app.baseten.co",
-        qmark="",
-    ).execute()
+    # If users need to adjust the remote url, they
+    # can do so manually in the .trussrc file.
+    remote_url = "https://app.baseten.co"
     api_key = inquirer.secret(
         message="🤫 Quiety paste your API_KEY:",
         qmark="",

--- a/truss/remote/remote_cli.py
+++ b/truss/remote/remote_cli.py
@@ -13,7 +13,7 @@ def inquire_remote_config() -> RemoteConfig:
     # can do so manually in the .trussrc file.
     remote_url = "https://app.baseten.co"
     api_key = inquirer.secret(
-        message="🤫 Quiety paste your API_KEY:",
+        message="🤫 Quietly paste your API_KEY:",
         qmark="",
     ).execute()
     return RemoteConfig(


### PR DESCRIPTION
# Summary

Made the following changes:

* In `truss init`, default to TrussServer. Have option selection be an option passed in cmdline.
* In `truss init`, prompt user for model name
* In `truss push`, if there is no `.trussrc` file, default URL to https://app.baseten.co. Allow user to change manually in their config file.

# Testing

**Truss Init**

```
 @squidarth ➜ /workspaces/truss/foo (sshanker/easier-truss-commands) $ poetry run truss init bar
? What's the name of your model? Sid's llama
Truss Sid's llama was created in /workspaces/truss/foo/bar
@squidarth ➜ /workspaces/truss/foo (sshanker/easier-truss-commands) $ cd bar
@squidarth ➜ /workspaces/truss/foo/bar (sshanker/easier-truss-commands) $ ls
config.yaml  data  model  packages
@squidarth ➜ /workspaces/truss/foo/bar (sshanker/easier-truss-commands) $ cat config.yaml 
environment_variables: {}
external_package_dirs: []
model_metadata: {}
model_name: Sid's llama
python_version: py39
requirements: []
resources:
  accelerator: null
  cpu: 500m
  memory: 512Mi
  use_gpu: false
secrets: {}
system_packages: []
```

**Truss Push**

```
@squidarth ➜ /workspaces/truss/foo/bar (sshanker/easier-truss-commands) $ poetry run truss push
💻 Let's add a Baseten remote!
? 🤫 Quiety paste your API_KEY: *****************************************
Compressing... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Uploading... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Model Sid's llama was successfully pushed.
```