### PR TITLE
Add deployment_name parameter to 'truss push' command

### DIFF
--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -436,7 +436,7 @@ def push(
     publish: bool = False,
     trusted: bool = False,
     promote: bool = False,
-    deployment_name: str = None,
+    deployment_name: Optional[str] = None,
 ) -> None:
     """
     Pushes a truss to a TrussRemote.

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -426,7 +426,10 @@ def predict(
     "--deployment-name",
     type=str,
     required=False,
-    help="Name of the deployment created by the push.",
+    help=(
+        "Name of the deployment created by the push. Can only be "
+        "used in combination with --publish or --promote."
+    ),
 )
 @error_handling
 def push(

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -422,6 +422,12 @@ def predict(
     default=False,
     help="Trust truss with hosted secrets.",
 )
+@click.option(
+    "--deployment-name",
+    type=str,
+    required=False,
+    help="Name of the deployment created by the push.",
+)
 @error_handling
 def push(
     target_directory: str,
@@ -430,6 +436,7 @@ def push(
     publish: bool = False,
     trusted: bool = False,
     promote: bool = False,
+    deployment_name: str = None,
 ) -> None:
     """
     Pushes a truss to a TrussRemote.
@@ -454,7 +461,14 @@ def push(
         tr.spec.config.write_to_yaml_file(tr.spec.config_path, verbose=False)
 
     # TODO(Abu): This needs to be refactored to be more generic
-    service = remote_provider.push(tr, model_name, publish=publish, trusted=trusted, promote=promote)  # type: ignore
+    service = remote_provider.push(
+        tr,
+        model_name,
+        publish=publish,
+        trusted=trusted,
+        promote=promote,
+        deployment_name=deployment_name,
+    )  # type: ignore
 
     click.echo(f"✨ Model {model_name} was successfully pushed ✨")
 

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -1,5 +1,6 @@
 import logging
 from enum import Enum
+from typing import Optional
 
 import requests
 from truss.remote.baseten.auth import AuthService
@@ -72,7 +73,7 @@ class BasetenApi:
         semver_bump: str,
         client_version: str,
         is_trusted: bool,
-        deployment_name: str,
+        deployment_name: Optional[str] = None,
     ):
         query_string = f"""
         mutation {{
@@ -103,7 +104,7 @@ class BasetenApi:
         client_version: str,
         is_trusted: bool,
         promote: bool = False,
-        deployment_name: str = None,
+        deployment_name: Optional[str] = None,
     ):
         query_string = f"""
         mutation {{

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -84,7 +84,7 @@ class BasetenApi:
                 semver_bump: "{semver_bump}",
                 client_version: "{client_version}",
                 is_trusted: {'true' if is_trusted else 'false'},
-                {f'deployment_name: "{deployment_name}"' if deployment_name else ""}
+                {f'version_name: "{deployment_name}"' if deployment_name else ""}
             ) {{
                 id,
                 name,

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -72,6 +72,7 @@ class BasetenApi:
         semver_bump: str,
         client_version: str,
         is_trusted: bool,
+        deployment_name: str,
     ):
         query_string = f"""
         mutation {{
@@ -81,7 +82,8 @@ class BasetenApi:
                 config: "{config}",
                 semver_bump: "{semver_bump}",
                 client_version: "{client_version}",
-                is_trusted: {'true' if is_trusted else 'false'}
+                is_trusted: {'true' if is_trusted else 'false'},
+                {f'development_name: "{deployment_name}"' if deployment_name else ""}
             ) {{
                 id,
                 name,
@@ -101,6 +103,7 @@ class BasetenApi:
         client_version: str,
         is_trusted: bool,
         promote: bool = False,
+        deployment_name: str = None,
     ):
         query_string = f"""
         mutation {{
@@ -110,8 +113,9 @@ class BasetenApi:
                 config: "{config}",
                 semver_bump: "{semver_bump}",
                 client_version: "{client_version}",
-                is_trusted: {'true' if is_trusted else 'false'}
-                promote_after_deploy: {'true' if promote else 'false'}
+                is_trusted: {'true' if is_trusted else 'false'},
+                promote_after_deploy: {'true' if promote else 'false'},
+                {f'name: "{deployment_name}"' if deployment_name else ""}
             ) {{
                 id
             }}

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -83,7 +83,7 @@ class BasetenApi:
                 semver_bump: "{semver_bump}",
                 client_version: "{client_version}",
                 is_trusted: {'true' if is_trusted else 'false'},
-                {f'development_name: "{deployment_name}"' if deployment_name else ""}
+                {f'deployment_name: "{deployment_name}"' if deployment_name else ""}
             ) {{
                 id,
                 name,

--- a/truss/remote/baseten/core.py
+++ b/truss/remote/baseten/core.py
@@ -152,6 +152,7 @@ def create_truss_service(
     promote: bool = False,
     is_draft: Optional[bool] = False,
     model_id: Optional[str] = None,
+    deployment_name: Optional[str] = None,
 ) -> Tuple[str, str]:
     """
     Create a model in the Baseten remote.
@@ -164,6 +165,7 @@ def create_truss_service(
         semver_bump: Semver bump type, defaults to "MINOR"
         is_trusted: Whether the model is trusted, defaults to False
         promote: Whether to promote the model after deploy, defaults to False
+        deployment_name: Name to apply to the created deployment. Does not apply to development model
 
     Returns:
         A tuple of the model ID and version ID
@@ -187,6 +189,7 @@ def create_truss_service(
             semver_bump=semver_bump,
             client_version=f"truss=={truss.version()}",
             is_trusted=is_trusted,
+            deployment_name=deployment_name,
         )
         return (model_version_json["id"], model_version_json["version_id"])
 
@@ -199,6 +202,7 @@ def create_truss_service(
         client_version=f"truss=={truss.version()}",
         is_trusted=is_trusted,
         promote=promote,
+        deployment_name=deployment_name,
     )
     model_version_id = model_version_json["id"]
     return (model_id, model_version_id)

--- a/truss/remote/baseten/core.py
+++ b/truss/remote/baseten/core.py
@@ -165,7 +165,7 @@ def create_truss_service(
         semver_bump: Semver bump type, defaults to "MINOR"
         is_trusted: Whether the model is trusted, defaults to False
         promote: Whether to promote the model after deploy, defaults to False
-        deployment_name: Name to apply to the created deployment. Does not apply to development model
+        deployment_name: Name to apply to the created deployment. Not applied to development model
 
     Returns:
         A tuple of the model ID and version ID

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -66,12 +66,12 @@ class BasetenRemote(TrussRemote):
 
         if not publish and deployment_name:
             raise ValueError(
-                "deployment_name cannot be used for development deployment"
+                "ERROR: deployment name cannot be used for development deployment"
             )
 
         if deployment_name and not re.match(r"^[0-9a-zA-Z_\-\.]*$", deployment_name):
             raise ValueError(
-                "deployment_name must only contain alphanumeric, -, _ and . characters"
+                "ERROR: deployment name must only contain alphanumeric, -, _ and . characters"
             )
 
         encoded_config_str = base64_encoded_json_str(

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from pathlib import Path
 from typing import List, Optional, Tuple
 
@@ -66,6 +67,11 @@ class BasetenRemote(TrussRemote):
         if not publish and deployment_name:
             raise ValueError(
                 "deployment_name cannot be used for development deployment"
+            )
+
+        if deployment_name and not re.match(r"^[0-9a-zA-Z_\-\.]*$", deployment_name):
+            raise ValueError(
+                "deployment_name must only contain alphanumeric, -, _ and . characters"
             )
 
         encoded_config_str = base64_encoded_json_str(

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -47,6 +47,7 @@ class BasetenRemote(TrussRemote):
         publish: bool = True,
         trusted: bool = False,
         promote: bool = False,
+        deployment_name: str = None,
     ):
         if model_name.isspace():
             raise ValueError("Model name cannot be empty")
@@ -61,6 +62,11 @@ class BasetenRemote(TrussRemote):
             # If we are promoting a model after deploy, it must be published.
             # Draft models cannot be promoted.
             publish = True
+
+        if not publish and deployment_name:
+            raise ValueError(
+                "deployment_name cannot be used for development deployment"
+            )
 
         encoded_config_str = base64_encoded_json_str(
             gathered_truss._spec._config.to_dict()
@@ -78,6 +84,7 @@ class BasetenRemote(TrussRemote):
             model_id=model_id,
             is_trusted=trusted,
             promote=promote,
+            deployment_name=deployment_name,
         )
 
         return BasetenService(

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 import click
 import yaml
@@ -47,7 +47,7 @@ class BasetenRemote(TrussRemote):
         publish: bool = True,
         trusted: bool = False,
         promote: bool = False,
-        deployment_name: str = None,
+        deployment_name: Optional[str] = None,
     ):
         if model_name.isspace():
             raise ValueError("Model name cannot be empty")

--- a/truss/tests/remote/baseten/test_api.py
+++ b/truss/tests/remote/baseten/test_api.py
@@ -165,7 +165,7 @@ def test_create_model_from_truss(mock_post, mock_auth_service):
     assert 'semver_bump: "semver_bump"' in gql_mutation
     assert 'client_version: "client_version"' in gql_mutation
     assert "is_trusted: false" in gql_mutation
-    assert 'deployment_name: "deployment_name"' in gql_mutation
+    assert 'version_name: "deployment_name"' in gql_mutation
 
 
 @mock.patch("truss.remote.baseten.auth.AuthService")
@@ -193,4 +193,4 @@ def test_create_model_from_truss_does_not_send_deployment_name_if_not_specified(
     assert 'semver_bump: "semver_bump"' in gql_mutation
     assert 'client_version: "client_version"' in gql_mutation
     assert "is_trusted: true" in gql_mutation
-    assert "deployment_name: " not in gql_mutation
+    assert "version_name: " not in gql_mutation

--- a/truss/tests/remote/baseten/test_api.py
+++ b/truss/tests/remote/baseten/test_api.py
@@ -34,6 +34,24 @@ def mock_unsuccessful_response():
     return response
 
 
+def mock_create_model_version_response():
+    response = Response()
+    response.status_code = 200
+    response.json = mock.Mock(
+        return_value={"data": {"create_model_version_from_truss": {"id": "12345"}}}
+    )
+    return response
+
+
+def mock_create_model_response():
+    response = Response()
+    response.status_code = 200
+    response.json = mock.Mock(
+        return_value={"data": {"create_model_from_truss": {"id": "12345"}}}
+    )
+    return response
+
+
 @mock.patch("truss.remote.baseten.auth.AuthService")
 @mock.patch("requests.post", return_value=mock_successful_response())
 def test_post_graphql_query_success(mock_post, mock_auth_service):
@@ -64,3 +82,115 @@ def test_post_requests_error(mock_post, mock_auth_service):
     api = BasetenApi(api_url, mock_auth_service)
     with pytest.raises(requests.exceptions.HTTPError):
         api._post_graphql_query("sample_query_string")
+
+
+@mock.patch("truss.remote.baseten.auth.AuthService")
+@mock.patch("requests.post", return_value=mock_create_model_version_response())
+def test_create_model_version_from_truss(mock_post, mock_auth_service):
+    api_url = "https://test.com/api"
+    api = BasetenApi(api_url, mock_auth_service)
+
+    api.create_model_version_from_truss(
+        "model_id",
+        "s3key",
+        "config_str",
+        "semver_bump",
+        "client_version",
+        False,
+        False,
+        "deployment_name",
+    )
+
+    gql_mutation = mock_post.call_args[1]["data"]["query"]
+    assert 'model_id: "model_id"' in gql_mutation
+    assert 's3_key: "s3key"' in gql_mutation
+    assert 'config: "config_str"' in gql_mutation
+    assert 'semver_bump: "semver_bump"' in gql_mutation
+    assert 'client_version: "client_version"' in gql_mutation
+    assert "is_trusted: false" in gql_mutation
+    assert "promote_after_deploy: false" in gql_mutation
+    assert 'name: "deployment_name"' in gql_mutation
+
+
+@mock.patch("truss.remote.baseten.auth.AuthService")
+@mock.patch("requests.post", return_value=mock_create_model_version_response())
+def test_create_model_version_from_truss_does_not_send_deployment_name_if_not_specified(
+    mock_post, mock_auth_service
+):
+    api_url = "https://test.com/api"
+    api = BasetenApi(api_url, mock_auth_service)
+
+    api.create_model_version_from_truss(
+        "model_id",
+        "s3key",
+        "config_str",
+        "semver_bump",
+        "client_version",
+        True,
+        True,
+        deployment_name=None,
+    )
+
+    gql_mutation = mock_post.call_args[1]["data"]["query"]
+    assert 'model_id: "model_id"' in gql_mutation
+    assert 's3_key: "s3key"' in gql_mutation
+    assert 'config: "config_str"' in gql_mutation
+    assert 'semver_bump: "semver_bump"' in gql_mutation
+    assert 'client_version: "client_version"' in gql_mutation
+    assert "is_trusted: true" in gql_mutation
+    assert "promote_after_deploy: true" in gql_mutation
+    assert "name: " not in gql_mutation
+
+
+@mock.patch("truss.remote.baseten.auth.AuthService")
+@mock.patch("requests.post", return_value=mock_create_model_response())
+def test_create_model_from_truss(mock_post, mock_auth_service):
+    api_url = "https://test.com/api"
+    api = BasetenApi(api_url, mock_auth_service)
+
+    api.create_model_from_truss(
+        "model_name",
+        "s3key",
+        "config_str",
+        "semver_bump",
+        "client_version",
+        False,
+        "deployment_name",
+    )
+
+    gql_mutation = mock_post.call_args[1]["data"]["query"]
+    assert 'name: "model_name"' in gql_mutation
+    assert 's3_key: "s3key"' in gql_mutation
+    assert 'config: "config_str"' in gql_mutation
+    assert 'semver_bump: "semver_bump"' in gql_mutation
+    assert 'client_version: "client_version"' in gql_mutation
+    assert "is_trusted: false" in gql_mutation
+    assert 'deployment_name: "deployment_name"' in gql_mutation
+
+
+@mock.patch("truss.remote.baseten.auth.AuthService")
+@mock.patch("requests.post", return_value=mock_create_model_response())
+def test_create_model_from_truss_does_not_send_deployment_name_if_not_specified(
+    mock_post, mock_auth_service
+):
+    api_url = "https://test.com/api"
+    api = BasetenApi(api_url, mock_auth_service)
+
+    api.create_model_from_truss(
+        "model_name",
+        "s3key",
+        "config_str",
+        "semver_bump",
+        "client_version",
+        True,
+        deployment_name=None,
+    )
+
+    gql_mutation = mock_post.call_args[1]["data"]["query"]
+    assert 'name: "model_name"' in gql_mutation
+    assert 's3_key: "s3key"' in gql_mutation
+    assert 'config: "config_str"' in gql_mutation
+    assert 'semver_bump: "semver_bump"' in gql_mutation
+    assert 'client_version: "client_version"' in gql_mutation
+    assert "is_trusted: true" in gql_mutation
+    assert "deployment_name: " not in gql_mutation

--- a/truss/tests/remote/baseten/test_remote.py
+++ b/truss/tests/remote/baseten/test_remote.py
@@ -211,7 +211,7 @@ def test_push_raised_value_error_when_deployment_name_and_not_publish(
 
         with pytest.raises(
             ValueError,
-            match="deployment_name cannot be used for development deployment",
+            match="ERROR: deployment name cannot be used for development deployment",
         ):
             remote.push(th, "model_name", False, False, False, "dep_name")
 
@@ -238,6 +238,6 @@ def test_push_raised_value_error_when_deployment_name_is_not_valid(
 
         with pytest.raises(
             ValueError,
-            match="deployment_name must only contain alphanumeric, -, _ and . characters",
+            match="ERROR: deployment name must only contain alphanumeric, -, _ and . characters",
         ):
             remote.push(th, "model_name", True, False, False, "dep//name")

--- a/truss/tests/remote/baseten/test_remote.py
+++ b/truss/tests/remote/baseten/test_remote.py
@@ -214,3 +214,30 @@ def test_push_raised_value_error_when_deployment_name_and_not_publish(
             match="deployment_name cannot be used for development deployment",
         ):
             remote.push(th, "model_name", False, False, False, "dep_name")
+
+
+def test_push_raised_value_error_when_deployment_name_is_not_valid(
+    custom_model_truss_dir_with_pre_and_post,
+):
+    remote = BasetenRemote(_TEST_REMOTE_URL, "api_key")
+    model_response = {
+        "data": {
+            "model": {
+                "name": "model_name",
+                "id": "model_id",
+                "primary_version": {"id": "version_id"},
+            }
+        }
+    }
+    with requests_mock.Mocker() as m:
+        m.post(
+            remote._api._api_url,
+            json=model_response,
+        )
+        th = TrussHandle(custom_model_truss_dir_with_pre_and_post)
+
+        with pytest.raises(
+            ValueError,
+            match="deployment_name must only contain alphanumeric, -, _ and . characters",
+        ):
+            remote.push(th, "model_name", True, False, False, "dep//name")


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
This PR adds support for the deployment_name parameter in the `truss push` command. The command will error out when using this parameter with a development model version.

<!--
  How was the change described above implemented?
-->
## :computer: How
Add the parameter to the command and pass the value along to the baseten remote

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
I added unit test to cover the usage of this parameter and tested locally