### PR TITLE
Add ERROR in front of message and set color to 'red'

### DIFF
--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -63,7 +63,7 @@ def error_handling(f: Callable[..., object]):
         except click.UsageError as e:
             raise e  # You can re-raise the exception or handle it different
         except Exception as e:
-            click.echo(e)
+            click.secho(f"ERROR: {e}", fg="red")
 
     return wrapper
 

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -66,12 +66,12 @@ class BasetenRemote(TrussRemote):
 
         if not publish and deployment_name:
             raise ValueError(
-                "ERROR: deployment name cannot be used for development deployment"
+                "Deployment name cannot be used for development deployment"
             )
 
         if deployment_name and not re.match(r"^[0-9a-zA-Z_\-\.]*$", deployment_name):
             raise ValueError(
-                "ERROR: deployment name must only contain alphanumeric, -, _ and . characters"
+                "Deployment name must only contain alphanumeric, -, _ and . characters"
             )
 
         encoded_config_str = base64_encoded_json_str(

--- a/truss/tests/remote/baseten/test_remote.py
+++ b/truss/tests/remote/baseten/test_remote.py
@@ -211,7 +211,7 @@ def test_push_raised_value_error_when_deployment_name_and_not_publish(
 
         with pytest.raises(
             ValueError,
-            match="ERROR: deployment name cannot be used for development deployment",
+            match="Deployment name cannot be used for development deployment",
         ):
             remote.push(th, "model_name", False, False, False, "dep_name")
 
@@ -238,6 +238,6 @@ def test_push_raised_value_error_when_deployment_name_is_not_valid(
 
         with pytest.raises(
             ValueError,
-            match="ERROR: deployment name must only contain alphanumeric, -, _ and . characters",
+            match="Deployment name must only contain alphanumeric, -, _ and . characters",
         ):
             remote.push(th, "model_name", True, False, False, "dep//name")


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Change the format of errors reported by the CLI. We prepend `ERROR: ` to the message and colorize it red

Before:
![image](https://github.com/basetenlabs/truss/assets/2339610/698beda4-2352-45f4-bbbb-7c7702278fc3)


After:
![image](https://github.com/basetenlabs/truss/assets/2339610/ac3faec9-b149-4abc-bead-e5be00620e21)


<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
Adjusted unit tests and tested manually (see screenshots)
