### PR TITLE
Fix truss init.

### DIFF
--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -103,7 +103,7 @@ def image():
     type=click.Choice([server.value for server in ModelServer]),
 )
 @error_handling
-def init(target_directory, trainable, backend) -> None:
+def init(target_directory, backend) -> None:
     """Create a new truss.
 
     TARGET_DIRECTORY: A Truss is created in this directory


### PR DESCRIPTION
It looks like in this PR ( https://github.com/basetenlabs/truss/pull/626), we removed the `trainable` argument, without removing it from the function definition. Fixed it in this PR.

# Testing

```
$ poetry run truss init foo
? What's the name of your model? blah
Truss blah was created in /workspaces/truss/foo
@squidarth ➜ /workspaces/truss (sshanker/fix-cli) $ ls foo
config.yaml  data  model  packages
```