### PR TITLE
Configurable RPC retries

### DIFF
--- a/truss-chains/tests/itest_chain/itest_chain.py
+++ b/truss-chains/tests/itest_chain/itest_chain.py
@@ -61,7 +61,9 @@ class ItestChain(chains.ChainletBase):
         self,
         context: chains.DeploymentContext = chains.provide_context(),
         data_generator: GenerateData = chains.provide(GenerateData),
-        splitter: shared_chainlet.SplitText = chains.provide(shared_chainlet.SplitText),
+        splitter: shared_chainlet.SplitTextFailOnce = chains.provide(
+            shared_chainlet.SplitTextFailOnce, retries=2
+        ),
         text_to_num: TextToNum = chains.provide(TextToNum),
     ) -> None:
         super().__init__(context)

--- a/truss-chains/tests/itest_chain/user_package/shared_chainlet.py
+++ b/truss-chains/tests/itest_chain/user_package/shared_chainlet.py
@@ -21,7 +21,7 @@ class SplitTextOutput(pydantic.BaseModel):
     part_lens: list[int]
 
 
-class SplitText(chains.ChainletBase):
+class SplitTextFailOnce(chains.ChainletBase):
 
     remote_config = chains.RemoteConfig(
         docker_image=chains.DockerImage(
@@ -30,10 +30,18 @@ class SplitText(chains.ChainletBase):
         )
     )
 
+    def __init__(self, context: chains.DeploymentContext = chains.provide_context()):
+        super().__init__(context)
+        self._count = 0
+
     async def run(
         self, inputs: SplitTextInput, extra_arg: int
     ) -> Tuple[SplitTextOutput, int]:
         import numpy as np
+
+        self._count += 1
+        if self._count == 1:
+            raise ValueError("Haha this is a fake error.")
 
         if inputs.mode == Modes.MODE_0:
             print(f"Using mode: `{inputs.mode}`")

--- a/truss-chains/truss_chains/__init__.py
+++ b/truss-chains/truss_chains/__init__.py
@@ -17,6 +17,7 @@ from truss_chains.definitions import (
     DeploymentContext,
     DockerImage,
     RemoteConfig,
+    RPCOptions,
     UsageError,
 )
 from truss_chains.public_api import (
@@ -26,4 +27,5 @@ from truss_chains.public_api import (
     provide_context,
     run_local,
 )
+from truss_chains.stub import StubBase
 from truss_chains.utils import make_abs_path_here

--- a/truss-chains/truss_chains/code_gen.py
+++ b/truss-chains/truss_chains/code_gen.py
@@ -86,10 +86,10 @@ def _gen_load_src(chainlet_descriptor: definitions.ChainletAPIDescriptor):
     """Generates AST for the `load` method of the truss model."""
     stub_inits = []
     stub_args = []
-    for name, proc_cls in chainlet_descriptor.dependencies.items():
-        cls_name = utils.make_stub_name(proc_cls.__name__)
+    for name, dep in chainlet_descriptor.dependencies.items():
+        cls_name = utils.make_stub_name(dep.name)
         stub_inits.append(
-            f"{name} = stub.factory({cls_name}, self._context, '{proc_cls.__name__}')"
+            f"{name} = stub.factory({cls_name}, self._context, '{dep.name}')"
         )
         stub_args.append(f"{name}={name}")
 
@@ -291,7 +291,7 @@ def _endpoint_body_src(endpoint: definitions.EndpointAPIDescriptor) -> str:
 
 
 def _gen_stub_src(
-    Chainlet: definitions.ChainletAPIDescriptor,
+    chainlet: definitions.ChainletAPIDescriptor,
     maybe_pydantic_types_file: Optional[pathlib.Path],
 ) -> tuple[str, list[str]]:
     """Generates stub class source, e.g:
@@ -314,9 +314,9 @@ def _gen_stub_src(
         imports.append(f"import {definitions.STUB_TYPE_MODULE}")
 
     src_parts = [
-        f"class {utils.make_stub_name(Chainlet.name)}(stub.StubBase):",
-        _indent(_endpoint_signature_src(Chainlet.endpoint)),
-        _indent(_endpoint_body_src(Chainlet.endpoint), 2),
+        f"class {utils.make_stub_name(chainlet.name)}(stub.StubBase):",
+        _indent(_endpoint_signature_src(chainlet.endpoint)),
+        _indent(_endpoint_body_src(chainlet.endpoint), 2),
         "\n\n",
     ]
     return "\n".join(src_parts), imports

--- a/truss-chains/truss_chains/definitions.py
+++ b/truss-chains/truss_chains/definitions.py
@@ -183,9 +183,15 @@ class RemoteConfig(SafeModelNonSerializable):
         return self.assets.get_spec()
 
 
+class RPCOptions(SafeModel):
+    timeout_sec: int = 600
+    retries: int = 1
+
+
 class ServiceDescriptor(SafeModel):
     name: str
     predict_url: str
+    options: RPCOptions
 
 
 class DeploymentContext(generics.GenericModel, Generic[UserConfigT]):
@@ -298,10 +304,19 @@ class EndpointAPIDescriptor(SafeModelNonSerializable):
     is_generator: bool
 
 
+class DependencyDescriptor(SafeModelNonSerializable):
+    chainlet_cls: Type[ABCChainlet]
+    options: RPCOptions
+
+    @property
+    def name(self) -> str:
+        return self.chainlet_cls.__name__
+
+
 class ChainletAPIDescriptor(SafeModelNonSerializable):
     chainlet_cls: Type[ABCChainlet]
     src_path: str
-    dependencies: Mapping[str, Type[ABCChainlet]]
+    dependencies: Mapping[str, DependencyDescriptor]
     endpoint: EndpointAPIDescriptor
     user_config_type: TypeDescriptor
 

--- a/truss-chains/truss_chains/public_api.py
+++ b/truss-chains/truss_chains/public_api.py
@@ -5,13 +5,13 @@ from truss_chains import definitions, deploy, framework
 
 def provide_context() -> Any:
     """Sets a 'symbolic marker' for injecting a Context object at runtime."""
-    return framework.ContextProvisionPlaceholder()
+    return framework.ContextProvisionMarker()
 
 
-def provide(chainlet_cls: Type[definitions.ABCChainlet]) -> Any:
+def provide(chainlet_cls: Type[definitions.ABCChainlet], retries: int = 1) -> Any:
     """Sets a 'symbolic marker' for injecting a stub or local Chainlet at runtime."""
-    # TODO: extend with RPC customization, e.g. timeouts, retries etc.
-    return framework.ChainletProvisionPlaceholder(chainlet_cls)
+    options = definitions.RPCOptions(retries=retries)
+    return framework.ChainletProvisionMarker(chainlet_cls, options)
 
 
 class ChainletBase(definitions.ABCChainlet[definitions.UserConfigT]):

--- a/truss-chains/truss_chains/stub.py
+++ b/truss-chains/truss_chains/stub.py
@@ -4,45 +4,77 @@ import logging
 from typing import Optional, Type, TypeVar, final
 
 import httpx
+import tenacity
 from truss_chains import definitions, utils
-
-DEFAULT_TIMEOUT_SEC = 600
 
 
 class BasetenSession:
     """Helper to invoke predict method on baseten deployments."""
 
     def __init__(
-        self, service_descriptor: definitions.ServiceDescriptor, api_key: str
+        self,
+        service_descriptor: definitions.ServiceDescriptor,
+        api_key: str,
     ) -> None:
         logging.info(
-            f"Creating stub for `{service_descriptor.name}` with predict URL:\n"
-            f"\t`{service_descriptor.predict_url}`"
+            f"Creating stub for `{service_descriptor.name}` "
+            f"({service_descriptor.options.retries} retries) with predict URL:\n"
+            f"    `{service_descriptor.predict_url}`"
         )
         self._auth_header = {"Authorization": f"Api-Key {api_key}"}
         self._service_descriptor = service_descriptor
 
     @functools.cached_property
     def _client_sync(self) -> httpx.Client:
-        return httpx.Client(headers=self._auth_header, timeout=DEFAULT_TIMEOUT_SEC)
+        return httpx.Client(
+            headers=self._auth_header,
+            timeout=self._service_descriptor.options.timeout_sec,
+        )
 
     @functools.cached_property
     def _client_async(self) -> httpx.AsyncClient:
-        return httpx.AsyncClient(headers=self._auth_header, timeout=DEFAULT_TIMEOUT_SEC)
+        return httpx.AsyncClient(
+            headers=self._auth_header,
+            timeout=self._service_descriptor.options.timeout_sec,
+        )
 
     def predict_sync(self, json_payload):
-        return utils.handle_response(
-            self._client_sync.post(
-                self._service_descriptor.predict_url, json=json_payload
-            )
+        retrying = tenacity.Retrying(
+            stop=tenacity.stop_after_attempt(self._service_descriptor.options.retries),
+            retry=tenacity.retry_if_exception_type(Exception),
+            reraise=True,
         )
+        for attempt in retrying:
+            with attempt:
+                if (num := attempt.retry_state.attempt_number) > 1:
+                    logging.info(
+                        f"Retrying `{self._service_descriptor.name}`, " f"attempt {num}"
+                    )
+                return utils.handle_response(
+                    self._client_sync.post(
+                        self._service_descriptor.predict_url, json=json_payload
+                    ),
+                    self._service_descriptor.name,
+                )
 
     async def predict_async(self, json_payload):
-        return utils.handle_response(
-            await self._client_async.post(
-                self._service_descriptor.predict_url, json=json_payload
-            )
+        retrying = tenacity.AsyncRetrying(
+            stop=tenacity.stop_after_attempt(self._service_descriptor.options.retries),
+            retry=tenacity.retry_if_exception_type(Exception),
+            reraise=True,
         )
+        async for attempt in retrying:
+            with attempt:
+                if (num := attempt.retry_state.attempt_number) > 1:
+                    logging.info(
+                        f"Retrying `{self._service_descriptor.name}`, " f"attempt {num}"
+                    )
+                return utils.handle_response(
+                    await self._client_async.post(
+                        self._service_descriptor.predict_url, json=json_payload
+                    ),
+                    self._service_descriptor.name,
+                )
 
 
 class StubBase(abc.ABC):
@@ -59,11 +91,15 @@ class StubBase(abc.ABC):
         cls,
         predict_url: str,
         context: definitions.DeploymentContext,
+        options: Optional[definitions.RPCOptions] = None,
         name: Optional[str] = None,
     ):
         name = name or cls.__name__
+        options = options or definitions.RPCOptions()
         return cls(
-            definitions.ServiceDescriptor(name=name, predict_url=predict_url),
+            definitions.ServiceDescriptor(
+                name=name, predict_url=predict_url, options=options
+            ),
             api_key=context.get_baseten_api_key(),
         )
 

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -81,7 +81,7 @@ def error_handling(f: Callable[..., object]):
         except click.UsageError as e:
             raise e  # You can re-raise the exception or handle it different
         except Exception as e:
-            click.secho(f"ERROR: {e}", fg="red")
+            click.secho(f"ERROR ({type(e)}: {e}", fg="red")
 
     return wrapper
 

--- a/truss/truss_handle.py
+++ b/truss/truss_handle.py
@@ -159,6 +159,7 @@ class TrussHandle:
         patch_ping_url: Optional[str] = None,
         wait_for_server_ready: bool = True,
         network: Optional[str] = None,
+        container_name_prefix: Optional[str] = None,
     ):
         """
         Builds a docker image and runs it as a container. For control trusses,
@@ -172,7 +173,10 @@ class TrussHandle:
             patch_ping_url:  Mostly for testing, if supplied then a live
                              reload capable truss queries for truss changes
                              by hitting this url.
-            wait_for_server_ready: If true, wait for server to pass readiness probe before returning.
+            wait_for_server_ready: If true, wait for server to pass readiness
+              probe before returning.
+            network: docker network name.
+            container_name_prefix: optional docker container name prefix.
 
         Returns:
             Container, which can be used to get information about the running,
@@ -198,6 +202,12 @@ class TrussHandle:
             if patch_ping_url is not None:
                 envs["PATCH_PING_URL_TRUSS"] = patch_ping_url
 
+            if container_name_prefix:
+                suffix = str(uuid.uuid4()).split("-")[0]
+                name = f"{container_name_prefix}-{suffix}"
+            else:
+                name = None
+
             def _run_docker(gpus: Optional[str] = None):
                 return Docker.client().run(
                     image.id,
@@ -214,6 +224,7 @@ class TrussHandle:
                     gpus=gpus,
                     envs=envs,
                     add_hosts=[("host.docker.internal", "host-gateway")],
+                    name=name,
                 )
 
             try:


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Add configurable retries to invoking remote chainlets.

E.g.

```
... = chains.provide(SplitTextFailOnce, retries=2)
```

<!--
  How was the change described above implemented?
-->
## :computer: How


<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
https://github.com/basetenlabs/truss/actions/runs/8791637768