### PR TITLE
Return structured errors from ModelWrapper / Server.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,15 +5,16 @@
   "python.formatting.provider": "black",
   "python.testing.unittestEnabled": false,
   "python.testing.pytestEnabled": true,
-  "python.testing.pytestArgs": ["truss"],
-
+  "python.testing.pytestArgs": [
+    "truss"
+  ],
   // Per file type settings
   "[python]": {
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
-      "source.fixAll": true,
-      "source.organizeImports": true,
-      "source.sortMembers": true
+      "source.fixAll": "explicit",
+      "source.organizeImports": "explicit",
+      "source.sortMembers": "explicit"
     }
   }
 }

--- a/truss/tests/helpers.py
+++ b/truss/tests/helpers.py
@@ -1,4 +1,8 @@
+import traceback
 from pathlib import Path
+from typing import List, Optional
+
+import pydantic
 
 
 def create_truss(truss_dir: Path, config_contents: str, model_contents: str):
@@ -12,3 +16,49 @@ def create_truss(truss_dir: Path, config_contents: str, model_contents: str):
         file.write(config_contents)
     with open(model_file, "w", encoding="utf-8") as file:
         file.write(model_contents)
+
+
+class StackFrame(pydantic.BaseModel):
+    filename: str
+    lineno: int
+    name: str
+    line: str
+
+    @classmethod
+    def from_frame_summary(cls, frame: traceback.FrameSummary):
+        return cls(
+            filename=frame.filename,
+            lineno=frame.lineno,
+            name=frame.name,
+            line=frame.line,
+        )
+
+    def to_frame_summary(self) -> traceback.FrameSummary:
+        return traceback.FrameSummary(
+            filename=self.filename, lineno=self.lineno, name=self.name, line=self.line
+        )
+
+
+class TrussError(pydantic.BaseModel):
+    exception_class_name: str
+    exception_module_name: Optional[str]
+    exception_message: str
+    user_stack_trace: List[StackFrame]
+
+    def to_stack_summary(self) -> traceback.StackSummary:
+        return traceback.StackSummary.from_list(
+            frame.to_frame_summary() for frame in self.user_stack_trace
+        )
+
+    def format(self) -> str:
+        stack = "".join(traceback.format_list(self.to_stack_summary()))
+        exception_info = (
+            f"\n(Exception class defined in `{self.exception_module_name}`.)"
+            if self.exception_module_name
+            else ""
+        )
+        error = f"""{TrussError.__name__} (server-side)
+Traceback (most recent call last):
+{stack}{self.exception_class_name}: {self.exception_message}{exception_info}
+"""
+        return error


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Alternatively to returning non-descript "Internal Server Error" return a structured error message that is akin to a python exception and stack trace.

Motivation:
Workflows can have multiple nesting levels of processors calling other processors as RPCs. If somewhere in such a call stack an error occurs, it is useful for both informative purposes (a) and for programmatic error handling (b) to return richer error information.

For (a): if a workflow uses multiple processors and a request fails, it would be cumbersome to manually click through all logs of the deployed processors to find the actual stack trace. Being able to "chain" that information in a similar manner as `raise from` and surfacing the complete information up to the client who sent the request is an improved DX.

For (b): By including exception metadata such as the exception class name, we facilitate client-side error handling depending on the error cause. E.g. clients might distinguish fatal and retryable errors.

Security considerations:
* The stack trace is filtered to exclude those parts in the call stack that are truss-server internal and only include the frames from the user-defined model code.
* Users should not include sensitive information in the exception message itself (which will be included in the structured error) - unless this information is ok to be seen by the sender of the request. Often this might be the case, e.g. if the error message contains part of the input data, the sender has access to that data anyway.
* This feature is turned off by default and must be activated by a config flag (TBD).

<!--
  How was the change described above implemented?
-->
## :computer: How

Introduce pydantic model for error information and extend `_handle_exception` to populated it.

**Open Questions**:
* Where should this behavior be configured - top-level field in truss config?
* How can the pydantic model be shared without explicit duplication between "template" server code and as part of the truss library (as is currently in this PR)?


<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing

Integration tests are added.
