### PR TITLE
Fix `preserve_previous_production_deployment` flag

### DIFF
--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -451,7 +451,7 @@ def push(
     publish: bool = False,
     trusted: bool = False,
     promote: bool = False,
-    preserve_previous_prod_deployment: bool = False,
+    preserve_previous_production_deployment: bool = False,
     deployment_name: Optional[str] = None,
 ) -> None:
     """
@@ -483,7 +483,7 @@ def push(
         publish=publish,
         trusted=trusted,
         promote=promote,
-        preserve_previous_prod_deployment=preserve_previous_prod_deployment,
+        preserve_previous_prod_deployment=preserve_previous_production_deployment,
         deployment_name=deployment_name,
     )  # type: ignore
 


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
I noticed that `poetry run truss push` fails on `main` with:
```
helen@Helens-MacBook-Pro my-truss % poetry run truss push
ERROR: push() got an unexpected keyword argument 'preserve_previous_production_deployment'
```

This PR updates the arg to `push` to be consistent with the click CLI arg.

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
* Successfully pushed via `poetry run truss push`:
```
? 🎮 Which remote do you want to connect to? prod
Compressing... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Uploading... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
✨ Model local-model-2 was successfully pushed ✨

|---------------------------------------------------------------------------------------|
| Your model has been deployed as a development model. Development models allow you to  |
| iterate quickly during the deployment process.                                        |
|                                                                                       |
| When you are ready to publish your deployed model as a new deployment,                |
| pass `--publish` to the `truss push` command. To monitor changes to your model and    |
| rapidly iterate, run the `truss watch` command.                                       |
|                                                                                       |
|---------------------------------------------------------------------------------------|

🪵  View logs for your deployment at https://app.baseten.co/models/rwnpyvd3/logs/qjj724q
```