### PR TITLE
Exclude data dir contents when generating truss signature and truss hash

### DIFF
--- a/truss/contexts/image_builder/serving_image_builder.py
+++ b/truss/contexts/image_builder/serving_image_builder.py
@@ -488,7 +488,9 @@ class ServingImageBuilder(ImageBuilder):
             live_reload=config.live_reload,
             data_dir_exists=data_dir.exists(),
             bundled_packages_dir_exists=bundled_packages_dir.exists(),
-            truss_hash=directory_content_hash(self._truss_dir),
+            truss_hash=directory_content_hash(
+                self._truss_dir, [f"{self._spec.data_dir}/*"]
+            ),
             models=model_files,
             use_hf_secret=use_hf_secret,
             cached_files=cached_files,

--- a/truss/contexts/image_builder/serving_image_builder.py
+++ b/truss/contexts/image_builder/serving_image_builder.py
@@ -489,7 +489,7 @@ class ServingImageBuilder(ImageBuilder):
             data_dir_exists=data_dir.exists(),
             bundled_packages_dir_exists=bundled_packages_dir.exists(),
             truss_hash=directory_content_hash(
-                self._truss_dir, [f"{self._spec.data_dir}/*"]
+                self._truss_dir, self._spec.hash_ignore_patterns
             ),
             models=model_files,
             use_hf_secret=use_hf_secret,

--- a/truss/patch/dir_signature.py
+++ b/truss/patch/dir_signature.py
@@ -1,10 +1,13 @@
 from pathlib import Path
-from typing import Dict
+from typing import Dict, List, Optional
 
 from truss.patch.hash import file_content_hash_str
+from truss.patch.utils import path_matches_any_pattern
 
 
-def directory_content_signature(root: Path) -> Dict[str, str]:
+def directory_content_signature(
+    root: Path, ignore_patterns: Optional[List[str]] = None
+) -> Dict[str, str]:
     """Calculate content signature of a filesystem directory.
 
     Sort all files by path, store file path with content hash.
@@ -14,12 +17,12 @@ def directory_content_signature(root: Path) -> Dict[str, str]:
 
     Hash of directories is marked None.
     """
-    paths = list(
-        filter(
-            lambda path: not str(path.relative_to(root)).startswith("data/"),
-            list(root.glob("**/*")),
-        )
-    )
+
+    paths = [
+        path
+        for path in root.glob("**/*")
+        if not path_matches_any_pattern(path.relative_to(root), ignore_patterns)
+    ]
     paths.sort(key=lambda p: p.relative_to(root))
 
     def path_hash(pth: Path):

--- a/truss/patch/dir_signature.py
+++ b/truss/patch/dir_signature.py
@@ -14,7 +14,12 @@ def directory_content_signature(root: Path) -> Dict[str, str]:
 
     Hash of directories is marked None.
     """
-    paths = list(root.glob("**/*"))
+    paths = list(
+        filter(
+            lambda path: not str(path.relative_to(root)).startswith("data/"),
+            list(root.glob("**/*")),
+        )
+    )
     paths.sort(key=lambda p: p.relative_to(root))
 
     def path_hash(pth: Path):

--- a/truss/patch/hash.py
+++ b/truss/patch/hash.py
@@ -1,8 +1,8 @@
-import fnmatch
 from pathlib import Path
 from typing import Any, List, Optional
 
 from blake3 import blake3
+from truss.patch.utils import path_matches_any_pattern
 
 
 def directory_content_hash(
@@ -22,7 +22,7 @@ def directory_content_hash(
     paths = [
         path
         for path in root.glob("**/*")
-        if not _path_matches_any_pattern(path.relative_to(root), ignore_patterns)
+        if not path_matches_any_pattern(path.relative_to(root), ignore_patterns)
     ]
     paths.sort(key=lambda p: p.relative_to(root))
     for path in paths:
@@ -72,14 +72,3 @@ def str_hash_str(content: str) -> str:
     hasher = blake3()
     hasher.update(content.encode("utf-8"))
     return hasher.hexdigest()
-
-
-def _path_matches_any_pattern(path: Path, patterns: Optional[List[str]]) -> bool:
-    if patterns is None:
-        return False
-
-    for pattern in patterns:
-        if fnmatch.fnmatch(str(path), pattern):
-            return True
-
-    return False

--- a/truss/patch/signature.py
+++ b/truss/patch/signature.py
@@ -1,11 +1,14 @@
 from pathlib import Path
+from typing import List, Optional
 
 from truss.patch.dir_signature import directory_content_signature
 from truss.patch.types import TrussSignature
 
 
-def calc_truss_signature(truss_dir: Path) -> TrussSignature:
-    content_signature = directory_content_signature(truss_dir)
+def calc_truss_signature(
+    truss_dir: Path, ignore_patterns: Optional[List[str]] = None
+) -> TrussSignature:
+    content_signature = directory_content_signature(truss_dir, ignore_patterns)
     with (truss_dir / "config.yaml").open("r") as config_file:
         config = config_file.read()
     return TrussSignature(

--- a/truss/patch/types.py
+++ b/truss/patch/types.py
@@ -7,8 +7,8 @@ class TrussSignature:
     """Truss signature stores information for calculating patches for future
     changes to Truss.
 
-    Currently, it stores hashes of all of the paths in the truss directory, and
-    the truss config contents. Path hashes allow calculating added/updated/removes
+    Currently, it stores hashes of all of the paths in the truss directory excluding the data dir,
+    and the truss config contents. Path hashes allow calculating added/updated/removes
     paths in future trusses compared to this. Config contents allow calculating
     config changes, such as add/update/remove of python requirements etc.
     """

--- a/truss/patch/utils.py
+++ b/truss/patch/utils.py
@@ -1,0 +1,14 @@
+import fnmatch
+from pathlib import Path
+from typing import List, Optional
+
+
+def path_matches_any_pattern(path: Path, patterns: Optional[List[str]]) -> bool:
+    if patterns is None:
+        return False
+
+    for pattern in patterns:
+        if fnmatch.fnmatch(str(path), pattern):
+            return True
+
+    return False

--- a/truss/tests/conftest.py
+++ b/truss/tests/conftest.py
@@ -558,6 +558,22 @@ def _custom_model_from_code(
     return dir_path
 
 
+@pytest.fixture
+def custom_model_data_dir(tmp_path: Path):
+    data_file = tmp_path / "foo.bar"
+    data_file.touch()
+
+    def add_data(handle):
+        handle.add_data(str(data_file.resolve()))
+
+    yield _custom_model_from_code(
+        tmp_path,
+        "data_dir_truss",
+        CUSTOM_MODEL_CODE,
+        handle_ops=add_data,
+    )
+
+
 class Helpers:
     @staticmethod
     @contextlib.contextmanager

--- a/truss/tests/patch/test_dir_signature.py
+++ b/truss/tests/patch/test_dir_signature.py
@@ -29,7 +29,7 @@ def test_directory_content_signature_no_data_dir(tmp_path):
     data_dir.mkdir()
     (data_dir / "file3").touch()
 
-    content_sign = directory_content_signature(root)
+    content_sign = directory_content_signature(root=root, ignore_patterns=["data/*"])
 
     assert content_sign.keys() == {
         "data",

--- a/truss/tests/patch/test_dir_signature.py
+++ b/truss/tests/patch/test_dir_signature.py
@@ -11,11 +11,28 @@ def test_directory_content_signature(tmp_path):
     (subdir / "file3").touch()
 
     content_sign = directory_content_signature(root)
-    print(content_sign)
 
     assert content_sign.keys() == {
         "dir",
         "dir/file3",
+        "file1",
+        "file2",
+    }
+
+
+def test_directory_content_signature_no_data_dir(tmp_path):
+    root = tmp_path / "root"
+    root.mkdir()
+    (root / "file1").touch()
+    (root / "file2").touch()
+    data_dir = root / "data"
+    data_dir.mkdir()
+    (data_dir / "file3").touch()
+
+    content_sign = directory_content_signature(root)
+
+    assert content_sign.keys() == {
+        "data",
         "file1",
         "file2",
     }

--- a/truss/tests/patch/test_signature.py
+++ b/truss/tests/patch/test_signature.py
@@ -7,3 +7,12 @@ def test_calc_truss_signature(custom_model_truss_dir):
     assert "config.yaml" in sign.content_hashes_by_path
     with (custom_model_truss_dir / "config.yaml").open() as config_file:
         assert config_file.read() == sign.config
+
+
+def test_calc_truss_signature_ignore_data_dir(custom_model_data_dir):
+    sign = calc_truss_signature(custom_model_data_dir, ["data/*"])
+    assert (
+        len(sign.content_hashes_by_path) > 0
+        and "data/foo.bar" not in sign.content_hashes_by_path
+    )
+    assert "config.yaml" in sign.content_hashes_by_path

--- a/truss/truss_handle.py
+++ b/truss/truss_handle.py
@@ -846,14 +846,15 @@ class TrussHandle:
         if patch_ops is None:
             return None
 
-        ignore_patterns = [f"{self._spec.data_dir}/*"]
-
-        next_sign = calc_truss_signature(self._truss_dir, ignore_patterns)
         return PatchDetails(
             prev_signature=prev_sign,
             prev_hash=prev_truss_hash,
-            next_hash=directory_content_hash(self._truss_dir, ignore_patterns),
-            next_signature=next_sign,
+            next_hash=directory_content_hash(
+                self._truss_dir, self._spec.hash_ignore_patterns
+            ),
+            next_signature=calc_truss_signature(
+                self._truss_dir, self._spec.hash_ignore_patterns
+            ),
             patch_ops=patch_ops,
         )
 
@@ -1042,7 +1043,7 @@ class TrussHandle:
             # TODO(pankaj) Ignore training directory. But this is a bigger change
             # because it needs syncing with hash generation on baseten side as well.
             truss_hash = directory_content_hash(
-                self._truss_dir, [f"{self._spec.data_dir}/*"]
+                self._truss_dir, self._spec.hash_ignore_patterns
             )
             self._hash_for_mod_time = (truss_mod_time, truss_hash)
         return truss_hash

--- a/truss/truss_handle.py
+++ b/truss/truss_handle.py
@@ -846,11 +846,13 @@ class TrussHandle:
         if patch_ops is None:
             return None
 
-        next_sign = calc_truss_signature(self._truss_dir)
+        ignore_patterns = [f"{self._spec.data_dir}/*"]
+
+        next_sign = calc_truss_signature(self._truss_dir, ignore_patterns)
         return PatchDetails(
             prev_signature=prev_sign,
             prev_hash=prev_truss_hash,
-            next_hash=directory_content_hash(self._truss_dir),
+            next_hash=directory_content_hash(self._truss_dir, ignore_patterns),
             next_signature=next_sign,
             patch_ops=patch_ops,
         )
@@ -1039,7 +1041,9 @@ class TrussHandle:
         else:
             # TODO(pankaj) Ignore training directory. But this is a bigger change
             # because it needs syncing with hash generation on baseten side as well.
-            truss_hash = directory_content_hash(self._truss_dir)
+            truss_hash = directory_content_hash(
+                self._truss_dir, [f"{self._spec.data_dir}/*"]
+            )
             self._hash_for_mod_time = (truss_mod_time, truss_hash)
         return truss_hash
 

--- a/truss/truss_spec.py
+++ b/truss/truss_spec.py
@@ -200,6 +200,13 @@ class TrussSpec:
     def apply_library_patches(self) -> bool:
         return self._config.apply_library_patches
 
+    @property
+    def hash_ignore_patterns(self) -> List[str]:
+        """By default, data directory contents are ignored when hashing,
+        as patching is not supported for these changes.
+        """
+        return [f"{self.data_dir}/*"]
+
 
 def _join_lines(lines: List[str]) -> str:
     return "\n".join(lines) + "\n"


### PR DESCRIPTION
Currently, patch operations require comparing content hashes of paths stored in the truss signature – making truss watch unusable for trusses with large bundled model binaries. This change also removes the computation of the file hash for files within the data directory.