### PR TITLE
Fix truss push output for TGI.

### DIFF
--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -3,7 +3,6 @@ import json
 import logging
 import os
 import sys
-import webbrowser
 from functools import wraps
 from pathlib import Path
 from typing import Callable, Optional
@@ -11,7 +10,6 @@ from typing import Callable, Optional
 import rich
 import rich_click as click
 import truss
-from InquirerPy import inquirer
 from truss.cli.create import ask_name, select_server_backend
 from truss.remote.baseten.core import (
     ModelId,
@@ -228,15 +226,10 @@ def watch(
         )
         sys.exit(1)
 
-    logs_url = remote_provider.get_remote_logs_url(model_name)  # type: ignore[attr-defined]
+    service = remote_provider.get_service(model_identifier=ModelName(model_name))
+    logs_url = remote_provider.get_remote_logs_url(service)
     rich.print(f"🪵  View logs for your deployment at {logs_url}")
-    if not logs:
-        logs = inquirer.confirm(
-            message="🗂  Open logs in a new tab?", default=True
-        ).execute()
-    if logs:
-        webbrowser.open_new_tab(logs_url)
-    remote_provider.sync_truss_to_dev_version_by_name(model_name, target_directory)  # type: ignore
+    remote_provider.sync_truss_to_dev_version_by_name(model_name, target_directory)
 
 
 def _extract_and_validate_model_identifier(
@@ -349,7 +342,9 @@ def predict(
 
     request_data = _extract_request_data(data=data, file=file)
 
-    service = remote_provider.get_baseten_service(model_identifier, published)  # type: ignore
+    service = remote_provider.get_service(
+        model_identifier=model_identifier, published=published
+    )
     result = service.predict(request_data)
     if inspect.isgenerator(result):
         for chunk in result:
@@ -414,11 +409,11 @@ def push(
         tr.spec.config.write_to_yaml_file(tr.spec.config_path, verbose=False)
 
     # TODO(Abu): This needs to be refactored to be more generic
-    _ = remote_provider.push(tr, model_name, publish=publish, trusted=trusted)  # type: ignore
+    service = remote_provider.push(tr, model_name, publish=publish, trusted=trusted)  # type: ignore
 
     click.echo(f"✨ Model {model_name} was successfully pushed ✨")
 
-    if not publish:
+    if service.is_draft:
         draft_model_text = """
 |---------------------------------------------------------------------------------------|
 | Your model has been deployed as a draft. Draft models allow you to                    |
@@ -433,13 +428,8 @@ def push(
 
         click.echo(draft_model_text)
 
-    logs_url = remote_provider.get_remote_logs_url(model_name, publish)  # type: ignore[attr-defined]
+    logs_url = remote_provider.get_remote_logs_url(service)  # type: ignore[attr-defined]
     rich.print(f"🪵  View logs for your deployment at {logs_url}")
-    should_open_logs = inquirer.confirm(
-        message="🗂  Open logs in a new tab?", default=True
-    ).execute()
-    if should_open_logs:
-        webbrowser.open_new_tab(logs_url)
 
 
 @truss_cli.command()

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -23,7 +23,7 @@ from truss.remote.baseten.core import (
 )
 from truss.remote.baseten.service import BasetenService
 from truss.remote.baseten.utils.transfer import base64_encoded_json_str
-from truss.remote.truss_remote import TrussRemote
+from truss.remote.truss_remote import TrussRemote, TrussService
 from truss.truss_config import ModelServer
 from truss.truss_handle import TrussHandle
 
@@ -119,9 +119,13 @@ class BasetenRemote(TrussRemote):
 
         return service_url_path, model_id, model_version_id
 
-    def get_baseten_service(
-        self, model_identifier: ModelIdentifier, published: bool = False
-    ) -> BasetenService:
+    def get_service(self, **kwargs) -> BasetenService:
+        try:
+            model_identifier = kwargs["model_identifier"]
+        except KeyError:
+            raise ValueError("Baseten Service requires a model_identifier")
+
+        published = kwargs.get("published", False)
         (
             service_url_path,
             model_id,
@@ -138,11 +142,9 @@ class BasetenRemote(TrussRemote):
 
     def get_remote_logs_url(
         self,
-        model_name: str,
-        published: bool = False,
+        service: TrussService,
     ) -> str:
-        service = self.get_baseten_service(ModelName(model_name), published)
-        return f"{self._remote_url}/models/{service._model_id}/versions/{service._model_version_id}/logs"
+        return service.logs_url(self._remote_url)
 
     def sync_truss_to_dev_version_by_name(
         self,

--- a/truss/remote/baseten/service.py
+++ b/truss/remote/baseten/service.py
@@ -77,3 +77,8 @@ class BasetenService(TrussService):
 
     def authenticate(self) -> dict:
         return self._auth_service.authenticate().header()
+
+    def logs_url(self, base_url: str) -> str:
+        return (
+            f"{base_url}/models/{self._model_id}/versions/{self._model_version_id}/logs"
+        )

--- a/truss/remote/truss_remote.py
+++ b/truss/remote/truss_remote.py
@@ -204,10 +204,11 @@ class TrussRemote(ABC):
         Get a TrussService object for interacting with the remote service.
 
         This method should be implemented in subclasses and return a TrussService
-        object for interacting with the remote service.
+        object for interacting with the remote service. This support keyword args,
+        so that implementing remotes can be flexible with how a service is instantiated.
 
         Args:
-            **kwargs: Additional keyword arguments for the get_service operation.
+            **kwargs: Keyword arguments for the get_service operation.
 
         """
         pass

--- a/truss/remote/truss_remote.py
+++ b/truss/remote/truss_remote.py
@@ -142,6 +142,13 @@ class TrussService(ABC):
         """
         return {}
 
+    @abstractmethod
+    def logs_url(self, base_url: str) -> str:
+        """
+        Get the URL for the service logs.
+        """
+        pass
+
 
 class TrussRemote(ABC):
     """
@@ -189,6 +196,44 @@ class TrussRemote(ABC):
         Args:
             **kwargs: Additional keyword arguments for the authentication operation.
         """
+        pass
+
+    @abstractmethod
+    def get_service(self, **kwargs):
+        """
+        Get a TrussService object for interacting with the remote service.
+
+        This method should be implemented in subclasses and return a TrussService
+        object for interacting with the remote service.
+
+        Args:
+            **kwargs: Additional keyword arguments for the get_service operation.
+
+        """
+        pass
+
+    @abstractmethod
+    def get_remote_logs_url(self, service: TrussService) -> str:
+        """
+        Get the URL for the remote service logs.
+
+        Args:
+            service: The TrussService object for interacting with the remote service.
+        """
+        pass
+
+    @abstractmethod
+    def sync_truss_to_dev_version_by_name(self, model_name: str, target_directory: str):
+        """
+        This method watches for changes to files in the `target_directory`,
+        and syncs them to the development version of the model, identified
+        by name.
+
+        Args:
+            model_name: The name of the model to sync to the dev version
+            target_directory: The directory to sync the model to
+        """
+
         pass
 
 

--- a/truss/tests/remote/test_remote_factory.py
+++ b/truss/tests/remote/test_remote_factory.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 import pytest
 from truss.remote.remote_factory import RemoteFactory
-from truss.remote.truss_remote import RemoteConfig, TrussRemote
+from truss.remote.truss_remote import RemoteConfig, TrussRemote, TrussService
 
 SAMPLE_CONFIG = {"api_key": "test_key", "remote_url": "http://test.com"}
 
@@ -35,6 +35,15 @@ class TestRemote(TrussRemote):
 
     def push(self):
         return {"status": "success"}
+
+    def get_remote_logs_url(self, service: TrussService) -> str:
+        raise NotImplementedError
+
+    def get_service(self, **kwargs):
+        raise NotImplementedError
+
+    def sync_truss_to_dev_version_by_name(self, model_name: str, target_directory: str):
+        raise NotImplementedError
 
 
 def mock_service_config():

--- a/truss/tests/remote/test_truss_remote.py
+++ b/truss/tests/remote/test_truss_remote.py
@@ -27,6 +27,9 @@ class TestTrussService(TrussService):
             return True
         return False
 
+    def logs_url(self, base_url: str) -> str:
+        return f"{base_url}/logs"
+
 
 def mock_successful_response():
     response = Response()


### PR DESCRIPTION
# Summary

Fixes a couple issues with the `truss push` path:
* It currently assumes that if the user did not pass `--publish` that they deployed a draft model. With TGI/vLLM, this is not true, since they are always non-draft, despite what flags are passed. This fixes that
* There were numerous type errors that we had ignored. I changed the API to resolve these, which I hope is an improvement 
* Removed the "Open  logs in new tab" thing that I've been finding annoying (other users have noted this too) when deploying models

# Testing

## Deploying a Draft Truss

```
$ poetry run truss push --model-name "test-100" examples/truss-public-gh-repo-test/
? 🎮 Which remote do you want to connect to? sid-prod
Compressing... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Uploading... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
✨ Model test-100 was successfully pushed ✨

|---------------------------------------------------------------------------------------|
| Your model has been deployed as a draft. Draft models allow you to                    |
| iterate quickly during the deployment process.                                        |
|                                                                                       |
| When you are ready to publish your deployed model as a new version,                   |
| pass `--publish` to the `truss push` command. To monitor changes to your model and    |
| rapidly iterate, run the `truss watch` command.                                       |
|                                                                                       |
|---------------------------------------------------------------------------------------|

🪵  View logs for your deployment at https://app.baseten.co/models/1Py97GP/versions/w5dmnm3/logs
```
## Deploying a Prod truss

```
 $ poetry run truss push --model-name "test-100" examples/truss-public-gh-repo
-test/ --publish
? 🎮 Which remote do you want to connect to? sid-prod
Compressing... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Uploading... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
✨ Model test-100 was successfully pushed ✨
🪵  View logs for your deployment at https://app.baseten.co/models/1Py97GP/versions/w678n2q/logs
```

## Deploying a TGI Truss
```
$ poetry run truss push examples/tgi/
? 🎮 Which remote do you want to connect to? sid-prod
Compressing... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Uploading... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
✨ Model Falcon-TGI-2 was successfully pushed ✨
🪵  View logs for your deployment at https://app.baseten.co/models/gPGpzKq/versions/qelm853/logs
```
