### PR TITLE
`truss predict` bug fixes / unit tests

### DIFF
--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -240,8 +240,10 @@ def _extract_and_validate_model_identifier(
     model_version_id: Optional[str],
     published: Optional[bool],
 ) -> ModelIdentifier:
-    if published and model_version_id:
-        raise click.UsageError("Cannot use --published with --model-version.")
+    if published and (model_id or model_version_id):
+        raise click.UsageError(
+            "Cannot use --published with --model or --model-version."
+        )
 
     model_identifier: ModelIdentifier
     if model_version_id:

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -240,10 +240,8 @@ def _extract_and_validate_model_identifier(
     model_version_id: Optional[str],
     published: Optional[bool],
 ) -> ModelIdentifier:
-    if published and (model_id or model_version_id):
-        raise click.UsageError(
-            "Cannot use --published with --model or --model-version."
-        )
+    if published and model_version_id:
+        raise click.UsageError("Cannot use --published with --model-version.")
 
     model_identifier: ModelIdentifier
     if model_version_id:

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -181,11 +181,14 @@ class BasetenApi:
 
     # TODO(helen): change naming to disambiguate from get_model_version_by_id
     def get_model_versions_by_id(self, model_id: str):
+        # TODO(helen): this doesn't work--need to update model_version query to
+        # support querying by model ID
         query_string = f"""
         {{
-            model_version(id: "{model_id}") {{
-                name
+        model_version(id: "{model_id}") {{
+            oracle{{
                 id
+                name
                 versions{{
                     id
                     semver
@@ -198,12 +201,13 @@ class BasetenApi:
                     }}
                 }}
             }}
-          }}
+        }}
+        }}
         """
         resp = self._post_graphql_query(query_string)
         return resp["data"]
 
-    # TODO(helen): remove
+    # TODO(helen): consider removing after get_model_versions_by_id works
     def get_model_by_id(self, model_id: str):
         query_string = f"""
         {{

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -167,6 +167,7 @@ class BasetenApi:
                     truss_hash
                     truss_signature
                     is_draft
+                    is_primary
                     current_model_deployment_status {{
                         status
                     }}
@@ -178,6 +179,31 @@ class BasetenApi:
         resp = self._post_graphql_query(query_string)
         return resp["data"]
 
+    # TODO(helen): change naming to disambiguate from get_model_version_by_id
+    def get_model_versions_by_id(self, model_id: str):
+        query_string = f"""
+        {{
+            model_version(id: "{model_id}") {{
+                name
+                id
+                versions{{
+                    id
+                    semver
+                    truss_hash
+                    truss_signature
+                    is_draft
+                    is_primary
+                    current_model_deployment_status {{
+                        status
+                    }}
+                }}
+            }}
+          }}
+        """
+        resp = self._post_graphql_query(query_string)
+        return resp["data"]
+
+    # TODO(helen): remove
     def get_model_by_id(self, model_id: str):
         query_string = f"""
         {{

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -183,19 +183,18 @@ class BasetenApi:
             model(id: "{model_id}") {{
                 name
                 id
-                versions{{
+                primary_version{{
                     id
                     semver
                     truss_hash
                     truss_signature
                     is_draft
-                    is_primary
                     current_model_deployment_status {{
                         status
                     }}
                 }}
             }}
-        }}
+          }}
         """
         resp = self._post_graphql_query(query_string)
         return resp["data"]

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -157,10 +157,9 @@ class BasetenApi:
     def get_model(self, model_name):
         query_string = f"""
         {{
-        model_version(name: "{model_name}") {{
-            oracle{{
-                id
+            model(name: "{model_name}") {{
                 name
+                id
                 versions{{
                     id
                     semver
@@ -173,7 +172,6 @@ class BasetenApi:
                     }}
                 }}
             }}
-        }}
         }}
         """
         resp = self._post_graphql_query(query_string)
@@ -197,7 +195,7 @@ class BasetenApi:
                     }}
                 }}
             }}
-          }}
+        }}
         """
         resp = self._post_graphql_query(query_string)
         return resp["data"]

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -179,16 +179,12 @@ class BasetenApi:
         resp = self._post_graphql_query(query_string)
         return resp["data"]
 
-    # TODO(helen): change naming to disambiguate from get_model_version_by_id
-    def get_model_versions_by_id(self, model_id: str):
-        # TODO(helen): this doesn't work--need to update model_version query to
-        # support querying by model ID
+    def get_model_by_id(self, model_id: str):
         query_string = f"""
         {{
-        model_version(id: "{model_id}") {{
-            oracle{{
-                id
+            model(id: "{model_id}") {{
                 name
+                id
                 versions{{
                     id
                     semver
@@ -196,30 +192,6 @@ class BasetenApi:
                     truss_signature
                     is_draft
                     is_primary
-                    current_model_deployment_status {{
-                        status
-                    }}
-                }}
-            }}
-        }}
-        }}
-        """
-        resp = self._post_graphql_query(query_string)
-        return resp["data"]
-
-    # TODO(helen): consider removing after get_model_versions_by_id works
-    def get_model_by_id(self, model_id: str):
-        query_string = f"""
-        {{
-            model(id: "{model_id}") {{
-                name
-                id
-                primary_version{{
-                    id
-                    semver
-                    truss_hash
-                    truss_signature
-                    is_draft
                     current_model_deployment_status {{
                         status
                     }}

--- a/truss/remote/baseten/core.py
+++ b/truss/remote/baseten/core.py
@@ -76,6 +76,17 @@ def get_dev_version_info(api: BasetenApi, model_name: str) -> dict:
         raise ValueError(f"No development version found with model name: {model_name}")
 
 
+# TODO(helen): add test coverage
+def get_prod_version_info_from_versions(versions: List[dict]) -> dict:
+    # Loop over versions instead of using the primary_version field because
+    # primary_version is set to the development version ID if no published
+    # models exist.
+    for version in versions:
+        if version["is_primary"] and not version["is_draft"]:
+            return version
+    raise ValueError("No production version found")
+
+
 def archive_truss(truss_handle: TrussHandle) -> IO:
     """
     Archive a TrussHandle into a tar file.

--- a/truss/remote/baseten/core.py
+++ b/truss/remote/baseten/core.py
@@ -81,7 +81,7 @@ def get_prod_version_info_from_versions(versions: List[dict]) -> Optional[dict]:
     # primary_version is set to the development version ID if no published
     # models exist.
     for version in versions:
-        if version["is_primary"] and not version["is_draft"]:
+        if version["is_primary"]:
             return version
     return None
 

--- a/truss/remote/baseten/core.py
+++ b/truss/remote/baseten/core.py
@@ -58,6 +58,15 @@ def get_model_versions_by_id(api: BasetenApi, model_id: ModelId) -> Tuple[str, L
 
 
 def get_dev_version_from_versions(versions: List[dict]) -> Optional[dict]:
+    """Given a list of model version dicts, returns the development version.
+
+    Args:
+        versions: List of model version dicts from the Baseten API
+
+    Returns:
+        The version in versions corresponding to the development model, or None
+        if no development model exists
+    """
     for version in versions:
         if version["is_draft"] is True:
             return version
@@ -65,6 +74,16 @@ def get_dev_version_from_versions(versions: List[dict]) -> Optional[dict]:
 
 
 def get_dev_version(api: BasetenApi, model_name: str) -> dict:
+    """Queries the Baseten API and returns a dict representing the
+    development version for the given model_name.
+
+    Args:
+        api: BasetenApi instance
+        model_name: Name of the model to get the development version for
+
+    Returns:
+        The development version of the model
+    """
     model = api.get_model(model_name)
     versions = model["model"]["versions"]
     dev_version = get_dev_version_from_versions(versions)

--- a/truss/remote/baseten/core.py
+++ b/truss/remote/baseten/core.py
@@ -52,11 +52,6 @@ def get_model_versions(api: BasetenApi, model_name: ModelName) -> Tuple[str, Lis
     return (query_result["id"], query_result["versions"])
 
 
-def get_model_versions_by_id(api: BasetenApi, model_id: ModelId) -> Tuple[str, List]:
-    query_result = api.get_model_by_id(model_id.value)["model"]
-    return (query_result["id"], query_result["versions"])
-
-
 def get_dev_version_from_versions(versions: List[dict]) -> Optional[dict]:
     """Given a list of model version dicts, returns the development version.
 

--- a/truss/remote/baseten/core.py
+++ b/truss/remote/baseten/core.py
@@ -47,36 +47,34 @@ def exists_model(api: BasetenApi, model_name: str) -> Optional[str]:
     return None
 
 
-def get_model_versions_info(api: BasetenApi, model_name: ModelName) -> Tuple[str, List]:
+def get_model_versions(api: BasetenApi, model_name: ModelName) -> Tuple[str, List]:
     query_result = api.get_model(model_name.value)["model"]
     return (query_result["id"], query_result["versions"])
 
 
-def get_model_versions_info_by_id(
-    api: BasetenApi, model_id: ModelId
-) -> Tuple[str, List]:
+def get_model_versions_by_id(api: BasetenApi, model_id: ModelId) -> Tuple[str, List]:
     query_result = api.get_model_by_id(model_id.value)["model"]
     return (query_result["id"], query_result["versions"])
 
 
-def get_dev_version_info_from_versions(versions: List[dict]) -> Optional[dict]:
+def get_dev_version_from_versions(versions: List[dict]) -> Optional[dict]:
     for version in versions:
         if version["is_draft"] is True:
             return version
     return None
 
 
-def get_dev_version_info(api: BasetenApi, model_name: str) -> dict:
+def get_dev_version(api: BasetenApi, model_name: str) -> dict:
     model = api.get_model(model_name)
     versions = model["model"]["versions"]
-    dev_version = get_dev_version_info_from_versions(versions)
+    dev_version = get_dev_version_from_versions(versions)
     if not dev_version:
         # TODO(helen): return dev_version in all cases rather than raising an error
         raise ValueError(f"No development version found with model name: {model_name}")
     return dev_version
 
 
-def get_prod_version_info_from_versions(versions: List[dict]) -> Optional[dict]:
+def get_prod_version_from_versions(versions: List[dict]) -> Optional[dict]:
     # Loop over versions instead of using the primary_version field because
     # primary_version is set to the development version ID if no published
     # models exist.

--- a/truss/remote/baseten/core.py
+++ b/truss/remote/baseten/core.py
@@ -1,5 +1,5 @@
 import logging
-from typing import IO, Optional, Tuple
+from typing import IO, List, Optional, Tuple
 
 import truss
 from truss.remote.baseten.api import BasetenApi
@@ -47,8 +47,17 @@ def exists_model(api: BasetenApi, model_name: str) -> Optional[str]:
     return None
 
 
-def get_model_versions_info(api: BasetenApi, model_name) -> Tuple[str, dict]:
-    query_result = api.get_model(model_name)["model_version"]["oracle"]
+def get_model_versions_info(api: BasetenApi, model_name: ModelName) -> Tuple[str, List]:
+    query_result = api.get_model(model_name.value)["model_version"]["oracle"]
+    return (query_result["id"], query_result["versions"])
+
+
+def get_model_versions_info_by_id(
+    api: BasetenApi, model_id: ModelId
+) -> Tuple[str, List]:
+    query_result = api.get_model_versions_by_id(model_id.value)["model_version"][
+        "oracle"
+    ]
     return (query_result["id"], query_result["versions"])
 
 

--- a/truss/remote/baseten/core.py
+++ b/truss/remote/baseten/core.py
@@ -48,7 +48,7 @@ def exists_model(api: BasetenApi, model_name: str) -> Optional[str]:
 
 
 def get_model_versions_info(api: BasetenApi, model_name: ModelName) -> Tuple[str, List]:
-    query_result = api.get_model(model_name.value)["model_version"]["oracle"]
+    query_result = api.get_model(model_name.value)["model"]
     return (query_result["id"], query_result["versions"])
 
 
@@ -61,7 +61,7 @@ def get_model_versions_info_by_id(
 
 def get_dev_version_info(api: BasetenApi, model_name: str) -> dict:
     model = api.get_model(model_name)
-    versions = model["model_version"]["oracle"]["versions"]
+    versions = model["model"]["versions"]
     for version in versions:
         if version["is_draft"] is True:
             return version

--- a/truss/remote/baseten/core.py
+++ b/truss/remote/baseten/core.py
@@ -59,13 +59,21 @@ def get_model_versions_info_by_id(
     return (query_result["id"], query_result["versions"])
 
 
-def get_dev_version_info(api: BasetenApi, model_name: str) -> dict:
-    model = api.get_model(model_name)
-    versions = model["model"]["versions"]
+# TODO(helen): add test coverage
+def get_dev_version_info_from_versions(versions: List[dict]) -> dict:
     for version in versions:
         if version["is_draft"] is True:
             return version
-    raise ValueError(f"No development version found with model name: {model_name}")
+    raise ValueError("No development version found")
+
+
+def get_dev_version_info(api: BasetenApi, model_name: str) -> dict:
+    model = api.get_model(model_name)
+    versions = model["model"]["versions"]
+    try:
+        return get_dev_version_info_from_versions(versions)
+    except ValueError:
+        raise ValueError(f"No development version found with model name: {model_name}")
 
 
 def archive_truss(truss_handle: TrussHandle) -> IO:

--- a/truss/remote/baseten/core.py
+++ b/truss/remote/baseten/core.py
@@ -59,7 +59,6 @@ def get_model_versions_info_by_id(
     return (query_result["id"], query_result["versions"])
 
 
-# TODO(helen): add test coverage
 def get_dev_version_info_from_versions(versions: List[dict]) -> dict:
     for version in versions:
         if version["is_draft"] is True:
@@ -76,7 +75,6 @@ def get_dev_version_info(api: BasetenApi, model_name: str) -> dict:
         raise ValueError(f"No development version found with model name: {model_name}")
 
 
-# TODO(helen): add test coverage
 def get_prod_version_info_from_versions(versions: List[dict]) -> dict:
     # Loop over versions instead of using the primary_version field because
     # primary_version is set to the development version ID if no published

--- a/truss/remote/baseten/core.py
+++ b/truss/remote/baseten/core.py
@@ -59,30 +59,31 @@ def get_model_versions_info_by_id(
     return (query_result["id"], query_result["versions"])
 
 
-def get_dev_version_info_from_versions(versions: List[dict]) -> dict:
+def get_dev_version_info_from_versions(versions: List[dict]) -> Optional[dict]:
     for version in versions:
         if version["is_draft"] is True:
             return version
-    raise ValueError("No development version found")
+    return None
 
 
 def get_dev_version_info(api: BasetenApi, model_name: str) -> dict:
     model = api.get_model(model_name)
     versions = model["model"]["versions"]
-    try:
-        return get_dev_version_info_from_versions(versions)
-    except ValueError:
+    dev_version = get_dev_version_info_from_versions(versions)
+    if not dev_version:
+        # TODO(helen): return dev_version in all cases rather than raising an error
         raise ValueError(f"No development version found with model name: {model_name}")
+    return dev_version
 
 
-def get_prod_version_info_from_versions(versions: List[dict]) -> dict:
+def get_prod_version_info_from_versions(versions: List[dict]) -> Optional[dict]:
     # Loop over versions instead of using the primary_version field because
     # primary_version is set to the development version ID if no published
     # models exist.
     for version in versions:
         if version["is_primary"] and not version["is_draft"]:
             return version
-    raise ValueError("No production version found")
+    return None
 
 
 def archive_truss(truss_handle: TrussHandle) -> IO:

--- a/truss/remote/baseten/core.py
+++ b/truss/remote/baseten/core.py
@@ -55,9 +55,7 @@ def get_model_versions_info(api: BasetenApi, model_name: ModelName) -> Tuple[str
 def get_model_versions_info_by_id(
     api: BasetenApi, model_id: ModelId
 ) -> Tuple[str, List]:
-    query_result = api.get_model_versions_by_id(model_id.value)["model_version"][
-        "oracle"
-    ]
+    query_result = api.get_model_by_id(model_id.value)["model"]
     return (query_result["id"], query_result["versions"])
 
 

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -117,25 +117,30 @@ class BasetenRemote(TrussRemote):
             service_url_path = f"/model_versions/{model_version_id}"
             return service_url_path, model_id, model_version_id
 
-        # Get model versions by either model name or ID.
         if isinstance(model_identifier, ModelName):
             model_id, model_versions = get_model_versions_info(api, model_identifier)
+            model_version = BasetenRemote._get_matching_version(
+                model_versions, published
+            )
+            model_version_id = model_version["id"]
+            service_url_path = f"/model_versions/{model_version_id}"
         elif isinstance(model_identifier, ModelId):
             model_id, model_versions = get_model_versions_info_by_id(
                 api, model_identifier
             )
+            # TODO(helen): make this consistent with getting the service via
+            # model_name and respect --published in service_url_path.
+            model_version = BasetenRemote._get_matching_version(
+                model_versions, published
+            )
+            model_version_id = model_version["id"]
+            service_url_path = f"/models/{model_id}"
         else:
             # Model identifier is of invalid type.
             raise click.UsageError(
                 "You must either be inside of a Truss directory, or provide --model-version or --model options."
             )
 
-        model_version = BasetenRemote._get_matching_version(model_versions, published)
-        model_version_id = model_version["id"]
-        # TODO(helen): comment on why we use models endpoint instead of
-        # model_versions. If primary version changes while this is executing,
-        # will service_url_path and model_version_id be inconsistent?
-        service_url_path = f"/models/{model_id}"
         return service_url_path, model_id, model_version_id
 
     def get_service(self, **kwargs) -> BasetenService:

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -89,7 +89,7 @@ class BasetenRemote(TrussRemote):
             try:
                 return get_dev_version_info_from_versions(model_versions)
             except ValueError:
-                raise ValueError(
+                raise click.UsageError(
                     "No development model found. Run `truss push` then try again."
                 )
 
@@ -97,7 +97,7 @@ class BasetenRemote(TrussRemote):
         try:
             return get_prod_version_info_from_versions(model_versions)
         except ValueError:
-            raise ValueError(
+            raise click.UsageError(
                 "No production model found. Run `truss push --publish` then try again."
             )
 

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -24,6 +24,7 @@ from truss.remote.baseten.core import (
     get_prod_version_info_from_versions,
     upload_truss,
 )
+from truss.remote.baseten.error import ApiError
 from truss.remote.baseten.service import BasetenService
 from truss.remote.baseten.utils.transfer import base64_encoded_json_str
 from truss.remote.truss_remote import TrussRemote, TrussService
@@ -105,7 +106,12 @@ class BasetenRemote(TrussRemote):
         api: BasetenApi, model_identifier: ModelIdentifier, published: bool
     ) -> Tuple[str, str, str]:
         if isinstance(model_identifier, ModelVersionId):
-            model_version = api.get_model_version_by_id(model_identifier.value)
+            try:
+                model_version = api.get_model_version_by_id(model_identifier.value)
+            except ApiError:
+                raise click.UsageError(
+                    f"Model version {model_identifier.value} not found."
+                )
             model_version_id = model_version["model_version"]["id"]
             model_id = model_version["model_version"]["oracle"]["id"]
             service_url_path = f"/model_versions/{model_version_id}"

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -85,20 +85,20 @@ class BasetenRemote(TrussRemote):
     def _get_matching_version(model_versions: List[dict], published: bool) -> dict:
         if not published:
             # Return the development model version.
-            try:
-                return get_dev_version_info_from_versions(model_versions)
-            except ValueError:
+            dev_version = get_dev_version_info_from_versions(model_versions)
+            if not dev_version:
                 raise click.UsageError(
                     "No development model found. Run `truss push` then try again."
                 )
+            return dev_version
 
         # Return the production deployment version.
-        try:
-            return get_prod_version_info_from_versions(model_versions)
-        except ValueError:
+        prod_version = get_prod_version_info_from_versions(model_versions)
+        if not prod_version:
             raise click.UsageError(
                 "No production model found. Run `truss push --publish` then try again."
             )
+        return prod_version
 
     @staticmethod
     def _get_service_url_path_and_model_ids(

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -81,7 +81,6 @@ class BasetenRemote(TrussRemote):
             truss_handle=truss_handle,
         )
 
-    # TODO(helen): consider free function; add docstring
     @staticmethod
     def _get_matching_version(model_versions: List[dict], published: bool) -> dict:
         if not published:
@@ -101,7 +100,6 @@ class BasetenRemote(TrussRemote):
                 "No production model found. Run `truss push --publish` then try again."
             )
 
-    # TODO(helen): consider free function; add docstring
     @staticmethod
     def _get_service_url_path_and_model_ids(
         api: BasetenApi, model_identifier: ModelIdentifier, published: bool

--- a/truss/tests/remote/baseten/test_core.py
+++ b/truss/tests/remote/baseten/test_core.py
@@ -1,7 +1,6 @@
 from tempfile import NamedTemporaryFile
 from unittest.mock import MagicMock
 
-import pytest
 from truss.remote.baseten import core
 
 
@@ -44,8 +43,8 @@ def test_get_dev_version_info_from_versions_error():
     versions = [
         {"id": "1", "is_draft": False},
     ]
-    with pytest.raises(ValueError):
-        core.get_dev_version_info_from_versions(versions)
+    dev_version_info = core.get_dev_version_info_from_versions(versions)
+    assert dev_version_info is None
 
 
 def test_get_dev_version_info():
@@ -75,5 +74,5 @@ def test_get_prod_version_info_from_versions_error():
         {"id": "1", "is_draft": True, "is_primary": False},
         {"id": "2", "is_draft": False, "is_primary": False},
     ]
-    with pytest.raises(ValueError):
-        core.get_prod_version_info_from_versions(versions)
+    prod_version_info = core.get_prod_version_info_from_versions(versions)
+    assert prod_version_info is None

--- a/truss/tests/remote/baseten/test_core.py
+++ b/truss/tests/remote/baseten/test_core.py
@@ -30,24 +30,24 @@ def test_upload_truss():
     assert core.upload_truss(api, test_file) == "key"
 
 
-def test_get_dev_version_info_from_versions():
+def test_get_dev_version_from_versions():
     versions = [
         {"id": "1", "is_draft": False},
         {"id": "2", "is_draft": True},
     ]
-    dev_version_info = core.get_dev_version_info_from_versions(versions)
-    assert dev_version_info["id"] == "2"
+    dev_version = core.get_dev_version_from_versions(versions)
+    assert dev_version["id"] == "2"
 
 
-def test_get_dev_version_info_from_versions_error():
+def test_get_dev_version_from_versions_error():
     versions = [
         {"id": "1", "is_draft": False},
     ]
-    dev_version_info = core.get_dev_version_info_from_versions(versions)
-    assert dev_version_info is None
+    dev_version = core.get_dev_version_from_versions(versions)
+    assert dev_version is None
 
 
-def test_get_dev_version_info():
+def test_get_dev_version():
     versions = [
         {"id": "1", "is_draft": False},
         {"id": "2", "is_draft": True},
@@ -55,24 +55,24 @@ def test_get_dev_version_info():
     api = MagicMock()
     api.get_model.return_value = {"model": {"versions": versions}}
 
-    dev_version_info = core.get_dev_version_info(api, "my_model")
-    assert dev_version_info["id"] == "2"
+    dev_version = core.get_dev_version(api, "my_model")
+    assert dev_version["id"] == "2"
 
 
-def test_get_prod_version_info_from_versions():
+def test_get_prod_version_from_versions():
     versions = [
         {"id": "1", "is_draft": False, "is_primary": False},
         {"id": "2", "is_draft": True, "is_primary": False},
         {"id": "3", "is_draft": False, "is_primary": True},
     ]
-    prod_version_info = core.get_prod_version_info_from_versions(versions)
-    assert prod_version_info["id"] == "3"
+    prod_version = core.get_prod_version_from_versions(versions)
+    assert prod_version["id"] == "3"
 
 
-def test_get_prod_version_info_from_versions_error():
+def test_get_prod_version_from_versions_error():
     versions = [
         {"id": "1", "is_draft": True, "is_primary": False},
         {"id": "2", "is_draft": False, "is_primary": False},
     ]
-    prod_version_info = core.get_prod_version_info_from_versions(versions)
-    assert prod_version_info is None
+    prod_version = core.get_prod_version_from_versions(versions)
+    assert prod_version is None

--- a/truss/tests/remote/baseten/test_remote.py
+++ b/truss/tests/remote/baseten/test_remote.py
@@ -1,0 +1,29 @@
+import click
+import pytest
+from truss.remote.baseten.remote import BasetenRemote
+
+
+def test_get_matching_version():
+    versions = [
+        {"id": "1", "is_draft": False, "is_primary": False},
+        {"id": "2", "is_draft": False, "is_primary": True},
+        {"id": "3", "is_draft": True, "is_primary": False},
+    ]
+    assert BasetenRemote._get_matching_version(versions, published=True)["id"] == "2"
+    assert BasetenRemote._get_matching_version(versions, published=False)["id"] == "3"
+
+
+def test_get_matching_version_dev_error():
+    versions = [
+        {"id": "1", "is_draft": False, "is_primary": True},
+    ]
+    with pytest.raises(click.UsageError):
+        BasetenRemote._get_matching_version(versions, published=False)
+
+
+def test_get_matching_version_prod_error():
+    versions = [
+        {"id": "1", "is_draft": True, "is_primary": False},
+    ]
+    with pytest.raises(click.UsageError):
+        BasetenRemote._get_matching_version(versions, published=True)

--- a/truss/tests/remote/baseten/test_remote.py
+++ b/truss/tests/remote/baseten/test_remote.py
@@ -1,29 +1,241 @@
 import click
 import pytest
+import requests_mock
+from truss.remote.baseten.core import ModelId, ModelName, ModelVersionId
 from truss.remote.baseten.remote import BasetenRemote
 
+_TEST_REMOTE_URL = "http://test_remote.com"
 
-def test_get_matching_version():
+
+def test_get_service_by_version_id():
+    remote = BasetenRemote(_TEST_REMOTE_URL, "api_key")
+
+    version = {
+        "id": "version_id",
+        "oracle": {
+            "id": "model_id",
+        },
+    }
+    model_version_response = {"data": {"model_version": version}}
+
+    with requests_mock.Mocker() as m:
+        m.post(
+            remote._api._api_url,
+            json=model_version_response,
+        )
+        service = remote.get_service(model_identifier=ModelVersionId("version_id"))
+
+    assert service.model_id == "model_id"
+    assert service.model_version_id == "version_id"
+
+
+def test_get_service_by_model_name():
+    remote = BasetenRemote(_TEST_REMOTE_URL, "api_key")
+
     versions = [
         {"id": "1", "is_draft": False, "is_primary": False},
         {"id": "2", "is_draft": False, "is_primary": True},
         {"id": "3", "is_draft": True, "is_primary": False},
     ]
-    assert BasetenRemote._get_matching_version(versions, published=True)["id"] == "2"
-    assert BasetenRemote._get_matching_version(versions, published=False)["id"] == "3"
+    model_response = {
+        "data": {
+            "model": {
+                "name": "model_name",
+                "id": "model_id",
+                "versions": versions,
+            }
+        }
+    }
+
+    with requests_mock.Mocker() as m:
+        m.post(
+            remote._api._api_url,
+            json=model_response,
+        )
+
+        # Check that the production version is returned when published is True.
+        service = remote.get_service(
+            model_identifier=ModelName("model_name"), published=True
+        )
+        assert service.model_id == "model_id"
+        assert service.model_version_id == "2"
+
+        # Check that the development version is returned when published is False.
+        service = remote.get_service(
+            model_identifier=ModelName("model_name"), published=False
+        )
+        assert service.model_id == "model_id"
+        assert service.model_version_id == "3"
 
 
-def test_get_matching_version_dev_error():
+def test_get_service_by_model_name_no_dev_version():
+    remote = BasetenRemote(_TEST_REMOTE_URL, "api_key")
+
     versions = [
         {"id": "1", "is_draft": False, "is_primary": True},
     ]
-    with pytest.raises(click.UsageError):
-        BasetenRemote._get_matching_version(versions, published=False)
+    model_response = {
+        "data": {
+            "model": {
+                "name": "model_name",
+                "id": "model_id",
+                "versions": versions,
+            }
+        }
+    }
+
+    with requests_mock.Mocker() as m:
+        m.post(
+            remote._api._api_url,
+            json=model_response,
+        )
+
+        # Check that the production version is returned when published is True.
+        service = remote.get_service(
+            model_identifier=ModelName("model_name"), published=True
+        )
+        assert service.model_id == "model_id"
+        assert service.model_version_id == "1"
+
+        # Since no development version exists, calling get_service with
+        # published=False should raise an error.
+        with pytest.raises(click.UsageError):
+            remote.get_service(
+                model_identifier=ModelName("model_name"), published=False
+            )
 
 
-def test_get_matching_version_prod_error():
+def test_get_service_by_model_name_no_prod_version():
+    remote = BasetenRemote(_TEST_REMOTE_URL, "api_key")
+
     versions = [
         {"id": "1", "is_draft": True, "is_primary": False},
     ]
-    with pytest.raises(click.UsageError):
-        BasetenRemote._get_matching_version(versions, published=True)
+    model_response = {
+        "data": {
+            "model": {
+                "name": "model_name",
+                "id": "model_id",
+                "versions": versions,
+            }
+        }
+    }
+
+    with requests_mock.Mocker() as m:
+        m.post(
+            remote._api._api_url,
+            json=model_response,
+        )
+
+        # Since no production version exists, calling get_service with
+        # published=True should raise an error.
+        with pytest.raises(click.UsageError):
+            remote.get_service(model_identifier=ModelName("model_name"), published=True)
+
+        # Check that the development version is returned when published is False.
+        service = remote.get_service(
+            model_identifier=ModelName("model_name"), published=False
+        )
+        assert service.model_id == "model_id"
+        assert service.model_version_id == "1"
+
+
+def test_get_service_by_model_id():
+    remote = BasetenRemote(_TEST_REMOTE_URL, "api_key")
+
+    versions = [
+        {"id": "1", "is_draft": False, "is_primary": False},
+        {"id": "2", "is_draft": False, "is_primary": True},
+        {"id": "3", "is_draft": True, "is_primary": False},
+    ]
+    model_response = {
+        "data": {
+            "model": {
+                "name": "model_name",
+                "id": "model_id",
+                "versions": versions,
+            }
+        }
+    }
+
+    with requests_mock.Mocker() as m:
+        m.post(
+            remote._api._api_url,
+            json=model_response,
+        )
+
+        service = remote.get_service(
+            model_identifier=ModelId("model_id"), published=True
+        )
+        assert service.model_id == "model_id"
+        assert service.model_version_id == "2"
+
+        service = remote.get_service(
+            model_identifier=ModelId("model_id"), published=False
+        )
+        assert service.model_id == "model_id"
+        assert service.model_version_id == "3"
+
+
+def test_get_service_by_model_id_no_dev_version():
+    remote = BasetenRemote(_TEST_REMOTE_URL, "api_key")
+
+    versions = [
+        {"id": "1", "is_draft": False, "is_primary": True},
+    ]
+    model_response = {
+        "data": {
+            "model": {
+                "name": "model_name",
+                "id": "model_id",
+                "versions": versions,
+            }
+        }
+    }
+
+    with requests_mock.Mocker() as m:
+        m.post(
+            remote._api._api_url,
+            json=model_response,
+        )
+
+        service = remote.get_service(
+            model_identifier=ModelId("model_id"), published=True
+        )
+        assert service.model_id == "model_id"
+        assert service.model_version_id == "1"
+
+        with pytest.raises(click.UsageError):
+            remote.get_service(model_identifier=ModelId("model_id"), published=False)
+
+
+def test_get_service_by_model_id_no_prod_version():
+    remote = BasetenRemote(_TEST_REMOTE_URL, "api_key")
+
+    versions = [
+        {"id": "1", "is_draft": True, "is_primary": False},
+    ]
+    model_response = {
+        "data": {
+            "model": {
+                "name": "model_name",
+                "id": "model_id",
+                "versions": versions,
+            }
+        }
+    }
+
+    with requests_mock.Mocker() as m:
+        m.post(
+            remote._api._api_url,
+            json=model_response,
+        )
+
+        with pytest.raises(click.UsageError):
+            remote.get_service(model_identifier=ModelId("model_id"), published=True)
+
+        service = remote.get_service(
+            model_identifier=ModelId("model_id"), published=False
+        )
+        assert service.model_id == "model_id"
+        assert service.model_version_id == "1"

--- a/truss/tests/remote/baseten/test_remote.py
+++ b/truss/tests/remote/baseten/test_remote.py
@@ -29,6 +29,18 @@ def test_get_service_by_version_id():
     assert service.model_version_id == "version_id"
 
 
+def test_get_service_by_version_id_no_version():
+    remote = BasetenRemote(_TEST_REMOTE_URL, "api_key")
+    model_version_response = {"errors": [{"message": "error"}]}
+    with requests_mock.Mocker() as m:
+        m.post(
+            remote._api._api_url,
+            json=model_version_response,
+        )
+        with pytest.raises(click.UsageError):
+            remote.get_service(model_identifier=ModelVersionId("version_id"))
+
+
 def test_get_service_by_model_name():
     remote = BasetenRemote(_TEST_REMOTE_URL, "api_key")
 


### PR DESCRIPTION
This PR addresses several issues with `truss predict`:
* ~~Unifies logic for getting the deployment version given a `model_name` or `model_id`~~
* ~~Supports using the `--published` flag with `--model` (i.e. model ID)~~
    * The above two points result in different and potentially unexpected behavior for users. Will leave this for a future PR--it should be bundled with changes to the API calls on the Baseten UI and more transparency in Truss CLI on what version is being used in `predict`
* Calling `truss predict --published` returns production version instead of the first non-development version
* Adds unit test coverage for helper functions in `core` and for `BasetenRemote`

### Testing
#### Unit tests
* `poetry run pytest truss/tests/remote/baseten/test_core.py`
* `poetry run pytest truss/tests/remote/baseten/test_remote.py`

#### Truss CLI
Tested manually on a model with four published deployments and one development deployment:
<img width="788" alt="image" src="https://github.com/basetenlabs/truss/assets/14193683/89880616-791a-4b38-a8f7-4bd5f984fc74">

For the production deployment, I set the `predict` function of my `Model` to return `"production model"` as its output. For the development deployment, I return `"development model"`. The other deployments simply return the `model_input`.

Model version ID:
```
@helenlyang ➜ /workspaces/truss/my-test-model (helenyang/bt-8803-fix-truss-predict) $ # production version
@helenlyang ➜ /workspaces/truss/my-test-model (helenyang/bt-8803-fix-truss-predict) $ poetry run truss predict --model-deployment qrj6d03 --data {}
? 🎮 Which remote do you want to connect to? prod
{
  "message": "production model"
}
```
```
@helenlyang ➜ /workspaces/truss/my-test-model (helenyang/bt-8803-fix-truss-predict) $ # development version
@helenlyang ➜ /workspaces/truss/my-test-model (helenyang/bt-8803-fix-truss-predict) $ poetry run truss predict --model-deployment qjd502q --data {}
? 🎮 Which remote do you want to connect to? prod
{
  "message": "development model"
}
```
```
@helenlyang ➜ /workspaces/truss/my-test-model (helenyang/bt-8803-fix-truss-predict) $ # published, non-production version
@helenlyang ➜ /workspaces/truss/my-test-model (helenyang/bt-8803-fix-truss-predict) $ poetry run truss predict --model-deployment qvvd0eq --data {}
? 🎮 Which remote do you want to connect to? prod
{}
```
Model name:
```
@helenlyang ➜ /workspaces/truss/my-test-model (helenyang/bt-8803-fix-truss-predict) $ # without --published; should use dev version
@helenlyang ➜ /workspaces/truss/my-test-model (helenyang/bt-8803-fix-truss-predict) $ poetry run truss predict --data {}
? 🎮 Which remote do you want to connect to? prod
{
  "message": "development model"
}
```
```
@helenlyang ➜ /workspaces/truss/my-test-model (helenyang/bt-8803-fix-truss-predict) $ # with --published; should use production version
@helenlyang ➜ /workspaces/truss/my-test-model (helenyang/bt-8803-fix-truss-predict) $ poetry run truss predict --published --data {}
? 🎮 Which remote do you want to connect to? prod
{
  "message": "production model"
}
```

Model ID:
```
@helenlyang ➜ /workspaces/truss/my-test-model (helenyang/bt-8803-fix-truss-predict) $ # should use production version
@helenlyang ➜ /workspaces/truss/my-test-model (helenyang/bt-8803-fix-truss-predict) $ poetry run truss predict --model 03ydnk43 --data {}
? 🎮 Which remote do you want to connect to? prod
{
  "message": "production model"
}
```
Testing on a second model with no production deployment:
```
@helenlyang ➜ /workspaces/truss/my-test-model (helenyang/bt-8803-fix-truss-predict) $ # if no production version exists, use the development version
@helenlyang ➜ /workspaces/truss/my-test-model (helenyang/bt-8803-fix-truss-predict) $ poetry run truss predict --model yqvvy0jq --data {}
? 🎮 Which remote do you want to connect to? prod
{
  "message": "development model"
}
```