### PR TITLE
Fix merge release branch action

### DIFF
--- a/.github/workflows/commit_new_release_to_main.yml
+++ b/.github/workflows/commit_new_release_to_main.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@v3
+      with:
+        token: ${{ secrets.BASETENBOT_GITHUB_TOKEN }}
 
     - name: Configure Git user as basetenbot
       run: |

--- a/.github/workflows/commit_new_release_to_main.yml
+++ b/.github/workflows/commit_new_release_to_main.yml
@@ -22,6 +22,7 @@ jobs:
     - name: Fetch all branches
       run: |
         git fetch --all --unshallow
+        git checkout release
         git pull origin release
 
     - name: Merge release into main with priority on main changes

--- a/.github/workflows/commit_new_release_to_main.yml
+++ b/.github/workflows/commit_new_release_to_main.yml
@@ -26,8 +26,8 @@ jobs:
 
     - name: Merge release into main with priority on main changes
       run: |
-        git checkout main
+        git checkout main2
         git merge --strategy-option=ours release -m "Merge release into main prioritizing main changes"
-        git push origin main
+        git push origin main2
       env:
         GH_TOKEN: ${{ secrets.BASETENBOT_GITHUB_TOKEN }}

--- a/.github/workflows/commit_new_release_to_main.yml
+++ b/.github/workflows/commit_new_release_to_main.yml
@@ -29,8 +29,8 @@ jobs:
 
     - name: Merge release into main with priority on main changes
       run: |
-        git checkout main2
-        git merge --strategy-option=ours release -m "Merge release into main prioritizing main changes"
-        git push origin main2
+        git checkout main
+        git merge --strategy-option=ours release
+        git push origin main
       env:
         GH_TOKEN: ${{ secrets.BASETENBOT_GITHUB_TOKEN }}


### PR DESCRIPTION
# Summary

The release to main action is continuing to fail, this time with an error that it could not bypass branch protections.


# Testing

1. Made a branch called "main2"
2. Set up branch protection rule on it, requiring a pull request and approval
3. Update the action to push to main2 instead of main
4. Run the action in _this_ branch
5. Check that it fails when I remove the "with: token" directive
6. Check that it succeeds when running on main branch normally

Note that main is currently up to date with release