### PR TITLE
Add H100 support

### DIFF
--- a/truss/tests/test_config.py
+++ b/truss/tests/test_config.py
@@ -87,6 +87,7 @@ def test_parse_resources(input_dict, expect_resources, output_dict):
         ("T4", AcceleratorSpec(Accelerator.T4, 1)),
         ("A10G:4", AcceleratorSpec(Accelerator.A10G, 4)),
         ("A100:8", AcceleratorSpec(Accelerator.A100, 8)),
+        ("H100", AcceleratorSpec(Accelerator.H100, 1)),
     ],
 )
 def test_acc_spec_from_str(input_str, expected_acc):

--- a/truss/truss_config.py
+++ b/truss/truss_config.py
@@ -52,6 +52,7 @@ class Accelerator(Enum):
     A10G = "A10G"
     V100 = "V100"
     A100 = "A100"
+    H100 = "H100"
 
 
 @dataclass


### PR DESCRIPTION

## :rocket: What

Allow support for H100s in truss. 

## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing

Ensured that TrussConfig parses correctly & can push (with truss push -- doesn't fully deploy because requires backend support)