### PR TITLE
Fix merge to main action

### DIFF
--- a/.github/workflows/commit_new_release_to_main.yml
+++ b/.github/workflows/commit_new_release_to_main.yml
@@ -1,7 +1,6 @@
 name: Merge release into main
 
 on:
-  workflow_dispatch:
   push:
     branches:
       - release

--- a/.github/workflows/commit_new_release_to_main.yml
+++ b/.github/workflows/commit_new_release_to_main.yml
@@ -1,6 +1,7 @@
 name: Merge release into main
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - release

--- a/.github/workflows/commit_new_release_to_main.yml
+++ b/.github/workflows/commit_new_release_to_main.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Merge release into main with priority on main changes
       run: |
         git checkout main
-        git merge --strategy-option=ours release -m "Merge release into main prioritizing main changes"
+        git merge --strategy-option=ours origin/release -m "Merge release into main prioritizing main changes"
         git push origin main
       env:
         GH_TOKEN: ${{ secrets.BASETENBOT_GITHUB_TOKEN }}


### PR DESCRIPTION
Merging the `release` branch seems to cause problems. We're fetching all branches before this step, so merging in origin/release is correct.

Also updated the branch protection rules to allow basetenbot to push to main.