### PR TITLE
Allow for null value for hf_cache in truss_config.

### DIFF
--- a/truss/tests/test_config.py
+++ b/truss/tests/test_config.py
@@ -1,3 +1,4 @@
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -203,6 +204,14 @@ def test_non_default_train():
     new_config["train"] = updated_train
 
     assert new_config == config.to_dict(verbose=False)
+
+
+def test_null_hf_cache_key():
+    config_yaml_dict = {"hf_cache": None}
+    with tempfile.NamedTemporaryFile(mode="w", delete=False) as tmp_file:
+        yaml.safe_dump(config_yaml_dict, tmp_file)
+    config = TrussConfig.from_yaml(Path(tmp_file.name))
+    assert config.hf_cache == HuggingFaceCache.from_list([])
 
 
 def test_huggingface_cache_single_model_default_revision():

--- a/truss/truss_config.py
+++ b/truss/truss_config.py
@@ -489,7 +489,10 @@ class TrussConfig:
                 d.get("external_data"), ExternalData.from_list
             ),
             base_image=transform_optional(d.get("base_image"), BaseImage.from_dict),
-            hf_cache=HuggingFaceCache.from_list(d.get("hf_cache", [])),
+            hf_cache=transform_optional(
+                d.get("hf_cache") or [],
+                HuggingFaceCache.from_list,
+            ),
         )
         config.validate()
         return config


### PR DESCRIPTION
# Summary

We encountered an issue yesterday where a user was seeing build failures on 0.7.3, with the exception stacktrace:

```
  File "/truss/truss_config.py", line 124, in from_list
    return HuggingFaceCache([HuggingFaceModel.from_dict(item) for item in items])
TypeError: 'NoneType' object is not iterable
```

from this, it looks like the value of hf_cache in the config.yaml is `null`.

In https://github.com/basetenlabs/truss/pull/623/files#, we recently made hf_cache not-nullable, and so having hf_cache: null in your config.yaml causes problems.

In this PR, we treat a `null` hf_cache the same as an **empty** hf_cache value.

# More notes

This is very much a hack to get us unblocked. We should 100% move in the direction of having clear validations on these Truss Config values (error out with a good error if `hf_cache` is null). Another thing to make sure of in a follow-up is that the config that gets pushed locally is the same thing that the server sees (even for future keys).


# Testing

Tested with truss client locally:

Create a truss with `hf_cache: null` as a key. Notice that it still pushes correctly.
