### PR TITLE
Fix whitespace log

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.1rc1"
+version = "0.9.1rc2"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.1rc2"
+version = "0.9.1rc2dev0"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/templates/shared/logging.py
+++ b/truss/templates/shared/logging.py
@@ -39,7 +39,7 @@ class StreamToLogger:
         return getattr(self.stream, name)
 
     def write(self, buf):
-        # If we encounter a newline, then log with the buffer and a newline
+        # If we encounter a newline, then log with the buffer
         if buf.endswith("\n"):
             buf = buf[:-1]
             self.log_buffer += buf

--- a/truss/templates/shared/logging.py
+++ b/truss/templates/shared/logging.py
@@ -38,7 +38,9 @@ class StreamToLogger:
         return getattr(self.stream, name)
 
     def write(self, buf):
-        self.logger.log(self.log_level, buf)
+        buf = buf.rstrip()  # Removes trailing spaces
+        if buf and not buf.isspace():  # Checks if the message is not just whitespace
+            self.logger.log(self.log_level, buf)
 
     def flush(self):
         """


### PR DESCRIPTION
Prevent logging messages that are just whitespace. Remove trailing whitespace from logs.

Tested by first building the container without the change and querying it locally. We get "\n" logs from `print` in the Truss. The solution is to remove new lines and strip trailing whitespace from any buffer that is being written into the logs. 

![SCR-20240207-iucj](https://github.com/basetenlabs/truss/assets/10859091/42f493d5-1f91-4dc8-b363-f55fb478252a)

On dev:
<img width="715" alt="SCR-20240207-lwbt" src="https://github.com/basetenlabs/truss/assets/10859091/15fac355-09a5-4f04-acc6-fffbbd2310e7">

Simple echo server with the following model.py:
```python
class Model:
    def __init__(self, **kwargs):
        self._model = None

    def load(self):
        # Load model here and assign to self._model.
        pass

    def predict(self, model_input):
        # Run model inference here
        print("Running model inference... (not really this is a simple print)")
        print("""Here is a multiliine print statement
that will cause a linting error.

hello world!

""")
        return model_input
```

