### PR TITLE
Fall back to default `.truss_ignore` in  truss upload

### DIFF
--- a/truss/remote/baseten/core.py
+++ b/truss/remote/baseten/core.py
@@ -120,6 +120,8 @@ def archive_truss(truss_handle: TrussHandle) -> IO:
     truss_ignore_file = truss_dir / ".truss_ignore"
     if truss_ignore_file.exists():
         ignore_patterns = load_trussignore_patterns(truss_ignore_file=truss_ignore_file)
+    else:
+        ignore_patterns = load_trussignore_patterns()
 
     try:
         temp_file = create_tar_with_progress_bar(truss_dir, ignore_patterns)


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
If a user doesn't provide a `.truss_ignore` in their truss directory, fall back to the default `.truss_ignore` file specified in the truss package.

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
* Tested manually by creating a truss with a `venv`, pushing via `poetry run truss push --publish`, and downloading the truss