### PR TITLE
Don't show server response in `truss push` errors

### DIFF
--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -38,7 +38,7 @@ class BasetenApi:
         resp_dict = resp.json()
         errors = resp_dict.get("errors")
         if errors:
-            raise ApiError(errors[0]["message"], resp)
+            raise ApiError(errors[0]["message"])
         return resp_dict
 
     def model_s3_upload_credentials(self):

--- a/truss/remote/baseten/error.py
+++ b/truss/remote/baseten/error.py
@@ -1,6 +1,3 @@
-import json
-
-
 class Error(Exception):
     """Base Baseten Error"""
 
@@ -17,16 +14,7 @@ class ApiError(Error):
         self.response = response
 
     def __str__(self):
-        error_str = self.message
-        if (
-            self.response is not None
-        ):  # non-200 Response objects are falsy, hence the not None.
-            error_message = json.loads(self.response.content)
-            error_message = (
-                error_message["error"] if "error" in error_message else error_message
-            )
-            error_str = f"{error_str}\n<Server response: {error_message}>"
-        return error_str
+        return self.message
 
 
 class AuthorizationError(Error):

--- a/truss/remote/baseten/error.py
+++ b/truss/remote/baseten/error.py
@@ -9,12 +9,7 @@ class Error(Exception):
 class ApiError(Error):
     """Errors in calling the Baseten API."""
 
-    def __init__(self, message, response=None):
-        super().__init__(message)
-        self.response = response
-
-    def __str__(self):
-        return self.message
+    pass
 
 
 class AuthorizationError(Error):


### PR DESCRIPTION
# Summary
This PR removes the full server response from the Truss CLI console output on `truss push` errors. The console output will only include the message used to initialize the `ApiError`.

IIUC [this](https://github.com/basetenlabs/truss/blob/8966035bd55d158221a7bae45d5373ec38f344ca/truss/remote/baseten/api.py#L38-L41) is the only usage of `ApiError`; here, the `ApiError` message is set to the message of the first error in the server response.

# Testing
I manually added a second remote to `~/.trussrc` with an invalid API key:
```
[baseten]
remote_provider = baseten
api_key = {MY_ACTUAL_API_KEY}
remote_url = https://app.baseten.co
[baseten-invalid]
remote_provider = baseten
api_key = abc
remote_url = https://app.baseten.co
```

Running `poetry run truss push` and selecting the invalid remote with this change:
```
? 🎮 Which remote do you want to connect to? baseten-invalid
You have to log in to perform the request
```

Prior to this change:
```
? 🎮 Which remote do you want to connect to? baseten-invalid
You have to log in to perform the request
<Server response: {'errors': [{'message': 'You have to log in to perform the request', 'locations': [{'line': 3, 'column': 13}], 'path': ['models'], 'extensions': {'code': 'UNAUTHENTICATED_ACCESS'}}], 'data': {'models': None}}>
```