### PR TITLE
add trt-llm enum to build.model_server enum

### DIFF
--- a/truss/contexts/image_builder/serving_image_builder.py
+++ b/truss/contexts/image_builder/serving_image_builder.py
@@ -346,7 +346,7 @@ def get_files_to_cache(config: TrussConfig, truss_dir: Path, build_dir: Path):
 def update_config_and_gather_files(
     config: TrussConfig, truss_dir: Path, build_dir: Path
 ):
-    if config.build.model_server != ModelServer.TrussServer:
+    if config.build.model_server not in [ModelServer.TrussServer, ModelServer.TRT_LLM]:
         model_key = update_model_key(config)
         update_model_name(config, model_key)
     return get_files_to_cache(config, truss_dir, build_dir)
@@ -496,6 +496,7 @@ class ServingImageBuilder(ImageBuilder):
         elif config.build.model_server is ModelServer.TRITON:
             create_triton_build_dir(config, build_dir, truss_dir)
             return
+        # ModelServer.TrussServer and ModelServer.TRT_LLM use the default truss image builder
 
         data_dir = build_dir / config.data_dir  # type: ignore[operator]
 

--- a/truss/truss_config.py
+++ b/truss/truss_config.py
@@ -152,6 +152,12 @@ class Runtime:
 
 
 class ModelServer(Enum):
+    """
+    To determine the image builder path for trusses built from alternative server backends.
+    This enum is also used to gate development deployments to BasetenRemote
+    https://github.com/basetenlabs/truss/blob/7505c17a2ddd4a6fa626b9126772999dc8f3fa86/truss/remote/baseten/remote.py#L56-L57
+    """
+
     TrussServer = "TrussServer"
     TGI = "TGI"
     VLLM = "VLLM"

--- a/truss/truss_config.py
+++ b/truss/truss_config.py
@@ -156,6 +156,7 @@ class ModelServer(Enum):
     TGI = "TGI"
     VLLM = "VLLM"
     TRITON = "TRITON"
+    TRT_LLM = "TRT_LLM"
 
 
 @dataclass


### PR DESCRIPTION
- This PR extends the `ModelServer` enum to include `TRT-LLM` to ensure that models with this server implementation are not permitted to be deployed as development deployments. This is to facilitate rollout of examples [[llama](https://github.com/basetenlabs/truss-examples/tree/main/llama/llama-2-7b-trt-llm), [mistral](https://github.com/basetenlabs/truss-examples/tree/main/mistral/mistral-7b-trt-llm)] that utilize TRT-LLM while we are adding feature completeness to these offerings.
- I tested a deployment of these example trusses and verified that they result in published deployments along with a PR to change the example config https://github.com/basetenlabs/truss-examples/pull/78