### PR TITLE
Support for Pydantic I/O Types

### DIFF
--- a/slay-examples/text_to_num/requirements.txt
+++ b/slay-examples/text_to_num/requirements.txt
@@ -1,3 +1,4 @@
+datamodel-code-generator
 git+https://github.com/basetenlabs/truss.git
 httpx
 libcst

--- a/slay/__init__.py
+++ b/slay/__init__.py
@@ -1,13 +1,5 @@
 # flake8: noqa F401
-from slay.definitions import (
-    Assets,
-    Compute,
-    Config,
-    Context,
-    Image,
-    UsageError,
-    make_abs_path_here,
-)
+from slay.definitions import Assets, Compute, Config, Context, Image, UsageError
 from slay.public_api import (
     ProcessorBase,
     deploy_remotely,
@@ -15,3 +7,4 @@ from slay.public_api import (
     provide_context,
     run_local,
 )
+from slay.utils import make_abs_path_here

--- a/slay/code_gen.py
+++ b/slay/code_gen.py
@@ -223,6 +223,15 @@ def _remove_root_model_and_separate_imports(pydantic_src: str) -> tuple[str, lis
 def _export_pydantic_schemas(
     dependencies: Iterable[definitions.ProcessorAPIDescriptor],
 ) -> Mapping[str, Any]:
+    """Creates a dict with all pydantic schemas used as input or output types by the
+    dependencies.
+
+    If a schema itself depends on another class (e.g. an enum definition), these
+    dependent schemas are also added to the dict.
+
+    It is enforced that pydantic models across the code base have different names,
+    to avoid conflicts; automatic disambiguation is not yet implemented.
+    """
     name_to_schema: dict[str, Any] = {}
 
     def safe_add_schema(type_descr: definitions.TypeDescriptor):

--- a/slay/public_api.py
+++ b/slay/public_api.py
@@ -1,8 +1,3 @@
-"""
-TODO:
-  * Shim to call already hosted baseten model.
-  * Helper to create a `Processor` from a truss dir.
-"""
 from typing import Any, ContextManager, Mapping, Optional, Type, final
 
 from slay import definitions, framework, utils
@@ -15,11 +10,14 @@ def provide_context() -> Any:
 
 def provide(processor_cls: Type[definitions.ABCProcessor]) -> Any:
     """Sets a 'symbolic marker' for injecting a stub or local processor at runtime."""
-    # TODO: consider adding retry or timeout config here.
+    # TODO: extend with RPC customization, e.g. timeouts, retries etc.
     return framework.ProcessorProvisionPlaceholder(processor_cls)
 
 
 class ProcessorBase(definitions.ABCProcessor[definitions.UserConfigT]):
+
+    default_config = definitions.Config()
+
     def __init_subclass__(cls, **kwargs) -> None:
         super().__init_subclass__(**kwargs)
         framework.check_and_register_class(cls)

--- a/slay/stub.py
+++ b/slay/stub.py
@@ -12,13 +12,12 @@ DEFAULT_TIMEOUT_SEC = 600
 class BasetenSession:
     """Helper to invoke predict method on baseten deployments."""
 
-    # TODO: make timeout, retries etc. configurable.
     def __init__(
         self, service_descriptor: definitions.ServiceDescriptor, api_key: str
     ) -> None:
         logging.info(
-            f"Stub session for {service_descriptor.name} with predict URL "
-            f"`{service_descriptor.predict_url}`."
+            f"Creating stub for `{service_descriptor.name}` with predict URL:\n"
+            f"\t`{service_descriptor.predict_url}`"
         )
         self._auth_header = {"Authorization": f"Api-Key {api_key}"}
         self._service_descriptor = service_descriptor

--- a/slay/truss_adapter/code_gen.py
+++ b/slay/truss_adapter/code_gen.py
@@ -1,10 +1,17 @@
 import logging
 import pathlib
+import textwrap
 from typing import Any
 
 import libcst
 from slay import definitions, utils
 from slay.truss_adapter import model_skeleton
+
+INDENT = " " * 4
+
+
+def _indent(text: str, num: int = 1) -> str:
+    return textwrap.indent(text, INDENT * num)
 
 
 class _SpecifyProcessorTypeAnnotation(libcst.CSTTransformer):
@@ -35,14 +42,77 @@ class _SpecifyProcessorTypeAnnotation(libcst.CSTTransformer):
         return updated_node.with_changes(body=tuple(new_body))
 
 
+def _gen_load_src(processor_name: str):
+    """Generates AST for the `load` method of the truss model."""
+    body = _indent(
+        "\n".join(
+            [
+                f'logging.info(f"Loading processor `{processor_name}`.")',
+                f"self._processor = {processor_name}(context=self._context)",
+            ]
+        )
+    )
+    return libcst.parse_statement("\n".join(["def load(self) -> None:", body]))
+
+
+def _gen_predict_src(
+    endpoint_descriptor: definitions.EndpointAPIDescriptor, processor_name: str
+):
+    """Generates AST for the `predict` method of the truss model."""
+    if endpoint_descriptor.is_generator:
+        # TODO: implement generator.
+        raise NotImplementedError("Generator.")
+
+    parts = []
+    def_str = "async def" if endpoint_descriptor.is_async else "def"
+    parts.append(f"{def_str} predict(self, payload):")
+    # Add error handling context manager:
+    parts.append(
+        _indent(
+            f"with utils.exception_to_http_error("
+            f'include_stack=True, processor_name="{processor_name}"):'
+        )
+    )
+    # Convert items from json payload dict to an arg-list, parsing pydantic models.
+    args = ", ".join(
+        (
+            f"{arg_name}={arg_type.as_src_str()}.parse_obj(payload['{arg_name}'])"
+            if arg_type.is_pydantic
+            else f"{arg_name}=payload['{arg_name}']"
+        )
+        for arg_name, arg_type in endpoint_descriptor.input_names_and_types
+    )
+    # Invoke processor.
+    maybe_await = "await " if endpoint_descriptor.is_async else ""
+    parts.append(
+        _indent(
+            f"result = {maybe_await}self._processor.{endpoint_descriptor.name}({args})",
+            2,
+        )
+    )
+    # Return as json tuple, serialize pydantic models.
+    if len(endpoint_descriptor.output_types) == 1:
+        output_type = endpoint_descriptor.output_types[0]
+        result = "result.dict()" if output_type.is_pydantic else "result"
+    else:
+        result_parts = [
+            f"result[{i}].dict()" if t.is_pydantic else f"result[{i}]"
+            for i, t in enumerate(endpoint_descriptor.output_types)
+        ]
+        result = f"{', '.join(result_parts)}"
+
+    parts.append(_indent(f"return {result}"))
+
+    return libcst.parse_statement("\n".join(parts))
+
+
 def generate_truss_model(
     processor_descriptor: definitions.ProcessorAPIDescriptor,
 ) -> tuple[libcst.CSTNode, list[libcst.SimpleStatementLine], libcst.CSTNode]:
-    logging.info(f"Generating Baseten model for `{processor_descriptor.cls_name}`.")
+    logging.info(f"Generating Truss model for `{processor_descriptor.cls_name}`.")
     skeleton_tree = libcst.parse_module(
         pathlib.Path(model_skeleton.__file__).read_text()
     )
-
     imports: list[Any] = [
         node
         for node in skeleton_tree.body
@@ -62,63 +132,20 @@ def generate_truss_model(
         and node.name.value == model_skeleton.ProcessorModel.__name__
     )
 
-    load_def = libcst.parse_statement(
-        f"""
-def load(self) -> None:
-    logging.info(f"Initializing processor `{processor_descriptor.cls_name}`.")
-    self._processor = {processor_descriptor.cls_name}(context=self._context)
-"""
+    load_def = _gen_load_src(processor_descriptor.cls_name)
+    predict_def = _gen_predict_src(
+        processor_descriptor.endpoint, processor_descriptor.cls_name
     )
-
-    endpoint_descriptor = processor_descriptor.endpoint
-    def_str = "async def" if endpoint_descriptor.is_async else "def"
-    # Convert json payload dict to processor args.
-    obj_arg_parts = ", ".join(
-        (
-            f"{arg_name}={arg_type.as_src_str()}.parse_obj(payload['{arg_name}'])"
-            if arg_type.is_pydantic
-            else f"{arg_name}=payload['{arg_name}']"
-        )
-        for arg_name, arg_type in endpoint_descriptor.input_names_and_types
-    )
-
-    if len(endpoint_descriptor.output_types) == 1:
-        output_type = endpoint_descriptor.output_types[0]
-        result = "result.dict()" if output_type.is_pydantic else "result"
-    else:
-        result_parts = [
-            f"result[{i}].dict()" if t.is_pydantic else f"result[{i}]"
-            for i, t in enumerate(endpoint_descriptor.output_types)
-        ]
-        result = f"({', '.join(result_parts)})"
-
-    maybe_await = "await " if endpoint_descriptor.is_async else ""
-
-    predict_def = libcst.parse_statement(
-        f"""
-{def_str} predict(self, payload):
-    with utils.exception_to_http_error(
-        include_stack=True, processor_name="{processor_descriptor.cls_name}"):
-        result = {maybe_await}self._processor.{endpoint_descriptor.name}({obj_arg_parts})
-        return  {result}
-
-"""
-    )
-    new_body: list[Any] = list(class_definition.body.body) + [
-        load_def,
-        predict_def,
-    ]
+    new_body: list[Any] = list(class_definition.body.body) + [load_def, predict_def]
     new_block = libcst.IndentedBlock(body=new_body)
     class_definition = class_definition.with_changes(body=new_block)
     class_definition = class_definition.visit(  # type: ignore[assignment]
         _SpecifyProcessorTypeAnnotation(processor_descriptor.cls_name)
     )
-
     if issubclass(processor_descriptor.user_config_type.raw, type(None)):
         userconfig_pin = libcst.parse_statement("UserConfigT = None")
     else:
         userconfig_pin = libcst.parse_statement(
             f"UserConfigT = {processor_descriptor.user_config_type.as_src_str()}"
         )
-
     return class_definition, imports, userconfig_pin

--- a/slay/truss_adapter/deploy.py
+++ b/slay/truss_adapter/deploy.py
@@ -158,7 +158,7 @@ class BasetenClient:
         truss_handle = truss.load(str(truss_root))
         model_name = truss_handle.spec.config.model_name
         assert model_name is not None
-        logging.info(f"Deploying model `{model_name}` (publish={publish}).")
+        logging.info(f"Deploying Truss model `{model_name}` (publish={publish}).")
         # Models must be trusted to use the API KEY secret.
         service = self._remote_provider.push(
             truss_handle, model_name=model_name, trusted=True, publish=publish

--- a/truss/test_data/workflow_text_to_num/requirements.txt
+++ b/truss/test_data/workflow_text_to_num/requirements.txt
@@ -1,3 +1,4 @@
+datamodel-code-generator
 git+https://github.com/basetenlabs/truss.git
 httpx
 libcst

--- a/truss/test_data/workflow_text_to_num/user_package/shared_processor.py
+++ b/truss/test_data/workflow_text_to_num/user_package/shared_processor.py
@@ -1,4 +1,24 @@
+import enum
+from typing import Tuple
+
+import pydantic
 import slay
+
+
+class Modes(str, enum.Enum):
+    MODE_0 = "MODE_0"
+    MODE_1 = "MODE_1"
+
+
+class SplitTextInput(pydantic.BaseModel):
+    data: str
+    num_partitions: int
+    mode: Modes
+
+
+class SplitTextOutput(pydantic.BaseModel):
+    parts: list[str]
+    part_lens: list[int]
 
 
 class SplitText(slay.ProcessorBase):
@@ -9,8 +29,19 @@ class SplitText(slay.ProcessorBase):
         .pip_requirements(["numpy"])
     )
 
-    async def run(self, data: str, num_partitions: int) -> tuple[list[str], int]:
+    async def run(
+        self, inputs: SplitTextInput, extra_arg: int
+    ) -> Tuple[SplitTextOutput, int]:
         import numpy as np
 
-        parts = np.array_split(np.array(list(data)), num_partitions)
-        return ["".join(part) for part in parts], 123
+        if inputs.mode == Modes.MODE_0:
+            print(f"Using mode: `{inputs.mode}`")
+        elif inputs.mode == Modes.MODE_1:
+            print(f"Using mode: `{inputs.mode}`")
+        else:
+            raise NotImplementedError(inputs.mode)
+
+        parts_arr = np.array_split(np.array(list(inputs.data)), inputs.num_partitions)
+        parts = ["".join(part) for part in parts_arr]
+        part_lens = [len(part) for part in parts]
+        return SplitTextOutput(parts=parts, part_lens=part_lens), 123

--- a/truss/test_data/workflow_text_to_num/workflow.py
+++ b/truss/test_data/workflow_text_to_num/workflow.py
@@ -73,8 +73,15 @@ class Workflow(slay.ProcessorBase):
 
     async def run(self, length: int, num_partitions: int) -> tuple[int, str, int]:
         data = self._data_generator.run(length)
-        text_parts, number = await self._data_splitter.run(data, num_partitions)
+        text_parts, number = await self._data_splitter.run(
+            shared_processor.SplitTextInput(
+                data=data,
+                num_partitions=num_partitions,
+                mode=shared_processor.Modes.MODE_1,
+            ),
+            extra_arg=123,
+        )
         value = 0
-        for part in text_parts:
+        for part in text_parts.parts:
             value += self._text_to_num.run(part)
         return value, data, number


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
* Add support for pydantic I/O types of processors.
* Extend integration test to use pydantic types for some processors (and mixed pydantic, simple).
* Cleanup code generation.

Trailing TODO: https://linear.app/baseten/issue/BT-10419/replace-datamodel-generation-with-original-model-defs

<!--
  How was the change described above implemented?
-->
## :computer: How
* Use pydantic's schema export + pydantic data model generator to add auto-generated model definitions to the stub source files.

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
