### PR TITLE
Pin types-requests library for now

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2853,13 +2853,13 @@ test = ["black (>=22.3.0,<23.0.0)", "coverage (>=6.2,<7.0)", "isort (>=5.0.6,<6.
 
 [[package]]
 name = "types-requests"
-version = "2.31.0.4"
+version = "2.31.0.2"
 description = "Typing stubs for requests"
 optional = false
 python-versions = "*"
 files = [
-    {file = "types-requests-2.31.0.4.tar.gz", hash = "sha256:a111041148d7e04bf100c476bc4db3ee6b0a1cd0b4018777f6a660b1c4f1318d"},
-    {file = "types_requests-2.31.0.4-py3-none-any.whl", hash = "sha256:c7a9d6b62776f21b169a94a0e9d2dfcae62fa9149f53594ff791c3ae67325490"},
+    {file = "types-requests-2.31.0.2.tar.gz", hash = "sha256:6aa3f7faf0ea52d728bb18c0a0d1522d9bfd8c72d26ff6f61bfc3d06a411cf40"},
+    {file = "types_requests-2.31.0.2-py3-none-any.whl", hash = "sha256:56d181c85b5925cbc59f4489a57e72a8b2166f18273fd8ba7b6fe0c0b986f12a"},
 ]
 
 [package.dependencies]
@@ -3032,4 +3032,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.12"
-content-hash = "8de50fe4062722298a59ecb25bc0dd62ce182a574eecdcce24aa0ee36bfb6d9d"
+content-hash = "9fb25cdb6a0f9175d8600b4a022f2a0725ae37b18806a8e2075dab2d1b22f0b3"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2852,6 +2852,31 @@ doc = ["cairosvg (>=2.5.2,<3.0.0)", "mdx-include (>=1.4.1,<2.0.0)", "mkdocs (>=1
 test = ["black (>=22.3.0,<23.0.0)", "coverage (>=6.2,<7.0)", "isort (>=5.0.6,<6.0.0)", "mypy (==0.910)", "pytest (>=4.4.0,<8.0.0)", "pytest-cov (>=2.10.0,<5.0.0)", "pytest-sugar (>=0.9.4,<0.10.0)", "pytest-xdist (>=1.32.0,<4.0.0)", "rich (>=10.11.0,<14.0.0)", "shellingham (>=1.3.0,<2.0.0)"]
 
 [[package]]
+name = "types-requests"
+version = "2.31.0.4"
+description = "Typing stubs for requests"
+optional = false
+python-versions = "*"
+files = [
+    {file = "types-requests-2.31.0.4.tar.gz", hash = "sha256:a111041148d7e04bf100c476bc4db3ee6b0a1cd0b4018777f6a660b1c4f1318d"},
+    {file = "types_requests-2.31.0.4-py3-none-any.whl", hash = "sha256:c7a9d6b62776f21b169a94a0e9d2dfcae62fa9149f53594ff791c3ae67325490"},
+]
+
+[package.dependencies]
+types-urllib3 = "*"
+
+[[package]]
+name = "types-urllib3"
+version = "1.26.25.14"
+description = "Typing stubs for urllib3"
+optional = false
+python-versions = "*"
+files = [
+    {file = "types-urllib3-1.26.25.14.tar.gz", hash = "sha256:229b7f577c951b8c1b92c1bc2b2fdb0b49847bd2af6d1cc2a2e3dd340f3bda8f"},
+    {file = "types_urllib3-1.26.25.14-py3-none-any.whl", hash = "sha256:9683bbb7fb72e32bfe9d2be6e04875fbe1b3eeec3cbb4ea231435aa7fd6b4f0e"},
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.7.1"
 description = "Backported and Experimental Type Hints for Python 3.7+"
@@ -3007,4 +3032,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.12"
-content-hash = "8520b032a300043124ace0ad0d3a16ca399a385247b1cbeef12e0dc674541266"
+content-hash = "8de50fe4062722298a59ecb25bc0dd62ce182a574eecdcce24aa0ee36bfb6d9d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ pytest-split = "^0.8.1"
 httpx = {extras = ["cli"], version = "^0.24.1"}
 requests-mock = "^1.11.0"
 flask = "^2.3.3"
+types-requests = "2.31.0.4"
 
 [build-system]
 requires = ["poetry-core>=1.2.1"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ pytest-split = "^0.8.1"
 httpx = {extras = ["cli"], version = "^0.24.1"}
 requests-mock = "^1.11.0"
 flask = "^2.3.3"
-types-requests = "2.31.0.4"
+types-requests = "2.31.0.2"
 
 [build-system]
 requires = ["poetry-core>=1.2.1"]


### PR DESCRIPTION
In a recent release of `types-requests, an issue was introduced in which the "request" argument of HttpError is required. It's not actually required by `requests`, so this broke some of our code.

There's a PR out to fix this: https://github.com/python/typeshed/pull/10776. Let's make this check more flexible after that lands & there's a next release.

We should also move towards having version constraints around our other type stubs.