### PR TITLE
Throw 500s when Triton encounters exceptions

### DIFF
--- a/truss/templates/trtllm/packages/triton_client.py
+++ b/truss/templates/trtllm/packages/triton_client.py
@@ -1,4 +1,3 @@
-import json
 import os
 import shutil
 import subprocess
@@ -13,6 +12,7 @@ from constants import (
     GRPC_SERVICE_PORT,
     TENSORRT_LLM_MODEL_REPOSITORY_PATH,
 )
+from fastapi import HTTPException
 from schema import ModelInput
 from utils import download_engine, prepare_model_repository
 
@@ -139,7 +139,9 @@ class TritonClient:
                     result = result.as_numpy("text_output")
                     yield result[0].decode("utf-8")
                 else:
-                    yield json.dumps({"status": "error", "message": error.message()})
+                    raise HTTPException(
+                        status_code=error.status(), detail=error.message()
+                    )
 
         except grpcclient.InferenceServerException as e:
-            print(f"InferenceServerException: {e}")
+            raise HTTPException(status_code=500, detail=str(e))

--- a/truss/templates/trtllm/packages/triton_client.py
+++ b/truss/templates/trtllm/packages/triton_client.py
@@ -139,9 +139,8 @@ class TritonClient:
                     result = result.as_numpy("text_output")
                     yield result[0].decode("utf-8")
                 else:
-                    raise HTTPException(
-                        status_code=error.status(), detail=error.message()
-                    )
+                    status = 500 if not error.status() else error.status()
+                    raise HTTPException(status_code=status, detail=error.message())
 
         except grpcclient.InferenceServerException as e:
             raise HTTPException(status_code=500, detail=str(e))


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What

This PR updates the Triton / TRT-LLM template to throw 500s when it encounters an exception. _This only applies in the non-streaming usecase_. 

<!--
  How was the change described above implemented?
-->
## :computer: How

We throw a FastAPI `HTTPException` when encountering a Triton `InferenceServerException`. Thanks to the change in [this](https://github.com/basetenlabs/truss/pull/886) PR, Truss will automatically propagate the exception to the underlying FastAPI server and pass more granular response types / status codes to the client. 

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing

I reproduced this code in an individual truss and confirmed that when `stream` is set to False, exceptions return responses with a `500` status code and appropriate message. 