### PR TITLE
Remove the path check for PRs, so lint & test always run.

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,12 +2,6 @@ name: PR
 
 on:
   pull_request:
-    paths:
-      - poetry.lock
-      - pyproject.yaml
-      - "truss/**"
-      - "docs/**"
-      - .github/workflows/pr.yml
 
 concurrency:
   group: pr-${{ github.ref_name }}

--- a/truss-utils/truss_utils/s3.py
+++ b/truss-utils/truss_utils/s3.py
@@ -1,7 +1,9 @@
-import boto3
 from io import BytesIO
 
+import boto3
+
 s3 = boto3.client("s3")
+
 
 def get_byte_stream_for_s3_path(s3_path: str) -> BytesIO:
     """
@@ -16,6 +18,7 @@ def get_byte_stream_for_s3_path(s3_path: str) -> BytesIO:
     bucket_name, s3_key = s3_path.replace("s3://", "").split("/", 1)
     s3_object = s3.get_object(Bucket=bucket_name, Key=s3_key)
     return BytesIO(s3_object["Body"].read())
+
 
 def download_from_s3(s3_path: str, local_path: str) -> None:
     """


### PR DESCRIPTION
Recently changed the Truss Repo to require lint & test pass before merging. Now, if there are paths that changed that don't match the hard-coded list, the checks won't run, and the PRs won't be able to merged.

To fix that, I remove the path check here for PRs.