### PR TITLE
Template out the data folder for TGI / VLLM

### DIFF
--- a/truss/contexts/image_builder/serving_image_builder.py
+++ b/truss/contexts/image_builder/serving_image_builder.py
@@ -206,10 +206,13 @@ def create_tgi_build_dir(config: TrussConfig, build_dir: Path, truss_dir: Path):
     dockerfile_template = read_template_from_fs(
         TEMPLATES_DIR, "tgi/tgi.Dockerfile.jinja"
     )
+
+    data_dir = build_dir / "data"
     dockerfile_content = dockerfile_template.render(
         hf_access_token=hf_access_token,
         models=model_files,
         hf_cache=config.hf_cache,
+        data_dir_exists=Path(data_dir).exists(),
     )
     dockerfile_filepath = build_dir / "Dockerfile"
     dockerfile_filepath.write_text(dockerfile_content)
@@ -252,11 +255,13 @@ def create_vllm_build_dir(config: TrussConfig, build_dir: Path, truss_dir: Path)
     )
     nginx_template = read_template_from_fs(TEMPLATES_DIR, "vllm/proxy.conf.jinja")
 
+    data_dir = build_dir / "data"
     dockerfile_content = dockerfile_template.render(
         hf_access_token=hf_access_token,
         models=model_files,
         should_install_server_requirements=True,
         hf_cache=config.hf_cache,
+        data_dir_exists=data_dir.exists(),
     )
     dockerfile_filepath = build_dir / "Dockerfile"
     dockerfile_filepath.write_text(dockerfile_content)

--- a/truss/templates/server.Dockerfile.jinja
+++ b/truss/templates/server.Dockerfile.jinja
@@ -53,6 +53,7 @@ COPY ./{{config.data_dir}} /app/data
 {%- endif %}
 
 {%- if config.hf_cache != None %}
+RUN mkdir /app
 RUN curl -s https://baseten-public.s3.us-west-2.amazonaws.com/bin/b10cp-5fe8dc7da-linux-amd64 -o /app/b10cp; chmod +x /app/b10cp
 ENV B10CP_PATH_TRUSS /app/b10cp
 COPY ./cache_requirements.txt /app/cache_requirements.txt

--- a/truss/templates/tgi/tgi.Dockerfile.jinja
+++ b/truss/templates/tgi/tgi.Dockerfile.jinja
@@ -12,7 +12,10 @@ ENV HUGGING_FACE_HUB_TOKEN {{hf_access_token}}
 
 
 {%- if hf_cache %}
+RUN mkdir /app
+        {%- if data_dir_exists %}
 COPY ./data /app/data
+        {%- endif %}
 RUN curl -s https://baseten-public.s3.us-west-2.amazonaws.com/bin/b10cp-5fe8dc7da-linux-amd64 -o /app/b10cp; chmod +x /app/b10cp
 ENV B10CP_PATH_TRUSS /app/b10cp
 COPY ./cache_requirements.txt /app/cache_requirements.txt

--- a/truss/templates/vllm/vllm.Dockerfile.jinja
+++ b/truss/templates/vllm/vllm.Dockerfile.jinja
@@ -13,7 +13,10 @@ ENV HUGGING_FACE_HUB_TOKEN {{hf_access_token}}
 
 
 {%- if hf_cache %}
+RUN mkdir /app
+        {%- if data_dir_exists %}
 COPY ./data /app/data
+        {%- endif %}
 RUN curl -s https://baseten-public.s3.us-west-2.amazonaws.com/bin/b10cp-5fe8dc7da-linux-amd64 -o /app/b10cp; chmod +x /app/b10cp
 ENV B10CP_PATH_TRUSS /app/b10cp
 COPY ./cache_requirements.txt /app/cache_requirements.txt


### PR DESCRIPTION
Currently, users must have a data_dir if they're using the `hf_cache` key. In reality, this should not be the case. The `data_dir` is only necessary if they have account credentials (e.g. gcs) for their bucket. For caching Hugging Face weights, there may be no `data_dir`.