### PR TITLE
Fixes for truss release automation

### DIFF
--- a/.github/workflows/commit_new_release_to_main.yml
+++ b/.github/workflows/commit_new_release_to_main.yml
@@ -13,10 +13,10 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v2
 
-    - name: Configure Git user as baseten-bot
+    - name: Configure Git user as basetenbot
       run: |
-        git config user.name "baseten-bot"
-        git config user.email "baseten-bot@baseten.co"
+        git config user.name "basetenbot"
+        git config user.email "basetenbot@baseten.co"
 
     - name: Fetch all branches
       run: |

--- a/.github/workflows/commit_new_release_to_main.yml
+++ b/.github/workflows/commit_new_release_to_main.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Configure Git user as basetenbot
       run: |
         git config user.name "basetenbot"
-        git config user.email "basetenbot@baseten.co"
+        git config user.email "96544894+basetenbot@users.noreply.github.com"
 
     - name: Fetch all branches
       run: |

--- a/.github/workflows/create_release_pr.yml
+++ b/.github/workflows/create_release_pr.yml
@@ -50,3 +50,4 @@ jobs:
         gh pr merge $PR_URL --auto --merge
       env:
         INPUT_VERSION: ${{ github.event.inputs.version }}
+        GH_TOKEN: ${{ secrets.BASETENBOT_GITHUB_TOKEN }}

--- a/.github/workflows/create_release_pr.yml
+++ b/.github/workflows/create_release_pr.yml
@@ -44,7 +44,9 @@ jobs:
 
     - name: Make PR
       run: |
-        PR_URL=$(gh pr create --base release --head refs/heads/bump-version-$INPUT_VERSION --title "Release $INPUT_VERSION" --body "Release $INPUT_VERSION")
+        CURR_VERSION=$(curl https://pypi.org/pypi/truss/json | jq ".info.version")
+        PR_BODY="Updating Truss from [$CURR_VERSION](https://pypi.org/pypi/truss/json) to $INPUT_VERSION."
+        PR_URL=$(gh pr create --base release --head refs/heads/bump-version-$INPUT_VERSION --title "Release $INPUT_VERSION" --body "$BODY")
         gh pr merge $PR_URL --auto --merge
       env:
         INPUT_VERSION: ${{ github.event.inputs.version }}

--- a/.github/workflows/create_release_pr.yml
+++ b/.github/workflows/create_release_pr.yml
@@ -28,7 +28,7 @@ jobs:
 
     - name: Commit changes
       run: |
-        git config --local user.email "basetenbot@baseten.co"
+        git config --local user.email "96544894+basetenbot@users.noreply.github.com"
         git config --local user.name "basetenbot"
         git add pyproject.toml
         git commit -m "Bump version to $INPUT_VERSION"

--- a/.github/workflows/create_release_pr.yml
+++ b/.github/workflows/create_release_pr.yml
@@ -28,8 +28,8 @@ jobs:
 
     - name: Commit changes
       run: |
-        git config --local user.email "baseten-bot@baseten.co"
-        git config --local user.name "baseten-bot"
+        git config --local user.email "basetenbot@baseten.co"
+        git config --local user.name "basetenbot"
         git add pyproject.toml
         git commit -m "Bump version to $INPUT_VERSION"
       env:
@@ -46,7 +46,7 @@ jobs:
       run: |
         CURR_VERSION=$(curl https://pypi.org/pypi/truss/json | jq ".info.version")
         PR_BODY="Updating Truss from [$CURR_VERSION](https://pypi.org/pypi/truss/json) to $INPUT_VERSION."
-        PR_URL=$(gh pr create --base release --head refs/heads/bump-version-$INPUT_VERSION --title "Release $INPUT_VERSION" --body "$BODY")
+        PR_URL=$(gh pr create --base release --head refs/heads/bump-version-$INPUT_VERSION --title "Release $INPUT_VERSION" --body "$PR_BODY")
         gh pr merge $PR_URL --auto --merge
       env:
         INPUT_VERSION: ${{ github.event.inputs.version }}

--- a/.github/workflows/create_release_pr.yml
+++ b/.github/workflows/create_release_pr.yml
@@ -44,7 +44,7 @@ jobs:
 
     - name: Make PR
       run: |
-        PR_URL=gh pr create --base release --head refs/heads/bump-version-$INPUT_VERSION --title "Release $INPUT_VERSION"
+        PR_URL=$(gh pr create --base release --head refs/heads/bump-version-$INPUT_VERSION --title "Release $INPUT_VERSION" --body "Release $INPUT_VERSION")
         gh pr merge $PR_URL --auto --merge
       env:
         INPUT_VERSION: ${{ github.event.inputs.version }}


### PR DESCRIPTION
# Summary

This is a follow-up to https://github.com/basetenlabs/truss/pull/578. The flow for releasing Truss is now:
* Kick off the "Create Release PR" action in the Github UI
* Get someone to review the PR that gets created
* After approval, the PR will merge automatically (unless integration tests fail)
* A separate action will run merging the version update back into the main branch. If in the meantime, someone commits a version update to the main branch, it won't get overwritten here
