### PR TITLE
Better json handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.7.13"
+version = "0.7.14rc1"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.7.14rc1"
+version = "0.7.14rc2"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -258,14 +258,17 @@ def _extract_and_validate_model_identifier(
 
 
 def _extract_request_data(data: Optional[str], file: Optional[Path]):
-    if data is not None:
-        return json.loads(data)
-    elif file is not None:
-        return json.loads(Path(file).read_text())
-    else:
-        raise click.UsageError(
-            "You must provide exactly one of '--data (-d)' or '--file (-f)' options."
-        )
+    try:
+        if data is not None:
+            return json.loads(data)
+        if file is not None:
+            return json.loads(Path(file).read_text())
+    except json.JSONDecodeError:
+        raise click.UsageError("Request data must be valid json.")
+
+    raise click.UsageError(
+        "You must provide exactly one of '--data (-d)' or '--file (-f)' options."
+    )
 
 
 @truss_cli.command()

--- a/truss/remote/truss_remote.py
+++ b/truss/remote/truss_remote.py
@@ -59,7 +59,7 @@ class TrussService(ABC):
         if method == "GET":
             response = requests.request(method, url, headers=headers, stream=stream)
         elif method == "POST":
-            if not data:
+            if data is None:
                 raise ValueError("POST request must have data")
             response = requests.request(
                 method, url, json=data, headers=headers, stream=stream

--- a/truss/templates/server/common/truss_server.py
+++ b/truss/templates/server/common/truss_server.py
@@ -132,7 +132,12 @@ class BasetenEndpoints:
         if self.is_binary(request):
             body = truss_msgpack_deserialize(body_raw)
         else:
-            body = json.loads(body_raw)
+            try:
+                body = json.loads(body_raw)
+            except json.JSONDecodeError as e:
+                raise HTTPException(
+                    status_code=400, detail=f"Invalid JSON payload: {str(e)}"
+                )
 
         # calls ModelWrapper.__call__, which runs validate, preprocess, predict, and postprocess
         response: Union[Dict, Generator] = await model(


### PR DESCRIPTION
# Summary

This fixes a couple issues w/ how we handle JSOn in truss.

### Server-side

If you pass in bad json during inference-time, the server just throws up & returns 500, with a really hard to understand error that is hard to parse.

### Client-side

* If you pass in bad JSON, it throws an exception rather than a nice Click exception.
* If you pass in an empty JSON "{}", it just doesn't send it to the server. An unusual case, but it should be allowed, since it's valid jsoin

Fix these issues here.


# Testing

## Client-side


```
$ truss predict -d "{}"
```

works

```
$ truss predict -d "{"
```

gives you:

```
$ poetry run truss predict -d "{"
? 🎮 Which remote do you want to connect to? sid-prod
                                                                                                                                                                                                                                       
 Usage: truss predict [OPTIONS]                                                                                                                                                                                                        
                                                                                                                                                                                                                                       
 Try 'truss predict --help' for help.                                                                                                                                                                                                  
╭─ Error ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ Request data must be valid json.                                                                                                                                                                                                    │
╰──────────────────────────────────────────────────────────
```

### Server-side 

Before change:

Massive stacktrace on server-side:

```
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/starlette/middleware/base.py", line 78, in call_next
    message = await recv_stream.receive()
  File "/usr/local/lib/python3.9/site-packages/anyio/streams/memory.py", line 118, in receive
    raise EndOfStream
anyio.EndOfStream

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/uvicorn/protocols/http/h11_impl.py", line 429, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
  File "/usr/local/lib/python3.9/site-packages/uvicorn/middleware/proxy_headers.py", line 78, in __call__
    return await self.app(scope, receive, send)
  File "/usr/local/lib/python3.9/site-packages/fastapi/applications.py", line 276, in __call__
    await super().__call__(scope, receive, send)
  File "/usr/local/lib/python3.9/site-packages/starlette/applications.py", line 122, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/usr/local/lib/python3.9/site-packages/starlette/middleware/errors.py", line 184, in __call__
    raise exc
  File "/usr/local/lib/python3.9/site-packages/starlette/middleware/errors.py", line 162, in __call__
    await self.app(scope, receive, _send)
  File "/usr/local/lib/python3.9/site-packages/starlette/middleware/base.py", line 108, in __call__
    response = await self.dispatch_func(request, call_next)
  File "/app/common/termination_handler_middleware.py", line 47, in __call__
    response = await call_next(request)
  File "/usr/local/lib/python3.9/site-packages/starlette/middleware/base.py", line 84, in call_next
    raise app_exc
  File "/usr/local/lib/python3.9/site-packages/starlette/middleware/base.py", line 70, in coro
    await self.app(scope, receive_or_disconnect, send_no_error)
  File "/usr/local/lib/python3.9/site-packages/starlette/middleware/exceptions.py", line 79, in __call__
    raise exc
  File "/usr/local/lib/python3.9/site-packages/starlette/middleware/exceptions.py", line 68, in __call__
    await self.app(scope, receive, sender)
  File "/usr/local/lib/python3.9/site-packages/fastapi/middleware/asyncexitstack.py", line 21, in __call__
    raise e
  File "/usr/local/lib/python3.9/site-packages/fastapi/middleware/asyncexitstack.py", line 18, in __call__
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.9/site-packages/starlette/routing.py", line 718, in __call__
    await route.handle(scope, receive, send)
  File "/usr/local/lib/python3.9/site-packages/starlette/routing.py", line 276, in handle
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.9/site-packages/starlette/routing.py", line 66, in app
    response = await func(request)
  File "/usr/local/lib/python3.9/site-packages/fastapi/routing.py", line 237, in app
    raw_response = await run_endpoint_function(
  File "/usr/local/lib/python3.9/site-packages/fastapi/routing.py", line 163, in run_endpoint_function
    return await dependant.call(**values)
  File "/app/common/truss_server.py", line 135, in predict
    body = json.loads(body_raw)
  File "/usr/local/lib/python3.9/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "/usr/local/lib/python3.9/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/local/lib/python3.9/json/decoder.py", line 353, in raw_decode
    obj, end = self.scan_once(s, idx)
json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 1 column 11 (char 10)
```

After change:

On client:
```
curl -X POST https://app.dev.baseten.co/model_versions/yqvpzjq/predict   -H 'Authorization: Api-Key OXU9DeI1.FPP2EabJHraUugOgi2FwSzyAmOrVRB8Q'   -d '{"a": "b", "c": true' 
{
        "error": "Invalid JSON payload: Expecting ',' delimiter: line 1 column 21 (char 20)"
}
```

On Server: 

<img width="878" alt="test-201___Model___Baseten" src="https://github.com/basetenlabs/truss/assets/850115/59e22c0d-fbae-4502-9a93-baaf72adda4e">

