### PR TITLE
Increment version of HF Hub

### DIFF
--- a/truss/templates/server/requirements.txt
+++ b/truss/templates/server/requirements.txt
@@ -13,4 +13,4 @@ uvloop==0.17.0
 psutil==5.9.4
 joblib==1.2.0
 requests==2.31.0
-huggingface-hub==0.16.2
+huggingface-hub==0.16.4


### PR DESCRIPTION
This PR increments the version of the huggingface_hub lib. 

Currently, `pip` installing `transformers` is broken due to a version incompatibility. `transformers` expects `huggingface_hub` to be v16.4 and we install v16.2. 