### PR TITLE
Improvements to truss CLI.

### DIFF
--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -392,6 +392,7 @@ def predict(
     default=False,
     help="Trust truss with hosted secrets.",
 )
+@error_handling
 def push(
     target_directory: str,
     remote: str,

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -392,7 +392,6 @@ def predict(
     default=False,
     help="Trust truss with hosted secrets.",
 )
-@error_handling
 def push(
     target_directory: str,
     remote: str,
@@ -424,9 +423,27 @@ def push(
         tr.spec.config.write_to_yaml_file(tr.spec.config_path, verbose=False)
 
     # TODO(Abu): This needs to be refactored to be more generic
-    _ = remote_provider.push(tr, model_name, publish=publish, trusted=trusted)  # type: ignore
+    service = remote_provider.push(tr, model_name, publish=publish, trusted=trusted)  # type: ignore
 
-    click.echo(f"Model {model_name} was successfully pushed.")
+    model_overview_url = service.resource_url
+    click.echo(f"✨ Model {model_name} was successfully pushed ✨")
+
+    if not publish:
+        draft_model_text = """
+|---------------------------------------------------------------------------------------|
+| Your model has been deployed as a draft. Draft models allow you to                    |
+| iterate quickly during the deployment process.                                        |
+|                                                                                       |
+| When you are ready to publish your deployed model as a new version,                   |
+| pass `--publish` to the `truss push` command. To monitor changes to your model and    |
+| rapidly iterate, run the `truss watch` command                                        |
+|                                                                                       |
+|---------------------------------------------------------------------------------------|
+"""
+
+        click.echo(draft_model_text)
+
+    click.echo(f"🔎 Visit {model_overview_url} for more information on your live model.")
 
 
 @truss_cli.command()

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -6,15 +6,21 @@ import sys
 import webbrowser
 from functools import wraps
 from pathlib import Path
-from typing import Callable, Optional, Union
+from typing import Callable, Optional
 
 import rich
 import rich_click as click
 import truss
 from InquirerPy import inquirer
 from truss.cli.create import ask_name, select_server_backend
+from truss.remote.baseten.core import (
+    ModelId,
+    ModelIdentifier,
+    ModelName,
+    ModelVersionId,
+)
 from truss.remote.remote_cli import inquire_model_name, inquire_remote_name
-from truss.remote.remote_factory import RemoteFactory
+from truss.remote.remote_factory import USER_TRUSSRC_PATH, RemoteFactory
 from truss.truss_config import ModelServer
 
 logging.basicConfig(level=logging.INFO)
@@ -242,6 +248,42 @@ def watch(
     remote_provider.sync_truss_to_dev_version_by_name(model_name, target_directory)  # type: ignore
 
 
+def _extract_and_validate_model_identifier(
+    target_directory: str,
+    model_id: Optional[str],
+    model_version_id: Optional[str],
+    published: Optional[bool],
+) -> ModelIdentifier:
+    if published and (model_id or model_version_id):
+        raise click.UsageError(
+            "Cannot use --published with --model or --model-version."
+        )
+
+    model_identifier: ModelIdentifier
+    if model_version_id:
+        model_identifier = ModelVersionId(model_version_id)
+    elif model_id:
+        model_identifier = ModelId(model_id)
+    else:
+        tr = _get_truss_from_directory(target_directory=target_directory)
+        model_name = tr.spec.config.model_name
+        if not model_name:
+            raise click.UsageError("Truss config is missing a model name.")
+        model_identifier = ModelName(model_name)
+    return model_identifier
+
+
+def _extract_request_data(data: Optional[str], file: Optional[Path]):
+    if data is not None:
+        return json.loads(data)
+    elif file is not None:
+        return json.loads(Path(file).read_text())
+    else:
+        raise click.UsageError(
+            "You must provide exactly one of '--data (-d)' or '--file (-f)' options."
+        )
+
+
 @truss_cli.command()
 @click.option("--target_directory", required=False, help="Directory of truss")
 @click.option(
@@ -271,14 +313,27 @@ def watch(
     default=False,
     help="Invoked the published model version.",
 )
-@error_handling
+@click.option(
+    "--model-version",
+    type=str,
+    required=False,
+    help="ID of model version to invoke",
+)
+@click.option(
+    "--model",
+    type=str,
+    required=False,
+    help="ID of model to invoke",
+)
 @echo_output
 def predict(
     target_directory: str,
     remote: str,
-    data: Union[bytes, str],
+    data: Optional[str],
     file: Optional[Path],
     published: Optional[bool],
+    model_version: Optional[str],
+    model: Optional[str],
 ):
     """
     Invokes the packaged model
@@ -294,24 +349,16 @@ def predict(
 
     remote_provider = RemoteFactory.create(remote=remote)
 
-    tr = _get_truss_from_directory(target_directory=target_directory)
+    model_identifier = _extract_and_validate_model_identifier(
+        target_directory,
+        model_id=model,
+        model_version_id=model_version,
+        published=published,
+    )
 
-    model_name = tr.spec.config.model_name
-    if not model_name:
-        raise click.UsageError(
-            "You must provide exactly one of '--data (-d)' or '--file (-f)' options."
-        )
+    request_data = _extract_request_data(data=data, file=file)
 
-    if data is not None:
-        request_data = json.loads(data)
-    elif file is not None:
-        request_data = json.loads(Path(file).read_text())
-    else:
-        raise click.UsageError(
-            "You must provide exactly one of '--data (-d)' or '--file (-f)' options."
-        )
-
-    service = remote_provider.get_baseten_service(model_name, published)  # type: ignore
+    service = remote_provider.get_baseten_service(model_identifier, published)  # type: ignore
     result = service.predict(request_data)
     if inspect.isgenerator(result):
         for chunk in result:
@@ -380,6 +427,24 @@ def push(
     _ = remote_provider.push(tr, model_name, publish=publish, trusted=trusted)  # type: ignore
 
     click.echo(f"Model {model_name} was successfully pushed.")
+
+
+@truss_cli.command()
+def configure():
+    # Read the original file content
+    with open(USER_TRUSSRC_PATH, "r") as f:
+        original_content = f.read()
+
+    # Open the editor and get the modified content
+    edited_content = click.edit(original_content)
+
+    # If the content was modified, save it
+    if edited_content is not None and edited_content != original_content:
+        with open(USER_TRUSSRC_PATH, "w") as f:
+            f.write(edited_content)
+            click.echo(f"Changes saved to {USER_TRUSSRC_PATH}")
+    else:
+        click.echo("No changes made.")
 
 
 @container.command()  # type: ignore

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -413,7 +413,6 @@ def push(
 
     tr = _get_truss_from_directory(target_directory=target_directory)
 
-    # Push
     model_name = model_name or tr.spec.config.model_name
     if not model_name:
         model_name = inquire_model_name()

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -424,9 +424,8 @@ def push(
         tr.spec.config.write_to_yaml_file(tr.spec.config_path, verbose=False)
 
     # TODO(Abu): This needs to be refactored to be more generic
-    service = remote_provider.push(tr, model_name, publish=publish, trusted=trusted)  # type: ignore
+    _ = remote_provider.push(tr, model_name, publish=publish, trusted=trusted)  # type: ignore
 
-    model_overview_url = service.resource_url
     click.echo(f"✨ Model {model_name} was successfully pushed ✨")
 
     if not publish:
@@ -444,7 +443,13 @@ def push(
 
         click.echo(draft_model_text)
 
-    click.echo(f"🔎 Visit {model_overview_url} for more information on your live model.")
+    logs_url = remote_provider.get_remote_logs_url(model_name)  # type: ignore[attr-defined]
+    rich.print(f"🪵  View logs for your deployment at {logs_url}")
+    should_open_logs = inquirer.confirm(
+        message="🗂  Open logs in a new tab?", default=True
+    ).execute()
+    if should_open_logs:
+        webbrowser.open_new_tab(logs_url)
 
 
 @truss_cli.command()

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -436,7 +436,7 @@ def push(
 |                                                                                       |
 | When you are ready to publish your deployed model as a new version,                   |
 | pass `--publish` to the `truss push` command. To monitor changes to your model and    |
-| rapidly iterate, run the `truss watch` command                                        |
+| rapidly iterate, run the `truss watch` command.                                       |
 |                                                                                       |
 |---------------------------------------------------------------------------------------|
 """

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -143,7 +143,6 @@ class BasetenApi:
             oracle{{
                 id
                 name
-                id
                 versions{{
                     id
                     semver
@@ -157,6 +156,42 @@ class BasetenApi:
             }}
         }}
         }}
+        """
+        resp = self._post_graphql_query(query_string)
+        return resp["data"]
+
+    def get_model_by_id(self, model_id: str):
+        query_string = f"""
+        {{
+            model(id: "{model_id}") {{
+                name
+                id
+                primary_version{{
+                    id
+                    semver
+                    truss_hash
+                    truss_signature
+                    is_draft
+                    current_model_deployment_status {{
+                        status
+                    }}
+                }}
+            }}
+          }}
+        """
+        resp = self._post_graphql_query(query_string)
+        return resp["data"]
+
+    def get_model_version_by_id(self, model_version_id: str):
+        query_string = f"""
+        {{
+            model_version(id: "{model_version_id}") {{
+                id
+                oracle{{
+                    id
+                }}
+            }}
+          }}
         """
         resp = self._post_graphql_query(query_string)
         return resp["data"]

--- a/truss/remote/baseten/core.py
+++ b/truss/remote/baseten/core.py
@@ -10,6 +10,25 @@ from truss.truss_handle import TrussHandle
 logger = logging.getLogger(__name__)
 
 
+class ModelIdentifier:
+    value: str
+
+
+class ModelName(ModelIdentifier):
+    def __init__(self, name: str):
+        self.value = name
+
+
+class ModelId(ModelIdentifier):
+    def __init__(self, model_id: str):
+        self.value = model_id
+
+
+class ModelVersionId(ModelIdentifier):
+    def __init__(self, model_version_id: str):
+        self.value = model_version_id
+
+
 def exists_model(api: BasetenApi, model_name: str) -> Optional[str]:
     """
     Check if a model with the given name exists in the Baseten remote.

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -74,7 +74,6 @@ class BasetenRemote(TrussRemote):
             model_version_id=model_version_id,
             is_draft=not publish,
             api_key=self._auth_service.authenticate().value,
-            remote_url=self._remote_url,
             service_url=f"{self._remote_url}/model_versoins/{model_version_id}",
             truss_handle=truss_handle,
         )
@@ -134,7 +133,6 @@ class BasetenRemote(TrussRemote):
             model_version_id=model_version_id,
             is_draft=not published,
             api_key=self._auth_service.authenticate().value,
-            remote_url=self._remote_url,
             service_url=f"{self._remote_url}{service_url_path}",
         )
 

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -73,7 +73,7 @@ class BasetenRemote(TrussRemote):
             model_version_id=model_version_id,
             is_draft=not publish,
             api_key=self._auth_service.authenticate().value,
-            service_url=f"{self._remote_url}/model_versions/{model_version_id}",
+            service_url=self._remote_url,
             truss_handle=truss_handle,
         )
 
@@ -118,7 +118,7 @@ class BasetenRemote(TrussRemote):
             model_version_id=model_version_id,
             is_draft=not published,
             api_key=self._auth_service.authenticate().value,
-            service_url=f"{self._remote_url}/model_versions/{model_version_id}",
+            service_url=self._remote_url,
         )
 
     def get_remote_logs_url(

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -1,6 +1,7 @@
 import logging
 from pathlib import Path
 
+import click
 import yaml
 from requests import ReadTimeout
 from truss.contexts.local_loader.truss_file_syncer import TrussFilesSyncer
@@ -8,6 +9,10 @@ from truss.local.local_config_handler import LocalConfigHandler
 from truss.remote.baseten.api import BasetenApi
 from truss.remote.baseten.auth import AuthService
 from truss.remote.baseten.core import (
+    ModelId,
+    ModelIdentifier,
+    ModelName,
+    ModelVersionId,
     archive_truss,
     create_truss_service,
     exists_model,
@@ -73,25 +78,41 @@ class BasetenRemote(TrussRemote):
         )
 
     def get_baseten_service(
-        self, model_name: str, published: bool = False
+        self, model_identifier: ModelIdentifier, published: bool = False
     ) -> BasetenService:
-        model_id, model_versions = get_model_versions_info(self._api, model_name)
-        model_version = None
-        if published:
-            for mv in model_versions:
-                if not mv["is_draft"]:
-                    model_version = mv
-                    break
-        else:
-            for mv in model_versions:
-                if mv["is_draft"]:
-                    model_version = mv
-                    break
-        if model_version is None:
-            raise ValueError(
-                "No appropriate model version found. Run `truss push` then try again."
+        if isinstance(model_identifier, ModelName):
+            model_id, model_versions = get_model_versions_info(
+                self._api, model_identifier.value
             )
-        model_version_id = model_version["id"]
+            model_version = None
+            if published:
+                for mv in model_versions:
+                    if not mv["is_draft"]:
+                        model_version = mv
+                        break
+            else:
+                for mv in model_versions:
+                    if mv["is_draft"]:
+                        model_version = mv
+                        break
+            if model_version is None:
+                raise ValueError(
+                    "No appropriate model version found. Run `truss push` then try again."
+                )
+            model_version_id = model_version["id"]
+        elif isinstance(model_identifier, ModelId):
+            model = self._api.get_model_by_id(model_identifier.value)
+            model_id = model["model"]["id"]
+            model_version_id = model["model"]["primary_version"]["id"]
+        elif isinstance(model_identifier, ModelVersionId):
+            model_version = self._api.get_model_version_by_id(model_identifier.value)
+            model_version_id = model_version["model_version"]["id"]
+            model_id = model_version["model_version"]["oracle"]["id"]
+        else:
+            raise click.UsageError(
+                "You must either be inside of a Truss directory, or provide --model-version or --model options."
+            )
+
         return BasetenService(
             model_id=model_id,
             model_version_id=model_version_id,
@@ -105,7 +126,7 @@ class BasetenRemote(TrussRemote):
         model_name: str,
         published: bool = False,
     ) -> str:
-        service = self.get_baseten_service(model_name, published)
+        service = self.get_baseten_service(ModelName(model_name), published)
         return f"{self._remote_url}/models/{service._model_id}/versions/{service._model_version_id}/logs"
 
     def sync_truss_to_dev_version_by_name(

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -74,7 +74,7 @@ class BasetenRemote(TrussRemote):
             model_version_id=model_version_id,
             is_draft=not publish,
             api_key=self._auth_service.authenticate().value,
-            service_url=f"{self._remote_url}/model_versoins/{model_version_id}",
+            service_url=f"{self._remote_url}/model_versions/{model_version_id}",
             truss_handle=truss_handle,
         )
 

--- a/truss/remote/baseten/service.py
+++ b/truss/remote/baseten/service.py
@@ -14,14 +14,12 @@ class BasetenService(TrussService):
         model_version_id: str,
         is_draft: bool,
         api_key: str,
-        remote_url: str,
         service_url: str,
         truss_handle: Optional[TrussHandle] = None,
     ):
         super().__init__(is_draft=is_draft, service_url=service_url)
         self._model_id = model_id
         self._model_version_id = model_version_id
-        self._remote_url = remote_url
         self._auth_service = AuthService(api_key=api_key)
         self._truss_handle = truss_handle
 

--- a/truss/remote/baseten/service.py
+++ b/truss/remote/baseten/service.py
@@ -14,12 +14,14 @@ class BasetenService(TrussService):
         model_version_id: str,
         is_draft: bool,
         api_key: str,
+        remote_url: str,
         service_url: str,
         truss_handle: Optional[TrussHandle] = None,
     ):
         super().__init__(is_draft=is_draft, service_url=service_url)
         self._model_id = model_id
         self._model_version_id = model_version_id
+        self._remote_url = remote_url
         self._auth_service = AuthService(api_key=api_key)
         self._truss_handle = truss_handle
 
@@ -39,11 +41,11 @@ class BasetenService(TrussService):
 
     @property
     def invocation_url(self) -> str:
-        return f"{self._service_url}/model_versions/{self._model_version_id}/predict"
+        return f"{self._service_url}/predict"
 
     @property
     def resource_url(self) -> str:
-        return f"{self._service_url}/models/{self._model_id}"
+        return f"{self._remote_url}/models/{self._model_id}"
 
     def predict(
         self,

--- a/truss/remote/baseten/service.py
+++ b/truss/remote/baseten/service.py
@@ -29,7 +29,12 @@ class BasetenService(TrussService):
     def is_ready(self) -> bool:
         raise NotImplementedError
 
-    def predict(self, model_request_body: Dict):
+    def predict(
+        self,
+        model_request_body: Dict,
+        model_id: Optional[str] = None,
+        model_version_id: Optional[str] = None,
+    ):
         invocation_url = f"{self._service_url}/predict"
         response = self._send_request(
             invocation_url, "POST", data=model_request_body, stream=True

--- a/truss/remote/baseten/service.py
+++ b/truss/remote/baseten/service.py
@@ -29,15 +29,28 @@ class BasetenService(TrussService):
     def is_ready(self) -> bool:
         raise NotImplementedError
 
+    @property
+    def model_id(self) -> str:
+        return self._model_id
+
+    @property
+    def model_version_id(self) -> str:
+        return self._model_version_id
+
+    @property
+    def invocation_url(self) -> str:
+        return f"{self._service_url}/model_versions/{self._model_version_id}/predict"
+
+    @property
+    def resource_url(self) -> str:
+        return f"{self._service_url}/models/{self._model_id}"
+
     def predict(
         self,
         model_request_body: Dict,
-        model_id: Optional[str] = None,
-        model_version_id: Optional[str] = None,
     ):
-        invocation_url = f"{self._service_url}/predict"
         response = self._send_request(
-            invocation_url, "POST", data=model_request_body, stream=True
+            self.invocation_url, "POST", data=model_request_body, stream=True
         )
 
         if response.headers.get("transfer-encoding") == "chunked":

--- a/truss/remote/baseten/service.py
+++ b/truss/remote/baseten/service.py
@@ -43,10 +43,6 @@ class BasetenService(TrussService):
     def invocation_url(self) -> str:
         return f"{self._service_url}/predict"
 
-    @property
-    def resource_url(self) -> str:
-        return f"{self._remote_url}/models/{self._model_id}"
-
     def predict(
         self,
         model_request_body: Dict,

--- a/truss/remote/remote_cli.py
+++ b/truss/remote/remote_cli.py
@@ -2,7 +2,7 @@ from typing import List
 
 import rich
 from InquirerPy import inquirer
-from truss.remote.remote_factory import RemoteFactory
+from truss.remote.remote_factory import USER_TRUSSRC_PATH, RemoteFactory
 from truss.remote.truss_remote import RemoteConfig
 
 
@@ -16,6 +16,7 @@ def inquire_remote_config() -> RemoteConfig:
         message="🤫 Quietly paste your API_KEY:",
         qmark="",
     ).execute()
+
     return RemoteConfig(
         name="baseten",
         configs={
@@ -38,6 +39,8 @@ def inquire_remote_name(available_remotes: List[str]) -> str:
         return available_remotes[0]
     remote_config = inquire_remote_config()
     RemoteFactory.update_remote_config(remote_config)
+
+    rich.print(f"💾 Remote config saved to {USER_TRUSSRC_PATH}")
     return remote_config.name
 
 


### PR DESCRIPTION
# Summary

Made some improvements to the `truss` CLI:

* `truss predict` now supports `--model` and `--model-version` arguments
* `truss configure` now exists which edits the `.trussrc` file

Will follow up this change with a couple more changes:
1. Printing URL after truss push 
2. Clean up the get_baseten_service path -- the code here is quite messy (I wish we could use pattern matching!)
3. I really dislike that we edit the config.yaml after truss push, it feels pretty janky that we do that and would like to revisit that

# testing

Truss Push:

```
$ poetry run truss push
Compressing... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Uploading... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
✨ Model Baseten Test Model was successfully pushed ✨

|---------------------------------------------------------------------------------------|
| Your model has been deployed as a draft. Draft models allow you to                    |
| iterate quickly during the deployment process.                                        |
|                                                                                       |
| When you are ready to publish your deployed model as a new version,                   |
| pass `--publish` to the `truss push` command. To monitor changes to your model and    |
| rapidly iterate, run the `truss watch` command                                        |
|                                                                                       |
|---------------------------------------------------------------------------------------|

🪵  View logs for your deployment at https://app.baseten.co/models/pBDEAQ0/versions/wpjvdlw/logs
? 🗂  Open logs in a new tab? Yes
```


Truss predict:

```
@squidarth ➜ /workspaces/truss/truss-public-gh-repo-test (main) $ poetry run truss predict -d '{"inputs": "b"}'
{
  "predictions": "b"
}

@squidarth ➜ /workspaces/truss/truss-public-gh-repo-test (main) $ poetry run truss predict -d '{"inputs": "b"}' --model pBDEAQ0
{
  "predictions": "b"
}

@squidarth ➜ /workspaces/truss/truss-public-gh-repo-test (main) $ poetry run truss predict -d '{"inputs": "b"}' --model-version wpjvdlw
{
  "predictions": "b"
}

```