### PR TITLE
Fix control server failing to install

### DIFF
--- a/truss/templates/control/requirements.txt
+++ b/truss/templates/control/requirements.txt
@@ -1,5 +1,5 @@
 dataclasses-json==0.5.7
-truss==0.7.19rc2
+truss==0.9.1rc1
 fastapi==0.109.1
 uvicorn==0.24.0
 uvloop==0.19.0


### PR DESCRIPTION
## :rocket: What

Follow-up from https://github.com/basetenlabs/truss/pull/820. In that PR, we bump the fastapi version of the control server without changing the truss version the control server depends on. This is problematic, because older versions of Truss depend on 0.104 still, so the control server fails to deploy. We caught this in the integration tests.


We should follow this up with a better and safer process for updating base images.

## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing

Running integration tests
