### PR TITLE
Adding 5min timeout to internal nginx proxy

### DIFF
--- a/truss/templates/tgi/proxy.conf.jinja
+++ b/truss/templates/tgi/proxy.conf.jinja
@@ -11,6 +11,7 @@ server {
     # Readiness
     location ~ ^/v1/models/model$ {
         proxy_redirect off;
+        proxy_read_timeout 300s;
 
         rewrite ^/v1/models/model$ /health break;
 
@@ -20,6 +21,7 @@ server {
     # Predict
     location ~ ^/v1/models/model:predict$ {
         proxy_redirect off;
+        proxy_read_timeout 300s;
 
         rewrite ^/v1/models/model:predict$ /{{endpoint}} break;
 

--- a/truss/templates/tgi/proxy.conf.jinja
+++ b/truss/templates/tgi/proxy.conf.jinja
@@ -1,5 +1,6 @@
 
 server {
+    # We use the proxy_read_timeout directive here (instead of proxy_send_timeout) as it sets the timeout for reading a response from the proxied server vs. setting a timeout for sending a request to the proxied server.
     listen 8080;
 
     # Liveness

--- a/truss/templates/vllm/proxy.conf.jinja
+++ b/truss/templates/vllm/proxy.conf.jinja
@@ -1,4 +1,5 @@
 server {
+    # We use the proxy_read_timeout directive here (instead of proxy_send_timeout) as it sets the timeout for reading a response from the proxied server vs. setting a timeout for sending a request to the proxied server.
     listen 8080;
 
     # Liveness

--- a/truss/templates/vllm/proxy.conf.jinja
+++ b/truss/templates/vllm/proxy.conf.jinja
@@ -1,4 +1,3 @@
-
 server {
     listen 8080;
 
@@ -11,6 +10,7 @@ server {
     # Readiness
     location ~ ^/v1/models/model$ {
         proxy_redirect off;
+        proxy_read_timeout 300s;
 
         rewrite ^/v1/models/model$ /v1/models break;
 
@@ -20,6 +20,7 @@ server {
     # Predict
     location ~ ^/v1/models/model:predict$ {
         proxy_redirect off;
+        proxy_read_timeout 300s;
 
         rewrite ^/v1/models/model:predict$ {{server_endpoint}} break;
 


### PR DESCRIPTION
### Overview

For TGI and vLLM, we use a nginx proxy to re-route prediction requests to the correct underlying path. Nginx, however, has a 60 second default timeout which affects longer generation requests. This PR updates this timeout to be 5 mins. 

We use the `proxy_read_timeout` directive here (instead of `proxy_send_timeout`) as it sets the timeout for reading a response from the proxied server vs. setting a timeout for sending a request to the proxied server. 

### Testing

- [x] Tested manually on prod