### PR TITLE
Ensure external data works on GPU image

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.7.18"
+version = "0.7.19rc0"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/templates/server.Dockerfile.jinja
+++ b/truss/templates/server.Dockerfile.jinja
@@ -58,7 +58,7 @@ RUN pip install -r server_requirements.txt --no-cache-dir && rm -rf /root/.cache
 
 {%- if external_data_files %}
 {% for url, dst in external_data_files %}
-RUN mkdir -p {{ dst.parent }}; wget "{{ url }}" -O {{ dst }}
+RUN mkdir -p {{ dst.parent }}; curl -L "{{ url }}" -o {{ dst }}
 {% endfor %}
 {%- endif  %}
 

--- a/truss/tests/conftest.py
+++ b/truss/tests/conftest.py
@@ -300,6 +300,42 @@ def custom_model_external_data_access_tuple_fixture(tmp_path: Path):
 
 
 @pytest.fixture
+def custom_model_external_data_access_tuple_fixture_gpu(tmp_path: Path):
+    content = "test"
+    filename = "test.txt"
+    (tmp_path / filename).write_text(content)
+    port = 9089
+    proc = subprocess.Popen(
+        ["python", "-m", "http.server", str(port), "--bind", "*"],
+        cwd=tmp_path,
+    )
+    try:
+        url = f"http://localhost:{port}/{filename}"
+        # Add arbitrary get params to get that they don't cause issues, the
+        # server above ignores them.
+        # url_with_get_params = f"{url}?foo=bar&baz=bla"
+        url_with_get_params = f"{url}?foo=bar&baz=bla"
+
+        def modify_handle(h):
+            h.add_external_data_item(
+                url=url_with_get_params, local_data_path="test.txt"
+            )
+            h.enable_gpu()
+
+        yield (
+            _custom_model_from_code(
+                tmp_path,
+                "external_data_access",
+                EXTERNAL_DATA_ACCESS,
+                handle_ops=modify_handle,
+            ),
+            content,
+        )
+    finally:
+        proc.kill()
+
+
+@pytest.fixture
 def custom_model_with_external_package(tmp_path: Path):
     ext_pkg_path = tmp_path / "ext_pkg"
     ext_pkg_path.mkdir()

--- a/truss/tests/test_truss_handle.py
+++ b/truss/tests/test_truss_handle.py
@@ -783,6 +783,16 @@ def test_external_data(custom_model_external_data_access_tuple_fixture):
         assert result == expected_content
 
 
+@pytest.mark.integration
+def test_external_data_gpu(custom_model_external_data_access_tuple_fixture_gpu):
+    truss_dir, expected_content = custom_model_external_data_access_tuple_fixture_gpu
+    th = TrussHandle(truss_dir)
+    tag = "test-external-data-access-tag:0.0.1"
+    with ensure_kill_all():
+        result = th.docker_predict([], tag=tag, network="host")
+        assert result == expected_content
+
+
 def _container_exists(container) -> bool:
     for row in Docker.client().ps():
         if row.id.startswith(container.id):


### PR DESCRIPTION
## Problem

GPU images did not have `wget` installed so the external data download failed. This wasn't caught in integration tests

## Solution
1. added integration test on GPU image. Ensured it failed before fix.
2. fixed with `curl -L` to follow redirect instead.

## Testing
Ran integration and manual tests locally.

https://github.com/basetenlabs/truss/actions/runs/6907789475