### PR TITLE
Improve truss watch: sleep on main thread

### DIFF
--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -1,6 +1,7 @@
 import logging
 import re
 from pathlib import Path
+import time
 from typing import List, Optional, Tuple
 
 import click
@@ -213,7 +214,7 @@ class BasetenRemote(TrussRemote):
         # thread to keep it alive. When this loop is interrupted by the user, then the whole process
         # can shutdown gracefully.
         while True:
-            pass
+            time.sleep(100)
 
     def patch(
         self,

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -205,6 +205,8 @@ class BasetenRemote(TrussRemote):
             raise click.UsageError(
                 "No development model found. Run `truss push` then try again."
             )
+
+        # TODO(helen): refactor this such that truss watch runs on the main thread.
         TrussFilesSyncer(
             Path(target_directory),
             self,


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
This updates the infinite loop on the main thread to `sleep` instead of `pass`, which should prevent the main thread from consuming CPU resources and interfering with the performance of the background thread that runs `truss watch`.

It'll be better to move this onto the main thread entirely--I'll work on refactoring and open a separate PR. In the meantime, this PR should make `truss watch` far more responsive (see loom linked below).

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
This loom shows the difference in performance with / without this PR: https://www.loom.com/share/343bd7f9f2d7439db1d8ee2716599521?sid=ee595d04-c983-4e47-909f-8074a9aa62f4
