### PR TITLE
Update GPU .devcontainer to skip docker redownload

### DIFF
--- a/.devcontainer/gpu/Dockerfile
+++ b/.devcontainer/gpu/Dockerfile
@@ -25,7 +25,6 @@ ENV PATH=/home/vscode/.poetry/bin:$PATH
 
 USER root
 
-# RUN curl https://get.docker.com | sh && sudo systemctl --now enable docker
 RUN distribution=$(. /etc/os-release;echo $ID$VERSION_ID) \
       && curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg \
       && curl -s -L https://nvidia.github.io/libnvidia-container/$distribution/libnvidia-container.list | \

--- a/.devcontainer/gpu/Dockerfile
+++ b/.devcontainer/gpu/Dockerfile
@@ -25,7 +25,7 @@ ENV PATH=/home/vscode/.poetry/bin:$PATH
 
 USER root
 
-RUN curl https://get.docker.com | sh && sudo systemctl --now enable docker
+# RUN curl https://get.docker.com | sh && sudo systemctl --now enable docker
 RUN distribution=$(. /etc/os-release;echo $ID$VERSION_ID) \
       && curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg \
       && curl -s -L https://nvidia.github.io/libnvidia-container/$distribution/libnvidia-container.list | \


### PR DESCRIPTION
```
  28 |     USER root
  29 |     
  30 | >>> RUN curl https://get.docker.com | sh && sudo systemctl --now enable docker
  31 |     RUN distribution=$(. /etc/os-release;echo $ID$VERSION_ID) \
  32 |           && curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg \
```

We remove the line that was causing the codespace to fail and everything seems to work now.