### PR TITLE
Prevent persisting empty values

### DIFF
--- a/truss/remote/remote_cli.py
+++ b/truss/remote/remote_cli.py
@@ -2,8 +2,18 @@ from typing import List
 
 import rich
 from InquirerPy import inquirer
+from InquirerPy.validator import ValidationError, Validator
 from truss.remote.remote_factory import USER_TRUSSRC_PATH, RemoteFactory
 from truss.remote.truss_remote import RemoteConfig
+
+
+class NonEmptyValidator(Validator):
+    def validate(self, document):
+        if not document.text.strip():
+            raise ValidationError(
+                message="Please enter a non-empty value",
+                cursor_position=len(document.text),
+            )
 
 
 def inquire_remote_config() -> RemoteConfig:
@@ -15,6 +25,7 @@ def inquire_remote_config() -> RemoteConfig:
     api_key = inquirer.secret(
         message="🤫 Quietly paste your API_KEY:",
         qmark="",
+        validate=NonEmptyValidator(),
     ).execute()
 
     return RemoteConfig(


### PR DESCRIPTION

## :rocket: What

Right now with truss, if  you submit an empty value for your API key, it saves it. This prevents you from pushing subsequently and shows a fairly unclear error.

In this PR, we prevent saving empty values, so that users don't run into this case.

Resolves issue in this PR: https://github.com/basetenlabs/truss/issues/790. There's still some work we can do to make the login experience better.

## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing

Tested locally, this is the error you get if you try to submit an empty value (ie: many spaces)

<img width="877" alt="remote_cli_py_—_truss__Codespaces__improved_capybara_" src="https://github.com/basetenlabs/truss/assets/850115/2a0129d2-6fae-4b83-a3dc-794e574b09b9">

