### PR TITLE
Automation for new Truss releases

### DIFF
--- a/.github/workflows/commit_new_release_to_main.yml
+++ b/.github/workflows/commit_new_release_to_main.yml
@@ -1,0 +1,31 @@
+name: Merge release into main
+
+on:
+  push:
+    branches:
+      - release
+
+jobs:
+  merge-to-main:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Configure Git user as baseten-bot
+      run: |
+        git config user.name "baseten-bot"
+        git config user.email "baseten-bot@baseten.co"
+
+    - name: Fetch all branches
+      run: |
+        git fetch --all
+
+    - name: Merge release into main with priority on main changes
+      run: |
+        git checkout main
+        git merge --strategy-option=ours release -m "Merge release into main prioritizing main changes"
+        git push origin main
+      env:
+        GH_TOKEN: ${{ secrets.BASETENBOT_GITHUB_TOKEN }}

--- a/.github/workflows/create_release_pr.yml
+++ b/.github/workflows/create_release_pr.yml
@@ -25,6 +25,7 @@ jobs:
       env:
         INPUT_VERSION: ${{ github.event.inputs.version }}
 
+
     - name: Commit changes
       run: |
         git config --local user.email "baseten-bot@baseten.co"
@@ -34,8 +35,16 @@ jobs:
       env:
         INPUT_VERSION: ${{ github.event.inputs.version }}
 
+    # TODO: Also push changes to main
     - name: Push changes to new branch
       run: |
         git push origin HEAD:refs/heads/bump-version-${{ github.event.inputs.version }}
       env:
         GH_TOKEN: ${{ secrets.BASETENBOT_GITHUB_TOKEN }}
+
+    - name: Make PR
+      run: |
+        PR_URL=gh pr create --base release --head refs/heads/bump-version-$INPUT_VERSION --title "Release $INPUT_VERSION"
+        gh pr merge $PR_URL --auto --merge
+      env:
+        INPUT_VERSION: ${{ github.event.inputs.version }}

--- a/.github/workflows/create_release_pr.yml
+++ b/.github/workflows/create_release_pr.yml
@@ -1,0 +1,41 @@
+name: Create Release PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to bump to'
+        required: true
+
+jobs:
+  bump_version:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Install poetry
+      run: |
+        curl -sSL https://install.python-poetry.org | python3 -
+
+    - name: Bump version in pyproject.toml
+      run: |
+        poetry version $INPUT_VERSION
+      env:
+        INPUT_VERSION: ${{ github.event.inputs.version }}
+
+    - name: Commit changes
+      run: |
+        git config --local user.email "baseten-bot@baseten.co"
+        git config --local user.name "baseten-bot"
+        git add pyproject.toml
+        git commit -m "Bump version to $INPUT_VERSION"
+      env:
+        INPUT_VERSION: ${{ github.event.inputs.version }}
+
+    - name: Push changes to new branch
+      run: |
+        git push origin HEAD:refs/heads/bump-version-${{ github.event.inputs.version }}
+      env:
+        GH_TOKEN: ${{ secrets.BASETENBOT_GITHUB_TOKEN }}


### PR DESCRIPTION
This is a WIP, but to test, I need to have this on the main branch unfortunately. The new flow for creating a Truss will be:
1. Trigger the "Create Release PR" Github Action, and provide the new version ID. This will commit a new version to main and create a PR from a new branch w/ the new version to `release` (we will also commit the new release version number to `main`)
2. Someone approves the release PR. It will have auto-merge on, so once it's approved & tests pass, it will get merged.

This is better because:
* No PRs need to be created manually
* Everything can be done from Github UI