### PR TITLE
Move error handling out of `get_dev_version`

### DIFF
--- a/truss/remote/baseten/core.py
+++ b/truss/remote/baseten/core.py
@@ -68,7 +68,7 @@ def get_dev_version_from_versions(versions: List[dict]) -> Optional[dict]:
     return None
 
 
-def get_dev_version(api: BasetenApi, model_name: str) -> dict:
+def get_dev_version(api: BasetenApi, model_name: str) -> Optional[dict]:
     """Queries the Baseten API and returns a dict representing the
     development version for the given model_name.
 
@@ -81,11 +81,7 @@ def get_dev_version(api: BasetenApi, model_name: str) -> dict:
     """
     model = api.get_model(model_name)
     versions = model["model"]["versions"]
-    dev_version = get_dev_version_from_versions(versions)
-    if not dev_version:
-        # TODO(helen): return dev_version in all cases rather than raising an error
-        raise ValueError(f"No development version found with model name: {model_name}")
-    return dev_version
+    return get_dev_version_from_versions(versions)
 
 
 def get_prod_version_from_versions(versions: List[dict]) -> Optional[dict]:

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -176,7 +176,13 @@ class BasetenRemote(TrussRemote):
         target_directory: str,
     ):
         # verify that development deployment exists for given model name
-        _ = get_dev_version(self._api, model_name)  # pylint: disable=protected-access
+        dev_version = get_dev_version(
+            self._api, model_name
+        )  # pylint: disable=protected-access
+        if not dev_version:
+            raise click.UsageError(
+                "No development model found. Run `truss push` then try again."
+            )
         TrussFilesSyncer(
             Path(target_directory),
             self,
@@ -205,6 +211,11 @@ class BasetenRemote(TrussRemote):
             return
         model_name = truss_handle.spec.config.model_name
         dev_version = get_dev_version(self._api, model_name)  # type: ignore
+        if not dev_version:
+            logger.error(
+                f"No development deployment found with model name: {model_name}"
+            )
+            return
         truss_hash = dev_version.get("truss_hash", None)
         truss_signature = dev_version.get("truss_signature", None)
         if not (truss_hash and truss_signature):


### PR DESCRIPTION
Follow-up to https://github.com/basetenlabs/truss/pull/723#discussion_r1393394021. This updates core.get_dev_version to return None if a development version doesn’t exist and updates callsites to raise errors.

### Testing
Tested truss watch manually in CLI.
- I’m able to patch changes to my development model
- If no development model exists when `truss watch` is called, we typically don’t reach the errors raised in this PR because an exception is raised here: https://github.com/basetenlabs/truss/blob/3465408e9248f90950ff02146776f09bf78f9244/truss/cli/cli.py#L231
- Tested the edge case where the development model exists when `truss watch` is called but is deleted while `truss watch` runs. We hit the error in `BasetenRemote.patch` as expected:
![image](https://github.com/basetenlabs/truss/assets/14193683/366be858-7161-44b0-a75e-17053cf0de69)


- Also tried simulating the edge case where the dev model is deleted between `get_service` and `sync_truss_to_dev_version_by_name` calls by adding a `time.sleep` and deleting the model. We raise an error as expected
![image](https://github.com/basetenlabs/truss/assets/14193683/069fda7f-858f-4a4e-97f4-0bf730e5f6c5)