### PR TITLE
Add --promote option to `truss push`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.7.22rc1"
+version = "0.7.22rc5"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.7.22rc5"
+version = "0.7.22rc6"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.7.21"
+version = "0.7.22rc1"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -409,6 +409,14 @@ def predict(
     default=False,
     help="Trust truss with hosted secrets.",
 )
+@click.option(
+    "--promote",
+    type=bool,
+    is_flag=True,
+    required=False,
+    default=False,
+    help="After deploy completes, promotes the truss to production.",
+)
 @error_handling
 def push(
     target_directory: str,
@@ -416,6 +424,7 @@ def push(
     model_name: str,
     publish: bool = False,
     trusted: bool = False,
+    promote: bool = False,
 ) -> None:
     """
     Pushes a truss to a TrussRemote.
@@ -440,7 +449,7 @@ def push(
         tr.spec.config.write_to_yaml_file(tr.spec.config_path, verbose=False)
 
     # TODO(Abu): This needs to be refactored to be more generic
-    service = remote_provider.push(tr, model_name, publish=publish, trusted=trusted)  # type: ignore
+    service = remote_provider.push(tr, model_name, publish=publish, trusted=trusted, promote=promote)  # type: ignore
 
     click.echo(f"✨ Model {model_name} was successfully pushed ✨")
 

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -476,6 +476,11 @@ Please push with --trusted to grant access to secrets.
 """
         console.print(not_trusted_text, style="red")
 
+    if promote:
+        promotion_text = """Your Truss has been deployed as a production model. After it successfully deploys,
+it will become the next production deployment of your model."""
+        console.print(promotion_text, style="green")
+
     logs_url = remote_provider.get_remote_logs_url(service)  # type: ignore[attr-defined]
     rich.print(f"🪵  View logs for your deployment at {logs_url}")
 

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -111,7 +111,7 @@ class BasetenApi:
                 semver_bump: "{semver_bump}",
                 client_version: "{client_version}",
                 is_trusted: {'true' if is_trusted else 'false'}
-                promote: {'true' if promote else 'false'}
+                promote_after_deploy: {'true' if promote else 'false'}
             ) {{
                 id
             }}

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -100,6 +100,7 @@ class BasetenApi:
         semver_bump: str,
         client_version: str,
         is_trusted: bool,
+        promote: bool = False,
     ):
         query_string = f"""
         mutation {{
@@ -110,6 +111,7 @@ class BasetenApi:
                 semver_bump: "{semver_bump}",
                 client_version: "{client_version}",
                 is_trusted: {'true' if is_trusted else 'false'}
+                promote: {'true' if promote else 'false'}
             ) {{
                 id
             }}

--- a/truss/remote/baseten/core.py
+++ b/truss/remote/baseten/core.py
@@ -149,6 +149,7 @@ def create_truss_service(
     config: str,
     semver_bump: str = "MINOR",
     is_trusted: bool = False,
+    promote: bool = False,
     is_draft: Optional[bool] = False,
     model_id: Optional[str] = None,
 ) -> Tuple[str, str]:
@@ -162,6 +163,7 @@ def create_truss_service(
         config: Base64 encoded JSON string of the Truss config
         semver_bump: Semver bump type, defaults to "MINOR"
         is_trusted: Whether the model is trusted, defaults to False
+        promote: Whether to promote the model after deploy, defaults to False
 
     Returns:
         A tuple of the model ID and version ID
@@ -196,6 +198,7 @@ def create_truss_service(
         semver_bump=semver_bump,
         client_version=f"truss=={truss.version()}",
         is_trusted=is_trusted,
+        promote=promote,
     )
     model_version_id = model_version_json["id"]
     return (model_id, model_version_id)

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -46,6 +46,7 @@ class BasetenRemote(TrussRemote):
         model_name: str,
         publish: bool = True,
         trusted: bool = False,
+        promote: bool = False,
     ):
         if model_name.isspace():
             raise ValueError("Model name cannot be empty")
@@ -70,6 +71,7 @@ class BasetenRemote(TrussRemote):
             is_draft=not publish,
             model_id=model_id,
             is_trusted=trusted,
+            promote=promote,
         )
 
         return BasetenService(

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -56,6 +56,12 @@ class BasetenRemote(TrussRemote):
         gathered_truss = TrussHandle(truss_handle.gather())
         if gathered_truss.spec.model_server != ModelServer.TrussServer:
             publish = True
+
+        if promote:
+            # If we are promoting a model after deploy, it must be published.
+            # Draft models cannot be promoted.
+            publish = True
+
         encoded_config_str = base64_encoded_json_str(
             gathered_truss._spec._config.to_dict()
         )


### PR DESCRIPTION

## :rocket: What

Many baseten users have asked for a feature where they can push a new version of a model, and have it become the production version immediately after the deploy. This PR adds a `--promote` flag to `truss push` to allow users to do exactly that. This is blocked on https://github.com/basetenlabs/baseten/pull/7673 making it to prod

## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing

Tested this end-to-end:

https://www.loom.com/share/3ee84a59a6ea45578935f5de2099242e
