### PR TITLE
Fix truss predict output.

### DIFF
--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -353,7 +353,7 @@ def predict(
     result = service.predict(request_data)
     if inspect.isgenerator(result):
         for chunk in result:
-            rich.print(chunk, end="")
+            click.echo(chunk, nl=False)
         return
     rich.print_json(data=result)
 


### PR DESCRIPTION
Resolves https://linear.app/baseten/issue/BT-8869/truss-predict-output-should-not-be-richly-rendered, where `truss predict` tries to rich print the text. This leads to weird parsing issues. Fix it by using `click.echo` instead.

# Testing
```
In [11]: click.echo("<s><s>[INST] What is the Mistral wind? [/INST] The Mistral is", nl=False)
<s><s>[INST] What is the Mistral wind? [/INST] The Mistral is
```

## Testing with an actual model:

```
 $ poetry run truss predict --model rBLXMzB -d '"MODEL"'
? 🎮 Which remote do you want to connect to? sid-prod
<s><s>[INST] What is the Mistral wind? [/INST] The Mistral is0<s><s>[INST] What is the Mistral wind? [/INST] The Mistral is1<s><s>[INST] What is the Mistral wind? [/INST] The Mistral is2<s><s>[INST] What is the Mistral wind? [/INST] The Mistral is3<s><s>[INST] What is the Mistral wind? [/INST] The Mistral is4
```