### PR TITLE
Gracefully handle client disconnects

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.6.5rc2"
+version = "0.6.5rc3"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.6.5rc4"
+version = "0.6.5rc5"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.6.5rc3"
+version = "0.6.5rc4"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/templates/control/control/endpoints.py
+++ b/truss/templates/control/control/endpoints.py
@@ -35,6 +35,7 @@ async def proxy(request: Request):
         request_body = await request.body()
     except ClientDisconnect:
         # If the client disconnects, we don't need to proxy the request
+        request.app.state.logger.info("Client disconnected")
         return Response(status_code=499)
 
     inf_serv_req = client.build_request(

--- a/truss/templates/control/control/endpoints.py
+++ b/truss/templates/control/control/endpoints.py
@@ -35,7 +35,6 @@ async def proxy(request: Request):
         request_body = await request.body()
     except ClientDisconnect:
         # If the client disconnects, we don't need to proxy the request
-        request.app.state.logger.info("Client disconnected")
         return Response(status_code=499)
 
     inf_serv_req = client.build_request(

--- a/truss/templates/server/common/truss_server.py
+++ b/truss/templates/server/common/truss_server.py
@@ -15,7 +15,7 @@ import common.errors as errors
 import shared.util as utils
 import uvicorn
 from common.termination_handler_middleware import TerminationHandlerMiddleware
-from fastapi import Depends, FastAPI, Request
+from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.responses import ORJSONResponse, StreamingResponse
 from fastapi.routing import APIRoute as FastAPIRoute
 from model_wrapper import ModelWrapper
@@ -26,6 +26,7 @@ from shared.serialization import (
     truss_msgpack_serialize,
 )
 from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import ClientDisconnect
 from starlette.responses import Response
 
 # [IMPORTANT] A lot of things depend on this currently.
@@ -41,7 +42,10 @@ async def parse_body(request: Request) -> bytes:
     """
     Used by FastAPI to read body in an asynchronous manner
     """
-    return await request.body()
+    try:
+        return await request.body()
+    except ClientDisconnect as exc:
+        raise HTTPException(status_code=499, detail="Unauthorized") from exc
 
 
 FORMAT = "%(asctime)s.%(msecs)03d %(name)s %(levelname)s [%(funcName)s():%(lineno)s] %(message)s"

--- a/truss/templates/server/common/truss_server.py
+++ b/truss/templates/server/common/truss_server.py
@@ -44,8 +44,9 @@ async def parse_body(request: Request) -> bytes:
     """
     try:
         return await request.body()
-    except ClientDisconnect:
-        raise HTTPException(status_code=499, detail="Client disconnected")
+    except ClientDisconnect as exc:
+        logging.info("Client disconnected")
+        raise HTTPException(status_code=499, detail="Client disconnected") from exc
 
 
 FORMAT = "%(asctime)s.%(msecs)03d %(name)s %(levelname)s [%(funcName)s():%(lineno)s] %(message)s"

--- a/truss/templates/server/common/truss_server.py
+++ b/truss/templates/server/common/truss_server.py
@@ -44,8 +44,8 @@ async def parse_body(request: Request) -> bytes:
     """
     try:
         return await request.body()
-    except ClientDisconnect as exc:
-        raise HTTPException(status_code=499, detail="Client disconnected") from exc
+    except ClientDisconnect:
+        raise HTTPException(status_code=499, detail="Client disconnected")
 
 
 FORMAT = "%(asctime)s.%(msecs)03d %(name)s %(levelname)s [%(funcName)s():%(lineno)s] %(message)s"

--- a/truss/templates/server/common/truss_server.py
+++ b/truss/templates/server/common/truss_server.py
@@ -45,7 +45,7 @@ async def parse_body(request: Request) -> bytes:
     try:
         return await request.body()
     except ClientDisconnect as exc:
-        raise HTTPException(status_code=499, detail="Unauthorized") from exc
+        raise HTTPException(status_code=499, detail="Client disconnected") from exc
 
 
 FORMAT = "%(asctime)s.%(msecs)03d %(name)s %(levelname)s [%(funcName)s():%(lineno)s] %(message)s"

--- a/truss/templates/server/common/truss_server.py
+++ b/truss/templates/server/common/truss_server.py
@@ -45,7 +45,6 @@ async def parse_body(request: Request) -> bytes:
     try:
         return await request.body()
     except ClientDisconnect as exc:
-        logging.info("Client disconnected")
         raise HTTPException(status_code=499, detail="Client disconnected") from exc
 
 


### PR DESCRIPTION
# Summary 

Full context is in this issue: https://github.com/basetenlabs/truss/issues/476.

Couple main changes here:
* Right now, when clients disconnect (this happens during periods of load & can be due to client timeouts), they see a large, hard to parse stacktrace in their logs, there's no reason for that. After this change, this will not show up in the logs, and will manifest as 499 errors (which is the http code for client disconnects)
* Remove request timeout from control server. There's no reason for this -- the 

# Testing

Calling a model in dev with "0.99" as the timeout simulated this issue. 

```
curl -X POST https://app.dev.baseten.co/models/pBDEAQ0/predict \
  -H "Authorization: Api-Key ${PROD_API_KEY}" \
  -d '{"inputs": "b", "c": true}' -m 0.99
```

FastAPI doesn't log 499s by default, because these are considered "unfinished requests", so I temporarily added a "Log" statement where we return the 499s, and observed these:

<img width="974" alt="Baseten_Test_Model_2___Model___Baseten" src="https://github.com/basetenlabs/truss/assets/850115/9e88c12d-e890-4d4b-8a40-1011c6061183">

