### PR TITLE
Better error message for truss predict.

### DIFF
--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -53,6 +53,8 @@ def error_handling(f: Callable[..., object]):
     def wrapper(*args, **kwargs):
         try:
             f(*args, **kwargs)
+        except click.UsageError as e:
+            raise e  # You can re-raise the exception or handle it different
         except Exception as e:
             click.echo(e)
 
@@ -296,14 +298,18 @@ def predict(
 
     model_name = tr.spec.config.model_name
     if not model_name:
-        raise ValueError("Model name not set. Did you `truss push`?")
+        raise click.UsageError(
+            "You must provide exactly one of '--data (-d)' or '--file (-f)' options."
+        )
 
     if data is not None:
         request_data = json.loads(data)
     elif file is not None:
         request_data = json.loads(Path(file).read_text())
     else:
-        raise ValueError("At least one of request or request-file must be supplied.")
+        raise click.UsageError(
+            "You must provide exactly one of '--data (-d)' or '--file (-f)' options."
+        )
 
     service = remote_provider.get_baseten_service(model_name, published)  # type: ignore
     result = service.predict(request_data)


### PR DESCRIPTION
Let's move towards using click.UsageError in places, instead of ValueError.

![Cursor_and_remote_py_—_truss__Codespaces_](https://github.com/basetenlabs/truss/assets/850115/cdc85786-d834-454e-9f4a-6231d1841789)
