### PR TITLE
Adding configuration to set the streaming request timeout

### DIFF
--- a/truss/templates/server/model_wrapper.py
+++ b/truss/templates/server/model_wrapper.py
@@ -275,6 +275,10 @@ class ModelWrapper:
             Generator: In case of streaming response
         """
 
+        streaming_read_timeout = self._config.get("runtime", {}).get(
+            "streaming_read_timeout", STREAMING_RESPONSE_QUEUE_READ_TIMEOUT_SECS
+        )
+
         if self.truss_schema is not None:
             try:
                 body = self.truss_schema.input_type(**body)
@@ -332,7 +336,7 @@ class ModelWrapper:
                     while True:
                         chunk = await asyncio.wait_for(
                             response_queue.get(),
-                            timeout=STREAMING_RESPONSE_QUEUE_READ_TIMEOUT_SECS,
+                            timeout=streaming_read_timeout,
                         )
                         if chunk is None:
                             return

--- a/truss/templates/server/model_wrapper.py
+++ b/truss/templates/server/model_wrapper.py
@@ -275,6 +275,7 @@ class ModelWrapper:
             Generator: In case of streaming response
         """
 
+        # The streaming read timeout is the amount of time in between streamed chunks before a timeout is triggered
         streaming_read_timeout = self._config.get("runtime", {}).get(
             "streaming_read_timeout", STREAMING_RESPONSE_QUEUE_READ_TIMEOUT_SECS
         )
@@ -332,6 +333,7 @@ class ModelWrapper:
                 task.add_done_callback(lambda _: semaphore_release_function())
                 task.add_done_callback(self._background_tasks.discard)
 
+                # The gap between responses in a stream must be < streaming_read_timeout
                 async def _response_generator():
                     while True:
                         chunk = await asyncio.wait_for(

--- a/truss/test_data/test_streaming_read_timeout/config.yaml
+++ b/truss/test_data/test_streaming_read_timeout/config.yaml
@@ -1,17 +1,4 @@
-apply_library_patches: true
-bundled_packages_dir: packages
-data_dir: data
-description: null
-environment_variables: {}
-examples_filename: examples.yaml
-external_package_dirs: []
-input_type: Any
-live_reload: false
-model_class_filename: model.py
-model_class_name: Model
-model_framework: custom
 model_metadata: {}
-model_module_dir: model
 model_name: null
 model_type: custom
 python_version: py39
@@ -23,16 +10,3 @@ resources:
   use_gpu: false
 runtime:
   streaming_read_timeout: 1
-secrets: {}
-spec_version: '2.0'
-system_packages: []
-train:
-  resources:
-    accelerator: null
-    cpu: 500m
-    memory: 512Mi
-    use_gpu: false
-  training_class_filename: train.py
-  training_class_name: Train
-  training_module_dir: train
-  variables: {}

--- a/truss/test_data/test_streaming_read_timeout/config.yaml
+++ b/truss/test_data/test_streaming_read_timeout/config.yaml
@@ -1,0 +1,38 @@
+apply_library_patches: true
+bundled_packages_dir: packages
+data_dir: data
+description: null
+environment_variables: {}
+examples_filename: examples.yaml
+external_package_dirs: []
+input_type: Any
+live_reload: false
+model_class_filename: model.py
+model_class_name: Model
+model_framework: custom
+model_metadata: {}
+model_module_dir: model
+model_name: null
+model_type: custom
+python_version: py39
+requirements: []
+resources:
+  accelerator: null
+  cpu: 500m
+  memory: 512Mi
+  use_gpu: false
+runtime:
+  streaming_read_timeout: 1
+secrets: {}
+spec_version: '2.0'
+system_packages: []
+train:
+  resources:
+    accelerator: null
+    cpu: 500m
+    memory: 512Mi
+    use_gpu: false
+  training_class_filename: train.py
+  training_class_name: Train
+  training_module_dir: train
+  variables: {}

--- a/truss/test_data/test_streaming_read_timeout/model/model.py
+++ b/truss/test_data/test_streaming_read_timeout/model/model.py
@@ -1,0 +1,24 @@
+import time
+from typing import Any, Dict, List
+
+
+class Model:
+    def __init__(self, **kwargs) -> None:
+        self._data_dir = kwargs["data_dir"]
+        self._config = kwargs["config"]
+        self._secrets = kwargs["secrets"]
+        self._model = None
+
+    def load(self):
+        # Load model here and assign to self._model.
+        pass
+
+    def predict(self, model_input: Any) -> Dict[str, List]:
+        # Invoke model on model_input and calculate predictions here.
+        def inner():
+            time.sleep(2)
+            for i in range(5):
+                time.sleep(3)
+                yield str(i)
+
+        return inner()

--- a/truss/tests/templates/server/test_model_wrapper.py
+++ b/truss/tests/templates/server/test_model_wrapper.py
@@ -68,3 +68,20 @@ def test_model_wrapper_load_error_more_than_allowed(app_path, helpers):
         # Allow load thread to execute
         time.sleep(1)
         assert model_wrapper.load_failed()
+
+
+@pytest.mark.integration
+async def test_model_wrapper_streaming_timeout(app_path):
+    if "model_wrapper" in sys.modules:
+        model_wrapper_module = sys.modules["model_wrapper"]
+        importlib.reload(model_wrapper_module)
+    else:
+        model_wrapper_module = importlib.import_module("model_wrapper")
+    model_wraper_class = getattr(model_wrapper_module, "ModelWrapper")
+
+    # Create an instance of ModelWrapper with streaming_read_timeout set to 5 seconds
+    config = yaml.safe_load((app_path / "config.yaml").read_text())
+    config["runtime"]["streaming_read_timeout"] = 5
+    model_wrapper = model_wraper_class(config)
+    model_wrapper.load()
+    assert model_wrapper._config.get("runtime").get("streaming_read_timeout") == 5

--- a/truss/truss_config.py
+++ b/truss/truss_config.py
@@ -31,6 +31,7 @@ DEFAULT_EXAMPLES_FILENAME = "examples.yaml"
 DEFAULT_SPEC_VERSION = "2.0"
 DEFAULT_PREDICT_CONCURRENCY = 1
 DEFAULT_NUM_WORKERS = 1
+DEFAULT_STREAMING_RESPONSE_READ_TIMEOUT = 60
 
 DEFAULT_CPU = "1"
 DEFAULT_MEMORY = "2Gi"
@@ -140,21 +141,27 @@ class ModelCache:
 class Runtime:
     predict_concurrency: int = DEFAULT_PREDICT_CONCURRENCY
     num_workers: int = DEFAULT_NUM_WORKERS
+    streaming_read_timeout: int = DEFAULT_STREAMING_RESPONSE_READ_TIMEOUT
 
     @staticmethod
     def from_dict(d):
         predict_concurrency = d.get("predict_concurrency", DEFAULT_PREDICT_CONCURRENCY)
         num_workers = d.get("num_workers", DEFAULT_NUM_WORKERS)
+        streaming_read_timeout = d.get(
+            "streaming_read_timeout", DEFAULT_STREAMING_RESPONSE_READ_TIMEOUT
+        )
 
         return Runtime(
             predict_concurrency=predict_concurrency,
             num_workers=num_workers,
+            streaming_read_timeout=streaming_read_timeout,
         )
 
     def to_dict(self):
         return {
             "predict_concurrency": self.predict_concurrency,
             "num_workers": self.num_workers,
+            "streaming_read_timeout": self.streaming_read_timeout,
         }
 
 


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What

A user was facing issues seeing 4xx status code after a 60 second timeout. They wanted to make this parameter configurable so that they can increase the timeout for streaming use-cases.

<!--
  How was the change described above implemented?
-->
## :computer: How

Inside the `config.yaml` under runtime, a new key can be set called `streaming_read_timeout`. Setting this key overrides the default streaming timeout which is 60 seconds. This way, users can configure the streaming timeout through the configuration file for one-off use-cases and we don't have to change the default timeout for the rest of the users.

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing

Tested it locally with a higher timeout and lower timeout to ensure it fails on the lower timeout and succeeds on the higher timeout.
