### PR TITLE
single worker, multiple uvicorn server process multiprocessing

### DIFF
--- a/truss/templates/server/common/truss_server.py
+++ b/truss/templates/server/common/truss_server.py
@@ -328,10 +328,8 @@ class TrussServer:
             serversocket.bind((cfg.host, cfg.port))
             serversocket.listen(5)
 
-            num_server_procs = (
-                self._config.get("runtime", {}).get(
-                    "num_workers", DEFAULT_NUM_SERVER_PROCESSES
-                ),
+            num_server_procs = self._config.get("runtime", {}).get(
+                "num_workers", DEFAULT_NUM_SERVER_PROCESSES
             )
             logging.info(f"starting {num_server_procs} uvicorn server processes")
             servers: List[UvicornCustomServer] = []

--- a/truss/templates/server/common/truss_server.py
+++ b/truss/templates/server/common/truss_server.py
@@ -267,9 +267,7 @@ class TrussServer:
             http="h11",
             host="0.0.0.0",
             port=self.http_port,
-            workers=self._config.get("runtime", {}).get(
-                "num_workers", DEFAULT_NUM_WORKERS
-            ),
+            workers=DEFAULT_NUM_WORKERS,
             log_config={
                 "version": 1,
                 "formatters": {
@@ -320,7 +318,10 @@ class TrussServer:
             serversocket.bind((cfg.host, cfg.port))
             serversocket.listen(5)
 
-            logging.info(f"starting uvicorn with {cfg.workers} workers")
+            num_workers = (
+                self._config.get("runtime", {}).get("num_workers", DEFAULT_NUM_WORKERS),
+            )
+            logging.info(f"starting {num_workers} uvicorn server processes")
             servers: List[UvicornCustomServer] = []
             for _ in range(cfg.workers):
                 server = UvicornCustomServer(config=cfg, sockets=[serversocket])

--- a/truss/templates/server/common/truss_server.py
+++ b/truss/templates/server/common/truss_server.py
@@ -34,6 +34,7 @@ from starlette.responses import Response
 # 1. Self-termination on model load fail.
 # 2. Graceful termination.
 DEFAULT_NUM_WORKERS = 1
+DEFAULT_NUM_SERVER_PROCESSES = 1
 WORKER_TERMINATION_TIMEOUT_SECS = 120.0
 WORKER_TERMINATION_CHECK_INTERVAL_SECS = 0.5
 
@@ -318,12 +319,14 @@ class TrussServer:
             serversocket.bind((cfg.host, cfg.port))
             serversocket.listen(5)
 
-            num_workers = (
-                self._config.get("runtime", {}).get("num_workers", DEFAULT_NUM_WORKERS),
+            num_server_procs = (
+                self._config.get("runtime", {}).get(
+                    "num_workers", DEFAULT_NUM_SERVER_PROCESSES
+                ),
             )
-            logging.info(f"starting {num_workers} uvicorn server processes")
+            logging.info(f"starting {num_server_procs} uvicorn server processes")
             servers: List[UvicornCustomServer] = []
-            for _ in range(num_workers):
+            for _ in range(num_server_procs):
                 server = UvicornCustomServer(config=cfg, sockets=[serversocket])
                 server.start()
                 servers.append(server)

--- a/truss/templates/server/common/truss_server.py
+++ b/truss/templates/server/common/truss_server.py
@@ -323,7 +323,7 @@ class TrussServer:
             )
             logging.info(f"starting {num_workers} uvicorn server processes")
             servers: List[UvicornCustomServer] = []
-            for _ in range(cfg.workers):
+            for _ in range(num_workers):
                 server = UvicornCustomServer(config=cfg, sockets=[serversocket])
                 server.start()
                 servers.append(server)


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What

We discovered that the current plumbing of multiple workers spawns both multiple uvicorn server processes **and** multiple workers associated with each uvicorn server. This change makes explicit how truss server leverages multiprocessing. 

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
