### PR TITLE
Support MIG on Truss

### DIFF
--- a/truss/tests/test_config.py
+++ b/truss/tests/test_config.py
@@ -87,6 +87,7 @@ def test_parse_resources(input_dict, expect_resources, output_dict):
         ("A10G:4", AcceleratorSpec(Accelerator.A10G, 4)),
         ("A100:8", AcceleratorSpec(Accelerator.A100, 8)),
         ("H100", AcceleratorSpec(Accelerator.H100, 1)),
+        ("H100_40GB", AcceleratorSpec(Accelerator.H100_40GB, 1)),
     ],
 )
 def test_acc_spec_from_str(input_str, expected_acc):

--- a/truss/truss_config.py
+++ b/truss/truss_config.py
@@ -51,6 +51,7 @@ class Accelerator(Enum):
     V100 = "V100"
     A100 = "A100"
     H100 = "H100"
+    H100_40GB = "H100_40GB"
 
 
 @dataclass


### PR DESCRIPTION

## :rocket: What

Support MIG on truss. The way you'd specify this in your config is by:

```
resources:
    accelerator: H100_40GB
```

Using underscores here really simplifies things. (Using a dash like we do on the backend will not work)
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing

I don't have access to MIG on my account, but confirmed the truss side of this works at least:

```
$ truss push
💻 Let's add a Baseten remote!
? 🤫 Quietly paste your API_KEY: *****************************************
💾 Remote config saved to /home/vscode/.trussrc
Compressing... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Uploading... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
ERROR: Deploying this model requires an instance with the spec: GPU Type: H100-40GB, GPU Count: 1, CPU Limit: 1000, CPU Memory Limit: 2048.

Please contact support@baseten.co to request this instance type.
```
