### PR TITLE
Drop `huggingface-hub` requirement for Truss Server

### DIFF
--- a/truss/templates/server/requirements.txt
+++ b/truss/templates/server/requirements.txt
@@ -13,4 +13,3 @@ uvloop==0.17.0
 psutil==5.9.4
 joblib==1.2.0
 requests==2.31.0
-huggingface-hub==0.16.4


### PR DESCRIPTION
Very simple change. See title.

I ran the `ai-search` example Bola mentioned earlier in Slack. Dropping this requirement (and setting `live_reload: true`) makes everything work as expected.