### PR TITLE
Fix issue with python executable

### DIFF
--- a/truss/templates/control/control/server.py
+++ b/truss/templates/control/control/server.py
@@ -7,18 +7,11 @@ from application import create_app
 
 CONTROL_SERVER_PORT = int(os.environ.get("CONTROL_SERVER_PORT", "8080"))
 INFERENCE_SERVER_PORT = int(os.environ.get("INFERENCE_SERVER_PORT", "8090"))
-PYTHON_EXECUTABLE_LOOKUP_PATHS = [
-    "/usr/local/bin/python",
-    "/usr/local/bin/python3",
-    "/usr/bin/python",
-    "/usr/bin/python3",
-]
 
 
 def _identify_python_executable_path() -> str:
-    for path in PYTHON_EXECUTABLE_LOOKUP_PATHS:
-        if Path(path).exists():
-            return path
+    if "PYTHON_EXECUTABLE" in os.environ:
+        return os.environ["PYTHON_EXECUTABLE"]
 
     raise RuntimeError("Unable to find python, make sure it's installed.")
 


### PR DESCRIPTION
Currently seeing the issue below with non-standard python paths in custom base images. Since the dockerfile sets this env var (both in the case of custom image, and in the case of normal image) we should rely on it for the python to run the inference server, instead of only looking for standard python path's, which we are not using to install the necessary requirements.

## Context:
Config excerpt:
```
base_image:
  image: "custom/image:tag"
  python_executable_path: /app/env/bin/python
```

Since `/app/env/bin/python` is not in the current `PYTHON_EXECUTABLE_LOOKTUP_PATHS`, we're always going to be running the wrong python.

This results in the following error
```
root@baseten-model-qz48jow-00001-deployment-5ffdc55685-gkbzv:/app# /usr/bin/python3 /app/inference_server.py
Traceback (most recent call last):
  File "/app/inference_server.py", line 4, in <module>
    import yaml
ModuleNotFoundError: No module named 'yaml'
```
because the server requirements are installed using ` /app/env/bin/python -m pip install ..` 