### PR TITLE
Explicitly defining HF auth token for Triton models

### DIFF
--- a/truss/templates/trtllm/packages/tensorrt_llm_model_repository/postprocessing/1/model.py
+++ b/truss/templates/trtllm/packages/tensorrt_llm_model_repository/postprocessing/1/model.py
@@ -60,17 +60,20 @@ class TritonPythonModel:
         model_config = json.loads(args["model_config"])
         # NOTE: Keep this in sync with the truss model.py variable
         tokenizer_dir = os.environ["TRITON_TOKENIZER_REPOSITORY"]
+        hf_auth_token = os.environ.get("HF_AUTH_TOKEN", None)
         tokenizer_type = model_config["parameters"]["tokenizer_type"]["string_value"]
 
         if tokenizer_type == "t5":
-            self.tokenizer = T5Tokenizer(vocab_file=tokenizer_dir, padding_side="left")
+            self.tokenizer = T5Tokenizer(
+                vocab_file=tokenizer_dir, padding_side="left", token=hf_auth_token
+            )
         elif tokenizer_type == "auto":
             self.tokenizer = AutoTokenizer.from_pretrained(
-                tokenizer_dir, padding_side="left"
+                tokenizer_dir, padding_side="left", token=hf_auth_token
             )
         elif tokenizer_type == "llama":
             self.tokenizer = LlamaTokenizer.from_pretrained(
-                tokenizer_dir, legacy=False, padding_side="left"
+                tokenizer_dir, legacy=False, padding_side="left", token=hf_auth_token
             )
         else:
             raise AttributeError(f"Unexpected tokenizer type: {tokenizer_type}")

--- a/truss/templates/trtllm/packages/tensorrt_llm_model_repository/postprocessing/1/model.py
+++ b/truss/templates/trtllm/packages/tensorrt_llm_model_repository/postprocessing/1/model.py
@@ -60,7 +60,7 @@ class TritonPythonModel:
         model_config = json.loads(args["model_config"])
         # NOTE: Keep this in sync with the truss model.py variable
         tokenizer_dir = os.environ["TRITON_TOKENIZER_REPOSITORY"]
-        hf_auth_token = os.environ.get("HF_AUTH_TOKEN", None)
+        hf_auth_token = os.environ.get("HUGGING_FACE_HUB_TOKEN", None)
         tokenizer_type = model_config["parameters"]["tokenizer_type"]["string_value"]
 
         if tokenizer_type == "t5":

--- a/truss/templates/trtllm/packages/tensorrt_llm_model_repository/preprocessing/1/model.py
+++ b/truss/templates/trtllm/packages/tensorrt_llm_model_repository/preprocessing/1/model.py
@@ -58,20 +58,23 @@ class TritonPythonModel:
         model_config = json.loads(args["model_config"])
         # NOTE: Keep this in sync with the truss model.py variable
         tokenizer_dir = os.environ["TRITON_TOKENIZER_REPOSITORY"]
+        hf_auth_token = os.environ.get("HF_AUTH_TOKEN", None)
         tokenizer_type = model_config["parameters"]["tokenizer_type"]["string_value"]
         self.add_special_tokens = model_config["parameters"].get(
             "add_special_tokens", {"string_value": "false"}
         )["string_value"].lower() in ["true", "1", "t", "y", "yes"]
 
         if tokenizer_type == "t5":
-            self.tokenizer = T5Tokenizer(vocab_file=tokenizer_dir, padding_side="left")
+            self.tokenizer = T5Tokenizer(
+                vocab_file=tokenizer_dir, padding_side="left", token=hf_auth_token
+            )
         elif tokenizer_type == "auto":
             self.tokenizer = AutoTokenizer.from_pretrained(
-                tokenizer_dir, padding_side="left"
+                tokenizer_dir, padding_side="left", token=hf_auth_token
             )
         elif tokenizer_type == "llama":
             self.tokenizer = LlamaTokenizer.from_pretrained(
-                tokenizer_dir, legacy=False, padding_side="left"
+                tokenizer_dir, legacy=False, padding_side="left", token=hf_auth_token
             )
         else:
             raise AttributeError(f"Unexpected tokenizer type: {tokenizer_type}")

--- a/truss/templates/trtllm/packages/tensorrt_llm_model_repository/preprocessing/1/model.py
+++ b/truss/templates/trtllm/packages/tensorrt_llm_model_repository/preprocessing/1/model.py
@@ -58,7 +58,7 @@ class TritonPythonModel:
         model_config = json.loads(args["model_config"])
         # NOTE: Keep this in sync with the truss model.py variable
         tokenizer_dir = os.environ["TRITON_TOKENIZER_REPOSITORY"]
-        hf_auth_token = os.environ.get("HF_AUTH_TOKEN", None)
+        hf_auth_token = os.environ.get("HUGGING_FACE_HUB_TOKEN", None)
         tokenizer_type = model_config["parameters"]["tokenizer_type"]["string_value"]
         self.add_special_tokens = model_config["parameters"].get(
             "add_special_tokens", {"string_value": "false"}


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What

This PR explicitly passes the HF auth token to the Triton models, particularly useful for gated repositories.

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
