### PR TITLE
Fixing vLLM image

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.7.2rc1"
+version = "0.7.2rc2"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.7.2"
+version = "0.7.2rc1"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/templates/vllm/proxy.conf.jinja
+++ b/truss/templates/vllm/proxy.conf.jinja
@@ -21,7 +21,7 @@ server {
     location ~ ^/v1/models/model:predict$ {
         proxy_redirect off;
 
-        rewrite ^/v1/models/model:predict$ /generate break;
+        rewrite ^/v1/models/model:predict$ {{server_endpoint}} break;
 
         proxy_pass http://127.0.0.1:8081;
     }

--- a/truss/templates/vllm/supervisord.conf.jinja
+++ b/truss/templates/vllm/supervisord.conf.jinja
@@ -4,7 +4,7 @@ logfile=/dev/null
 logfile_maxbytes=0
 
 [program:vllm-server]
-command=python -m vllm.entrypoints.api_server --host=0.0.0.0 --port=8081 {{extra_args}}
+command=python -m vllm.entrypoints.openai.api_server --host=0.0.0.0 --port=8081 {{extra_args}}
 startsecs=0
 autostart=true
 autorestart=true

--- a/truss/templates/vllm/vllm.Dockerfile.jinja
+++ b/truss/templates/vllm/vllm.Dockerfile.jinja
@@ -4,7 +4,6 @@
 
 FROM baseten/vllm:v0.3 as vllm
 
-FROM baseten/vllm:v0.1 as vllm
 EXPOSE 8080-9000
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \


### PR DESCRIPTION
We accidentally replaced the OpenAI-compatible vLLM server with a generic FastAPI server implementation that was missing the health check.

### Testing
Fix was tested on in-cluster node. 

### TODO
- [ ] Test this PR end-to-end on node