### PR TITLE
Add base image dockerfile for XTTS example

### DIFF
--- a/docker/base_images/xtts.Dockerfile
+++ b/docker/base_images/xtts.Dockerfile
@@ -1,0 +1,5 @@
+FROM baseten/truss-server-base:3.10-gpu-v0.7.16
+
+RUN pip uninstall cython -y
+
+RUN pip install git+https://github.com/coqui-ai/TTS.git


### PR DESCRIPTION
@htrivedi99 needed a base image for XTTS example. I'm just adding this PR to document how we got it to work. 

Maybe it's best to move some of these to truss-examples at some point. I am not sure.