### PR TITLE
Fix truss push --publish without existing draft model.

### DIFF
--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -433,7 +433,7 @@ def push(
 
         click.echo(draft_model_text)
 
-    logs_url = remote_provider.get_remote_logs_url(model_name)  # type: ignore[attr-defined]
+    logs_url = remote_provider.get_remote_logs_url(model_name, publish)  # type: ignore[attr-defined]
     rich.print(f"🪵  View logs for your deployment at {logs_url}")
     should_open_logs = inquirer.confirm(
         message="🗂  Open logs in a new tab?", default=True


### PR DESCRIPTION
# Summary 

@varunshenoy  reported that there's an issue with `truss push --publish` when there's no existing draft model. This is because we were invoking the function to get the remote logs url incorrectly. Fixed that here


# Testing

```
$ poetry run truss push --model-name "test-92" examples/truss-public-gh-repo-test/ --publish
? 🎮 Which remote do you want to connect to? sid-prod
Compressing... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Uploading... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
✨ Model test-92 was successfully pushed ✨
🪵  View logs for your deployment at https://app.baseten.co/models/gPGpebq/versions/w5d19r3/logs
? 🗂  Open logs in a new tab? No
```