### PR TITLE
Add the keep-previous-prod-settings option to truss push

### DIFF
--- a/docs/reference/cli/push.mdx
+++ b/docs/reference/cli/push.mdx
@@ -18,8 +18,8 @@ Push the truss as a published deployment. If no production deployment exists, pr
 <ParamField body="--promote" type="BOOL">
 Push the truss as a published deployment. Even if a production deployment exists, promote the truss to production after deploy completes.
 </ParamField>
-<ParamField body="--keep-previous-production-settings" type="BOOL">
-Keep the previous production deployment's autoscaling setting. When not specified, the previous production deployment will be updated to allow scaling to zero. Can only be use in combination with --promote option
+<ParamField body="--preserve-previous-production-settings" type="BOOL">
+Preserve the previous production deployment's autoscaling setting. When not specified, the previous production deployment will be updated to allow it to scale to zero. Can only be use in combination with --promote option.
 </ParamField>
 <ParamField body="--trusted" type="BOOL">
 Give Truss access to secrets on remote host.

--- a/docs/reference/cli/push.mdx
+++ b/docs/reference/cli/push.mdx
@@ -18,7 +18,7 @@ Push the truss as a published deployment. If no production deployment exists, pr
 <ParamField body="--promote" type="BOOL">
 Push the truss as a published deployment. Even if a production deployment exists, promote the truss to production after deploy completes.
 </ParamField>
-<ParamField body="--preserve-previous-production-settings" type="BOOL">
+<ParamField body="--preserve-previous-production-deployment" type="BOOL">
 Preserve the previous production deployment's autoscaling setting. When not specified, the previous production deployment will be updated to allow it to scale to zero. Can only be use in combination with --promote option.
 </ParamField>
 <ParamField body="--trusted" type="BOOL">

--- a/docs/reference/cli/push.mdx
+++ b/docs/reference/cli/push.mdx
@@ -18,6 +18,9 @@ Push the truss as a published deployment. If no production deployment exists, pr
 <ParamField body="--promote" type="BOOL">
 Push the truss as a published deployment. Even if a production deployment exists, promote the truss to production after deploy completes.
 </ParamField>
+<ParamField body="--keep-previous-production-settings" type="BOOL">
+Keep the previous production deployment's autoscaling setting. When not specified, the previous production deployment will be updated to allow scaling to zero. Can only be use in combination with --promote option
+</ParamField>
 <ParamField body="--trusted" type="BOOL">
 Give Truss access to secrets on remote host.
 </ParamField>

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -451,7 +451,7 @@ def push(
     publish: bool = False,
     trusted: bool = False,
     promote: bool = False,
-    preserve_previous_prod_settings: bool = False,
+    preserve_previous_prod_deployment: bool = False,
     deployment_name: Optional[str] = None,
 ) -> None:
     """
@@ -483,7 +483,7 @@ def push(
         publish=publish,
         trusted=trusted,
         promote=promote,
-        preserve_previous_prod_settings=preserve_previous_prod_settings,
+        preserve_previous_prod_deployment=preserve_previous_prod_deployment,
         deployment_name=deployment_name,
     )  # type: ignore
 

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -415,14 +415,14 @@ def predict(
     ),
 )
 @click.option(
-    "--keep-previous-production-settings",
+    "--preserve-previous-production-deployment",
     type=bool,
     is_flag=True,
     required=False,
     default=False,
     help=(
-        "Keep the previous production deployment's autoscaling setting. When not specified, "
-        "the previous production deployment will be updated to allow scaling to zero. "
+        "Preserve the previous production deployment's autoscaling setting. When not specified, "
+        "the previous production deployment will be updated to allow it to scale to zero. "
         "Can only be use in combination with --promote option"
     ),
 )
@@ -451,7 +451,7 @@ def push(
     publish: bool = False,
     trusted: bool = False,
     promote: bool = False,
-    keep_previous_prod_settings: bool = False,
+    preserve_previous_prod_settings: bool = False,
     deployment_name: Optional[str] = None,
 ) -> None:
     """
@@ -483,7 +483,7 @@ def push(
         publish=publish,
         trusted=trusted,
         promote=promote,
-        keep_previous_prod_settings=keep_previous_prod_settings,
+        preserve_previous_prod_settings=preserve_previous_prod_settings,
         deployment_name=deployment_name,
     )  # type: ignore
 

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -415,6 +415,18 @@ def predict(
     ),
 )
 @click.option(
+    "--keep-previous-production-settings",
+    type=bool,
+    is_flag=True,
+    required=False,
+    default=False,
+    help=(
+        "Keep the previous production deployment's autoscaling setting. When not specified, "
+        "the previous production deployment will be updated to allow scaling to zero. "
+        "Can only be use in combination with --promote option"
+    ),
+)
+@click.option(
     "--trusted",
     type=bool,
     is_flag=True,
@@ -439,6 +451,7 @@ def push(
     publish: bool = False,
     trusted: bool = False,
     promote: bool = False,
+    keep_previous_prod_settings: bool = False,
     deployment_name: Optional[str] = None,
 ) -> None:
     """
@@ -470,6 +483,7 @@ def push(
         publish=publish,
         trusted=trusted,
         promote=promote,
+        keep_previous_prod_settings=keep_previous_prod_settings,
         deployment_name=deployment_name,
     )  # type: ignore
 

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -104,7 +104,7 @@ class BasetenApi:
         client_version: str,
         is_trusted: bool,
         promote: bool = False,
-        keep_previous_prod_settings: bool = False,
+        preserve_previous_prod_settings: bool = False,
         deployment_name: Optional[str] = None,
     ):
         query_string = f"""
@@ -117,7 +117,7 @@ class BasetenApi:
                 client_version: "{client_version}",
                 is_trusted: {'true' if is_trusted else 'false'},
                 promote_after_deploy: {'true' if promote else 'false'},
-                scale_down_old_production: {'false' if keep_previous_prod_settings else 'true'},
+                scale_down_old_production: {'false' if preserve_previous_prod_settings else 'true'},
                 {f'name: "{deployment_name}"' if deployment_name else ""}
             ) {{
                 id

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -104,7 +104,7 @@ class BasetenApi:
         client_version: str,
         is_trusted: bool,
         promote: bool = False,
-        preserve_previous_prod_settings: bool = False,
+        preserve_previous_prod_deployment: bool = False,
         deployment_name: Optional[str] = None,
     ):
         query_string = f"""
@@ -117,7 +117,7 @@ class BasetenApi:
                 client_version: "{client_version}",
                 is_trusted: {'true' if is_trusted else 'false'},
                 promote_after_deploy: {'true' if promote else 'false'},
-                scale_down_old_production: {'false' if preserve_previous_prod_settings else 'true'},
+                scale_down_old_production: {'false' if preserve_previous_prod_deployment else 'true'},
                 {f'name: "{deployment_name}"' if deployment_name else ""}
             ) {{
                 id

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -104,6 +104,7 @@ class BasetenApi:
         client_version: str,
         is_trusted: bool,
         promote: bool = False,
+        keep_previous_prod_settings: bool = False,
         deployment_name: Optional[str] = None,
     ):
         query_string = f"""
@@ -116,6 +117,7 @@ class BasetenApi:
                 client_version: "{client_version}",
                 is_trusted: {'true' if is_trusted else 'false'},
                 promote_after_deploy: {'true' if promote else 'false'},
+                scale_down_old_production: {'false' if keep_previous_prod_settings else 'true'},
                 {f'name: "{deployment_name}"' if deployment_name else ""}
             ) {{
                 id

--- a/truss/remote/baseten/core.py
+++ b/truss/remote/baseten/core.py
@@ -160,7 +160,7 @@ def create_truss_service(
     semver_bump: str = "MINOR",
     is_trusted: bool = False,
     promote: bool = False,
-    keep_previous_prod_settings: bool = False,
+    preserve_previous_prod_settings: bool = False,
     is_draft: Optional[bool] = False,
     model_id: Optional[str] = None,
     deployment_name: Optional[str] = None,
@@ -176,7 +176,7 @@ def create_truss_service(
         semver_bump: Semver bump type, defaults to "MINOR"
         is_trusted: Whether the model is trusted, defaults to False
         promote: Whether to promote the model after deploy, defaults to False
-        keep_previous_prod_settings: Wheter to scale old production deployment to zero
+        preserve_previous_prod_settings: Wheter to scale old production deployment to zero
         deployment_name: Name to apply to the created deployment. Not applied to development model
 
     Returns:
@@ -214,7 +214,7 @@ def create_truss_service(
         client_version=f"truss=={truss.version()}",
         is_trusted=is_trusted,
         promote=promote,
-        keep_previous_prod_settings=keep_previous_prod_settings,
+        preserve_previous_prod_settings=preserve_previous_prod_settings,
         deployment_name=deployment_name,
     )
     model_version_id = model_version_json["id"]

--- a/truss/remote/baseten/core.py
+++ b/truss/remote/baseten/core.py
@@ -160,6 +160,7 @@ def create_truss_service(
     semver_bump: str = "MINOR",
     is_trusted: bool = False,
     promote: bool = False,
+    keep_previous_prod_settings: bool = False,
     is_draft: Optional[bool] = False,
     model_id: Optional[str] = None,
     deployment_name: Optional[str] = None,
@@ -175,6 +176,7 @@ def create_truss_service(
         semver_bump: Semver bump type, defaults to "MINOR"
         is_trusted: Whether the model is trusted, defaults to False
         promote: Whether to promote the model after deploy, defaults to False
+        keep_previous_prod_settings: Wheter to scale old production deployment to zero
         deployment_name: Name to apply to the created deployment. Not applied to development model
 
     Returns:
@@ -212,6 +214,7 @@ def create_truss_service(
         client_version=f"truss=={truss.version()}",
         is_trusted=is_trusted,
         promote=promote,
+        keep_previous_prod_settings=keep_previous_prod_settings,
         deployment_name=deployment_name,
     )
     model_version_id = model_version_json["id"]

--- a/truss/remote/baseten/core.py
+++ b/truss/remote/baseten/core.py
@@ -160,7 +160,7 @@ def create_truss_service(
     semver_bump: str = "MINOR",
     is_trusted: bool = False,
     promote: bool = False,
-    preserve_previous_prod_settings: bool = False,
+    preserve_previous_prod_deployment: bool = False,
     is_draft: Optional[bool] = False,
     model_id: Optional[str] = None,
     deployment_name: Optional[str] = None,
@@ -176,7 +176,7 @@ def create_truss_service(
         semver_bump: Semver bump type, defaults to "MINOR"
         is_trusted: Whether the model is trusted, defaults to False
         promote: Whether to promote the model after deploy, defaults to False
-        preserve_previous_prod_settings: Wheter to scale old production deployment to zero
+        preserve_previous_prod_deployment: Wheter to scale old production deployment to zero
         deployment_name: Name to apply to the created deployment. Not applied to development model
 
     Returns:
@@ -214,7 +214,7 @@ def create_truss_service(
         client_version=f"truss=={truss.version()}",
         is_trusted=is_trusted,
         promote=promote,
-        preserve_previous_prod_settings=preserve_previous_prod_settings,
+        preserve_previous_prod_deployment=preserve_previous_prod_deployment,
         deployment_name=deployment_name,
     )
     model_version_id = model_version_json["id"]

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -48,7 +48,7 @@ class BasetenRemote(TrussRemote):
         publish: bool = True,
         trusted: bool = False,
         promote: bool = False,
-        keep_previous_prod_settings: bool = False,
+        preserve_previous_prod_settings: bool = False,
         deployment_name: Optional[str] = None,
     ):
         if model_name.isspace():
@@ -70,9 +70,9 @@ class BasetenRemote(TrussRemote):
                 "Deployment name cannot be used for development deployment"
             )
 
-        if not promote and keep_previous_prod_settings:
+        if not promote and preserve_previous_prod_settings:
             raise ValueError(
-                "keep-previous-production-settings can only be used with the '--promote' option"
+                "preserve-previous-production-settings can only be used with the '--promote' option"
             )
 
         if deployment_name and not re.match(r"^[0-9a-zA-Z_\-\.]*$", deployment_name):
@@ -96,7 +96,7 @@ class BasetenRemote(TrussRemote):
             model_id=model_id,
             is_trusted=trusted,
             promote=promote,
-            keep_previous_prod_settings=keep_previous_prod_settings,
+            preserve_previous_prod_settings=preserve_previous_prod_settings,
             deployment_name=deployment_name,
         )
 

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -48,6 +48,7 @@ class BasetenRemote(TrussRemote):
         publish: bool = True,
         trusted: bool = False,
         promote: bool = False,
+        keep_previous_prod_settings: bool = False,
         deployment_name: Optional[str] = None,
     ):
         if model_name.isspace():
@@ -67,6 +68,11 @@ class BasetenRemote(TrussRemote):
         if not publish and deployment_name:
             raise ValueError(
                 "Deployment name cannot be used for development deployment"
+            )
+
+        if not promote and keep_previous_prod_settings:
+            raise ValueError(
+                "keep-previous-production-settings can only be used with the '--promote' option"
             )
 
         if deployment_name and not re.match(r"^[0-9a-zA-Z_\-\.]*$", deployment_name):
@@ -90,6 +96,7 @@ class BasetenRemote(TrussRemote):
             model_id=model_id,
             is_trusted=trusted,
             promote=promote,
+            keep_previous_prod_settings=keep_previous_prod_settings,
             deployment_name=deployment_name,
         )
 

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -48,7 +48,7 @@ class BasetenRemote(TrussRemote):
         publish: bool = True,
         trusted: bool = False,
         promote: bool = False,
-        preserve_previous_prod_settings: bool = False,
+        preserve_previous_prod_deployment: bool = False,
         deployment_name: Optional[str] = None,
     ):
         if model_name.isspace():
@@ -70,9 +70,9 @@ class BasetenRemote(TrussRemote):
                 "Deployment name cannot be used for development deployment"
             )
 
-        if not promote and preserve_previous_prod_settings:
+        if not promote and preserve_previous_prod_deployment:
             raise ValueError(
-                "preserve-previous-production-settings can only be used with the '--promote' option"
+                "preserve-previous-production-deployment can only be used with the '--promote' option"
             )
 
         if deployment_name and not re.match(r"^[0-9a-zA-Z_\-\.]*$", deployment_name):
@@ -96,7 +96,7 @@ class BasetenRemote(TrussRemote):
             model_id=model_id,
             is_trusted=trusted,
             promote=promote,
-            preserve_previous_prod_settings=preserve_previous_prod_settings,
+            preserve_previous_prod_deployment=preserve_previous_prod_deployment,
             deployment_name=deployment_name,
         )
 

--- a/truss/tests/contexts/image_builder/test_serving_image_builder.py
+++ b/truss/tests/contexts/image_builder/test_serving_image_builder.py
@@ -122,17 +122,14 @@ def test_correct_hf_files_accessed_for_caching():
         files_to_cache = flatten_cached_files(files_to_cache)
         assert str(hf_path / "version.txt") in files_to_cache
 
-        # It's unlikely the repo will change
-        assert (
-            str(
-                hf_path
-                / "models--openai--whisper-small/blobs/59ef8a839f271fa2183c6a4c302669d097e43b6d"
-            )
-            in files_to_cache
-        )
+        blobs = [
+            blob
+            for blob in files_to_cache
+            if blob.startswith(f"{hf_path}/models--openai--whisper-small/blobs/")
+        ]
+        assert len(blobs) >= 1
 
         files = model_files[model]["files"]
-
         assert "model.safetensors" in files
         assert "tokenizer_config.json" in files
 

--- a/truss/tests/remote/baseten/test_remote.py
+++ b/truss/tests/remote/baseten/test_remote.py
@@ -265,6 +265,6 @@ def test_push_raised_value_error_when_keep_previous_prod_settings_and_not_promot
 
         with pytest.raises(
             ValueError,
-            match="preserve-previous-production-settings can only be used with the '--promote' option",
+            match="preserve-previous-production-deployment can only be used with the '--promote' option",
         ):
             remote.push(th, "model_name", False, False, False, True)

--- a/truss/tests/remote/baseten/test_remote.py
+++ b/truss/tests/remote/baseten/test_remote.py
@@ -213,7 +213,7 @@ def test_push_raised_value_error_when_deployment_name_and_not_publish(
             ValueError,
             match="Deployment name cannot be used for development deployment",
         ):
-            remote.push(th, "model_name", False, False, False, "dep_name")
+            remote.push(th, "model_name", False, False, False, False, "dep_name")
 
 
 def test_push_raised_value_error_when_deployment_name_is_not_valid(
@@ -240,4 +240,31 @@ def test_push_raised_value_error_when_deployment_name_is_not_valid(
             ValueError,
             match="Deployment name must only contain alphanumeric, -, _ and . characters",
         ):
-            remote.push(th, "model_name", True, False, False, "dep//name")
+            remote.push(th, "model_name", True, False, False, False, "dep//name")
+
+
+def test_push_raised_value_error_when_keep_previous_prod_settings_and_not_promote(
+    custom_model_truss_dir_with_pre_and_post,
+):
+    remote = BasetenRemote(_TEST_REMOTE_URL, "api_key")
+    model_response = {
+        "data": {
+            "model": {
+                "name": "model_name",
+                "id": "model_id",
+                "primary_version": {"id": "version_id"},
+            }
+        }
+    }
+    with requests_mock.Mocker() as m:
+        m.post(
+            remote._api._api_url,
+            json=model_response,
+        )
+        th = TrussHandle(custom_model_truss_dir_with_pre_and_post)
+
+        with pytest.raises(
+            ValueError,
+            match="keep-previous-production-settings can only be used with the '--promote' option",
+        ):
+            remote.push(th, "model_name", False, False, False, True)

--- a/truss/tests/remote/baseten/test_remote.py
+++ b/truss/tests/remote/baseten/test_remote.py
@@ -265,6 +265,6 @@ def test_push_raised_value_error_when_keep_previous_prod_settings_and_not_promot
 
         with pytest.raises(
             ValueError,
-            match="keep-previous-production-settings can only be used with the '--promote' option",
+            match="preserve-previous-production-settings can only be used with the '--promote' option",
         ):
             remote.push(th, "model_name", False, False, False, True)


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Adds support to not scale down the previous production deployment. This can be done by specifying the `--keep-previous-production-settings` flag when using the `--promote` flag. This will result in the previous production keeping its production settings (so most likely not scaled down to zero when no longer receiving traffic) 

@philipkiely I tagged you in the review to validate the docs change.

<!--
  How was the change described above implemented?
-->
## :computer: How
Add the cli option and pass it along to the baseten remote and api.

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
Add unit tests and tested locally
