### PR TITLE
Throw build error on conflicting requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.6.5rc1"
+version = "0.6.5rc2"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/contexts/image_builder/serving_image_builder.py
+++ b/truss/contexts/image_builder/serving_image_builder.py
@@ -370,10 +370,15 @@ class ServingImageBuilder(ImageBuilder):
         with open(base_truss_server_reqs_filepath, "r") as f:
             base_server_requirements = f.read()
 
+        # If the user has provided python requirements,
+        # append the truss server requirements, so that any conflicts
+        # are detected and cause a build failure. If there are no
+        # requirements provided, we just pass an empty string,
+        # as there's no need to install anything.
         user_provided_python_requirements = (
             base_server_requirements + spec.requirements_txt
             if spec.requirements
-            else spec.requirements_txt
+            else ""
         )
         (build_dir / REQUIREMENTS_TXT_FILENAME).write_text(
             user_provided_python_requirements

--- a/truss/contexts/image_builder/serving_image_builder.py
+++ b/truss/contexts/image_builder/serving_image_builder.py
@@ -353,10 +353,8 @@ class ServingImageBuilder(ImageBuilder):
             )
 
         # Copy base TrussServer requirements if supplied custom base image
+        base_truss_server_reqs_filepath = SERVER_CODE_DIR / REQUIREMENTS_TXT_FILENAME
         if config.base_image:
-            base_truss_server_reqs_filepath = (
-                SERVER_CODE_DIR / REQUIREMENTS_TXT_FILENAME
-            )
             copy_into_build_dir(
                 base_truss_server_reqs_filepath, BASE_SERVER_REQUIREMENTS_TXT_FILENAME
             )
@@ -369,7 +367,17 @@ class ServingImageBuilder(ImageBuilder):
         if should_install_server_requirements:
             copy_into_build_dir(server_reqs_filepath, SERVER_REQUIREMENTS_TXT_FILENAME)
 
-        (build_dir / REQUIREMENTS_TXT_FILENAME).write_text(spec.requirements_txt)
+        with open(base_truss_server_reqs_filepath, "r") as f:
+            base_server_requirements = f.read()
+
+        user_provided_python_requirements = (
+            base_server_requirements + spec.requirements_txt
+            if spec.requirements
+            else spec.requirements_txt
+        )
+        (build_dir / REQUIREMENTS_TXT_FILENAME).write_text(
+            user_provided_python_requirements
+        )
         (build_dir / SYSTEM_PACKAGES_TXT_FILENAME).write_text(spec.system_packages_txt)
 
         self._render_dockerfile(

--- a/truss/tests/contexts/image_builder/test_serving_image_builder.py
+++ b/truss/tests/contexts/image_builder/test_serving_image_builder.py
@@ -31,3 +31,21 @@ def test_serving_image_dockerfile_from_user_base_image(custom_model_truss_dir):
         gen_docker_lines = filter_empty_lines(gen_docker_lines)
         server_docker_lines = filter_empty_lines(server_docker_lines)
         assert gen_docker_lines == server_docker_lines
+
+
+def test_requirements_setup_in_build_dir(custom_model_truss_dir):
+    th = TrussHandle(custom_model_truss_dir)
+    th.add_python_requirement("numpy")
+    builder_context = ServingImageBuilderContext
+    image_builder = builder_context.run(th.spec.truss_dir)
+
+    with TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir)
+        image_builder.prepare_image_build_dir(tmp_path)
+        with open(tmp_path / "requirements.txt", "r") as f:
+            requirements_content = f.read()
+
+        with open(f"{BASE_DIR}/../../../templates/server/requirements.txt", "r") as f:
+            base_requirements_content = f.read()
+
+        assert requirements_content == base_requirements_content + "numpy\n"


### PR DESCRIPTION
# Summary

There's an [issue now](https://github.com/basetenlabs/truss/issues/598) https://github.com/basetenlabs/truss/issues/598 where if you install a requirement that conflicts with a requirement of the truss server, there ends up being a soft failure where things just subtly break. In this PR, we change how we construct the user requirements such that  we get a _hard failure_ when installing the conflicting requirements.

Note that I spent a while trying to figure out if there is a pip install command that considers packages _currently installed_, and failed to find anything that works. The only thing that I could find that does is just including all of the packages to install in one command.

## What's left

We don't touch the Truss watch flow in this PR, so if you add a new dependency during Truss Watch, you'll get into the same state as before. Will tackle that separately, it's a little bit more involved

# Testing

Pushed RC up and built new context. Pushed a truss with "tensorflow=2.6.2" specified, and watched the build fail

![Cursor_and_Baseten_Test_Model___Model___Baseten](https://github.com/basetenlabs/truss/assets/850115/77b2c2a4-9c7b-4459-b53a-d6cf29411466)
t context builder:

