### PR TITLE
Prevent caching folders on S3

### DIFF
--- a/truss/contexts/image_builder/serving_image_builder.py
+++ b/truss/contexts/image_builder/serving_image_builder.py
@@ -158,7 +158,11 @@ class S3Cache(RemoteCache):
 
         all_objects = []
         for blob in bucket.objects.filter(Prefix=path):
+            # leave out folders
+            if blob.key[-1] == "/":
+                continue
             all_objects.append(blob.key)
+
         return all_objects
 
     def prepare_for_cache(self, filenames):


### PR DESCRIPTION
In `model_cache`, a user may put the following code:
```yaml
model_cache:
- repo_id: s3://mysecretmodel/folder/
```

Here, the prefix is `folder`. If `folder` is recognized as a blob on S3, the build would previously attempt to cache `s3://mysecretmodel/folder/` and then fail to cache all of the files in the folder. There are some cases where `folder` is not recognized as a blob and no failure would occur.

This is pretty confusing. To minimize ambiguity, this PR ensures that folders are never targeted by the `cache_warmer`. Only files.