### PR TITLE
Add logging to `control/truss_hash` endpoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.1rc1"
+version = "0.9.1rc2"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/templates/control/control/endpoints.py
+++ b/truss/templates/control/control/endpoints.py
@@ -109,7 +109,7 @@ async def patch(request: Request) -> Dict[str, str]:
 
 @control_app.get("/control/truss_hash")
 async def truss_hash(request: Request) -> Dict[str, Any]:
-    request.app.state.logger.info("truss hash request received")
+    request.app.state.logger.info(f"truss hash request received. request: {request}")
     t_hash = request.app.state.inference_server_controller.truss_hash()
     request.app.state.logger.info("Returning truss hash")
     return {"result": t_hash}

--- a/truss/templates/control/control/endpoints.py
+++ b/truss/templates/control/control/endpoints.py
@@ -109,7 +109,9 @@ async def patch(request: Request) -> Dict[str, str]:
 
 @control_app.get("/control/truss_hash")
 async def truss_hash(request: Request) -> Dict[str, Any]:
+    request.app.state.logger.info("truss hash request received")
     t_hash = request.app.state.inference_server_controller.truss_hash()
+    request.app.state.logger.info("Returning truss hash")
     return {"result": t_hash}
 
 


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What

Adds logging to the control server's `truss_hash` endpoint so we can better root cause 500s and timeouts.

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
