### PR TITLE
Rename GCS -> GCP.

### DIFF
--- a/truss/tests/test_config.py
+++ b/truss/tests/test_config.py
@@ -118,7 +118,7 @@ def test_acc_spec_from_str(input_str, expected_acc):
                 "image": "custom_base_image",
                 "python_executable_path": "/path/python",
                 "docker_auth": {
-                    "auth_method": "GCS_SERVICE_ACCOUNT_JSON",
+                    "auth_method": "GCP_SERVICE_ACCOUNT_JSON",
                     "secret_name": "some-secret-name",
                     "registry": "some-docker-registry",
                 },
@@ -127,7 +127,7 @@ def test_acc_spec_from_str(input_str, expected_acc):
                 image="custom_base_image",
                 python_executable_path="/path/python",
                 docker_auth=DockerAuthSettings(
-                    auth_method=DockerAuthType.GCS_SERVICE_ACCOUNT_JSON,
+                    auth_method=DockerAuthType.GCP_SERVICE_ACCOUNT_JSON,
                     secret_name="some-secret-name",
                     registry="some-docker-registry",
                 ),
@@ -136,7 +136,7 @@ def test_acc_spec_from_str(input_str, expected_acc):
                 "image": "custom_base_image",
                 "python_executable_path": "/path/python",
                 "docker_auth": {
-                    "auth_method": "GCS_SERVICE_ACCOUNT_JSON",
+                    "auth_method": "GCP_SERVICE_ACCOUNT_JSON",
                     "secret_name": "some-secret-name",
                     "registry": "some-docker-registry",
                 },

--- a/truss/truss_config.py
+++ b/truss/truss_config.py
@@ -303,7 +303,7 @@ class DockerAuthType(Enum):
     authentication we support.
     """
 
-    GCS_SERVICE_ACCOUNT_JSON = "GCS_SERVICE_ACCOUNT_JSON"
+    GCP_SERVICE_ACCOUNT_JSON = "GCP_SERVICE_ACCOUNT_JSON"
 
 
 @dataclass


### PR DESCRIPTION

## :rocket: What

Follow-up from this change: https://github.com/basetenlabs/baseten/pull/8198. Originally called the option "GCS", but realized that that is specifically "Google Cloud Storage", which this does not refer to. 

This should go out in conjunction with https://github.com/basetenlabs/baseten/pull/8213

## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing

See https://github.com/basetenlabs/baseten/pull/8198 for the full testing instructions
