### PR TITLE
Add truss --wait

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.9rc1"
+version = "0.9.9rc3"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.9rc3"
+version = "0.9.9rc4"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.8"
+version = "0.9.9rc1"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -550,7 +550,7 @@ it will become the next production deployment of your model."""
                         timeout_seconds is not None
                         and time.time() - start_time > timeout_seconds
                     ):
-                        status.update("[bold red]Deployment timed out.")
+                        console.print("Deployment timed out.", style="red")
                         sys.exit(1)
 
                     status.update(
@@ -569,7 +569,7 @@ it will become the next production deployment of your model."""
                         sys.exit(1)
 
             except RemoteNetworkError:
-                status.update("[bold red]Deployment failed: Could not reach remote.")
+                console.print("Deployment failed: Could not reach remote.", style="red")
                 sys.exit(1)
 
 

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -553,7 +553,9 @@ it will become the next production deployment of your model."""
                         status.update("[bold red]Deployment timed out.")
                         sys.exit(1)
 
-                    status.update(f"[bold green]{deployment_status}")
+                    status.update(
+                        f"[bold green]Deploying...Current Status: {deployment_status}"
+                    )
 
                     if deployment_status == ACTIVE_STATUS:
                         console.print("Deployment succeeded.", style="bold green")

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -560,11 +560,14 @@ it will become the next production deployment of your model."""
                         return
 
                     if deployment_status not in DEPLOYING_STATUSES:
-                        console.print("Deployment succeeded.", style="bold green")
+                        console.print(
+                            f"Deployment failed with status {deployment_status}.",
+                            style="red",
+                        )
                         sys.exit(1)
 
             except RemoteNetworkError:
-                status.update("[bold red]Deployment failed -- could not reach remote.")
+                status.update("[bold red]Deployment failed: Could not reach remote.")
                 sys.exit(1)
 
 

--- a/truss/remote/baseten/core.py
+++ b/truss/remote/baseten/core.py
@@ -12,6 +12,10 @@ from truss.util.path import load_trussignore_patterns
 logger = logging.getLogger(__name__)
 
 
+DEPLOYING_STATUSES = ["BUILDING", "DEPLOYING", "LOADING_MODEL", "UPDATING"]
+ACTIVE_STATUS = "ACTIVE"
+
+
 class ModelIdentifier:
     value: str
 

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -41,6 +41,10 @@ API_URL_MAPPING = {
     "http://localhost:8000": "http://api.localhost:8000",
 }
 
+# If a non-standard domain is used with the baseten remote, default to
+# using the production api routes
+DEFAULT_API_DOMAIN = "https://api.baseten.co"
+
 
 class BasetenRemote(TrussRemote):
     def __init__(self, remote_url: str, api_key: str, **kwargs):
@@ -50,7 +54,7 @@ class BasetenRemote(TrussRemote):
             f"{self._remote_url}/graphql/",
             # Ensure we strip off trailing '/' to denormalize
             # URLs.
-            API_URL_MAPPING[self._remote_url.strip("/")],
+            API_URL_MAPPING.get(self._remote_url.strip("/"), DEFAULT_API_DOMAIN),
             self._auth_service,
         )
 

--- a/truss/remote/baseten/service.py
+++ b/truss/remote/baseten/service.py
@@ -88,7 +88,7 @@ class BasetenService(TrussService):
     def logs_url(self, base_url: str) -> str:
         return f"{base_url}/models/{self._model_id}/logs/{self._model_version_id}"
 
-    @retry(stop=stop_after_delay(60), wait=wait_fixed(1))
+    @retry(stop=stop_after_delay(60), wait=wait_fixed(1), reraise=True)
     def _fetch_deployment(self):
         return self._api.get_deployment(self._model_id, self._model_version_id)
 

--- a/truss/remote/truss_remote.py
+++ b/truss/remote/truss_remote.py
@@ -149,6 +149,13 @@ class TrussService(ABC):
         """
         pass
 
+    @abstractmethod
+    def poll_deployment_status(self):
+        """
+        Poll for a deployment status.
+        """
+        pass
+
 
 class TrussRemote(ABC):
     """

--- a/truss/tests/remote/baseten/test_remote.py
+++ b/truss/tests/remote/baseten/test_remote.py
@@ -6,6 +6,7 @@ from truss.remote.baseten.remote import BasetenRemote
 from truss.truss_handle import TrussHandle
 
 _TEST_REMOTE_URL = "http://test_remote.com"
+_TEST_REMOTE_GRAPHQL_PATH = "http://test_remote.com/graphql/"
 
 
 def test_get_service_by_version_id():
@@ -21,7 +22,7 @@ def test_get_service_by_version_id():
 
     with requests_mock.Mocker() as m:
         m.post(
-            remote._api._api_url,
+            _TEST_REMOTE_GRAPHQL_PATH,
             json=model_version_response,
         )
         service = remote.get_service(model_identifier=ModelVersionId("version_id"))
@@ -35,7 +36,7 @@ def test_get_service_by_version_id_no_version():
     model_version_response = {"errors": [{"message": "error"}]}
     with requests_mock.Mocker() as m:
         m.post(
-            remote._api._api_url,
+            _TEST_REMOTE_GRAPHQL_PATH,
             json=model_version_response,
         )
         with pytest.raises(click.UsageError):
@@ -62,7 +63,7 @@ def test_get_service_by_model_name():
 
     with requests_mock.Mocker() as m:
         m.post(
-            remote._api._api_url,
+            _TEST_REMOTE_GRAPHQL_PATH,
             json=model_response,
         )
 
@@ -99,7 +100,7 @@ def test_get_service_by_model_name_no_dev_version():
 
     with requests_mock.Mocker() as m:
         m.post(
-            remote._api._api_url,
+            _TEST_REMOTE_GRAPHQL_PATH,
             json=model_response,
         )
 
@@ -136,7 +137,7 @@ def test_get_service_by_model_name_no_prod_version():
 
     with requests_mock.Mocker() as m:
         m.post(
-            remote._api._api_url,
+            _TEST_REMOTE_GRAPHQL_PATH,
             json=model_response,
         )
 
@@ -168,7 +169,7 @@ def test_get_service_by_model_id():
 
     with requests_mock.Mocker() as m:
         m.post(
-            remote._api._api_url,
+            _TEST_REMOTE_GRAPHQL_PATH,
             json=model_response,
         )
 
@@ -182,7 +183,7 @@ def test_get_service_by_model_id_no_model():
     model_response = {"errors": [{"message": "error"}]}
     with requests_mock.Mocker() as m:
         m.post(
-            remote._api._api_url,
+            _TEST_REMOTE_GRAPHQL_PATH,
             json=model_response,
         )
         with pytest.raises(click.UsageError):
@@ -204,7 +205,7 @@ def test_push_raised_value_error_when_deployment_name_and_not_publish(
     }
     with requests_mock.Mocker() as m:
         m.post(
-            remote._api._api_url,
+            _TEST_REMOTE_GRAPHQL_PATH,
             json=model_response,
         )
         th = TrussHandle(custom_model_truss_dir_with_pre_and_post)
@@ -231,7 +232,7 @@ def test_push_raised_value_error_when_deployment_name_is_not_valid(
     }
     with requests_mock.Mocker() as m:
         m.post(
-            remote._api._api_url,
+            _TEST_REMOTE_GRAPHQL_PATH,
             json=model_response,
         )
         th = TrussHandle(custom_model_truss_dir_with_pre_and_post)
@@ -258,7 +259,7 @@ def test_push_raised_value_error_when_keep_previous_prod_settings_and_not_promot
     }
     with requests_mock.Mocker() as m:
         m.post(
-            remote._api._api_url,
+            _TEST_REMOTE_GRAPHQL_PATH,
             json=model_response,
         )
         th = TrussHandle(custom_model_truss_dir_with_pre_and_post)

--- a/truss/tests/remote/test_truss_remote.py
+++ b/truss/tests/remote/test_truss_remote.py
@@ -30,6 +30,10 @@ class TestTrussService(TrussService):
     def logs_url(self, base_url: str) -> str:
         return f"{base_url}/logs"
 
+    def poll_deployment_status():
+        for status in ["DEPLOYING", "ACTIVE"]:
+            yield status
+
 
 def mock_successful_response():
     response = Response()

--- a/truss/util/errors.py
+++ b/truss/util/errors.py
@@ -1,0 +1,2 @@
+class RemoteNetworkError(Exception):
+    pass


### PR DESCRIPTION
## :rocket: What

A few customers now have asked for a `--wait` option that you can use when calling `truss push` that waits until the deploy is complete to finish. In this PR, we add a `--wait` option and a `--timeout-seconds` option so that users can use `--wait` in their deploy scripts.


## :computer: How


## :microscope: Testing

I deployed an RC: 

Give it a shot here:

```
$ pip install truss==0.9.9rc4
```

```
$ truss push --wait
```

To test it out!

https://www.loom.com/share/9ac68aadf173473ebd99a805b1aca378