### PR TITLE
Log message on 400

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.7.15"
+version = "0.7.16rc1"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/templates/server/common/truss_server.py
+++ b/truss/templates/server/common/truss_server.py
@@ -45,7 +45,9 @@ async def parse_body(request: Request) -> bytes:
     try:
         return await request.body()
     except ClientDisconnect as exc:
-        raise HTTPException(status_code=499, detail="Client disconnected") from exc
+        error_message = "Client disconnected"
+        logging.error(error_message)
+        raise HTTPException(status_code=499, detail=error_message) from exc
 
 
 FORMAT = "%(asctime)s.%(msecs)03d %(name)s %(levelname)s [%(funcName)s():%(lineno)s] %(message)s"
@@ -135,9 +137,9 @@ class BasetenEndpoints:
             try:
                 body = json.loads(body_raw)
             except json.JSONDecodeError as e:
-                raise HTTPException(
-                    status_code=400, detail=f"Invalid JSON payload: {str(e)}"
-                )
+                error_message = f"Invalid JSON payload: {str(e)}"
+                logging.error(error_message)
+                raise HTTPException(status_code=400, detail=error_message)
 
         # calls ModelWrapper.__call__, which runs validate, preprocess, predict, and postprocess
         response: Union[Dict, Generator] = await model(


### PR DESCRIPTION
# Summary

We've had a couple cases where there have been spikes of 400s. When this happens, and the 400s are coming from the model pod, we don't have any real means of understanding what happened. In this PR, we add some logging when we return BadRequest exceptions from Truss, so that we can understand the errors on the pod better.

# Testing

Deployed a model locally, and curled it with malformed json. Got this:

![test_92___Model___Baseten](https://github.com/basetenlabs/truss/assets/850115/fcde1aaa-5d7e-4723-b15b-9e34ae916d10)
