### PR TITLE
Cleanup Truss APIs around predict URLs.

### DIFF
--- a/slay/framework.py
+++ b/slay/framework.py
@@ -562,7 +562,6 @@ def _create_remote_service(
             baseten_service = baseten_client.deploy_truss(
                 truss_dir, publish=options.publish, promote=options.promote
             )
-            logs_url = baseten_client.get_logs_url(baseten_service)
         # Assuming baseten_url is like "https://app.baseten.co" or ""https://app.dev.baseten.co",
         deploy_url = options.baseten_url.replace(
             "https://", f"https://model-{baseten_service.model_id}."
@@ -577,7 +576,7 @@ def _create_remote_service(
         service = definitions.ServiceDescriptor(
             name=model_name, predict_url=f"{deploy_url}/predict"
         )
-        logging.info(f"🪵  View logs for your deployment at {logs_url}.")
+        logging.info(f"🪵  View logs for your deployment at {baseten_service.logs_url}.")
     else:
         raise NotImplementedError(options)
 

--- a/slay/truss_adapter/deploy.py
+++ b/slay/truss_adapter/deploy.py
@@ -176,6 +176,3 @@ class BasetenClient:
         if service is None:
             raise ValueError()
         return cast(b10_service.BasetenService, service)
-
-    def get_logs_url(self, service: b10_service.BasetenService) -> str:
-        return self._remote_provider.get_remote_logs_url(service)

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -233,8 +233,7 @@ def watch(
         sys.exit(1)
 
     service = remote_provider.get_service(model_identifier=ModelName(model_name))
-    logs_url = remote_provider.get_remote_logs_url(service)
-    rich.print(f"🪵  View logs for your deployment at {logs_url}")
+    rich.print(f"🪵  View logs for your deployment at {service.logs_url}")
     remote_provider.sync_truss_to_dev_version_by_name(model_name, target_directory)
 
 
@@ -537,8 +536,7 @@ Please push with --trusted to grant access to secrets.
 it will become the next production deployment of your model."""
         console.print(promotion_text, style="green")
 
-    logs_url = remote_provider.get_remote_logs_url(service)  # type: ignore[attr-defined]
-    rich.print(f"🪵  View logs for your deployment at {logs_url}")
+    rich.print(f"🪵  View logs for your deployment at {service.logs_url}")
     if wait:
         start_time = time.time()
         with console.status("[bold green]Deploying...") as status:

--- a/truss/remote/baseten/auth.py
+++ b/truss/remote/baseten/auth.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 class ApiKey:
     value: str
 
-    def __init__(self, value: str):
+    def __init__(self, value: str) -> None:
         self.value = value
 
     def header(self):
@@ -18,12 +18,12 @@ class ApiKey:
 
 
 class AuthService:
-    def __init__(self, api_key: Optional[str] = None):
+    def __init__(self, api_key: Optional[str] = None) -> None:
         if not api_key:
             api_key = os.environ.get("BASETEN_API_KEY", None)
         self._api_key = api_key
 
-    def validate(self):
+    def validate(self) -> None:
         if not self._api_key:
             raise AuthorizationError("No API key provided.")
 

--- a/truss/tests/remote/baseten/test_api.py
+++ b/truss/tests/remote/baseten/test_api.py
@@ -55,9 +55,7 @@ def mock_create_model_response():
 
 @pytest.fixture
 def baseten_api(mock_auth_service):
-    return BasetenApi(
-        "https://test.com/graphql", "https://api.test.com", mock_auth_service
-    )
+    return BasetenApi("https://app.test.com", mock_auth_service)
 
 
 @mock.patch("requests.post", return_value=mock_successful_response())

--- a/truss/tests/remote/test_remote_factory.py
+++ b/truss/tests/remote/test_remote_factory.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 import pytest
 from truss.remote.remote_factory import RemoteFactory
-from truss.remote.truss_remote import RemoteConfig, TrussRemote, TrussService
+from truss.remote.truss_remote import RemoteConfig, TrussRemote
 
 SAMPLE_CONFIG = {"api_key": "test_key", "remote_url": "http://test.com"}
 
@@ -35,9 +35,6 @@ class TestRemote(TrussRemote):
 
     def push(self):
         return {"status": "success"}
-
-    def get_remote_logs_url(self, service: TrussService) -> str:
-        raise NotImplementedError
 
     def get_service(self, **kwargs):
         raise NotImplementedError

--- a/truss/tests/remote/test_truss_remote.py
+++ b/truss/tests/remote/test_truss_remote.py
@@ -8,29 +8,33 @@ TEST_SERVICE_URL = "http://test.com"
 
 
 class TestTrussService(TrussService):
-    def __init__(self, remote_url: str, is_draft: bool, **kwargs):
-        super().__init__(remote_url, is_draft, **kwargs)
-        self._remote_url = remote_url
+    def __init__(self, _service_url: str, is_draft: bool, **kwargs):
+        super().__init__(_service_url, is_draft, **kwargs)
 
     def authenticate(self):
-        return {"Authorization": "Test"}
+        return {}
 
-    def is_live(self):
-        response = self._send_request(self._remote_url, "GET")
+    def is_live(self) -> bool:
+        response = self._send_request(self._service_url, "GET")
         if response.status_code == 200:
             return True
         return False
 
-    def is_ready(self):
-        response = self._send_request(self._remote_url, "GET")
+    def is_ready(self) -> bool:
+        response = self._send_request(self._service_url, "GET")
         if response.status_code == 200:
             return True
         return False
 
-    def logs_url(self, base_url: str) -> str:
-        return f"{base_url}/logs"
+    @property
+    def logs_url(self) -> str:
+        raise NotImplementedError()
 
-    def poll_deployment_status():
+    @property
+    def predict_url(self) -> str:
+        return f"{self._service_url}/v1/models/model:predict"
+
+    def poll_deployment_status(self) -> str:
         for status in ["DEPLOYING", "ACTIVE"]:
             yield status
 


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Simplify getting URLs (service methods do not depend on remote anmore). Add type annos, clean up unused methods.
<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
