### PR TITLE
Fix integration tests

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3227,4 +3227,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.12"
-content-hash = "54dbe4a5d6765fd101e79912ec8fd6f4241ed6e2621f678661110035a329e1b9"
+content-hash = "d9d57baef767678d7062a6bec64fc540a6be7fff8be5082db20e03329da97285"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ inquirerpy = "^0.3.4"
 google-cloud-storage = "2.10.0"
 loguru = ">=0.7.2"
 uvloop = "^0.19.0"
+pathspec = ">=0.9.0"
 
 
 [tool.poetry.group.builder.dependencies]
@@ -64,6 +65,7 @@ huggingface_hub = ">=0.19.4"
 google-cloud-storage = "2.10.0"
 boto3 = "^1.26.157"
 loguru = ">=0.7.2"
+pathspec = ">=0.9.0"
 
 [tool.poetry.dev-dependencies]
 ipython = "^7.16"

--- a/truss/truss_handle.py
+++ b/truss/truss_handle.py
@@ -61,7 +61,12 @@ from truss.server.shared.serialization import (
 from truss.truss_config import BaseImage, ExternalData, ExternalDataItem, TrussConfig
 from truss.truss_spec import TrussSpec
 from truss.types import Example, PatchDetails, PatchRequest
-from truss.util.path import copy_file_path, copy_tree_path, get_max_modified_time_of_dir
+from truss.util.path import (
+    copy_file_path,
+    copy_tree_path,
+    get_max_modified_time_of_dir,
+    load_trussignore_patterns,
+)
 from truss.validation import validate_secret_name
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -891,7 +896,8 @@ class TrussHandle:
             "Truss supports patching and a running "
             "container found: attempting to patch the container"
         )
-        patch_details = self.calc_patch(running_truss_hash)
+        truss_ignore_patterns = load_trussignore_patterns()
+        patch_details = self.calc_patch(running_truss_hash, truss_ignore_patterns)
         if patch_details is None:
             logger.info("Unable to calculate patch.")
             return None


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
* Adds pathspec to `pyproject.toml`
* Fixes call to `TrussHandle.calc_patch`

Note that this fixes most, but not all, of the integration tests (see [run](https://github.com/basetenlabs/truss/actions/runs/8075749791)). Continuing to look into the RetryErrors.

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
