### PR TITLE
Fix source-mapping issue and use original types instead of pydantic generated.

### DIFF
--- a/truss-chains/examples/text_to_num/main.py
+++ b/truss-chains/examples/text_to_num/main.py
@@ -174,7 +174,7 @@ if __name__ == "__main__":
 
     import asyncio
 
-    class FakeMistralLLM(chains.ChainletBase):
+    class FakeMistralLLM:
         def run(self, data: str) -> str:
             return data.upper()
 

--- a/truss-chains/tests/chains_test.py
+++ b/truss-chains/tests/chains_test.py
@@ -15,7 +15,9 @@ def test_chain():
         root = Path(__file__).parent.resolve()
         chain_root = root / "itest_chain" / "itest_chain.py"
         entrypoint = framework.import_target(chain_root, "ItestChain")
-        options = deploy.DeploymentOptionsLocalDocker(chain_name="integration-test")
+        options = definitions.DeploymentOptionsLocalDocker(
+            chain_name="integration-test"
+        )
         service = deploy.deploy_remotely(entrypoint, options)
 
         url = service.run_url.replace("host.docker.internal", "localhost")

--- a/truss-chains/tests/itest_chain/itest_chain.py
+++ b/truss-chains/tests/itest_chain/itest_chain.py
@@ -3,6 +3,7 @@ import math
 import pydantic
 import truss_chains as chains
 from user_package import shared_chainlet
+from user_package.nested_package import io_types
 
 IMAGE_COMMON = chains.DockerImage(
     pip_requirements_file=chains.make_abs_path_here("requirements.txt")
@@ -74,10 +75,10 @@ class ItestChain(chains.ChainletBase):
     async def run(self, length: int, num_partitions: int) -> tuple[int, str, int]:
         data = self._data_generator.run(length)
         text_parts, number = await self._data_splitter.run(
-            shared_chainlet.SplitTextInput(
+            io_types.SplitTextInput(
                 data=data,
                 num_partitions=num_partitions,
-                mode=shared_chainlet.Modes.MODE_1,
+                mode=io_types.Modes.MODE_1,
             ),
             extra_arg=123,
         )

--- a/truss-chains/tests/itest_chain/requirements.txt
+++ b/truss-chains/tests/itest_chain/requirements.txt
@@ -1,5 +1,1 @@
-datamodel-code-generator
 git+https://github.com/basetenlabs/truss.git
-httpx
-libcst
-pydantic

--- a/truss-chains/tests/itest_chain/user_package/nested_package/io_types.py
+++ b/truss-chains/tests/itest_chain/user_package/nested_package/io_types.py
@@ -1,0 +1,14 @@
+import enum
+
+import pydantic
+
+
+class Modes(str, enum.Enum):
+    MODE_0 = "MODE_0"
+    MODE_1 = "MODE_1"
+
+
+class SplitTextInput(pydantic.BaseModel):
+    data: str
+    num_partitions: int
+    mode: Modes

--- a/truss-chains/tests/itest_chain/user_package/shared_chainlet.py
+++ b/truss-chains/tests/itest_chain/user_package/shared_chainlet.py
@@ -1,24 +1,14 @@
-import enum
-from typing import Tuple
+from typing import List, Tuple  # Cover testing of antique type annotations.
 
 import pydantic
 import truss_chains as chains
 
-
-class Modes(str, enum.Enum):
-    MODE_0 = "MODE_0"
-    MODE_1 = "MODE_1"
-
-
-class SplitTextInput(pydantic.BaseModel):
-    data: str
-    num_partitions: int
-    mode: Modes
+from .nested_package import io_types  # Cover testing of relative import resolution.
 
 
 class SplitTextOutput(pydantic.BaseModel):
-    parts: list[str]
-    part_lens: list[int]
+    parts: List[str]
+    part_lens: List[int]
 
 
 class SplitTextFailOnce(chains.ChainletBase):
@@ -35,7 +25,7 @@ class SplitTextFailOnce(chains.ChainletBase):
         self._count = 0
 
     async def run(
-        self, inputs: SplitTextInput, extra_arg: int
+        self, inputs: io_types.SplitTextInput, extra_arg: int
     ) -> Tuple[SplitTextOutput, int]:
         import numpy as np
 
@@ -43,9 +33,9 @@ class SplitTextFailOnce(chains.ChainletBase):
         if self._count == 1:
             raise ValueError("Haha this is a fake error.")
 
-        if inputs.mode == Modes.MODE_0:
+        if inputs.mode == io_types.Modes.MODE_0:
             print(f"Using mode: `{inputs.mode}`")
-        elif inputs.mode == Modes.MODE_1:
+        elif inputs.mode == io_types.Modes.MODE_1:
             print(f"Using mode: `{inputs.mode}`")
         else:
             raise NotImplementedError(inputs.mode)

--- a/truss-chains/truss_chains/code_gen.py
+++ b/truss-chains/truss_chains/code_gen.py
@@ -1,21 +1,40 @@
-import ast
-import json
+"""
+New plan:
+
+* Collapse truss dir in generated code.
+* Move main file completely unchanged (not even needed to remove main).
+* Put it into truss-packages, keep its name, assert there are no name conflicts.
+* In truss model file, generate stubs and truss model.
+* Import deps from source code.
+* Check set of imports that it does not create collisions.
+
+
+
+
+
+"""
+
 import logging
+import os
 import pathlib
 import shlex
+import shutil
 import subprocess
+import sys
 import textwrap
-from typing import Any, Iterable, Mapping, Optional, cast
+from typing import Any, Iterable, Mapping, Optional
 
-import datamodel_code_generator
 import libcst
-from datamodel_code_generator import model as generator_models
-from datamodel_code_generator.parser import jsonschema as jsonschema_parser
+from truss import truss_config
+from truss.contexts.image_builder import serving_image_builder
 from truss_chains import definitions, model_skeleton, utils
 
-INDENT = " " * 4
+_REQUIREMENTS_FILENAME = "pip_requirements.txt"
+_MODEL_FILENAME = "model.py"
+_MODEL_CLS_NAME = model_skeleton.TrussChainletModel.__name__
 
-_DEFS_KEY = "$defs"
+
+INDENT = " " * 4
 
 
 def _indent(text: str, num: int = 1) -> str:
@@ -39,175 +58,63 @@ def _format_python_file(file_path: pathlib.Path) -> None:
     _run_simple_subprocess(f"isort {file_path}")
 
 
-def make_chainlet_dir(
-    chain_name: str,
+class _Source(definitions.SafeModelNonSerializable):
+    src: str
+    imports: set[str] = set()
+
+
+def _gen_import_and_ref(raw_type: Any) -> _Source:
+    """Returns e.g. ("from user_package import module", "module.OutputType")."""
+    if raw_type.__module__ == "__main__":
+        # TODO: assuming that main is copied into package dir and can be imported.
+        module_obj = sys.modules[raw_type.__module__]
+        if not module_obj.__file__:
+            raise definitions.APIDefinitionError(
+                f"File-based python code required. `{raw_type}` does not hava file."
+            )
+
+        file = os.path.basename(module_obj.__file__)
+        assert file.endswith(".py")
+        module_name = file.replace(".py", "")
+        import_src = f"import {module_name}"
+        ref_src = f"{module_name}.{raw_type.__name__}"
+    else:
+        parts = raw_type.__module__.split(".")
+        ref_src = f"{parts[-1]}.{raw_type.__name__}"
+        if len(parts) > 1:
+            import_src = f"from {'.'.join(parts[:-1])} import {parts[-1]}"
+        else:
+            import_src = f"import {parts[0]}"
+
+    return _Source(src=ref_src, imports={import_src})
+
+
+def _gen_type_import_and_ref(type_descr: definitions.TypeDescriptor) -> _Source:
+    """Returns e.g. ("from user_package import module", "module.OutputType")."""
+    if type_descr.is_pydantic:
+        return _gen_import_and_ref(type_descr.raw)
+
+    elif isinstance(type_descr.raw, type):
+        if not type_descr.raw.__module__ == "builtins":
+            raise TypeError(
+                f"{type_descr.raw} is not a builtin - cannot be rendered as source."
+            )
+        return _Source(src=type_descr.raw.__name__)
+    else:
+        return _Source(src=str(type_descr.raw))
+
+
+def _gen_chainlet_import_and_ref(
     chainlet_descriptor: definitions.ChainletAPIDescriptor,
-    root: pathlib.Path = pathlib.Path("/tmp"),
-) -> pathlib.Path:
-    chainlet_name = chainlet_descriptor.name
-    file_name = f"chainlet_{chainlet_name}"
-    chainlet_dir = root / definitions.GENERATED_CODE_DIR / chain_name / file_name
-    chainlet_dir.mkdir(exist_ok=True, parents=True)
-    return chainlet_dir
-
-
-# Truss Gen ############################################################################
-
-
-class _SpecifyChainletTypeAnnotation(libcst.CSTTransformer):
-    def __init__(self, new_annotation: str) -> None:
-        super().__init__()
-        self._new_annotation = new_annotation
-
-    def leave_SimpleStatementLine(
-        self,
-        original_node: libcst.SimpleStatementLine,
-        updated_node: libcst.SimpleStatementLine,
-    ) -> libcst.SimpleStatementLine:
-        new_body: list[Any] = []
-        for statement in updated_node.body:
-            if (
-                isinstance(statement, libcst.AnnAssign)
-                and isinstance(statement.target, libcst.Name)
-                and statement.target.value == "_chainlet"
-            ):
-                new_annotation = libcst.Annotation(
-                    annotation=libcst.Name(value=self._new_annotation)
-                )
-                new_statement = statement.with_changes(annotation=new_annotation)
-                new_body.append(new_statement)
-            else:
-                new_body.append(statement)
-
-        return updated_node.with_changes(body=tuple(new_body))
-
-
-def _gen_load_src(chainlet_descriptor: definitions.ChainletAPIDescriptor):
-    """Generates AST for the `load` method of the truss model."""
-    stub_inits = []
-    stub_args = []
-    for name, dep in chainlet_descriptor.dependencies.items():
-        cls_name = utils.make_stub_name(dep.name)
-        stub_inits.append(
-            f"{name} = stub.factory({cls_name}, self._context, '{dep.name}')"
-        )
-        stub_args.append(f"{name}={name}")
-
-    if stub_args:
-        init_args = f"context=self._context, {', '.join(stub_args)}"
-    else:
-        init_args = "context=self._context"
-
-    body = _indent(
-        "\n".join(
-            [f"logging.info(f'Loading Chainlet `{chainlet_descriptor.name}`.')"]
-            + stub_inits
-            + [f"self._chainlet = {chainlet_descriptor.name}({init_args})"]
-        )
-    )
-    return libcst.parse_statement("\n".join(["def load(self) -> None:", body]))
-
-
-def _gen_predict_src(
-    endpoint_descriptor: definitions.EndpointAPIDescriptor, chainlet_name: str
-):
-    """Generates AST for the `predict` method of the truss model."""
-    if endpoint_descriptor.is_generator:
-        # TODO: implement generator.
-        raise NotImplementedError("Generator.")
-
-    parts = []
-    def_str = "async def" if endpoint_descriptor.is_async else "def"
-    parts.append(f"{def_str} predict(self, payload):")
-    # Add error handling context manager:
-    parts.append(
-        _indent(
-            f"with utils.exception_to_http_error("
-            f'include_stack=True, chainlet_name="{chainlet_name}"):'
-        )
-    )
-    # Convert items from json payload dict to an arg-list, parsing pydantic models.
-    args = ", ".join(
-        (
-            f"{arg_name}={arg_type.as_src_str()}.parse_obj(payload['{arg_name}'])"
-            if arg_type.is_pydantic
-            else f"{arg_name}=payload['{arg_name}']"
-        )
-        for arg_name, arg_type in endpoint_descriptor.input_names_and_types
-    )
-    # Invoke Chainlet.
-    maybe_await = "await " if endpoint_descriptor.is_async else ""
-    parts.append(
-        _indent(
-            f"result = {maybe_await}self._chainlet.{endpoint_descriptor.name}({args})",
-            2,
-        )
-    )
-    # Return as json tuple, serialize pydantic models.
-    if len(endpoint_descriptor.output_types) == 1:
-        output_type = endpoint_descriptor.output_types[0]
-        result = "result.dict()" if output_type.is_pydantic else "result"
-    else:
-        result_parts = [
-            f"result[{i}].dict()" if t.is_pydantic else f"result[{i}]"
-            for i, t in enumerate(endpoint_descriptor.output_types)
-        ]
-        result = f"{', '.join(result_parts)}"
-
-    parts.append(_indent(f"return {result}"))
-
-    return libcst.parse_statement("\n".join(parts))
-
-
-def _generate_truss_model(
-    chainlet_descriptor: definitions.ChainletAPIDescriptor,
-) -> tuple[libcst.CSTNode, list[libcst.SimpleStatementLine], libcst.CSTNode]:
-    logging.info(f"Generating Truss model for `{chainlet_descriptor.name}`.")
-    skeleton_tree = libcst.parse_module(
-        pathlib.Path(model_skeleton.__file__).read_text()
-    )
-    imports: list[Any] = [
-        node
-        for node in skeleton_tree.body
-        if isinstance(node, libcst.SimpleStatementLine)
-        and any(
-            isinstance(stmt, libcst.Import) or isinstance(stmt, libcst.ImportFrom)
-            for stmt in node.body
-        )
-    ]
-    imports.append(libcst.parse_statement("import logging"))
-    imports.append(libcst.parse_statement("from truss_chains import utils"))
-
-    class_definition: libcst.ClassDef = utils.expect_one(
-        node
-        for node in skeleton_tree.body
-        if isinstance(node, libcst.ClassDef)
-        and node.name.value == model_skeleton.TrussChainletModel.__name__
-    )
-
-    load_def = _gen_load_src(chainlet_descriptor)
-    predict_def = _gen_predict_src(
-        chainlet_descriptor.endpoint, chainlet_descriptor.name
-    )
-    new_body: list[Any] = list(class_definition.body.body) + [load_def, predict_def]
-    new_block = libcst.IndentedBlock(body=new_body)
-    class_definition = class_definition.with_changes(body=new_block)
-    class_definition = class_definition.visit(  # type: ignore[assignment]
-        _SpecifyChainletTypeAnnotation(chainlet_descriptor.name)
-    )
-    if issubclass(chainlet_descriptor.user_config_type.raw, type(None)):
-        userconfig_pin = libcst.parse_statement("UserConfigT = type(None)")
-    else:
-        userconfig_pin = libcst.parse_statement(
-            f"UserConfigT = {chainlet_descriptor.user_config_type.as_src_str()}"
-        )
-    return class_definition, imports, userconfig_pin
+) -> _Source:
+    """Returns e.g. ("from user_package import module", "module.OutputType")."""
+    return _gen_import_and_ref(chainlet_descriptor.chainlet_cls)
 
 
 # Stub Gen #############################################################################
 
 
-def _endpoint_signature_src(endpoint: definitions.EndpointAPIDescriptor):
+def _endpoint_signature_src(endpoint: definitions.EndpointAPIDescriptor) -> _Source:
     """
     E.g.: `async def run(self, data: str, num_partitions: int) -> tuple[list, int]:`
     """
@@ -215,24 +122,32 @@ def _endpoint_signature_src(endpoint: definitions.EndpointAPIDescriptor):
         # TODO: implement generator.
         raise NotImplementedError("Generator.")
 
-    def_str = "async def" if endpoint.is_async else "def"
-    args = ", ".join(
-        f"{arg_name}: {arg_type.as_src_str(definitions.STUB_TYPE_MODULE)}"
-        for arg_name, arg_type in endpoint.input_names_and_types
-    )
-    if len(endpoint.output_types) == 1:
-        output_type = (
-            f"{endpoint.output_types[0].as_src_str(definitions.STUB_TYPE_MODULE)}"
-        )
+    imports = set()
+    args = []
+    for arg_name, arg_type in endpoint.input_names_and_types:
+        arg_ref = _gen_type_import_and_ref(arg_type)
+        imports.update(arg_ref.imports)
+        args.append(f"{arg_name}: {arg_ref.src}")
+
+    outputs = []
+    for output_type in endpoint.output_types:
+        out_ref = _gen_type_import_and_ref(output_type)
+        outputs.append(out_ref.src)
+        imports.update(out_ref.imports)
+
+    if len(outputs) == 1:
+        output = outputs[0]
     else:
-        out_types = ", ".join(
-            t.as_src_str(definitions.STUB_TYPE_MODULE) for t in endpoint.output_types
-        )
-        output_type = f"tuple[{out_types}]"
-    return f"{def_str} {endpoint.name}(self, {args}) -> {output_type}:"
+        output = f"tuple[{', '.join(outputs)}]"
+
+    def_str = "async def" if endpoint.is_async else "def"
+    return _Source(
+        src=f"{def_str} {endpoint.name}(self, {','.join(args)}) -> {output}:",
+        imports=imports,
+    )
 
 
-def _endpoint_body_src(endpoint: definitions.EndpointAPIDescriptor) -> str:
+def _endpoint_body_src(endpoint: definitions.EndpointAPIDescriptor) -> _Source:
     """Generates source code for calling the stub and wrapping the I/O types.
 
     E.g.:
@@ -245,55 +160,51 @@ def _endpoint_body_src(endpoint: definitions.EndpointAPIDescriptor) -> str:
     if endpoint.is_generator:
         raise NotImplementedError("Generator")
 
+    imports = set()
     parts = []
     # Pack arg list as json dictionary.
-    json_arg_parts = (
-        (
-            f"'{arg_name}': {arg_name}.dict()"
-            if arg_type.is_pydantic
-            else f"'{arg_name}': {arg_name}"
-        )
-        for arg_name, arg_type in endpoint.input_names_and_types
-    )
-    json_args = f"{{{', '.join(json_arg_parts)}}}"
-    parts.append(f"json_args = {json_args}")
+    json_args = []
+    for arg_name, arg_type in endpoint.input_names_and_types:
+        if arg_type.is_pydantic:
+            json_args.append(f"'{arg_name}': {arg_name}.dict()")
+        else:
+            json_args.append(f"'{arg_name}': {arg_name}")
+    parts.append(f"json_args = {{{', '.join(json_args)}}}")
+
     # Invoke remote.
-    remote_call = (
-        "await self._remote.predict_async(json_args)"
-        if endpoint.is_async
-        else "self._remote.predict_sync(json_args)"
-    )
+    if endpoint.is_async:
+        remote_call = "await self._remote.predict_async(json_args)"
+    else:
+        remote_call = "self._remote.predict_sync(json_args)"
+
     parts.append(f"json_result = {remote_call}")
+
     # Unpack response and parse as pydantic models if needed.
     if len(endpoint.output_types) == 1:
         output_type = utils.expect_one(endpoint.output_types)
         if output_type.is_pydantic:
-            type_str = output_type.as_src_str(definitions.STUB_TYPE_MODULE)
-            ret = f"{type_str}.parse_obj(json_result)"
+            out_ref = _gen_type_import_and_ref(output_type)
+            imports.update(out_ref.imports)
+            result = f"{out_ref.src}.parse_obj(json_result)"
         else:
-            ret = "json_result"
+            result = "json_result"
     else:
-        ret_parts = ", ".join(
-            (
-                (
-                    f"{output_type.as_src_str(definitions.STUB_TYPE_MODULE)}"
-                    f".parse_obj(json_result[{i}])"
-                )
-                if output_type.is_pydantic
-                else f"json_result[{i}]"
-            )
-            for i, output_type in enumerate(endpoint.output_types)
-        )
-        ret = f"{ret_parts}"
-    parts.append(f"return {ret}")
+        outputs = []
+        for i, output_type in enumerate(endpoint.output_types):
+            if output_type.is_pydantic:
+                out_ref = _gen_type_import_and_ref(output_type)
+                outputs.append(f"{out_ref.src}.parse_obj(json_result[{i}])")
+                imports.update(out_ref.imports)
+            else:
+                outputs.append(f"json_result[{i}]")
 
-    return "\n".join(parts)
+        result = ", ".join(outputs)
+
+    parts.append(f"return {result}")
+    return _Source(src="\n".join(parts), imports=imports)
 
 
-def _gen_stub_src(
-    chainlet: definitions.ChainletAPIDescriptor,
-    maybe_pydantic_types_file: Optional[pathlib.Path],
-) -> tuple[str, list[str]]:
+def _gen_stub_src(chainlet: definitions.ChainletAPIDescriptor) -> _Source:
     """Generates stub class source, e.g:
 
     ```
@@ -309,186 +220,363 @@ def _gen_stub_src(
             return (SplitTextOutput.parse_obj(json_result[0]), json_result[1])
     ```
     """
-    imports = ["from truss_chains import stub"]
-    if maybe_pydantic_types_file:
-        imports.append(f"import {definitions.STUB_TYPE_MODULE}")
+    imports = {"from truss_chains import stub"}
+    signature = _endpoint_signature_src(chainlet.endpoint)
+    imports.update(signature.imports)
+    body = _endpoint_body_src(chainlet.endpoint)
+    imports.update(body.imports)
 
     src_parts = [
-        f"class {utils.make_stub_name(chainlet.name)}(stub.StubBase):",
-        _indent(_endpoint_signature_src(chainlet.endpoint)),
-        _indent(_endpoint_body_src(chainlet.endpoint), 2),
-        "\n\n",
+        f"class {chainlet.name}(stub.StubBase):",
+        _indent(signature.src),
+        _indent(body.src, 2),
+        "\n",
     ]
-    return "\n".join(src_parts), imports
+    return _Source(src="\n".join(src_parts), imports=imports)
 
 
-def _remove_root_model(pydantic_src: str) -> str:
-    """To process source code generated by `datamodel_code_generator`."""
-    tree = ast.parse(pydantic_src)
-    src = []
-    for node in tree.body:
-        if isinstance(node, ast.ClassDef) and node.name == "Model":
-            continue
-        else:
-            src.append(node)
-
-    return f"{ast.unparse(ast.Module(body=src, type_ignores=[]))}\n\n"
-
-
-def _export_pydantic_schemas(
+def _gen_stub_src_for_deps(
     dependencies: Iterable[definitions.ChainletAPIDescriptor],
-) -> Mapping[str, Any]:
-    """Creates a dict with all pydantic schemas used as input or output types by the
-    dependencies.
-
-    If a schema itself depends on another class (e.g. an enum definition), these
-    dependent schemas are also added to the dict.
-
-    It is enforced that pydantic models across the code base have different names,
-    to avoid conflicts; automatic disambiguation is not yet implemented.
-    """
-    name_to_schema: dict[str, Any] = {}
-
-    def safe_add_schema(type_descr: definitions.TypeDescriptor):
-        if not type_descr.is_pydantic:
-            return
-
-        name = type_descr.raw.__name__
-        schema = type_descr.raw.schema()
-        if existing_schema := name_to_schema.get(name):
-            if existing_schema != schema:
-                raise NotImplementedError(
-                    f"Two pydantic models with same name `{name}."
-                )
-        else:
-            # Move definitions needed by the current type to top level.
-            if _DEFS_KEY in schema:
-                for def_name, def_schema in schema[_DEFS_KEY].items():
-                    if existing_def_schema := name_to_schema.get(def_name):
-                        if existing_def_schema != def_schema:
-                            raise NotImplementedError(
-                                f"Two pydantic models with same name `{def_name}."
-                            )
-                    else:
-                        name_to_schema[def_name] = def_schema
-                schema.pop(_DEFS_KEY)
-
-            name_to_schema[name] = schema
-
-    for dep in dependencies:
-        for _, input_type in dep.endpoint.input_names_and_types:
-            safe_add_schema(input_type)
-        for output_type in dep.endpoint.output_types:
-            safe_add_schema(output_type)
-    return name_to_schema
-
-
-def gen_pydantic_models(
-    file_path: pathlib.Path,
-    dependencies: Iterable[definitions.ChainletAPIDescriptor],
-) -> Optional[pathlib.Path]:
-    name_to_schema = _export_pydantic_schemas(dependencies)
-
-    if not name_to_schema:
-        return None
-
-    combined_schema = {_DEFS_KEY: name_to_schema}
-    # TODO: parameterize pydantic and python version properly.
-    py_version = datamodel_code_generator.PythonVersion.PY_39
-    data_model_types = generator_models.get_data_model_types(
-        data_model_type=datamodel_code_generator.DataModelType.PydanticBaseModel,
-        target_python_version=py_version,
-    )
-    with utils.log_level(logging.INFO):
-        parser = jsonschema_parser.JsonSchemaParser(
-            json.dumps(combined_schema),
-            data_model_type=data_model_types.data_model,
-            data_model_root_type=data_model_types.root_model,
-            data_model_field_type=data_model_types.field_model,
-            data_type_manager_type=data_model_types.data_type_manager,
-            target_python_version=py_version,
-            capitalise_enum_members=True,
-            use_subclass_enum=True,
-            strict_nullable=True,
-            apply_default_values_for_required_fields=True,
-            use_default_kwarg=True,
-            use_standard_collections=True,
-        )
-        pydantic_module_src: str = cast(str, parser.parse())
-    file_path.write_text(_remove_root_model(pydantic_module_src))
-    return file_path
-
-
-def _generate_stub_src_for_deps(
-    dependencies: Iterable[definitions.ChainletAPIDescriptor],
-    pydantic_types_file: Optional[pathlib.Path],
-) -> Optional[tuple[str, set[str]]]:
+) -> Optional[_Source]:
     """Generates a source code and imports for stub classes."""
     imports = set()
     src_parts = []
-
     for dep in dependencies:
-        stub_src, new_imports = _gen_stub_src(dep, pydantic_types_file)
-        imports.update(new_imports)
-        src_parts.append(stub_src)
+        stub_src = _gen_stub_src(dep)
+        imports.update(stub_src.imports)
+        src_parts.append(stub_src.src)
 
     if not (imports or src_parts):
         return None
-    return "\n".join(src_parts), imports
+    return _Source(src="\n".join(src_parts), imports=imports)
+
+
+# Truss Chainlet Gen ###################################################################
+
+
+def _make_chainlet_dir(
+    chain_name: str,
+    chainlet_descriptor: definitions.ChainletAPIDescriptor,
+    root: pathlib.Path,
+) -> pathlib.Path:
+    chainlet_name = chainlet_descriptor.name
+    dir_name = f"chainlet_{chainlet_name}"
+    chainlet_dir = root / definitions.GENERATED_CODE_DIR / chain_name / dir_name
+    chainlet_dir.mkdir(exist_ok=True, parents=True)
+    return chainlet_dir
+
+
+class _SpecifyChainletTypeAnnotation(libcst.CSTTransformer):
+    """Inserts the concrete chainlet class into `_chainlet: definitions.ABCChainlet`."""
+
+    def __init__(self, new_annotation: str) -> None:
+        super().__init__()
+        self._new_annotation = libcst.parse_expression(new_annotation)
+
+    def leave_SimpleStatementLine(
+        self,
+        original_node: libcst.SimpleStatementLine,
+        updated_node: libcst.SimpleStatementLine,
+    ) -> libcst.SimpleStatementLine:
+        new_body: list[Any] = []
+        for statement in updated_node.body:
+            if (
+                isinstance(statement, libcst.AnnAssign)
+                and isinstance(statement.target, libcst.Name)
+                and statement.target.value == "_chainlet"
+            ):
+                new_annotation = libcst.Annotation(annotation=self._new_annotation)
+                new_statement = statement.with_changes(annotation=new_annotation)
+                new_body.append(new_statement)
+            else:
+                new_body.append(statement)
+
+        return updated_node.with_changes(body=tuple(new_body))
+
+
+def _gen_load_src(chainlet_descriptor: definitions.ChainletAPIDescriptor) -> _Source:
+    """Generates AST for the `load` method of the truss model."""
+    imports = {"from truss_chains import stub", "import logging"}
+    stubs = []
+    stub_args = []
+    for name, dep in chainlet_descriptor.dependencies.items():
+        stubs.append(f"{name} = stub.factory({dep.name}, self._context, '{dep.name}')")
+        stub_args.append(f"{name}={name}")
+
+    if stub_args:
+        init_args = f"context=self._context, {', '.join(stub_args)}"
+    else:
+        init_args = "context=self._context"
+
+    user_chainlet_ref = _gen_chainlet_import_and_ref(chainlet_descriptor)
+    imports.update(user_chainlet_ref.imports)
+    body = _indent(
+        "\n".join(
+            [f"logging.info(f'Loading Chainlet `{chainlet_descriptor.name}`.')"]
+            + stubs
+            + [f"self._chainlet = {user_chainlet_ref.src}({init_args})"]
+        )
+    )
+    src = "\n".join(["def load(self) -> None:", body])
+    return _Source(src=src, imports=imports)
+
+
+def _gen_predict_src(chainlet_descriptor: definitions.ChainletAPIDescriptor) -> _Source:
+    """Generates AST for the `predict` method of the truss model."""
+    if chainlet_descriptor.endpoint.is_generator:
+        # TODO: implement generator.
+        raise NotImplementedError("Generator.")
+
+    imports = set()
+    parts = []
+    def_str = "async def" if chainlet_descriptor.endpoint.is_async else "def"
+    parts.append(f"{def_str} predict(self, payload):")
+    # Add error handling context manager:
+    parts.append(
+        _indent(
+            f"with utils.exception_to_http_error("
+            f'include_stack=True, chainlet_name="{chainlet_descriptor.name}"):'
+        )
+    )
+    # Convert items from json payload dict to an arg-list, parsing pydantic models.
+    args = []
+    for arg_name, arg_type in chainlet_descriptor.endpoint.input_names_and_types:
+        if arg_type.is_pydantic:
+            type_ref = _gen_type_import_and_ref(arg_type)
+            imports.update(type_ref.imports)
+            args.append(f"{arg_name}={type_ref.src}.parse_obj(payload['{arg_name}'])")
+        else:
+            args.append(f"{arg_name}=payload['{arg_name}']")
+
+    # Invoke Chainlet.
+    maybe_await = "await " if chainlet_descriptor.endpoint.is_async else ""
+    args_src = ",".join(args)
+    run = chainlet_descriptor.endpoint.name
+    parts.append(_indent(f"result = {maybe_await}self._chainlet.{run}({args_src})", 2))
+
+    # Return as json tuple, serialize pydantic models.
+    if len(chainlet_descriptor.endpoint.output_types) == 1:
+        output_type = chainlet_descriptor.endpoint.output_types[0]
+        result = "result.dict()" if output_type.is_pydantic else "result"
+    else:
+        result_parts = [
+            f"result[{i}].dict()" if t.is_pydantic else f"result[{i}]"
+            for i, t in enumerate(chainlet_descriptor.endpoint.output_types)
+        ]
+        result = f"{', '.join(result_parts)}"
+
+    parts.append(_indent(f"return {result}"))
+
+    return _Source(src="\n".join(parts), imports=imports)
+
+
+def _gen_truss_chainlet_model(
+    chainlet_descriptor: definitions.ChainletAPIDescriptor,
+) -> _Source:
+    logging.info(f"Generating Truss model for `{chainlet_descriptor.name}`.")
+    skeleton_tree = libcst.parse_module(
+        pathlib.Path(model_skeleton.__file__).read_text()
+    )
+    imports: set[str] = set(
+        libcst.Module(body=[node]).code
+        for node in skeleton_tree.body
+        if isinstance(node, libcst.SimpleStatementLine)
+        and any(
+            isinstance(stmt, libcst.Import) or isinstance(stmt, libcst.ImportFrom)
+            for stmt in node.body
+        )
+    )
+
+    imports.add("import logging")
+    imports.add("from truss_chains import utils")
+
+    class_definition: libcst.ClassDef = utils.expect_one(
+        node
+        for node in skeleton_tree.body
+        if isinstance(node, libcst.ClassDef)
+        and node.name.value == model_skeleton.TrussChainletModel.__name__
+    )
+
+    load_src = _gen_load_src(chainlet_descriptor)
+    imports.update(load_src.imports)
+    predict_src = _gen_predict_src(chainlet_descriptor)
+    imports.update(predict_src.imports)
+
+    new_body: list[Any] = list(class_definition.body.body) + [
+        libcst.parse_statement(load_src.src),
+        libcst.parse_statement(predict_src.src),
+    ]
+
+    user_chainlet_ref = _gen_chainlet_import_and_ref(chainlet_descriptor)
+    imports.update(user_chainlet_ref.imports)
+
+    new_block = libcst.IndentedBlock(body=new_body)
+    class_definition = class_definition.with_changes(body=new_block)
+    class_definition = class_definition.visit(  # type: ignore[assignment]
+        _SpecifyChainletTypeAnnotation(user_chainlet_ref.src)
+    )
+    model_class_src = libcst.Module(body=[class_definition]).code
+
+    if issubclass(chainlet_descriptor.user_config_type.raw, type(None)):
+        userconfig_pin = "UserConfigT = type(None)"
+    else:
+        user_config_ref = _gen_type_import_and_ref(chainlet_descriptor.user_config_type)
+        imports.update(user_config_ref.imports)
+        userconfig_pin = f"UserConfigT = {user_config_ref.src}"
+    return _Source(src=f"{userconfig_pin}\n\n{model_class_src}", imports=imports)
 
 
 # Remote Chainlet Gen #################################################################
 
 
-class _MainRemover(ast.NodeTransformer):
-    """Removes main-section from module AST."""
-
-    def visit_If(self, node):
-        """Robustly matches variations of `if __name__ == "__main__":`."""
-        if (
-            isinstance(node.test, ast.Compare)
-            and any(
-                isinstance(c, ast.Name) and c.id == "__name__"
-                for c in ast.walk(node.test.left)
-            )
-            and any(
-                isinstance(c, ast.Constant) and c.value == "__main__"
-                for c in ast.walk(node.test)
-            )
-        ):
-            return None
-        return self.generic_visit(node)
-
-
-def _remove_main_section(source_code: str) -> str:
-    """Removes main-section from module source."""
-    parsed_code = ast.parse(source_code)
-    transformer = _MainRemover()
-    transformed_ast = transformer.visit(parsed_code)
-    return ast.unparse(transformed_ast)
-
-
-def generate_chainlet_source(
-    file_path: pathlib.Path,
+def _gen_truss_chainlet_file(
+    chainlet_dir: pathlib.Path,
     chainlet_descriptor: definitions.ChainletAPIDescriptor,
     dependencies: Iterable[definitions.ChainletAPIDescriptor],
-    pydantic_types_file: Optional[pathlib.Path],
-):
+) -> pathlib.Path:
     """Generates code that wraps a Chainlet as a truss-compatible model."""
-    maybe_stub_src = _generate_stub_src_for_deps(dependencies, pydantic_types_file)
+    file_path = chainlet_dir / truss_config.DEFAULT_MODEL_MODULE_DIR / _MODEL_FILENAME
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    # TODO: why does truss *need* an init file?
+    (chainlet_dir / truss_config.DEFAULT_MODEL_MODULE_DIR / "__init__.py").write_text(
+        ""
+    )
+    imports = set()
+    src_parts = []
+    if maybe_stub_src := _gen_stub_src_for_deps(dependencies):
+        imports.update(maybe_stub_src.imports)
+        src_parts.append(maybe_stub_src.src)
 
-    source_code = _remove_main_section(file_path.read_text())
-    if maybe_stub_src:
-        stub_src, stub_imports = maybe_stub_src
-        stub_imports_str = "\n".join(stub_imports)
-        source_code = f"{stub_imports_str}\n{source_code}\n{stub_src}"
-
-    source_tree = libcst.parse_module(source_code)
-
-    # TODO: Chainlet isolation: either prune file from high-confidence unneeded.
-
-    model_def, imports, userconfig_pin = _generate_truss_model(chainlet_descriptor)
-    new_body: list[Any] = imports + list(source_tree.body) + [userconfig_pin, model_def]
-    source_tree = source_tree.with_changes(body=new_body)
-    file_path.write_text(source_tree.code)
+    model_src = _gen_truss_chainlet_model(chainlet_descriptor)
+    src_parts.append(model_src.src)
+    imports.update(model_src.imports)
+    imports_str = "\n".join(imports)
+    src_str = "\n".join(src_parts)
+    file_path.write_text(f"{imports_str}\n{src_str}")
     _format_python_file(file_path)
+    return file_path
+
+
+# Truss Gen ############################################################################
+
+
+def _copy_python_source_files(root_dir: pathlib.Path, dest_dir: pathlib.Path) -> None:
+    """Copy all python files under root recursively, but skips pycache."""
+
+    def python_files_only(path, names):
+        return [name for name in names if name == "__pycache__"]
+
+    shutil.copytree(root_dir, dest_dir, ignore=python_files_only, dirs_exist_ok=True)
+
+
+def _make_truss_config(
+    chainlet_dir: pathlib.Path,
+    chains_config: definitions.RemoteConfig,
+    user_config: definitions.UserConfigT,
+    chainlet_to_service: Mapping[str, definitions.ServiceDescriptor],
+    model_name: str,
+) -> truss_config.TrussConfig:
+    """Generate a truss config for a Chainlet."""
+    config = truss_config.TrussConfig()
+    config.model_name = model_name
+    config.model_class_filename = _MODEL_FILENAME
+    config.model_class_name = _MODEL_CLS_NAME
+    # Compute.
+    compute = chains_config.get_compute_spec()
+    config.resources.cpu = str(compute.cpu_count)
+    config.resources.accelerator = compute.accelerator
+    config.resources.use_gpu = bool(compute.accelerator.count)
+    # TODO: expose this setting directly.
+    config.runtime.predict_concurrency = compute.cpu_count
+    # Image.
+    image = chains_config.docker_image
+    config.base_image = truss_config.BaseImage(image=image.base_image)
+    pip_requirements: list[str] = []
+    if image.pip_requirements_file:
+        pip_requirements.extend(
+            req
+            for req in pathlib.Path(image.pip_requirements_file.abs_path)
+            .read_text()
+            .splitlines()
+            if not req.strip().startswith("#")
+        )
+    pip_requirements.extend(image.pip_requirements)
+    # TODO: `pip_requirements` will add server requirements which give version
+    #  conflicts. Check if that's still the case after relaxing versions.
+    # config.requirements = pip_requirements
+    pip_requirements_file_path = chainlet_dir / _REQUIREMENTS_FILENAME
+    pip_requirements_file_path.write_text("\n".join(pip_requirements))
+    # Absolute paths don't work with remote build.
+    config.requirements_file = _REQUIREMENTS_FILENAME
+    config.system_packages = image.apt_requirements
+    # Assets.
+    assets = chains_config.get_asset_spec()
+    config.secrets = assets.secrets
+    if definitions.BASETEN_API_SECRET_NAME not in config.secrets:
+        config.secrets[definitions.BASETEN_API_SECRET_NAME] = definitions.SECRET_DUMMY
+    else:
+        logging.info(
+            f"Chains automatically add {definitions.BASETEN_API_SECRET_NAME} "
+            "to secrets - no need to manually add it."
+        )
+    config.model_cache.models = assets.cached
+    # Metadata.
+    chains_metadata: definitions.TrussMetadata = definitions.TrussMetadata(
+        user_config=user_config, chainlet_to_service=chainlet_to_service
+    )
+    config.model_metadata[definitions.TRUSS_CONFIG_CHAINS_KEY] = chains_metadata.dict()
+    config.write_to_yaml_file(
+        chainlet_dir / serving_image_builder.CONFIG_FILE, verbose=True
+    )
+    return config
+
+
+def gen_truss_chainlet(
+    options: definitions.DeploymentOptions,
+    chainlet_descriptor: definitions.ChainletAPIDescriptor,
+    dependencies: Iterable[definitions.ChainletAPIDescriptor],
+    chainlet_name_to_url: Mapping[str, str],
+    chain_root: pathlib.Path,
+    gen_root: pathlib.Path,
+) -> pathlib.Path:
+    # TODO: support file-based config (and/or merge file and python-src config values).
+    remote_config = chainlet_descriptor.chainlet_cls.remote_config
+    chainlet_name = remote_config.name or chainlet_descriptor.name
+    # Filter needed services and customize options.
+    dep_services = {}
+    for dep in chainlet_descriptor.dependencies.values():
+        dep_services[dep.name] = definitions.ServiceDescriptor(
+            name=dep.name,
+            predict_url=chainlet_name_to_url[dep.name],
+            options=dep.options,
+        )
+
+    chainlet_dir = _make_chainlet_dir(options.chain_name, chainlet_descriptor, gen_root)
+
+    _make_truss_config(
+        chainlet_dir,
+        remote_config,
+        chainlet_descriptor.chainlet_cls.default_user_config,
+        dep_services,
+        f"{options.chain_name}.{chainlet_name}",
+    )
+    # TODO This assume all imports are absolute w.r.t chain root (or site-packages).
+    #   Also: apparently packages need an `__init__`, or crash.
+    _copy_python_source_files(
+        chain_root, chainlet_dir / truss_config.DEFAULT_BUNDLED_PACKAGES_DIR
+    )
+    chainlet_file = _gen_truss_chainlet_file(
+        chainlet_dir, chainlet_descriptor, dependencies
+    )
+    if remote_config.docker_image.data_dir:
+        data_dir = chainlet_dir / truss_config.DEFAULT_DATA_DIRECTORY
+        data_dir.mkdir(parents=True, exist_ok=True)
+        user_data_dir = remote_config.docker_image.data_dir.abs_path
+        shutil.copytree(user_data_dir, data_dir, dirs_exist_ok=True)
+
+    # Copy model file s.t. during debugging imports can are properly resolved.
+    shutil.copy(
+        chainlet_file,
+        chainlet_file.parent.parent / truss_config.DEFAULT_BUNDLED_PACKAGES_DIR,
+    )
+    return chainlet_dir

--- a/truss-chains/truss_chains/definitions.py
+++ b/truss-chains/truss_chains/definitions.py
@@ -1,8 +1,8 @@
 # TODO: this file contains too much implementation -> restructure.
-
 import abc
 import logging
 import os
+import pathlib
 import traceback
 from types import GenericAlias
 from typing import (
@@ -15,11 +15,14 @@ from typing import (
     Type,
     TypeVar,
     Union,
+    cast,
 )
 
 import pydantic
 from pydantic import generics
 from truss import truss_config
+from truss.remote import baseten as baseten_remote
+from truss.remote import remote_cli, remote_factory
 
 UserConfigT = TypeVar("UserConfigT", bound=Optional[pydantic.BaseModel])
 
@@ -27,20 +30,19 @@ BASETEN_API_SECRET_NAME = "baseten_chain_api_key"
 SECRET_DUMMY = "***"
 TRUSS_CONFIG_CHAINS_KEY = "chains_metadata"
 
-ENDPOINT_METHOD_NAME = "run"  # Referring to Chainlet method name exposed as endpoint.
+GENERATED_CODE_DIR = ".chains_generated"
+PREDICT_ENDPOINT_NAME = "/predict"
+
 # Below arg names must correspond to `definitions.ABCChainlet`.
+ENDPOINT_METHOD_NAME = "run"  # Referring to Chainlet method name exposed as endpoint.
 CONTEXT_ARG_NAME = "context"  # Referring to Chainlets `__init__` signature.
 SELF_ARG_NAME = "self"
 REMOTE_CONFIG_NAME = "remote_config"
 
-GENERATED_CODE_DIR = ".chains_generated"
-PREDICT_ENDPOINT_NAME = "/predict"
-chainlet_MODULE = "Chainlet"
-STUB_TYPE_MODULE = "stub_types"
-STUB_CLS_SUFFIX = "Stub"
-
 
 class SafeModel(pydantic.BaseModel):
+    """Pydantic base model with reasonable config."""
+
     class Config:
         arbitrary_types_allowed = False
         validate_all = True
@@ -49,6 +51,8 @@ class SafeModel(pydantic.BaseModel):
 
 
 class SafeModelNonSerializable(pydantic.BaseModel):
+    """Pydantic base model with reasonable config - allowing arbitrary types."""
+
     class Config:
         arbitrary_types_allowed = True
         validate_all = True
@@ -80,8 +84,8 @@ class AbsPath:
         self._creating_module = creating_module
         self._original_path = original_path
 
-    def raise_if_not_exists(self) -> None:
-        if not os.path.isfile(self._abs_file_path):
+    def _raise_if_not_exists(self, abs_path: str) -> None:
+        if not os.path.isfile(abs_path):
             raise MissingDependencyError(
                 f"With the file path `{self._original_path}` an absolute path relative "
                 f"to the calling module `{self._creating_module}` was created, "
@@ -95,7 +99,9 @@ class AbsPath:
                 f"Using abs path `{self._abs_file_path}` for path specified as "
                 f"`{self._original_path}` (in `{self._creating_module}`)."
             )
-        return self._abs_file_path
+        abs_path = self._abs_file_path
+        self._raise_if_not_exists(abs_path)
+        return abs_path
 
 
 class DockerImage(SafeModelNonSerializable):
@@ -104,6 +110,7 @@ class DockerImage(SafeModelNonSerializable):
     pip_requirements_file: Optional[AbsPath] = None
     pip_requirements: list[str] = []
     apt_requirements: list[str] = []
+    data_dir: Optional[AbsPath] = None
 
 
 class ComputeSpec(pydantic.BaseModel):
@@ -203,6 +210,7 @@ class DeploymentContext(generics.GenericModel, Generic[UserConfigT]):
         validate_assignment = True
         extra = pydantic.Extra.forbid
 
+    data_dir: pathlib.Path
     user_config: UserConfigT = pydantic.Field(default=None)
     chainlet_to_service: Mapping[str, ServiceDescriptor] = {}
     # secrets: Optional[secrets_resolver.Secrets] = None
@@ -266,26 +274,9 @@ class ABCChainlet(Generic[UserConfigT], abc.ABC):
 
 
 class TypeDescriptor(SafeModelNonSerializable):
-    """For describing I/O types of Chainlets.
-
-    Example:
-        repr(raw): <class 'user_package.shared_chainlet.SplitTextInput'>"
-        as_src_str(): 'SplitTextInput'
-
-    -> Source string, without further qualification, does not include any module path.
-    """
+    """For describing I/O types of Chainlets."""
 
     raw: Any  # The raw type annotation object (could be a type or GenericAlias).
-
-    def as_src_str(self, qualify_pydantic_types: Optional[str] = None) -> str:
-        # TODO: pydantic types will soon be handled differently.
-        if self.is_pydantic and qualify_pydantic_types:
-            return f"{qualify_pydantic_types}.{self.raw.__name__}"
-
-        if isinstance(self.raw, type):
-            return self.raw.__name__
-        else:
-            return str(self.raw)
 
     @property
     def is_pydantic(self) -> bool:
@@ -378,3 +369,50 @@ class RemoteErrorDetail(SafeModel):
 
 class GenericRemoteException(Exception):
     ...
+
+
+########################################################################################
+
+
+class DeploymentOptions(SafeModelNonSerializable):
+    chain_name: str
+    only_generate_trusses: bool = False
+
+
+class DeploymentOptionsBaseten(DeploymentOptions):
+    remote_provider: baseten_remote.BasetenRemote
+    publish: bool
+    promote: bool
+
+    @classmethod
+    def create(
+        cls,
+        chain_name: str,
+        publish: bool,
+        promote: bool,
+        only_generate_trusses: bool,
+        remote: Optional[str] = None,
+    ) -> "DeploymentOptionsBaseten":
+        if not remote:
+            remote = remote_cli.inquire_remote_name(
+                remote_factory.RemoteFactory.get_available_config_names()
+            )
+        remote_provider = cast(
+            baseten_remote.BasetenRemote,
+            remote_factory.RemoteFactory.create(remote=remote),
+        )
+        return DeploymentOptionsBaseten(
+            remote_provider=remote_provider,
+            chain_name=chain_name,
+            publish=publish,
+            promote=promote,
+            only_generate_trusses=only_generate_trusses,
+        )
+
+
+class DeploymentOptionsLocalDocker(DeploymentOptions):
+    # Local docker-to-docker requests don't need auth, but we need to set a
+    # value different from `SECRET_DUMMY` to not trigger the check that the secret
+    # is unset. Additionally, if local docker containers make calls to models deployed
+    # on baseten, a real API key must be provided (i.e. the default must be overridden).
+    baseten_chain_api_key: str = "docker_dummy_key"

--- a/truss-chains/truss_chains/deploy.py
+++ b/truss-chains/truss_chains/deploy.py
@@ -1,199 +1,16 @@
 import collections
 import inspect
 import logging
-import os
 import pathlib
-import shutil
-from typing import (
-    Any,
-    Dict,
-    Iterable,
-    Iterator,
-    Mapping,
-    MutableMapping,
-    Optional,
-    Type,
-    cast,
-)
+from typing import Any, Dict, Iterable, Iterator, MutableMapping, Optional, Type, cast
 
 import truss
-import truss_chains as chains
-from truss import truss_config
-from truss.contexts.image_builder import serving_image_builder
-from truss.remote import remote_cli, remote_factory
 from truss.remote.baseten import service as b10_service
-from truss_chains import code_gen, definitions, framework, model_skeleton, utils
-
-_REQUIREMENTS_FILENAME = "pip_requirements.txt"
-_MODEL_FILENAME = "model.py"
-_MODEL_CLS_NAME = model_skeleton.TrussChainletModel.__name__
-_TRUSS_DIR = ".truss_gen"
-
-
-# Truss Gen ############################################################################
-
-
-def _copy_python_source_files(root_dir: pathlib.Path, dest_dir: pathlib.Path) -> None:
-    """Copy all python files under root recursively, but skips generated code."""
-
-    def python_files_only(path, names):
-        return [
-            name
-            for name in names
-            if os.path.isfile(os.path.join(path, name))
-            and not name.endswith(".py")
-            or definitions.GENERATED_CODE_DIR in name
-        ]
-
-    shutil.copytree(root_dir, dest_dir, ignore=python_files_only, dirs_exist_ok=True)
-
-
-def _make_truss_config(
-    truss_dir: pathlib.Path,
-    chains_config: definitions.RemoteConfig,
-    user_config: definitions.UserConfigT,
-    chainlet_to_service: Mapping[str, definitions.ServiceDescriptor],
-    model_name: str,
-) -> truss_config.TrussConfig:
-    """Generate a truss config for a Chainlet."""
-    config = truss_config.TrussConfig()
-    config.model_name = model_name
-    config.model_class_filename = _MODEL_FILENAME
-    config.model_class_name = _MODEL_CLS_NAME
-    # Compute.
-    compute = chains_config.get_compute_spec()
-    config.resources.cpu = str(compute.cpu_count)
-    config.resources.accelerator = compute.accelerator
-    config.resources.use_gpu = bool(compute.accelerator.count)
-    # TODO: expose this setting directly.
-    config.runtime.predict_concurrency = compute.cpu_count
-    # Image.
-    image = chains_config.docker_image
-    config.base_image = truss_config.BaseImage(image=image.base_image)
-    pip_requirements: list[str] = []
-    if image.pip_requirements_file:
-        image.pip_requirements_file.raise_if_not_exists()
-        pip_requirements.extend(
-            req
-            for req in pathlib.Path(image.pip_requirements_file.abs_path)
-            .read_text()
-            .splitlines()
-            if not req.strip().startswith("#")
-        )
-    pip_requirements.extend(image.pip_requirements)
-    # `pip_requirements` will add server requirements which give version conflicts.
-    # config.requirements = pip_requirements
-    pip_requirements_file_path = truss_dir / _REQUIREMENTS_FILENAME
-    pip_requirements_file_path.write_text("\n".join(pip_requirements))
-    # TODO: apparently absolute paths don't work with remote build (but work in local).
-    config.requirements_file = _REQUIREMENTS_FILENAME  # str(pip_requirements_file_path)
-    config.system_packages = image.apt_requirements
-    # Assets.
-    assets = chains_config.get_asset_spec()
-    config.secrets = assets.secrets
-    if definitions.BASETEN_API_SECRET_NAME not in config.secrets:
-        config.secrets[definitions.BASETEN_API_SECRET_NAME] = definitions.SECRET_DUMMY
-    else:
-        logging.info(
-            f"Chains automatically add {definitions.BASETEN_API_SECRET_NAME} "
-            "to secrets - no need to manually add it."
-        )
-    config.model_cache.models = assets.cached
-    # Metadata.
-    chains_metadata: definitions.TrussMetadata = definitions.TrussMetadata(
-        user_config=user_config, chainlet_to_service=chainlet_to_service
-    )
-    config.model_metadata[definitions.TRUSS_CONFIG_CHAINS_KEY] = chains_metadata.dict()
-    return config
-
-
-def make_truss(
-    chainlet_dir: pathlib.Path,
-    chain_root: pathlib.Path,
-    chains_config: definitions.RemoteConfig,
-    user_config: definitions.UserConfigT,
-    model_name: str,
-    chainlet_to_service: Mapping[str, definitions.ServiceDescriptor],
-    maybe_stub_types_file: Optional[pathlib.Path],
-) -> pathlib.Path:
-    truss_dir = chainlet_dir / _TRUSS_DIR
-    truss_dir.mkdir(exist_ok=True)
-    config = _make_truss_config(
-        truss_dir, chains_config, user_config, chainlet_to_service, model_name
-    )
-    config.write_to_yaml_file(
-        truss_dir / serving_image_builder.CONFIG_FILE, verbose=True
-    )
-    # Copy other sources.
-    model_dir = truss_dir / truss_config.DEFAULT_MODEL_MODULE_DIR
-    model_dir.mkdir(parents=True, exist_ok=True)
-    shutil.copy(
-        chainlet_dir / f"{definitions.chainlet_MODULE}.py",
-        model_dir / _MODEL_FILENAME,
-    )
-    pkg_dir = truss_dir / truss_config.DEFAULT_BUNDLED_PACKAGES_DIR
-    pkg_dir.mkdir(parents=True, exist_ok=True)
-    if maybe_stub_types_file is not None:
-        shutil.copy(maybe_stub_types_file, pkg_dir)
-    # TODO This assume all imports are absolute w.r.t chain root (or site-packages).
-    #   Also: apparently packages need an `__init__`, or crash.
-    _copy_python_source_files(chain_root, pkg_dir / pkg_dir)
-
-    # TODO Truss package contains this from `{ include = "truss_chains", from = "." }`
-    #   pyproject.toml. But for quick dev loop just copy from local.
-    shutil.copytree(
-        os.path.dirname(chains.__file__),
-        pkg_dir / "truss_chains",
-        dirs_exist_ok=True,
-    )
-    return truss_dir
-
-
-########################################################################################
-
-
-class DeploymentOptions(definitions.SafeModelNonSerializable):
-    chain_name: str
-    only_generate_trusses: bool = False
-
-
-class DeploymentOptionsBaseten(DeploymentOptions):
-    remote_provider: remote_factory.TrussRemote
-    publish: bool
-    promote: bool
-
-    @classmethod
-    def create(
-        cls,
-        chain_name: str,
-        publish: bool,
-        promote: bool,
-        only_generate_trusses: bool,
-        remote: Optional[str] = None,
-    ) -> "DeploymentOptionsBaseten":
-        if not remote:
-            remote = remote_cli.inquire_remote_name(
-                remote_factory.RemoteFactory.get_available_config_names()
-            )
-        return DeploymentOptionsBaseten(
-            chain_name=chain_name,
-            remote_provider=remote_factory.RemoteFactory.create(remote=remote),
-            publish=publish,
-            promote=promote,
-            only_generate_trusses=only_generate_trusses,
-        )
-
-
-class DeploymentOptionsLocalDocker(DeploymentOptions):
-    # Local docker-to-docker requests don't need auth, but we need to set a
-    # value different from `SECRET_DUMMY` to not trigger the check that the secret
-    # is unset. Additionally, if local docker containers make calls to models deployed
-    # on baseten, a real API key must be provided (i.e. the default must be overridden).
-    baseten_chain_api_key: str = "docker_dummy_key"
+from truss_chains import code_gen, definitions, framework, utils
 
 
 def _deploy_to_baseten(
-    truss_dir: pathlib.Path, options: DeploymentOptionsBaseten
+    truss_dir: pathlib.Path, options: definitions.DeploymentOptionsBaseten
 ) -> b10_service.BasetenService:
     truss_handle = truss.load(str(truss_dir))
     model_name = truss_handle.spec.config.model_name
@@ -210,8 +27,6 @@ def _deploy_to_baseten(
         publish=options.publish,
         promote=options.promote,
     )
-    if not isinstance(service, b10_service.BasetenService):
-        raise TypeError("Remote provider did not return baseten service.")
     return cast(b10_service.BasetenService, service)
 
 
@@ -247,39 +62,14 @@ class DockerService(b10_service.TrussService):
 
 
 def _deploy_service(
-    chainlet_dir: pathlib.Path,
-    chain_root: pathlib.Path,
+    truss_dir: pathlib.Path,
     chainlet_descriptor: definitions.ChainletAPIDescriptor,
-    chainlet_name_to_url: Mapping[str, str],
-    maybe_stub_types_file: Optional[pathlib.Path],
-    options: DeploymentOptions,
+    options: definitions.DeploymentOptions,
 ) -> Optional[b10_service.TrussService]:
-    # Filter needed services and customize options.
-    dep_services = {}
-    for dep in chainlet_descriptor.dependencies.values():
-        dep_services[dep.name] = definitions.ServiceDescriptor(
-            name=dep.name,
-            predict_url=chainlet_name_to_url[dep.name],
-            options=dep.options,
-        )
-    # Convert to truss and deploy.
-    # TODO: support file-based config (and/or merge file and python-src config values).
-    remote_config = chainlet_descriptor.chainlet_cls.remote_config
-    chainlet_name = remote_config.name or chainlet_descriptor.name
-    model_name = f"{options.chain_name}.{chainlet_name}"
-    truss_dir = make_truss(
-        chainlet_dir,
-        chain_root,
-        remote_config,
-        chainlet_descriptor.chainlet_cls.default_user_config,
-        model_name,
-        dep_services,
-        maybe_stub_types_file,
-    )
     service: Optional[b10_service.TrussService]
     if options.only_generate_trusses:
         service = None
-    elif isinstance(options, DeploymentOptionsLocalDocker):
+    elif isinstance(options, definitions.DeploymentOptionsLocalDocker):
         port = utils.get_free_port()
         truss_handle = truss.load(str(truss_dir))
         truss_handle.add_secret(
@@ -290,18 +80,20 @@ def _deploy_service(
             detach=True,
             wait_for_server_ready=True,
             network="host",
-            container_name_prefix=model_name,
+            container_name_prefix=chainlet_descriptor.name,
         )
         # http://localhost:{port} seems to only work *sometimes* with docker.
         service = DockerService(f"http://host.docker.internal:{port}", is_draft=True)
-    elif isinstance(options, DeploymentOptionsBaseten):
+    elif isinstance(options, definitions.DeploymentOptionsBaseten):
         with utils.log_level(logging.INFO):
             service = _deploy_to_baseten(truss_dir, options)
     else:
         raise NotImplementedError(options)
 
     if service:
-        logging.info(f"Deployed service `{chainlet_name}` @ {service.predict_url}.")
+        logging.info(
+            f"Deployed service `{chainlet_descriptor.name}` @ {service.predict_url}."
+        )
     return service
 
 
@@ -369,8 +161,9 @@ class ChainService:
 
 def deploy_remotely(
     entrypoint: Type[definitions.ABCChainlet],
-    options: DeploymentOptions,
+    options: definitions.DeploymentOptions,
     non_entrypoint_root_dir: Optional[str] = None,
+    gen_root: pathlib.Path = pathlib.Path("/tmp"),
 ) -> ChainService:
     """
     * Gathers dependencies of `entrypoint`.
@@ -393,29 +186,15 @@ def deploy_remotely(
     for chainlet_descriptor in _get_ordered_dependencies([entrypoint]):
         logging.info(f"Deploying `{chainlet_descriptor.name}`.")
         deps = framework.global_chainlet_registry.get_dependencies(chainlet_descriptor)
-        chainlet_dir = code_gen.make_chainlet_dir(
-            options.chain_name, chainlet_descriptor
-        )
-        chainlet_filepath = pathlib.Path(
-            shutil.copy(
-                chainlet_descriptor.src_path,
-                chainlet_dir / f"{definitions.chainlet_MODULE}.py",
-            )
-        )
-        maybe_stub_types_file = code_gen.gen_pydantic_models(
-            chainlet_dir / f"{definitions.STUB_TYPE_MODULE}.py", deps
-        )
-        code_gen.generate_chainlet_source(
-            chainlet_filepath, chainlet_descriptor, deps, maybe_stub_types_file
-        )
-        service = _deploy_service(
-            chainlet_dir,
-            chain_root,
-            chainlet_descriptor,
-            chainlet_name_to_url,
-            maybe_stub_types_file,
+        chainlet_dir = code_gen.gen_truss_chainlet(
             options,
+            chainlet_descriptor,
+            deps,
+            chainlet_name_to_url,
+            chain_root,
+            gen_root,
         )
+        service = _deploy_service(chainlet_dir, chainlet_descriptor, options)
         if service:
             chain_service.add_service(chainlet_descriptor.name, service)
             chainlet_name_to_url[chainlet_descriptor.name] = service.predict_url

--- a/truss-chains/truss_chains/model_skeleton.py
+++ b/truss-chains/truss_chains/model_skeleton.py
@@ -24,13 +24,21 @@ class TrussChainletModel:
             user_config=truss_metadata.user_config,
             chainlet_to_service=truss_metadata.chainlet_to_service,
             secrets=secrets,
+            data_dir=data_dir,
         )
 
     # Below illustrated code will be added by code generation.
 
-    # def load(self):
-    #     self._chainlet = {ChainletCls}(self._context)
+    # def load(self) -> None:
+    #     logging.info(f"Loading Chainlet `SplitText`.")
+    #     self._chainlet = shared_chainlet.SplitText(context=self._context)
 
-    # Sync or async.
-    # def predict(self, payload):
-    #     return self._chainlet.{method_name}(payload)
+    # async def predict(self, payload):
+    #     with utils.exception_to_http_error(
+    #         include_stack=True, chainlet_name="SplitText"
+    #     ):
+    #         result = await self._chainlet.run(
+    #             inputs=shared_chainlet.SplitTextInput.parse_obj(payload["inputs"]),
+    #             extra_arg=payload["extra_arg"],
+    #         )
+    #     return result[0].dict(), result[1]

--- a/truss-chains/truss_chains/public_api.py
+++ b/truss-chains/truss_chains/public_api.py
@@ -50,7 +50,7 @@ def deploy_remotely(
     promote: bool = True,
     only_generate_trusses: bool = False,
 ) -> deploy.ChainService:
-    options = deploy.DeploymentOptionsBaseten.create(
+    options = definitions.DeploymentOptionsBaseten.create(
         chain_name=chain_name,
         publish=publish,
         promote=promote,

--- a/truss-chains/truss_chains/utils.py
+++ b/truss-chains/truss_chains/utils.py
@@ -284,10 +284,6 @@ def handle_response(response: httpx.Response, remote_name: str) -> Any:
     return response.json()
 
 
-def make_stub_name(chainlet_name: str) -> str:
-    return f"{chainlet_name}{definitions.STUB_CLS_SUFFIX}"
-
-
 class InjectedError(Exception):
     """Test error for debugging/dev."""
 

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -29,6 +29,7 @@ from truss.remote.remote_cli import inquire_model_name, inquire_remote_name
 from truss.remote.remote_factory import USER_TRUSSRC_PATH, RemoteFactory
 from truss.truss_config import Build, ModelServer
 from truss.util.errors import RemoteNetworkError
+from truss_chains import definitions as chains_def
 from truss_chains import deploy as chains_deploy
 from truss_chains import framework
 
@@ -341,7 +342,7 @@ def deploy(
     """
     chain_name = name or entrypoint
     entrypoint_cls = framework.import_target(source, entrypoint)
-    options = chains_deploy.DeploymentOptionsBaseten.create(
+    options = chains_def.DeploymentOptionsBaseten.create(
         chain_name=chain_name,
         promote=promote,
         publish=publish,


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What & How
* Remove the nesting of `.truss_generated` within `.chains_generated`: it's all directly the truss dir now (the nesting originated from the desire to have an abstraction level between *chainlets* and *truss models* as a implementation detail.
* Remove the scary :fearful:  pydantic datamodel generation. Instead trace the I/O types by their originating module paths and add those imports (and qualified references) when using these I/O types for stub generation.
* Cleanup the code generation code for better readability.
* Add "data_dir" functionality.
* Change code gen output structure:
    * Leave user file unchanged (fixes line mapping issue with stack traces).
    * Generated `TrussChainletModel` in new file, this file also contains the stubs used by that respective chainlet. I/O types file was replaced by direct imports/references.

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
Tested locally with branch, can only test in CI once merged, because main branch is used as dep.
