### PR TITLE
Update for new language.

### DIFF
--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -300,25 +300,25 @@ def _extract_request_data(data: Optional[str], file: Optional[Path]):
     is_flag=True,
     required=False,
     default=False,
-    help="Invoked the published model version.",
+    help="Call the published model deployment.",
 )
 @click.option(
     "--model-version",
     type=str,
     required=False,
-    help="[DEPRECATED] Use --model-deployment instead, this will be removed in future release. ID of model version",
+    help="[DEPRECATED] Use --model-deployment instead, this will be removed in future release. ID of model deployment",
 )
 @click.option(
     "--model-deployment",
     type=str,
     required=False,
-    help="ID of model deployment to invoke",
+    help="ID of model deployment to call",
 )
 @click.option(
     "--model",
     type=str,
     required=False,
-    help="ID of model to invoke",
+    help="ID of model to call",
 )
 @echo_output
 def predict(
@@ -332,7 +332,7 @@ def predict(
     model: Optional[str],
 ):
     """
-    Invokes the packaged model
+    Calls the packaged model
 
     TARGET_DIRECTORY: A Truss directory. If none, use current directory.
 
@@ -438,7 +438,7 @@ def push(
 | Your model has been deployed as a development model. Development models allow you to  |
 | iterate quickly during the deployment process.                                        |
 |                                                                                       |
-| When you are ready to publish your deployed model as a new version,                   |
+| When you are ready to publish your deployed model as a new deployment,                |
 | pass `--publish` to the `truss push` command. To monitor changes to your model and    |
 | rapidly iterate, run the `truss watch` command.                                       |
 |                                                                                       |

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -43,6 +43,8 @@ click.rich_click.COMMAND_GROUPS = {
     ]
 }
 
+console = rich.console.Console()
+
 
 def echo_output(f: Callable[..., object]):
     @wraps(f)
@@ -304,7 +306,13 @@ def _extract_request_data(data: Optional[str], file: Optional[Path]):
     "--model-version",
     type=str,
     required=False,
-    help="ID of model version to invoke",
+    help="[DEPRECATED] Use --model-deployment instead, this will be removed in future release. ID of model version",
+)
+@click.option(
+    "--model-deployment",
+    type=str,
+    required=False,
+    help="ID of model deployment to invoke",
 )
 @click.option(
     "--model",
@@ -320,6 +328,7 @@ def predict(
     file: Optional[Path],
     published: Optional[bool],
     model_version: Optional[str],
+    model_deployment: Optional[str],
     model: Optional[str],
 ):
     """
@@ -336,10 +345,17 @@ def predict(
 
     remote_provider = RemoteFactory.create(remote=remote)
 
+    if model_version:
+        console.print(
+            "[DEPRECATED] --model-version is deprecated, use --model-deployment instead.",
+            style="yellow",
+        )
+        model_deployment = model_version
+
     model_identifier = _extract_and_validate_model_identifier(
         target_directory,
         model_id=model,
-        model_version_id=model_version,
+        model_version_id=model_deployment,
         published=published,
     )
 
@@ -419,7 +435,7 @@ def push(
     if service.is_draft:
         draft_model_text = """
 |---------------------------------------------------------------------------------------|
-| Your model has been deployed as a draft. Draft models allow you to                    |
+| Your model has been deployed as a development model. Development models allow you to  |
 | iterate quickly during the deployment process.                                        |
 |                                                                                       |
 | When you are ready to publish your deployed model as a new version,                   |


### PR DESCRIPTION
# Summary

Update language for the new model management stuff. The main things that needed to change were model-version -> model-deployment & draft -> development.

# Testing

## Help text

```

$ poetry run truss predict --help
                                                                                                                                                                                                                                                                                          
 Usage: truss predict [OPTIONS]                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                          
 Invokes the packaged model                                                                                                                                                                                                                                                               
 TARGET_DIRECTORY: A Truss directory. If none, use current directory.                                                                                                                                                                                                                     
 REQUEST: String formatted as json that represents request                                                                                                                                                                                                                                
 REQUEST_FILE: Path to json file containing the request                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                          
╭─ Options ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ --target-directory      TEXT  Directory of truss                                                                                                                                                                                                                                       │
│ --remote                TEXT  Name of the remote in .trussrc to push to                                                                                                                                                                                                                │
│ --data              -d  TEXT  String formatted as json that represents request                                                                                                                                                                                                         │
│ --file              -f  PATH  Path to json file containing the request                                                                                                                                                                                                                 │
│ --published                   Invoked the published model version.                                                                                                                                                                                                                     │
│ --model-version         TEXT  [DEPRECATED] Use --model-deployment instead, this will be removed in future release. ID of model deployment                                                                                                                                              │
│ --model-deployment      TEXT  ID of model deployment to invoke                                                                                                                                                                                                                         │
│ --model                 TEXT  ID of model to invoke                                                                                                                                                                                                                                    │
│ --help                        Show this message and exit.                                                                                                                                                                                                                              │
╰────────────────────────────────────────────
```
## For truss predict

With model-version

```
$ poetry run truss predict --model-version w7p6myw -d '{"a": "b", "c": true}'
? 🎮 Which remote do you want to connect to? sid-prod
[DEPRECATED] --model-version is deprecated, use --model-deployment instead.
{
  "error": "Internal Server Error"
}

```

with model-deployment

```
$ poetry run truss predict --model-deployment w7p6myw -d '{"a": "b", "c": true}'
? 🎮 Which remote do you want to connect to? sid-prod
{
  "error": "Internal Server Error"
}
```
##  For Truss push

```
 $ poetry run truss push
? 🎮 Which remote do you want to connect to? sid-prod
Compressing... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Uploading... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
✨ Model test-201 was successfully pushed ✨

|---------------------------------------------------------------------------------------|
| Your model has been deployed as a development model. Development models allow you to  |
| iterate quickly during the deployment process.                                        |
|                                                                                       |
| When you are ready to publish your deployed model as a new version,                   |
| pass `--publish` to the `truss push` command. To monitor changes to your model and    |
| rapidly iterate, run the `truss watch` command.                                       |
|                                                                                       |
|---------------------------------------------------------------------------------------|

🪵  View logs for your deployment at https://app.baseten.co/models/7wl1n91q/versions/w7p6myw/logs
```