### PR TITLE
Hard-code h11 as the http-parser

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.7.17rc1"
+version = "0.7.17rc2"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/templates/control/control/server.py
+++ b/truss/templates/control/control/server.py
@@ -59,6 +59,10 @@ class ControlServer:
             application,
             host=application.state.control_server_host,
             port=application.state.control_server_port,
+            # We hard-code the http parser as h11 (the default) in case the user has
+            # httptools installed, which does not work with our requests & version
+            # of uvicorn.
+            http="h11",
         )
         cfg.setup_event_loop()
 

--- a/truss/templates/server/common/truss_server.py
+++ b/truss/templates/server/common/truss_server.py
@@ -261,6 +261,10 @@ class TrussServer:
     def start(self):
         cfg = uvicorn.Config(
             self.create_application(),
+            # We hard-code the http parser as h11 (the default) in case the user has
+            # httptools installed, which does not work with our requests & version
+            # of uvicorn.
+            http="h11",
             host="0.0.0.0",
             port=self.http_port,
             workers=NUM_WORKERS,


### PR DESCRIPTION
# Summary

We discovered an issue yesterday where if you install the `httptools` library in your Truss, and deploy it at as a development model, you cannot make requests to it. In this PR, we change uvicorn to hard-code `h11` as the http-parser, which prevents any interaction between http-tools and Truss.

To explain further -- uvicorn chooses an http-parser based on what pip packages are installed. `httptools` is apparently a faster parser, so it opts to use that if it's installed. However, `httptools` does not seem to like the requests that we get on development models, and we get back the following error:

```
{
    "error": "Invalid HTTP request received"
}
```

We still are not sure why we see these errors.

Made https://linear.app/baseten/issue/BT-9194/httptools-library-breaks-control-server to investigate this further.

# Testing

Simply make a truss with httptools installed, ie:

```
python_version: py39
requirements:
  - httptools==0.6.0
resources:
  cpu: 500m
  memory: 512Mi
  use_gpu: false
```

In the config. Notice that if you deploy as a development model, you cannot make requests. 

Tested on development that this fix works, and that you can make requests.