### PR TITLE
Simplify model query.

### DIFF
--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -1,4 +1,5 @@
 import logging
+from enum import Enum
 
 import requests
 from truss.remote.baseten.auth import AuthService
@@ -16,6 +17,9 @@ class BasetenApi:
         api_url: The URL of the Baseten API.
         auth_service: An AuthService instance.
     """
+
+    class GraphQLErrorCodes(Enum):
+        RESOURCE_NOT_FOUND = "RESOURCE_NOT_FOUND"
 
     def __init__(self, api_url: str, auth_service: AuthService):
         self._api_url = api_url
@@ -37,8 +41,12 @@ class BasetenApi:
 
         resp_dict = resp.json()
         errors = resp_dict.get("errors")
+
         if errors:
-            raise ApiError(errors[0]["message"])
+            message = errors[0]["message"]
+            error_code = errors[0].get("extensions", {}).get("code")
+
+            raise ApiError(message, error_code)
         return resp_dict
 
     def model_s3_upload_credentials(self):

--- a/truss/remote/baseten/error.py
+++ b/truss/remote/baseten/error.py
@@ -1,3 +1,6 @@
+from typing import Optional
+
+
 class Error(Exception):
     """Base Baseten Error"""
 
@@ -9,7 +12,9 @@ class Error(Exception):
 class ApiError(Error):
     """Errors in calling the Baseten API."""
 
-    pass
+    def __init__(self, message: str, graphql_error_code: Optional[str] = None):
+        super().__init__(message)
+        self.graphql_error_code = graphql_error_code
 
 
 class AuthorizationError(Error):

--- a/truss/tests/remote/baseten/test_core.py
+++ b/truss/tests/remote/baseten/test_core.py
@@ -2,16 +2,24 @@ from tempfile import NamedTemporaryFile
 from unittest.mock import MagicMock
 
 from truss.remote.baseten import core
+from truss.remote.baseten.api import BasetenApi
+from truss.remote.baseten.error import ApiError
 
 
 def test_exists_model():
+    def mock_get_model(model_name):
+        if model_name == "first model":
+            return {"model": {"id": "1"}}
+        elif model_name == "second model":
+            return {"model": {"id": "2"}}
+        else:
+            raise ApiError(
+                "Oracle not found",
+                BasetenApi.GraphQLErrorCodes.RESOURCE_NOT_FOUND.value,
+            )
+
     api = MagicMock()
-    api.models.return_value = {
-        "models": [
-            {"id": "1", "name": "first model"},
-            {"id": "2", "name": "second model"},
-        ]
-    }
+    api.get_model.side_effect = mock_get_model
 
     assert core.exists_model(api, "first model")
     assert core.exists_model(api, "second model")


### PR DESCRIPTION
## :rocket: What

We are currently querying for all user's models & versions to check whether a model exists or not. This is fairly expensive for some of the accounts that have lots of models (since the results are not paginated). Note that this query currently takes > 10 seconds for the truss CI examples user. 

### Context

My suspicion is that because this query takes so long, and because we trigger ~30 of them in parallel at the same time, the db gets loaded, and the queries slow down

## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing

Tested locally :
* Tested with both a truss where the name exists as well as one without.

```
$ poetry run truss push
```