### PR TITLE
Add vim .swp to .truss_ignore

### DIFF
--- a/truss/util/.truss_ignore
+++ b/truss/util/.truss_ignore
@@ -165,3 +165,6 @@ cython_debug/
 
 # temp files
 *.tmp
+
+# Swap files
+*.swp


### PR DESCRIPTION
@nrhodes noted that we're not properly ignoring these swp files in truss, which is leading to a bad experience with `truss push` and `truss watch`. Adding them here to avoid future problems there.