### PR TITLE
Make download in build a bit less noisy

### DIFF
--- a/truss/templates/server.Dockerfile.jinja
+++ b/truss/templates/server.Dockerfile.jinja
@@ -58,7 +58,7 @@ RUN pip install -r server_requirements.txt --no-cache-dir && rm -rf /root/.cache
 
 {%- if external_data_files %}
 {% for url, dst in external_data_files %}
-RUN mkdir -p {{ dst.parent }}; wget "{{ url }}" -O {{ dst }}
+RUN mkdir -p {{ dst.parent }}; wget "{{ url }}" -O {{ dst }} -nv
 {% endfor %}
 {%- endif  %}
 


### PR DESCRIPTION
Current download spits out too much moise.

<img width="1128" alt="image" src="https://github.com/basetenlabs/truss/assets/1748241/612bd998-af08-43b3-a3d1-3a1f693bdf59">
