### PR TITLE
Remove postprocess from lock

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.7.13"
+version = "0.7.13rc1"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.7.11"
+version = "0.7.12rc1"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/templates/server/common/truss_server.py
+++ b/truss/templates/server/common/truss_server.py
@@ -142,7 +142,7 @@ class BasetenEndpoints:
 
         # In the case that the model returns a Generator object, return a
         # StreamingResponse instead.
-        if isinstance(response, AsyncGenerator):
+        if isinstance(response, (AsyncGenerator, Generator)):
             # media_type in StreamingResponse sets the Content-Type header
             return StreamingResponse(response, media_type="application/octet-stream")
 


### PR DESCRIPTION
# Summary

Context for this change -- when we switched Truss to being async, we moved preprocess out of the predict lock, but did not move postprocess out. There are additional challenges around postprocess, particularly around handling the output of `predict`, if `predict` returns a generator.

In this PR, we move postprocess out of the predict lock in some of the scenarios:

* predict is non-streaming / postprocess is not streaming  : postprocess is not in the predict lock
* predict is non-streaming / postprocess is streaming  : postprocess is not in the predict lock
* predict is streaming: postprocess is still in the predict lock. I added a warning log in these cases (open to other suggestions here, such as raising an exception). The reason for this is that this is a fairly complicated change, and is also not a super likely scenario. Can revisit it at a later date.
  
# Testing

See integration tests for how I tested this in more detail. I also did some manual testing on dev & ensured that postprocess is applied & not part of the predict lock