### PR TITLE
Fix documentation for `truss push --publish`

### DIFF
--- a/docs/reference/cli/push.mdx
+++ b/docs/reference/cli/push.mdx
@@ -13,7 +13,7 @@ truss push [OPTIONS] [TARGET_DIRECTORY]
 Name of the remote in .trussrc to patch changes to.
 </ParamField>
 <ParamField body="--publish" type="BOOL">
-Publish truss as production deployment.
+Publish truss as non-development deployment. If no production model exists, promote the truss to production.
 </ParamField>
 <ParamField body="--trusted" type="BOOL">
 Give Truss access to secrets on remote host.

--- a/docs/reference/cli/push.mdx
+++ b/docs/reference/cli/push.mdx
@@ -13,7 +13,7 @@ truss push [OPTIONS] [TARGET_DIRECTORY]
 Name of the remote in .trussrc to patch changes to.
 </ParamField>
 <ParamField body="--publish" type="BOOL">
-Publish truss as non-development deployment. If no production model exists, promote the truss to production.
+Push the truss as a published deployment. If no production deployment exists, promote the truss to production.
 </ParamField>
 <ParamField body="--trusted" type="BOOL">
 Give Truss access to secrets on remote host.

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -396,7 +396,7 @@ def predict(
     is_flag=True,
     required=False,
     default=False,
-    help="Publish truss as production deployment.",
+    help="Publish truss as non-development deployment. If no production model exists, promote the truss to production.",
 )
 @click.option(
     "--trusted",

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -396,7 +396,10 @@ def predict(
     is_flag=True,
     required=False,
     default=False,
-    help="Publish truss as non-development deployment. If no production model exists, promote the truss to production.",
+    help=(
+        "Push the truss as a published deployment. If no production "
+        "deployment exists, promote the truss to production."
+    ),
 )
 @click.option(
     "--trusted",


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Updates `truss push --publish` docs to indicate that the truss is not always published as a prod deployment.

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
