### PR TITLE
removing separate caching step

### DIFF
--- a/truss/templates/cache.Dockerfile.jinja
+++ b/truss/templates/cache.Dockerfile.jinja
@@ -1,5 +1,3 @@
-FROM python:3.11-slim as cache_warmer
-
 RUN mkdir -p /app/model_cache
 WORKDIR /app
 

--- a/truss/templates/copy_cache_files.Dockerfile.jinja
+++ b/truss/templates/copy_cache_files.Dockerfile.jinja
@@ -1,3 +1,0 @@
-{% for file in cached_files %}
-COPY --from=cache_warmer {{file.source}} {{file.dst}}
-{% endfor %}

--- a/truss/templates/server.Dockerfile.jinja
+++ b/truss/templates/server.Dockerfile.jinja
@@ -1,7 +1,3 @@
-{%- if model_cache %}
-{%- include "cache.Dockerfile.jinja" %}
-{%- endif %}
-
 {% extends "base.Dockerfile.jinja" %}
 
 {% block base_image_patch %}
@@ -51,10 +47,9 @@ RUN pip install -r {{server_requirements_filename}} --no-cache-dir && rm -rf /ro
 
 
 {% block app_copy %}
-{%- if model_cache %}
-# Copy data before code for better caching
-    {%- include "copy_cache_files.Dockerfile.jinja"%}
-{%- endif %}
+    {%- if model_cache %}
+    {%- include "cache.Dockerfile.jinja" %}
+    {%- endif %}
 
 {%- if external_data_files %}
 {% for url, dst in external_data_files %}


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Instead of caching into a separate image and then copying, we cache directly onto the truss image. The performance benefit appears limited, and this should address an with the COPY step failing when hf revisions are specified.
<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
Tests were run
