### PR TITLE
Better error message for missing secrets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.7.7rc2"
+version = "0.7.7rc4"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/templates/shared/secrets_resolver.py
+++ b/truss/templates/shared/secrets_resolver.py
@@ -1,7 +1,9 @@
 import os
 from collections.abc import Mapping
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Optional
+
+SECRETS_DOC_LINK = "https://truss.baseten.co/docs/using-secrets"
 
 
 class SecretNotFound(Exception):
@@ -17,7 +19,7 @@ class SecretsResolver:
         return Secrets(config.get("secrets", {}))
 
     @staticmethod
-    def _resolve_secret(secret_name: str, default_value: str):
+    def _resolve_secret(secret_name: str, default_value: Optional[str]):
         secret_value = default_value
         secret_env_var_name = SecretsResolver.SECRET_ENV_VAR_PREFIX + secret_name
         if secret_env_var_name in os.environ:
@@ -39,15 +41,11 @@ class Secrets(Mapping):
 
     def __getitem__(self, key: str) -> str:
         if key not in self._base_secrets:
-            # Note this is the case where the secrets are not specified in
-            # config.yaml
-            raise SecretNotFound(f"Secret '{key}' not specified in the config.")
+            raise SecretNotFound(_secret_missing_error_message(key))
 
         found_secret = SecretsResolver._resolve_secret(key, self._base_secrets[key])
         if not found_secret:
-            raise SecretNotFound(
-                f"Secret '{key}' not found. Please check available secrets."
-            )
+            raise SecretNotFound(_secret_missing_error_message(key))
 
         return found_secret
 
@@ -58,3 +56,12 @@ class Secrets(Mapping):
 
     def __len__(self):
         return len(self._base_secrets)
+
+
+def _secret_missing_error_message(key: str) -> str:
+    return f"""
+Secret '{key}' not found. Please check that:
+  * The secret is defined in the secrets section of your config file
+  * The model was pushed with the --trusted flag
+ Read more about secrets here: {SECRETS_DOC_LINK}.
+    """

--- a/truss/templates/shared/secrets_resolver.py
+++ b/truss/templates/shared/secrets_resolver.py
@@ -60,8 +60,9 @@ class Secrets(Mapping):
 
 def _secret_missing_error_message(key: str) -> str:
     return f"""
-Secret '{key}' not found. Please check that:
-  * The secret is defined in the secrets section of your config file
+Secret '{key}' not found. Please ensure that:
+  * Secret '{key}' is defined in the 'secrets' section of the Truss config file
   * The model was pushed with the --trusted flag
+  * Secret '{key}' is defined in the secret manager
  Read more about secrets here: {SECRETS_DOC_LINK}.
     """

--- a/truss/tests/test_model_inference.py
+++ b/truss/tests/test_model_inference.py
@@ -336,6 +336,9 @@ secrets:
     """
 
     config_with_no_secret = "model_name: secrets-truss"
+    missing_secret_error_message = """Please check that:
+  * The secret is defined in the secrets section of your config file
+  * The model was pushed with the --trusted flag"""
 
     with ensure_kill_all(), tempfile.TemporaryDirectory(dir=".") as tmp_work_dir:
         truss_dir = Path(tmp_work_dir, "truss")
@@ -371,7 +374,7 @@ secrets:
 
         assert "error" in response.json()
 
-        assert_logs_contain_error(container.logs(), "not specified in the config")
+        assert_logs_contain_error(container.logs(), missing_secret_error_message)
         assert "Internal Server Error" in response.json()["error"]
 
     with ensure_kill_all(), tempfile.TemporaryDirectory(dir=".") as tmp_work_dir:
@@ -390,9 +393,7 @@ secrets:
         response = requests.post(full_url, json={})
         assert response.status_code == 500
 
-        assert_logs_contain_error(
-            container.logs(), "'secret' not found. Please check available secrets."
-        )
+        assert_logs_contain_error(container.logs(), missing_secret_error_message)
         assert "Internal Server Error" in response.json()["error"]
 
 

--- a/truss/tests/test_model_inference.py
+++ b/truss/tests/test_model_inference.py
@@ -336,8 +336,8 @@ secrets:
     """
 
     config_with_no_secret = "model_name: secrets-truss"
-    missing_secret_error_message = """Please check that:
-  * The secret is defined in the secrets section of your config file
+    missing_secret_error_message = """Secret 'secret' not found. Please ensure that:
+  * Secret 'secret' is defined in the 'secrets' section of the Truss config file
   * The model was pushed with the --trusted flag"""
 
     with ensure_kill_all(), tempfile.TemporaryDirectory(dir=".") as tmp_work_dir:


### PR DESCRIPTION
# Summary

Right now, the error messages that you get when secrets are missing are not super clear. Here -- I clear this up.

Open to feedback about the wording of this error message.

# Testing

Tested on dev, here's what it looks like in the logs:

<img width="932" alt="Cursor_and_test_model_17___Model___Baseten_🔊" src="https://github.com/basetenlabs/truss/assets/850115/0f03ffa1-3e68-4577-a3de-3c07b083e5c9">
