### PR TITLE
Private `hf_cache` fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.7.5dev1"
+version = "0.7.5"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.7.5dev0"
+version = "0.7.5dev1"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.7.5"
+version = "0.7.5dev0"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/contexts/image_builder/serving_image_builder.py
+++ b/truss/contexts/image_builder/serving_image_builder.py
@@ -231,11 +231,12 @@ def update_config_and_gather_files(
     if config.build.model_server != ModelServer.TrussServer:
         model_key = update_model_key(config)
         update_model_name(config, model_key)
-
     return get_files_to_cache(config, truss_dir, build_dir)
 
 
-def create_tgi_build_dir(config: TrussConfig, build_dir: Path, truss_dir: Path):
+def create_tgi_build_dir(
+    config: TrussConfig, build_dir: Path, truss_dir: Path, use_hf_secret: bool
+):
     copy_tree_path(truss_dir, build_dir)
 
     if not build_dir.exists():
@@ -259,6 +260,7 @@ def create_tgi_build_dir(config: TrussConfig, build_dir: Path, truss_dir: Path):
         data_dir_exists=data_dir.exists(),
         credentials_exists=credentials_file.exists(),
         cached_files=cached_file_paths,
+        use_hf_secret=use_hf_secret,
     )
     dockerfile_filepath = build_dir / "Dockerfile"
     dockerfile_filepath.write_text(dockerfile_content)
@@ -280,7 +282,9 @@ def create_tgi_build_dir(config: TrussConfig, build_dir: Path, truss_dir: Path):
     supervisord_filepath.write_text(supervisord_contents)
 
 
-def create_vllm_build_dir(config: TrussConfig, build_dir: Path, truss_dir: Path):
+def create_vllm_build_dir(
+    config: TrussConfig, build_dir: Path, truss_dir: Path, use_hf_secret
+):
     copy_tree_path(truss_dir, build_dir)
 
     server_endpoint_config = {
@@ -313,6 +317,7 @@ def create_vllm_build_dir(config: TrussConfig, build_dir: Path, truss_dir: Path)
         data_dir_exists=data_dir.exists(),
         credentials_exists=credentials_file.exists(),
         cached_files=cached_file_paths,
+        use_hf_secret=use_hf_secret,
     )
     dockerfile_filepath = build_dir / "Dockerfile"
     dockerfile_filepath.write_text(dockerfile_content)
@@ -362,10 +367,10 @@ class ServingImageBuilder(ImageBuilder):
             build_dir = build_truss_target_directory(model_framework_name)
 
         if config.build.model_server is ModelServer.TGI:
-            create_tgi_build_dir(config, build_dir, truss_dir)
+            create_tgi_build_dir(config, build_dir, truss_dir, use_hf_secret)
             return
         elif config.build.model_server is ModelServer.VLLM:
-            create_vllm_build_dir(config, build_dir, truss_dir)
+            create_vllm_build_dir(config, build_dir, truss_dir, use_hf_secret)
             return
         elif config.build.model_server is ModelServer.TRITON:
             create_triton_build_dir(config, build_dir, truss_dir)
@@ -481,6 +486,8 @@ class ServingImageBuilder(ImageBuilder):
         should_install_python_requirements = file_is_not_empty(
             build_dir / REQUIREMENTS_TXT_FILENAME
         )
+
+        hf_access_token = config.secrets.get(HF_ACCESS_TOKEN_SECRET_NAME)
         dockerfile_contents = dockerfile_template.render(
             should_install_server_requirements=should_install_server_requirements,
             base_image_name_and_tag=base_image_name_and_tag,
@@ -497,6 +504,7 @@ class ServingImageBuilder(ImageBuilder):
             cached_files=cached_files,
             credentials_exists=credentials_file.exists(),
             hf_cache=len(config.hf_cache.models) > 0,
+            hf_access_token=hf_access_token,
         )
         docker_file_path = build_dir / MODEL_DOCKERFILE_NAME
         docker_file_path.write_text(dockerfile_contents)

--- a/truss/contexts/image_builder/serving_image_builder.py
+++ b/truss/contexts/image_builder/serving_image_builder.py
@@ -45,6 +45,7 @@ BUILD_CONTROL_SERVER_DIR_NAME = "control"
 CONFIG_FILE = "config.yaml"
 
 HF_ACCESS_TOKEN_SECRET_NAME = "hf_access_token"
+HF_ACCESS_TOKEN_FILE_NAME = "hf-access-token"
 
 
 def create_triton_build_dir(config: TrussConfig, build_dir: Path, truss_dir: Path):
@@ -261,6 +262,7 @@ def create_tgi_build_dir(
         credentials_exists=credentials_file.exists(),
         cached_files=cached_file_paths,
         use_hf_secret=use_hf_secret,
+        hf_access_token_file_name=HF_ACCESS_TOKEN_FILE_NAME,
     )
     dockerfile_filepath = build_dir / "Dockerfile"
     dockerfile_filepath.write_text(dockerfile_content)
@@ -318,6 +320,7 @@ def create_vllm_build_dir(
         credentials_exists=credentials_file.exists(),
         cached_files=cached_file_paths,
         use_hf_secret=use_hf_secret,
+        hf_access_token_file_name=HF_ACCESS_TOKEN_FILE_NAME,
     )
     dockerfile_filepath = build_dir / "Dockerfile"
     dockerfile_filepath.write_text(dockerfile_content)
@@ -505,6 +508,7 @@ class ServingImageBuilder(ImageBuilder):
             credentials_exists=credentials_file.exists(),
             hf_cache=len(config.hf_cache.models) > 0,
             hf_access_token=hf_access_token,
+            hf_access_token_file_name=HF_ACCESS_TOKEN_FILE_NAME,
         )
         docker_file_path = build_dir / MODEL_DOCKERFILE_NAME
         docker_file_path.write_text(dockerfile_contents)

--- a/truss/templates/cache.Dockerfile.jinja
+++ b/truss/templates/cache.Dockerfile.jinja
@@ -17,6 +17,6 @@ RUN pip install -r /app/cache_requirements.txt --no-cache-dir && rm -rf /root/.c
 COPY ./cache_warmer.py /cache_warmer.py
 {% for repo, hf_dir in models.items() %}
         {% for file in hf_dir.files %}
-RUN python3 /cache_warmer.py {{file}} {{repo}} {% if hf_dir.revision != None %}{{hf_dir.revision}}{% endif %}
+{{ "RUN --mount=type=secret,id=hf_access_token,dst=/etc/secrets/hf_access_token" if use_hf_secret else "RUN" }} python3 /cache_warmer.py {{file}} {{repo}} {% if hf_dir.revision != None %}{{hf_dir.revision}}{% endif %}
         {% endfor %}
 {% endfor %}

--- a/truss/templates/cache.Dockerfile.jinja
+++ b/truss/templates/cache.Dockerfile.jinja
@@ -17,6 +17,6 @@ RUN pip install -r /app/cache_requirements.txt --no-cache-dir && rm -rf /root/.c
 COPY ./cache_warmer.py /cache_warmer.py
 {% for repo, hf_dir in models.items() %}
         {% for file in hf_dir.files %}
-{{ "RUN --mount=type=secret,id=hf_access_token,dst=/etc/secrets/hf_access_token" if use_hf_secret else "RUN" }} python3 /cache_warmer.py {{file}} {{repo}} {% if hf_dir.revision != None %}{{hf_dir.revision}}{% endif %}
+{{ "RUN --mount=type=secret,id=hf-access-token,dst=/etc/secrets/hf-access-token" if use_hf_secret else "RUN" }} python3 /cache_warmer.py {{file}} {{repo}} {% if hf_dir.revision != None %}{{hf_dir.revision}}{% endif %}
         {% endfor %}
 {% endfor %}

--- a/truss/templates/cache.Dockerfile.jinja
+++ b/truss/templates/cache.Dockerfile.jinja
@@ -17,6 +17,6 @@ RUN pip install -r /app/cache_requirements.txt --no-cache-dir && rm -rf /root/.c
 COPY ./cache_warmer.py /cache_warmer.py
 {% for repo, hf_dir in models.items() %}
         {% for file in hf_dir.files %}
-{{ "RUN --mount=type=secret,id=hf-access-token,dst=/etc/secrets/hf-access-token" if use_hf_secret else "RUN" }} python3 /cache_warmer.py {{file}} {{repo}} {% if hf_dir.revision != None %}{{hf_dir.revision}}{% endif %}
+{{ "RUN --mount=type=secret,id=" + hf_access_token_file_name + ",dst=/etc/secrets/" + hf_access_token_file_name if use_hf_secret else "RUN" }} python3 /cache_warmer.py {{file}} {{repo}} {% if hf_dir.revision != None %}{{hf_dir.revision}}{% endif %}
         {% endfor %}
 {% endfor %}

--- a/truss/tests/contexts/image_builder/test_serving_image_builder.py
+++ b/truss/tests/contexts/image_builder/test_serving_image_builder.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 import pytest
 from truss.contexts.image_builder.serving_image_builder import (
+    HF_ACCESS_TOKEN_FILE_NAME,
     ServingImageBuilderContext,
     get_files_to_cache,
     update_model_key,
@@ -253,13 +254,10 @@ def test_hf_cache_dockerfile():
     builder_context = ServingImageBuilderContext
     image_builder = builder_context.run(tr.spec.truss_dir)
 
-    secret_mount = (
-        "RUN --mount=type=secret,id=hf-access-token,dst=/etc/secrets/hf_access_token"
-    )
+    secret_mount = f"RUN --mount=type=secret,id={HF_ACCESS_TOKEN_FILE_NAME}"
     with TemporaryDirectory() as tmp_dir:
         tmp_path = Path(tmp_dir)
         image_builder.prepare_image_build_dir(tmp_path, use_hf_secret=True)
         with open(tmp_path / "Dockerfile", "r") as f:
             gen_docker_file = f.read()
-            print(gen_docker_file)
             assert secret_mount in gen_docker_file


### PR DESCRIPTION
Around a week ago, we noticed that builds around private Hugging Face repos started to break due to not being able to find the access token in the build.

There are two fixes that this PR introduces:
1. Bring back the `--mount` directive in the dockerfile for caching. This ensures that the cache warmer can pull the secret from an external mount. To support tgi/vllm/etc., propagate the `use_hf_secret` variable in the Dockerfile. This will add the `--mount` flag when we need a secrets mount.
2. Rename `hf_access_token` to `hf-access-token` to match with our backend settings.
3. To ensure being able to test Trusses with tokens written in plaintext within the `config.yml`: pass `hf_access_token` to the Dockerfile and programatically add it as an env variable if it is set. This is insecure in the context of a build (in a build we read from a secrets file) but is fine for testing.

### TODO:
- [x] add a test to ensure that the `--mount` is not dropped from the dockerfile