### PR TITLE
Support multiple uvicorn workers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.7.19rc2"
+version = "0.7.19rc3"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.7.19rc3"
+version = "0.7.20rc0"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/templates/server/common/truss_server.py
+++ b/truss/templates/server/common/truss_server.py
@@ -33,7 +33,7 @@ from starlette.responses import Response
 # Please consider the following when increasing this:
 # 1. Self-termination on model load fail.
 # 2. Graceful termination.
-NUM_WORKERS = 1
+DEFAULT_NUM_WORKERS = 1
 WORKER_TERMINATION_TIMEOUT_SECS = 120.0
 WORKER_TERMINATION_CHECK_INTERVAL_SECS = 0.5
 
@@ -267,7 +267,9 @@ class TrussServer:
             http="h11",
             host="0.0.0.0",
             port=self.http_port,
-            workers=NUM_WORKERS,
+            workers=self._config.get("runtime", {}).get(
+                "num_workers", DEFAULT_NUM_WORKERS
+            ),
             log_config={
                 "version": 1,
                 "formatters": {

--- a/truss/templates/server/model_wrapper.py
+++ b/truss/templates/server/model_wrapper.py
@@ -89,29 +89,26 @@ class ModelWrapper:
         if self.ready:
             return self.ready
 
-        # if we are already loading, just pass; our container will return 503 while we're loading
-        if not self._load_lock.acquire(block=False):
-            return False
+        # if we are already loading, block on aquiring the lock;
+        # this worker will return 503 while the worker with the lock is loading
+        with self._load_lock:
+            self._status = ModelWrapper.Status.LOADING
 
-        self._status = ModelWrapper.Status.LOADING
+            self._logger.info("Executing model.load()...")
 
-        self._logger.info("Executing model.load()...")
+            try:
+                start_time = time.perf_counter()
+                self.try_load()
+                self.ready = True
+                self._status = ModelWrapper.Status.READY
+                self._logger.info(
+                    f"Completed model.load() execution in {_elapsed_ms(start_time)} ms"
+                )
 
-        try:
-            start_time = time.perf_counter()
-            self.try_load()
-            self.ready = True
-            self._status = ModelWrapper.Status.READY
-            self._logger.info(
-                f"Completed model.load() execution in {_elapsed_ms(start_time)} ms"
-            )
-
-            return self.ready
-        except Exception:
-            self._logger.exception("Exception while loading model")
-            self._status = ModelWrapper.Status.FAILED
-        finally:
-            self._load_lock.release()
+                return self.ready
+            except Exception:
+                self._logger.exception("Exception while loading model")
+                self._status = ModelWrapper.Status.FAILED
 
         return self.ready
 
@@ -125,15 +122,7 @@ class ModelWrapper:
 
     def should_load(self) -> bool:
         # don't retry failed loads
-        # multiprocessing.Lock
-        has_acquired_lock = self._load_lock.acquire(block=False)
-        if has_acquired_lock:
-            self._load_lock.release()
-        return (
-            has_acquired_lock
-            and not self._status == ModelWrapper.Status.FAILED
-            and not self.ready
-        )
+        return not self._status == ModelWrapper.Status.FAILED and not self.ready
 
     def try_load(self):
         data_dir = Path("data")

--- a/truss/truss_config.py
+++ b/truss/truss_config.py
@@ -29,6 +29,7 @@ DEFAULT_DATA_DIRECTORY = "data"
 DEFAULT_EXAMPLES_FILENAME = "examples.yaml"
 DEFAULT_SPEC_VERSION = "2.0"
 DEFAULT_PREDICT_CONCURRENCY = 1
+DEFAULT_NUM_WORKERS = 1
 
 DEFAULT_CPU = "1"
 DEFAULT_MEMORY = "2Gi"
@@ -136,18 +137,22 @@ class ModelCache:
 @dataclass
 class Runtime:
     predict_concurrency: int = DEFAULT_PREDICT_CONCURRENCY
+    num_workers: int = DEFAULT_NUM_WORKERS
 
     @staticmethod
     def from_dict(d):
         predict_concurrency = d.get("predict_concurrency", DEFAULT_PREDICT_CONCURRENCY)
+        num_workers = d.get("num_workers", DEFAULT_NUM_WORKERS)
 
         return Runtime(
             predict_concurrency=predict_concurrency,
+            num_workers=num_workers,
         )
 
     def to_dict(self):
         return {
             "predict_concurrency": self.predict_concurrency,
+            "num_workers": self.num_workers,
         }
 
 


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What

We have found that for high performance inference workloads at substantial concurrency, `TrussServer` becomes CPU bound and bottlenecks performance. This PR introduces support for running multiple `uvicorn` workers to overcome this limit. This change is provisional to unblock benchmarking work and should be revisited to enforce idempotent model loads and proper termination handling. 
<!--
  How was the change described above implemented?
-->
## :computer: How

- Adds plumbing of `runtime.num_workers` config to the python process kicking the TrussServer
- Adds multiprocess blocking on the `ModelWrapper._load_lock` to handle loading across processes
<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
- Tested multiple worker loading in staging environment