### PR TITLE
unify target-directory option

### DIFF
--- a/docs/reference/cli/predict.mdx
+++ b/docs/reference/cli/predict.mdx
@@ -9,7 +9,7 @@ truss predict [OPTIONS]
 
 ### Options
 
-<ParamField body="--target_directory" type="TEXT">
+<ParamField body="--target-directory" type="TEXT">
 A Truss directory. If none, use current directory.
 </ParamField>
 <ParamField body="--remote" type="TEXT">

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -276,7 +276,7 @@ def _extract_request_data(data: Optional[str], file: Optional[Path]):
 
 
 @truss_cli.command()
-@click.option("--target_directory", required=False, help="Directory of truss")
+@click.option("--target-directory", required=False, help="Directory of truss")
 @click.option(
     "--remote",
     type=str,


### PR DESCRIPTION
- PR changed `target_directory` option to `target-directory` to be consistent with dash in `model-version` option