### PR TITLE
Remove error nesting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.7.1"
+version = "0.7.2rc7"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/templates/server/model_wrapper.py
+++ b/truss/templates/server/model_wrapper.py
@@ -366,7 +366,7 @@ def _handle_exception():
     # Note that logger.exception logs the stacktrace, such that the user can
     # debug this error from the logs.
     logging.exception("Internal Server Error")
-    raise HTTPException(status_code=500, detail={"message": "Internal Server Error"})
+    raise HTTPException(status_code=500, detail="Internal Server Error")
 
 
 def _intercept_exceptions_sync(func):

--- a/truss/tests/test_model_inference.py
+++ b/truss/tests/test_model_inference.py
@@ -424,7 +424,7 @@ def test_truss_with_errors():
 
         assert_logs_contain_error(container.logs(), "ValueError: error")
 
-        assert "Internal Server Error" in response.json()["error"]["message"]
+        assert "Internal Server Error" in response.json()["error"]
 
     model_preprocess_error = """
     class Model:
@@ -452,7 +452,7 @@ def test_truss_with_errors():
         assert "error" in response.json()
 
         assert_logs_contain_error(container.logs(), "ValueError: error")
-        assert "Internal Server Error" in response.json()["error"]["message"]
+        assert "Internal Server Error" in response.json()["error"]
 
     model_postprocess_error = """
     class Model:
@@ -479,7 +479,7 @@ def test_truss_with_errors():
         assert response.status_code == 500
         assert "error" in response.json()
         assert_logs_contain_error(container.logs(), "ValueError: error")
-        assert "Internal Server Error" in response.json()["error"]["message"]
+        assert "Internal Server Error" in response.json()["error"]
 
     model_async = """
     class Model:
@@ -505,7 +505,7 @@ def test_truss_with_errors():
 
         assert_logs_contain_error(container.logs(), "ValueError: error")
 
-        assert "Internal Server Error" in response.json()["error"]["message"]
+        assert "Internal Server Error" in response.json()["error"]
 
 
 @pytest.mark.integration


### PR DESCRIPTION
# Summary

Right now, the error message is nested under the "message" key. There isn't really a need for that, so remove that here.

So instead of:

```
{
        "error": {
                "message": "Internal Server Error"
        }
}
```

We have

```
{
        "error": "Internal Server Error"
}
```

# Testing

```
[~]$ curl -X POST https://app.dev.baseten.co/model_versions/7wll6ew/predict \
  -H 'Authorization: Api-Key qRpJu93t.Qx9wUFQ417op8qjM8O1ak1dO5YJTKZqX' \
  -d '{}'
{
        "error": "Internal Server Error"
}
```


