### PR TITLE
Warn when using secrets without `--trusted`

### DIFF
--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -430,15 +430,14 @@ def push(
     # TODO(Abu): This needs to be refactored to be more generic
     service = remote_provider.push(tr, model_name, publish=publish, trusted=trusted)  # type: ignore
 
+    click.echo(f"✨ Model {model_name} was successfully pushed ✨")
+
     # Log a warning if using secrets without --trusted.
     if tr.spec.config.secrets and not trusted:
         not_trusted_text = """
 Warning: your Truss has secrets but was not pushed with --trusted.
-Please push with --trusted to grant access to secrets.
-"""
-        click.echo(not_trusted_text)
-
-    click.echo(f"✨ Model {model_name} was successfully pushed ✨")
+Please push with --trusted to grant access to secrets."""
+        console.print(not_trusted_text, style="yellow")
 
     if service.is_draft:
         draft_model_text = """

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -432,13 +432,6 @@ def push(
 
     click.echo(f"✨ Model {model_name} was successfully pushed ✨")
 
-    # Log a warning if using secrets without --trusted.
-    if tr.spec.config.secrets and not trusted:
-        not_trusted_text = """
-Warning: your Truss has secrets but was not pushed with --trusted.
-Please push with --trusted to grant access to secrets."""
-        console.print(not_trusted_text, style="yellow")
-
     if service.is_draft:
         draft_model_text = """
 |---------------------------------------------------------------------------------------|
@@ -453,6 +446,14 @@ Please push with --trusted to grant access to secrets."""
 """
 
         click.echo(draft_model_text)
+
+    # Log a warning if using secrets without --trusted.
+    # TODO(helen): this could be moved to a separate function that includes more config checks.
+    if tr.spec.config.secrets and not trusted:
+        not_trusted_text = """Warning: your Truss has secrets but was not pushed with --trusted.
+Please push with --trusted to grant access to secrets.
+"""
+        console.print(not_trusted_text, style="red")
 
     logs_url = remote_provider.get_remote_logs_url(service)  # type: ignore[attr-defined]
     rich.print(f"🪵  View logs for your deployment at {logs_url}")

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -414,6 +414,14 @@ def push(
     # TODO(Abu): This needs to be refactored to be more generic
     service = remote_provider.push(tr, model_name, publish=publish, trusted=trusted)  # type: ignore
 
+    # Log a warning if using secrets without --trusted.
+    if tr.spec.config.secrets and not trusted:
+        not_trusted_text = """
+Warning: your Truss has secrets but was not pushed with --trusted.
+Please push with --trusted to grant access to secrets.
+"""
+        click.echo(not_trusted_text)
+
     click.echo(f"✨ Model {model_name} was successfully pushed ✨")
 
     if service.is_draft:


### PR DESCRIPTION
# Summary
This updates the CLI to print a warning if a Truss has secrets defined in its config but is pushed without `--trusted`.

# Testing
## `truss push`
Commands below were for pushing a Truss with a dummy secret in `config.yaml`:
```
secrets:
  dummy_access_token: null
```

Without `--trusted`: `poetry run truss push`
![image](https://github.com/basetenlabs/truss/assets/14193683/399ee0be-d80a-4033-ac53-bb583fed4b5d)

With `--trusted`: `poetry run truss push --trusted`
Output:
```
Compressing... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Uploading... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
✨ Model test-model was successfully pushed ✨

|---------------------------------------------------------------------------------------|
| Your model has been deployed as a draft. Draft models allow you to                    |
| iterate quickly during the deployment process.                                        |
|                                                                                       |
| When you are ready to publish your deployed model as a new version,                   |
| pass `--publish` to the `truss push` command. To monitor changes to your model and    |
| rapidly iterate, run the `truss watch` command.                                       |
|                                                                                       |
|---------------------------------------------------------------------------------------|

🪵  View logs for your deployment at https://app.baseten.co/models/7wl16p0q/versions/qrjrg13/logs
```