### PR TITLE
Revert "removing separate weight caching step"

### DIFF
--- a/truss/templates/cache.Dockerfile.jinja
+++ b/truss/templates/cache.Dockerfile.jinja
@@ -1,3 +1,5 @@
+FROM python:3.11-slim as cache_warmer
+
 RUN mkdir -p /app/model_cache
 WORKDIR /app
 

--- a/truss/templates/copy_cache_files.Dockerfile.jinja
+++ b/truss/templates/copy_cache_files.Dockerfile.jinja
@@ -1,0 +1,3 @@
+{% for file in cached_files %}
+COPY --from=cache_warmer {{file.source}} {{file.dst}}
+{% endfor %}

--- a/truss/templates/server.Dockerfile.jinja
+++ b/truss/templates/server.Dockerfile.jinja
@@ -1,3 +1,7 @@
+{%- if model_cache %}
+{%- include "cache.Dockerfile.jinja" %}
+{%- endif %}
+
 {% extends "base.Dockerfile.jinja" %}
 
 {% block base_image_patch %}
@@ -47,9 +51,10 @@ RUN pip install -r {{server_requirements_filename}} --no-cache-dir && rm -rf /ro
 
 
 {% block app_copy %}
-    {%- if model_cache %}
-    {%- include "cache.Dockerfile.jinja" %}
-    {%- endif %}
+{%- if model_cache %}
+# Copy data before code for better caching
+    {%- include "copy_cache_files.Dockerfile.jinja"%}
+{%- endif %}
 
 {%- if external_data_files %}
 {% for url, dst in external_data_files %}


### PR DESCRIPTION
Reverts basetenlabs/truss#872

The fix isn't complete since we now have overlapping requirements files. In the interest of de-risking deploys in the interim, let's revert.