### PR TITLE
Bump the truss version in control requirements.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.7.9"
+version = "0.7.10"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/templates/control/requirements.txt
+++ b/truss/templates/control/requirements.txt
@@ -1,5 +1,5 @@
 dataclasses-json==0.5.7
-truss==0.6.5rc1
+truss==0.7.9
 fastapi==0.95.0
 uvicorn==0.21.1
 uvloop==0.17.0


### PR DESCRIPTION
# Summary

We need to bump the Truss version on the control server, so that L4 is a valid accelerator type. In order to do this, we also need to increment the **context builder** version.

In this PR, we bump both of these versions