### PR TITLE
GCS Folder Fix

### DIFF
--- a/truss/contexts/image_builder/serving_image_builder.py
+++ b/truss/contexts/image_builder/serving_image_builder.py
@@ -114,6 +114,9 @@ def list_bucket_files(bucket_name, data_dir, is_trusted=False):
 
     all_objects = []
     for blob in blobs:
+        # leave out folders
+        if blob.name[-1] == "/":
+            continue
         all_objects.append(blob.name)
 
     return all_objects


### PR DESCRIPTION
A quick fix to ensure that `hf_cache` works with `gcs` folders, e.g. `gcs://llama-2-7b/folder_a/folder_b` etc.