### PR TITLE
Allow generic types in annotations

### DIFF
--- a/truss/templates/server/common/schema.py
+++ b/truss/templates/server/common/schema.py
@@ -78,6 +78,16 @@ def _parse_input_type(input_parameters: MappingProxyType) -> Optional[type]:
     return input_type
 
 
+def annotation_is_pydantic_model(annotation: Any) -> bool:
+    # This try/except clause a workaround for the fact that issubclass()
+    # does not work with generic types (ie: list, dict),
+    # and returns a TypeError
+    try:
+        return isinstance(annotation, type) and issubclass(annotation, BaseModel)
+    except TypeError:
+        return False
+
+
 def _parse_output_type(output_annotation: Any) -> Optional[OutputType]:
     """
     Therea are 4 possible cases for output_annotation:
@@ -90,7 +100,7 @@ def _parse_output_type(output_annotation: Any) -> Optional[OutputType]:
 
     If the output_annotation does not match one of these cases, returns None
     """
-    if isinstance(output_annotation, type) and issubclass(output_annotation, BaseModel):
+    if annotation_is_pydantic_model(output_annotation):
         return OutputType(type=output_annotation, supports_streaming=False)
 
     if _is_generator_type(output_annotation):

--- a/truss/tests/templates/server/test_schema.py
+++ b/truss/tests/templates/server/test_schema.py
@@ -61,6 +61,21 @@ def test_truss_schema_non_pydantic_output():
     assert schema is None
 
 
+def test_truss_schema_non_pydantic_generic_output():
+    class Model:
+        def predict(self, request: ModelInput) -> list[str]:
+            return ["foo", "bar"]
+
+    model = Model()
+
+    input_signature = inspect.signature(model.predict).parameters
+    output_signature = inspect.signature(model.predict).return_annotation
+
+    schema = TrussSchema.from_signature(input_signature, output_signature)
+
+    assert schema is None
+
+
 def test_truss_schema_async():
     class Model:
         async def predict(self, request: ModelInput) -> Awaitable[ModelOutput]:

--- a/truss/tests/templates/server/test_schema.py
+++ b/truss/tests/templates/server/test_schema.py
@@ -14,6 +14,21 @@ class ModelOutput(BaseModel):
     output: str
 
 
+def test_truss_schema_pydantic_empty_annotations():
+    class Model:
+        def predict(self, request):
+            return "hello"
+
+    model = Model()
+
+    input_signature = inspect.signature(model.predict).parameters
+    output_signature = inspect.signature(model.predict).return_annotation
+
+    schema = TrussSchema.from_signature(input_signature, output_signature)
+
+    assert schema is None
+
+
 def test_truss_schema_pydantic_input_and_output():
     class Model:
         def predict(self, request: ModelInput) -> ModelOutput:
@@ -61,10 +76,25 @@ def test_truss_schema_non_pydantic_output():
     assert schema is None
 
 
-def test_truss_schema_non_pydantic_generic_output():
+def test_truss_schema_list_types():
     class Model:
-        def predict(self, request: ModelInput) -> list[str]:
+        def predict(self, request: list[str]) -> list[str]:
             return ["foo", "bar"]
+
+    model = Model()
+
+    input_signature = inspect.signature(model.predict).parameters
+    output_signature = inspect.signature(model.predict).return_annotation
+
+    schema = TrussSchema.from_signature(input_signature, output_signature)
+
+    assert schema is None
+
+
+def test_truss_schema_dict_types():
+    class Model:
+        def predict(self, request: dict[str, str]) -> dict[str, str]:
+            return {"foo": "bar"}
 
     model = Model()
 


### PR DESCRIPTION

## :rocket: What

When we introduced typing for trusses, there is a bug where container types (lists/dicts/sets/etc) were failing to parse properly, which was breaking truss load.

The root cause here is a fairly subtle issue where checking `issubclass` basically doesn't work for the specific combo of checking a python "container-type" like `list` or `dict` against a pydantic BaseModel. See this issue for more details: https://github.com/pydantic/pydantic/discussions/5970#discussioncomment-6094877

Couldn't find a better solution here than catching type errors, but open to other ideas here. This might be the safest.

## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing

Relying on these integration tests & added some more unit tests
