### PR TITLE
Typo on main page

### DIFF
--- a/docs/welcome.mdx
+++ b/docs/welcome.mdx
@@ -7,7 +7,7 @@ description: "The simplest way to serve AI/ML models in production"
 
 * **Write once, run anywhere:** Package and test model code, weights, and dependencies with a model server that behaves the same in development and production.
 * **Fast developer loop:** Implement your model with fast feedback from a live reload server, and skip Docker and Kubernetes configuration with a batteries-included model serving environment.
-* **Support for all Python frameworks**: From `transformers` and `diffusors` to `PyTorch` and `Tensorflow` to `XGBoost` and `sklearn`, Truss supports models created with any framework, even entirely custom models.
+* **Support for all Python frameworks**: From `transformers` and `diffusers` to `PyTorch` and `Tensorflow` to `XGBoost` and `sklearn`, Truss supports models created with any framework, even entirely custom models.
 
 See Trusses for popular models including:
 


### PR DESCRIPTION
"diffusors" -> "diffusers"