### PR TITLE
better inference server process termination

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.7.24rc0"
+version = "0.7.24rc1"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.7.23"
+version = "0.7.24rc0"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.7.24rc1"
+version = "0.7.24rc2"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/templates/control/control/helpers/inference_server_process_controller.py
+++ b/truss/templates/control/control/helpers/inference_server_process_controller.py
@@ -4,7 +4,6 @@ import time
 from pathlib import Path
 from typing import List, Optional
 
-import shared.util as utils
 from helpers.context_managers import current_directory
 
 INFERENCE_SERVER_FAILED_FILE = Path("~/inference_server_crashed.txt").expanduser()
@@ -50,9 +49,9 @@ class InferenceServerProcessController:
 
     def stop(self):
         if self._inference_server_process is not None:
-            utils.kill_child_processes(self._inference_server_process.pid)
-            self._inference_server_process.kill()
 
+            self._inference_server_process.terminate()
+            self._inference_server_process.wait()
             # Introduce delay to avoid failing to grab the port
             time.sleep(3)
 

--- a/truss/templates/control/control/helpers/inference_server_process_controller.py
+++ b/truss/templates/control/control/helpers/inference_server_process_controller.py
@@ -1,11 +1,10 @@
 import logging
-import os
-import signal
 import subprocess
 import time
 from pathlib import Path
 from typing import List, Optional
 
+import shared.util as utils
 from helpers.context_managers import current_directory
 
 INFERENCE_SERVER_FAILED_FILE = Path("~/inference_server_crashed.txt").expanduser()
@@ -51,11 +50,8 @@ class InferenceServerProcessController:
 
     def stop(self):
         if self._inference_server_process is not None:
-            name = " ".join(self._inference_server_process_args)
-
-            for line in os.popen("ps ax | grep '" + name + "' | grep -v grep"):
-                pid = line.split()[0]
-                os.kill(int(pid), signal.SIGKILL)
+            utils.kill_child_processes(self._inference_server_process.pid)
+            self._inference_server_process.kill()
 
             # Introduce delay to avoid failing to grab the port
             time.sleep(3)

--- a/truss/templates/server/common/truss_server.py
+++ b/truss/templates/server/common/truss_server.py
@@ -342,8 +342,7 @@ class TrussServer:
                 for _ in range(termination_check_attempts):
                     time.sleep(WORKER_TERMINATION_CHECK_INTERVAL_SECS)
                     if utils.all_processes_dead(servers):
-                        # Exit main process
-                        sys.exit()
+                        return
 
             for sig in [signal.SIGINT, signal.SIGTERM, signal.SIGQUIT]:
                 signal.signal(sig, lambda sig, frame: stop_servers())

--- a/truss/templates/server/common/truss_server.py
+++ b/truss/templates/server/common/truss_server.py
@@ -175,6 +175,14 @@ class BasetenEndpoints:
 
 
 class TrussServer:
+    """This wrapper class manages creation and cleanup of uvicorn server processes running the FastAPI inference server app
+
+    TrussServer runs as a main process managing UvicornCustomServer subprocesses that in turn may manage
+    their own worker processes. Notably, this main process is kept alive when running `servers_task()`
+    because of the child uvicorn server processes' main loop.
+
+    """
+
     def __init__(
         self,
         http_port: int,

--- a/truss/templates/server/common/truss_server.py
+++ b/truss/templates/server/common/truss_server.py
@@ -65,6 +65,7 @@ class UvicornCustomServer(multiprocessing.Process):
         self.config = config
 
     def stop(self):
+        utils.kill_child_processes(self.pid)
         self.terminate()
 
     def run(self):
@@ -330,7 +331,6 @@ class TrussServer:
             def stop_servers():
                 # Send stop signal, then wait for all to exit
                 for server in servers:
-                    utils.kill_child_processes(server.pid)
                     # Sends term signal to the process, which should be handled
                     # by the termination handler.
                     server.stop()

--- a/truss/templates/server/common/truss_server.py
+++ b/truss/templates/server/common/truss_server.py
@@ -65,7 +65,6 @@ class UvicornCustomServer(multiprocessing.Process):
         self.config = config
 
     def stop(self):
-        utils.kill_child_processes(self.pid)
         self.terminate()
 
     def run(self):
@@ -250,6 +249,7 @@ class TrussServer:
         def exit_self():
             # Note that this kills the current process, the worker process, not
             # the main truss_server process.
+            utils.kill_child_processes(self.pid)
             sys.exit()
 
         termination_handler_middleware = TerminationHandlerMiddleware(

--- a/truss/templates/server/common/truss_server.py
+++ b/truss/templates/server/common/truss_server.py
@@ -249,7 +249,7 @@ class TrussServer:
         def exit_self():
             # Note that this kills the current process, the worker process, not
             # the main truss_server process.
-            utils.kill_child_processes(self.pid)
+            utils.kill_child_processes(os.getpid())
             sys.exit()
 
         termination_handler_middleware = TerminationHandlerMiddleware(

--- a/truss/templates/server/common/truss_server.py
+++ b/truss/templates/server/common/truss_server.py
@@ -330,6 +330,7 @@ class TrussServer:
             def stop_servers():
                 # Send stop signal, then wait for all to exit
                 for server in servers:
+                    utils.kill_child_processes(server.pid)
                     # Sends term signal to the process, which should be handled
                     # by the termination handler.
                     server.stop()

--- a/truss/templates/shared/util.py
+++ b/truss/templates/shared/util.py
@@ -6,7 +6,7 @@ from typing import Callable, Dict, List, TypeVar
 import psutil
 
 # number of seconds to wait for truss server child processes before sending kill signal
-CHILD_PROCESS_WAIT_TIMEOUT = 3
+CHILD_PROCESS_WAIT_TIMEOUT_SECONDS = 120
 
 
 def model_supports_predict_proba(model: object) -> bool:
@@ -71,7 +71,9 @@ def kill_child_processes(parent_pid: int):
     children = parent.children(recursive=True)
     for process in children:
         process.terminate()
-    gone, alive = psutil.wait_procs(children, timeout=CHILD_PROCESS_WAIT_TIMEOUT)
+    gone, alive = psutil.wait_procs(
+        children, timeout=CHILD_PROCESS_WAIT_TIMEOUT_SECONDS
+    )
     for process in alive:
         process.kill()
 

--- a/truss/templates/shared/util.py
+++ b/truss/templates/shared/util.py
@@ -5,6 +5,9 @@ from typing import Callable, Dict, List, TypeVar
 
 import psutil
 
+# number of seconds to wait for truss server child processes before sending kill signal
+CHILD_PROCESS_WAIT_TIMEOUT = 3
+
 
 def model_supports_predict_proba(model: object) -> bool:
     if not hasattr(model, "predict_proba"):
@@ -68,7 +71,7 @@ def kill_child_processes(parent_pid: int):
     children = parent.children(recursive=True)
     for process in children:
         process.terminate()
-    gone, alive = psutil.wait_procs(children, timeout=3)
+    gone, alive = psutil.wait_procs(children, timeout=CHILD_PROCESS_WAIT_TIMEOUT)
     for process in alive:
         process.kill()
 

--- a/truss/templates/shared/util.py
+++ b/truss/templates/shared/util.py
@@ -67,8 +67,10 @@ def kill_child_processes(parent_pid: int):
         return
     children = parent.children(recursive=True)
     for process in children:
+        process.terminate()
+    gone, alive = psutil.wait_procs(children, timeout=3)
+    for process in alive:
         process.kill()
-        process.wait()
 
 
 X = TypeVar("X")

--- a/truss/templates/shared/util.py
+++ b/truss/templates/shared/util.py
@@ -60,6 +60,17 @@ def all_processes_dead(procs: List[multiprocessing.Process]) -> bool:
     return True
 
 
+def kill_child_processes(parent_pid: int):
+    try:
+        parent = psutil.Process(parent_pid)
+    except psutil.NoSuchProcess:
+        return
+    children = parent.children(recursive=True)
+    for process in children:
+        process.kill()
+        process.wait()
+
+
 X = TypeVar("X")
 Y = TypeVar("Y")
 Z = TypeVar("Z")

--- a/truss/tests/contexts/image_builder/test_serving_image_builder.py
+++ b/truss/tests/contexts/image_builder/test_serving_image_builder.py
@@ -122,17 +122,14 @@ def test_correct_hf_files_accessed_for_caching():
         files_to_cache = flatten_cached_files(files_to_cache)
         assert str(hf_path / "version.txt") in files_to_cache
 
-        # It's unlikely the repo will change
-        assert (
-            str(
-                hf_path
-                / "models--openai--whisper-small/blobs/59ef8a839f271fa2183c6a4c302669d097e43b6d"
-            )
-            in files_to_cache
-        )
+        blobs = [
+            blob
+            for blob in files_to_cache
+            if blob.startswith(f"{hf_path}/models--openai--whisper-small/blobs/")
+        ]
+        assert len(blobs) >= 1
 
         files = model_files[model]["files"]
-
         assert "model.safetensors" in files
         assert "tokenizer_config.json" in files
 


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
This change is motivated by an effort make the usage of multiple uvicorn workers and their child processes to start the Triton Inference Server for some performant model offerings more production ready. Namely, we wanted to make sure that users can still use these trusses for development deployments by allowing for reloadable subprocesses as they iterate. 

This PR also cleans up some of the code we were using to handle termination of the inference server in general.
Notably, changing SIGKILL to SIGTERM when stopping the inference server process and the subsequent removal of `sys.exit()` in the truss server termination handler, which throws an uncaught `SystemExit` exception. We hadn't seen this exception before because we hadn't been handling the SIGKILL from the inference server process controller.
<!--
  How was the change described above implemented?
-->
## :computer: How
https://www.loom.com/share/9f8705c7079a4b8dbf5b555c4dc077ba?sid=f851b057-5005-493f-b1d9-2e5fc452bc4a
<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
- Tested server process and child process termination on dev and passed integration [tests](https://github.com/basetenlabs/truss/actions/runs/7659670024) that have coverage for the startup/shutdown flows
