### PR TITLE
Updated TGI version

### DIFF
--- a/truss/templates/tgi/tgi.Dockerfile.jinja
+++ b/truss/templates/tgi/tgi.Dockerfile.jinja
@@ -1,4 +1,4 @@
-FROM ghcr.io/huggingface/text-generation-inference:0.9.4
+FROM ghcr.io/huggingface/text-generation-inference:1.0.3
 EXPOSE 8080
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \


### PR DESCRIPTION
This PR updates the TGI image to the latest image, `v1.0.3`. 