### PR TITLE
BT-8763 Add L4 GPU to the list of supported accelerator types

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.7.7rc2"
+version = "0.7.8"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/truss_config.py
+++ b/truss/truss_config.py
@@ -42,6 +42,7 @@ DEFAULT_BLOB_BACKEND = HTTP_PUBLIC_BLOB_BACKEND
 
 class Accelerator(Enum):
     T4 = "T4"
+    L4 = "L4"
     A10G = "A10G"
     V100 = "V100"
     A100 = "A100"


### PR DESCRIPTION
Adding L4 as a supported accelerator type.