### PR TITLE
Always upgrade when pip installing during patch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.7.6"
+version = "0.7.7rc2"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/templates/control/control/helpers/truss_patch/model_container_patch_applier.py
+++ b/truss/templates/control/control/helpers/truss_patch/model_container_patch_applier.py
@@ -106,6 +106,7 @@ class ModelContainerPatchApplier:
                     self._pip_path,
                     "install",
                     python_requirement_patch.requirement,
+                    "--upgrade",
                 ],
                 check=True,
             )


### PR DESCRIPTION
Right now if you have:

```
- diffusers=X.X.X
```

and replace it with

```
- diffusers
```

It does not change the version when you do `truss watch`. It _will_ change if you do `truss push`.

In this PR, we change the bhavior to be the same.


# Testing

1. Deploy a Truss with `torch==1.12.1` in the requirements
2. Do `truss watch`

Notice that an installation of torch==2.0.1 happens.
<img width="1162" alt="test_model_17___Model___Baseten" src="https://github.com/basetenlabs/truss/assets/850115/7bbd4ffc-d770-41b2-a6a6-2fb422f0a9ea">

