### PR TITLE
Truss request validation return error in response, not log

### DIFF
--- a/truss/server/common/truss_server.py
+++ b/truss/server/common/truss_server.py
@@ -173,7 +173,6 @@ class BasetenEndpoints:
         model: ModelWrapper = self._safe_lookup_model(model_name)
 
         if model.truss_schema is None:
-            print("DID NOT FIND MODEL SCHEMA")
             # If there is not a TrussSchema, we return a 404.
 
             if model.ready:

--- a/truss/server/model_wrapper.py
+++ b/truss/server/model_wrapper.py
@@ -287,8 +287,9 @@ class ModelWrapper:
             try:
                 body = self.truss_schema.input_type(**body)
             except pydantic.ValidationError as e:
+                self._logger.info("Request Validation Error")
                 raise HTTPException(
-                    status_code=400, detail=f"Request Validation Error: {str(e)}"
+                    status_code=400, detail=f"Request Validation Error, {str(e)}"
                 ) from e
 
         payload = await self.preprocess(body, headers)

--- a/truss/server/model_wrapper.py
+++ b/truss/server/model_wrapper.py
@@ -287,9 +287,8 @@ class ModelWrapper:
             try:
                 body = self.truss_schema.input_type(**body)
             except pydantic.ValidationError as e:
-                self._logger.info("Request Validation Error: %s", {str(e)})
                 raise HTTPException(
-                    status_code=400, detail="Request Validation Error"
+                    status_code=400, detail=f"Request Validation Error: {str(e)}"
                 ) from e
 
         payload = await self.preprocess(body, headers)

--- a/truss/tests/test_model_schema.py
+++ b/truss/tests/test_model_schema.py
@@ -113,7 +113,11 @@ def test_truss_with_annotated_inputs_outputs():
 
         assert response.status_code == 400
         assert "error" in response.json()
-        assert "Request Validation Error" in response.json()["error"]
+
+        assert (
+            "Request Validation Error: 1 validation error for ModelInput"
+            in response.json()["error"]
+        )
 
         schema_response = requests.get(SCHEMA_URL)
 


### PR DESCRIPTION

## :rocket: What

One of the main pieces of feedback that we got during the truss types bug bash was that hiding the validation errors from the response, but including them in the logs is:
* Less secure (validation errors include the inputs)
* Not super helpful to users, since they can't see what they did wrong very easily.

## :computer: How


## :microscope: Testing

Relied on the ITs here.