### PR TITLE
Fix the merge action, take 2

### DIFF
--- a/.github/workflows/commit_new_release_to_main.yml
+++ b/.github/workflows/commit_new_release_to_main.yml
@@ -1,6 +1,7 @@
 name: Merge release into main
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - release
@@ -26,6 +27,5 @@ jobs:
       run: |
         git checkout main
         git merge --strategy-option=ours origin/release -m "Merge release into main prioritizing main changes"
-        git push origin main
       env:
         GH_TOKEN: ${{ secrets.BASETENBOT_GITHUB_TOKEN }}

--- a/.github/workflows/commit_new_release_to_main.yml
+++ b/.github/workflows/commit_new_release_to_main.yml
@@ -25,7 +25,11 @@ jobs:
 
     - name: Merge release into main with priority on main changes
       run: |
+        git remote -v
+        git branch -A
+        git checkout release
         git checkout main
+
         git merge --strategy-option=ours origin/release -m "Merge release into main prioritizing main changes"
       env:
         GH_TOKEN: ${{ secrets.BASETENBOT_GITHUB_TOKEN }}

--- a/.github/workflows/commit_new_release_to_main.yml
+++ b/.github/workflows/commit_new_release_to_main.yml
@@ -26,7 +26,6 @@ jobs:
     - name: Merge release into main with priority on main changes
       run: |
         git remote -v
-        git branch -A
         git checkout release
         git checkout main
 

--- a/.github/workflows/commit_new_release_to_main.yml
+++ b/.github/workflows/commit_new_release_to_main.yml
@@ -21,14 +21,13 @@ jobs:
 
     - name: Fetch all branches
       run: |
-        git fetch --all
+        git fetch --all --unshallow
+        git pull origin release
 
     - name: Merge release into main with priority on main changes
       run: |
-        git remote -v
-        git checkout release
         git checkout main
-
-        git merge --strategy-option=ours origin/release -m "Merge release into main prioritizing main changes"
+        git merge --strategy-option=ours release -m "Merge release into main prioritizing main changes"
+        git push origin main
       env:
         GH_TOKEN: ${{ secrets.BASETENBOT_GITHUB_TOKEN }}

--- a/.github/workflows/create_release_pr.yml
+++ b/.github/workflows/create_release_pr.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Make PR
       run: |
         CURR_VERSION=$(curl https://pypi.org/pypi/truss/json | jq ".info.version")
-        PR_BODY="Updating Truss from [$CURR_VERSION](https://pypi.org/pypi/truss/json) to $INPUT_VERSION."
+        PR_BODY="Updating Truss from [$CURR_VERSION](https://pypi.org/pypi/truss/json) to $INPUT_VERSION. **PLEASE ENSURE YOU MERGE, NOT SQUASH**"
         PR_URL=$(gh pr create --base release --head refs/heads/bump-version-$INPUT_VERSION --title "Release $INPUT_VERSION" --body "$PR_BODY")
       env:
         INPUT_VERSION: ${{ github.event.inputs.version }}


### PR DESCRIPTION
# Summary

While this new "merge-to-main" action worked when I tested, it actually failed on the release branch. The reason for this is that when the github action is run, the branch that it is run on is **cloned shallowly**. This means that when this ran on the release branch, the release branch was checked out with a depth 1, without the history available.

This meant that when we did:

```
git checkout main
git merge release
```

This was causing us to see an error to do with unrelated histories. The release branch in this case had no history!

The fix here is to ensure that we do an "unshallow" fetch. When a branch is checked out as a shallow clone, it is shallow until "unshallow" is set.

# Testing

I tested this by changing the action to point to a "release-test" branch instead of "release". See this successful action: https://github.com/basetenlabs/truss/actions/runs/5971947637/job/16201753972

