### PR TITLE
google tag manager

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -179,5 +179,10 @@
       "name": "Issues",
       "url": "https://github.com/basetenlabs/truss/issues"
     }
-  ]
+  ],
+  "analytics": {
+    "gtm": {
+        "tagId": "GTM-WXD4NQTW"
+    }
+  }
 }


### PR DESCRIPTION
Add google tag manager to Truss docs