### PR TITLE
Fix truss push.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.10rc2"
+version = "0.9.10rc4"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/cli/console.py
+++ b/truss/cli/console.py
@@ -1,5 +1,5 @@
-import rich
+from rich.console import Console
 
-console = rich.console.Console()
+console = Console()
 
-error_console = rich.console.Console(stderr=True, style="bold red")
+error_console = Console(stderr=True, style="bold red")


### PR DESCRIPTION

## :rocket: What

Customer reported that they could not no longer run `truss push`: https://basetenlabs.slack.com/archives/C05CTDKQMCK/p1714474177026289.

After some more digging, it looked related to how we use the rich library. It is very very strange, but rich.console.Console must be imported in a very particular way, and in this PR we fix that. 

To demonstrate:

```
In [2]: import rich
   ...: 
   ...: console = rich.console.Console()
   ...: 
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[2], line 3
      1 import rich
----> 3 console = rich.console.Console()

AttributeError: module 'rich' has no attribute 'console'

In [3]: from rich.console import Console

In [4]: console = Console()
# all works
```

## :computer: How

I'm still not sure what changed when, but this seems to be broken in older truss versions, so I suspect that something happened with the `rich` library very recently.


## :microscope: Testing

Pushed this as version 0.9.10rc4. Installed on fresh virtualenv, and verified that I could do:

```
$ truss push --publish --trusted
```