### PR TITLE
[Chains] Make context optional, various improvements.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ src_paths = ["isort", "test"]
 [tool.mypy]
 ignore_missing_imports = true
 python_version = "3.9"
-
+plugins = ["pydantic.mypy"]
 
 [tool.pytest.ini_options]
 markers = [

--- a/truss-chains/examples/text_to_num/main.py
+++ b/truss-chains/examples/text_to_num/main.py
@@ -20,7 +20,7 @@ class GenerateData(chains.ChainletBase):
 
     remote_config = chains.RemoteConfig(docker_image=chains.DockerImage())
 
-    def run(self, length: int) -> str:
+    def run_remote(self, length: int) -> str:
         return "".join(random.choices(string.ascii_letters + string.digits, k=length))
 
 
@@ -34,7 +34,7 @@ class MistraLLMConfig(pydantic.BaseModel):
     hf_model_name: str
 
 
-class MistralLLM(chains.ChainletBase[MistraLLMConfig]):
+class MistralLLM(chains.ChainletBase):
 
     remote_config = chains.RemoteConfig(
         docker_image=chains.DockerImage(
@@ -52,13 +52,12 @@ class MistralLLM(chains.ChainletBase[MistraLLMConfig]):
 
     def __init__(
         self,
-        context: chains.DeploymentContext[MistraLLMConfig] = chains.provide_context(),
+        context: chains.DeploymentContext[MistraLLMConfig] = chains.depends_context(),
     ) -> None:
-        super().__init__(context)
         import torch
         import transformers
 
-        model_name = self.user_config.hf_model_name
+        model_name = context.user_config.hf_model_name
 
         self._model = transformers.AutoModelForCausalLM.from_pretrained(
             model_name,
@@ -84,7 +83,7 @@ class MistralLLM(chains.ChainletBase[MistraLLMConfig]):
             "pad_token_id": self._tokenizer.pad_token_id,
         }
 
-    def run(self, data: str) -> str:
+    def run_remote(self, data: str) -> str:
         import torch
 
         formatted_prompt = f"[INST] {data} [/INST]"
@@ -101,24 +100,19 @@ class MistralP(Protocol):
     def __init__(self, context: chains.DeploymentContext) -> None:
         ...
 
-    def run(self, data: str) -> str:
+    def run_remote(self, data: str) -> str:
         ...
 
 
 class TextToNum(chains.ChainletBase):
     remote_config = chains.RemoteConfig(docker_image=chains.DockerImage())
 
-    def __init__(
-        self,
-        context: chains.DeploymentContext = chains.provide_context(),
-        mistral: MistralP = chains.provide(MistralLLM),
-    ) -> None:
-        super().__init__(context)
+    def __init__(self, mistral: MistralP = chains.depends(MistralLLM)) -> None:
         self._mistral = mistral
 
-    def run(self, data: str) -> int:
+    def run_remote(self, data: str) -> int:
         number = 0
-        generated_text = self._mistral.run(data)
+        generated_text = self._mistral.run_remote(data)
         for char in generated_text:
             number += ord(char)
 
@@ -131,19 +125,19 @@ class ExampleChain(chains.ChainletBase):
 
     def __init__(
         self,
-        context: chains.DeploymentContext = chains.provide_context(),
-        data_generator: GenerateData = chains.provide(GenerateData),
-        splitter: shared_chainlet.SplitText = chains.provide(shared_chainlet.SplitText),
-        text_to_num: TextToNum = chains.provide(TextToNum),
+        data_generator: GenerateData = chains.depends(GenerateData),
+        splitter: shared_chainlet.SplitText = chains.depends(shared_chainlet.SplitText),
+        text_to_num=chains.depends(TextToNum),
     ) -> None:
-        super().__init__(context)
         self._data_generator = data_generator
         self._data_splitter = splitter
         self._text_to_num = text_to_num
 
-    async def run(self, length: int, num_partitions: int) -> tuple[int, str, int]:
-        data = self._data_generator.run(length)
-        text_parts, number = await self._data_splitter.run(
+    async def run_remote(
+        self, length: int, num_partitions: int
+    ) -> tuple[int, str, int]:
+        data = self._data_generator.run_remote(length)
+        text_parts, number = await self._data_splitter.run_remote(
             shared_chainlet.SplitTextInput(
                 data=data,
                 num_partitions=num_partitions,
@@ -153,7 +147,7 @@ class ExampleChain(chains.ChainletBase):
         )
         value = 0
         for part in text_parts.parts:
-            value += self._text_to_num.run(part)
+            value += self._text_to_num.run_remote(part)
         return value, data, number
 
 
@@ -168,11 +162,11 @@ if __name__ == "__main__":
     import asyncio
 
     class FakeMistralLLM:
-        def run(self, data: str) -> str:
+        def run_remote(self, data: str) -> str:
             return data.upper()
 
     with chains.run_local():
         text_to_num_chainlet = TextToNum(mistral=FakeMistralLLM())
         wf = ExampleChain(text_to_num=text_to_num_chainlet)
-        tmp = asyncio.run(wf.run(length=123, num_partitions=123))
+        tmp = asyncio.run(wf.run_remote(length=123, num_partitions=123))
         print(tmp)

--- a/truss-chains/examples/text_to_num/main.py
+++ b/truss-chains/examples/text_to_num/main.py
@@ -17,9 +17,6 @@ from truss import truss_config
 
 
 class GenerateData(chains.ChainletBase):
-
-    remote_config = chains.RemoteConfig(docker_image=chains.DockerImage())
-
     def run_remote(self, length: int) -> str:
         return "".join(random.choices(string.ascii_letters + string.digits, k=length))
 
@@ -105,8 +102,6 @@ class MistralP(Protocol):
 
 
 class TextToNum(chains.ChainletBase):
-    remote_config = chains.RemoteConfig(docker_image=chains.DockerImage())
-
     def __init__(self, mistral: MistralP = chains.depends(MistralLLM)) -> None:
         self._mistral = mistral
 
@@ -121,8 +116,6 @@ class TextToNum(chains.ChainletBase):
 
 @chains.entrypoint
 class ExampleChain(chains.ChainletBase):
-    remote_config = chains.RemoteConfig(docker_image=chains.DockerImage())
-
     def __init__(
         self,
         data_generator: GenerateData = chains.depends(GenerateData),

--- a/truss-chains/examples/text_to_num/sub_package/shared_chainlet.py
+++ b/truss-chains/examples/text_to_num/sub_package/shared_chainlet.py
@@ -27,7 +27,7 @@ class SplitText(chains.ChainletBase):
         docker_image=chains.DockerImage(pip_requirements=["numpy"])
     )
 
-    async def run(
+    async def run_remote(
         self, inputs: SplitTextInput, extra_arg: int
     ) -> Tuple[SplitTextOutput, int]:
         import numpy as np

--- a/truss-chains/tests/chains_test.py
+++ b/truss-chains/tests/chains_test.py
@@ -1,8 +1,10 @@
 import logging
+import re
 from pathlib import Path
 
 import pytest
 import requests
+import truss_chains as chains
 from truss.tests.test_testing_utilities_for_other_tests import ensure_kill_all
 from truss_chains import definitions, deploy, framework, public_api, utils
 
@@ -46,16 +48,110 @@ async def test_chain_local():
     root = Path(__file__).parent.resolve()
     chain_root = root / "itest_chain" / "itest_chain.py"
     with framework.import_target(chain_root, "ItestChain") as entrypoint:
-
-        with pytest.raises(definitions.ChainsRuntimeError):
-            entrypoint().run(length=20, num_partitions=5)
-
         with public_api.run_local():
             with pytest.raises(ValueError):
                 # First time `SplitTextFailOnce` raises an error and
                 # currently local mode does not have retries.
-                result = await entrypoint().run(length=20, num_partitions=5)
+                result = await entrypoint().run_remote(length=20, num_partitions=5)
 
-            result = await entrypoint().run(length=20, num_partitions=5)
+            result = await entrypoint().run_remote(length=20, num_partitions=5)
             assert result == (4198, "erodfderodfderodfder", 123)
             print(result)
+
+        with pytest.raises(
+            definitions.ChainsRuntimeError,
+            match="Chainlets cannot be naively instantiated",
+        ):
+            await entrypoint().run_remote(length=20, num_partitions=5)
+
+
+# Chainlet Initialization Guarding #####################################################
+
+
+def test_raises_without_depends():
+
+    with pytest.raises(definitions.ChainsUsageError, match="chains.provide"):
+
+        class WithoutDepends(chains.ChainletBase):
+            def __init__(self, chainlet1):
+                self.chainlet1 = chainlet1
+
+            def run_remote(self) -> str:
+                return self.chainlet1.run_remote()
+
+
+class Chainlet1(chains.ChainletBase):
+    def run_remote(self) -> str:
+        return self.__class__.__name__
+
+
+class Chainlet2(chains.ChainletBase):
+    def run_remote(self) -> str:
+        return self.__class__.__name__
+
+
+class InitInInit(chains.ChainletBase):
+    def __init__(self, chainlet2=chains.depends(Chainlet2)):
+        self.chainlet1 = Chainlet1()
+        self.chainlet2 = chainlet2
+
+    def run_remote(self) -> str:
+        return self.chainlet1.run_remote()
+
+
+class InitInRun(chains.ChainletBase):
+    def run_remote(self) -> str:
+        Chainlet1()
+        return "abc"
+
+
+def foo():
+    return Chainlet1()
+
+
+class InitWithFn(chains.ChainletBase):
+    def __init__(self):
+        foo()
+
+    def run_remote(self) -> str:
+        return self.__class__.__name__
+
+
+def test_raises_init_in_init():
+    match = "Chainlets cannot be naively instantiated"
+    with pytest.raises(definitions.ChainsRuntimeError, match=match):
+        with chains.run_local():
+            InitInInit()
+
+
+def test_raises_init_in_run():
+    match = "Chainlets cannot be naively instantiated"
+    with pytest.raises(definitions.ChainsRuntimeError, match=match):
+        with chains.run_local():
+            chain = InitInRun()
+            chain.run_remote()
+
+
+def test_raises_init_in_function():
+    match = "Chainlets cannot be naively instantiated"
+    with pytest.raises(definitions.ChainsRuntimeError, match=match):
+        with chains.run_local():
+            InitWithFn()
+
+
+def test_raises_depends_usage():
+    class InlinedDepends(chains.ChainletBase):
+        def __init__(self):
+            self.chainlet1 = chains.depends(Chainlet1)
+
+        def run_remote(self) -> str:
+            return self.chainlet1.run_remote()
+
+    match = (
+        "`chains.depends(Chainlet1)` was used, but not as "
+        "an argument to the `__init__`"
+    )
+    with pytest.raises(definitions.ChainsRuntimeError, match=re.escape(match)):
+        with chains.run_local():
+            chain = InlinedDepends()
+            chain.run_remote()

--- a/truss-chains/tests/itest_chain/itest_chain.py
+++ b/truss-chains/tests/itest_chain/itest_chain.py
@@ -14,7 +14,7 @@ class GenerateData(chains.ChainletBase):
 
     remote_config = chains.RemoteConfig(docker_image=IMAGE_COMMON)
 
-    def run(self, length: int) -> str:
+    def run_remote(self, length: int) -> str:
         template = "erodfd"
         repetitions = int(math.ceil(length / len(template)))
         return (template * repetitions)[:length]
@@ -24,12 +24,15 @@ class DummyUserConfig(pydantic.BaseModel):
     multiplier: int
 
 
-class TextReplicator(chains.ChainletBase[DummyUserConfig]):
+class TextReplicator(chains.ChainletBase):
 
     remote_config = chains.RemoteConfig(docker_image=IMAGE_COMMON)
     default_user_config = DummyUserConfig(multiplier=2)
 
-    def run(self, data: str) -> str:
+    def __init__(self, context=chains.depends_context()):
+        self.user_config = context.user_config
+
+    def run_remote(self, data: str) -> str:
         if len(data) > 30:
             raise ValueError(f"This input is too long: {len(data)}.")
         return data * self.user_config.multiplier
@@ -40,15 +43,13 @@ class TextToNum(chains.ChainletBase):
 
     def __init__(
         self,
-        context: chains.DeploymentContext = chains.provide_context(),
-        replicator: TextReplicator = chains.provide(TextReplicator),
+        replicator: TextReplicator = chains.depends(TextReplicator),
     ) -> None:
-        super().__init__(context)
         self._replicator = replicator
 
-    def run(self, data: str) -> int:
+    def run_remote(self, data: str) -> int:
         number = 0
-        generated_text = self._replicator.run(data)
+        generated_text = self._replicator.run_remote(data)
         for char in generated_text:
             number += ord(char)
 
@@ -60,21 +61,19 @@ class ItestChain(chains.ChainletBase):
 
     def __init__(
         self,
-        context: chains.DeploymentContext = chains.provide_context(),
-        data_generator: GenerateData = chains.provide(GenerateData),
-        splitter: shared_chainlet.SplitTextFailOnce = chains.provide(
-            shared_chainlet.SplitTextFailOnce, retries=2
-        ),
-        text_to_num: TextToNum = chains.provide(TextToNum),
+        data_generator: GenerateData = chains.depends(GenerateData),
+        splitter=chains.depends(shared_chainlet.SplitTextFailOnce, retries=2),
+        text_to_num: TextToNum = chains.depends(TextToNum),
     ) -> None:
-        super().__init__(context)
         self._data_generator = data_generator
         self._data_splitter = splitter
         self._text_to_num = text_to_num
 
-    async def run(self, length: int, num_partitions: int) -> tuple[int, str, int]:
-        data = self._data_generator.run(length)
-        text_parts, number = await self._data_splitter.run(
+    async def run_remote(
+        self, length: int, num_partitions: int
+    ) -> tuple[int, str, int]:
+        data = self._data_generator.run_remote(length)
+        text_parts, number = await self._data_splitter.run_remote(
             io_types.SplitTextInput(
                 data=data,
                 num_partitions=num_partitions,
@@ -84,5 +83,5 @@ class ItestChain(chains.ChainletBase):
         )
         value = 0
         for part in text_parts.parts:
-            value += self._text_to_num.run(part)
+            value += self._text_to_num.run_remote(part)
         return value, data, number

--- a/truss-chains/tests/itest_chain/requirements.txt
+++ b/truss-chains/tests/itest_chain/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/basetenlabs/truss.git
+git+https://github.com/basetenlabs/truss.git@f3f164f061c465a59d9c520700660424c0e4f8ab

--- a/truss-chains/tests/itest_chain/user_package/shared_chainlet.py
+++ b/truss-chains/tests/itest_chain/user_package/shared_chainlet.py
@@ -20,11 +20,10 @@ class SplitTextFailOnce(chains.ChainletBase):
         )
     )
 
-    def __init__(self, context: chains.DeploymentContext = chains.provide_context()):
-        super().__init__(context)
+    def __init__(self):
         self._count = 0
 
-    async def run(
+    async def run_remote(
         self, inputs: io_types.SplitTextInput, extra_arg: int
     ) -> Tuple[SplitTextOutput, int]:
         import numpy as np

--- a/truss-chains/truss_chains/__init__.py
+++ b/truss-chains/truss_chains/__init__.py
@@ -23,10 +23,10 @@ from truss_chains.definitions import (
 )
 from truss_chains.public_api import (
     ChainletBase,
+    depends,
+    depends_context,
     deploy_remotely,
     entrypoint,
-    provide,
-    provide_context,
     run_local,
 )
 from truss_chains.stub import StubBase

--- a/truss-chains/truss_chains/definitions.py
+++ b/truss-chains/truss_chains/definitions.py
@@ -210,7 +210,7 @@ class Assets:
 class RemoteConfig(SafeModelNonSerializable):
     """Bundles config values needed to deploy a Chainlet."""
 
-    docker_image: DockerImage
+    docker_image: DockerImage = DockerImage()
     compute: Compute = Compute()
     assets: Assets = Assets()
     name: Optional[str] = None

--- a/truss-chains/truss_chains/deploy.py
+++ b/truss-chains/truss_chains/deploy.py
@@ -149,7 +149,7 @@ class ChainService:
     def run_url(self) -> str:
         return self.get_entrypoint.predict_url
 
-    def run(self, json: Dict) -> Any:
+    def run_remote(self, json: Dict) -> Any:
         return self.get_entrypoint.predict(json)
 
     def get_info(self) -> list[tuple[str, str, str]]:

--- a/truss-chains/truss_chains/example_chainlet.py
+++ b/truss-chains/truss_chains/example_chainlet.py
@@ -2,8 +2,6 @@ import truss_chains as chains
 
 
 class DummyGenerateData(chains.ChainletBase):
-    remote_config = chains.RemoteConfig(docker_image=chains.DockerImage())
-
     def run_remote(self) -> str:
         return "abc"
 
@@ -12,15 +10,11 @@ class DummyGenerateData(chains.ChainletBase):
 # module.
 class shared_chainlet:
     class DummySplitText(chains.ChainletBase):
-        remote_config = chains.RemoteConfig(docker_image=chains.DockerImage())
-
         def run_remote(self, data: str) -> list[str]:
             return [data[:2], data[2:]]
 
 
 class DummyExample(chains.ChainletBase):
-    remote_config = chains.RemoteConfig(docker_image=chains.DockerImage())
-
     def __init__(
         self,
         data_generator: DummyGenerateData = chains.depends(DummyGenerateData),

--- a/truss-chains/truss_chains/example_chainlet.py
+++ b/truss-chains/truss_chains/example_chainlet.py
@@ -4,7 +4,7 @@ import truss_chains as chains
 class DummyGenerateData(chains.ChainletBase):
     remote_config = chains.RemoteConfig(docker_image=chains.DockerImage())
 
-    def run(self) -> str:
+    def run_remote(self) -> str:
         return "abc"
 
 
@@ -14,7 +14,7 @@ class shared_chainlet:
     class DummySplitText(chains.ChainletBase):
         remote_config = chains.RemoteConfig(docker_image=chains.DockerImage())
 
-        def run(self, data: str) -> list[str]:
+        def run_remote(self, data: str) -> list[str]:
             return [data[:2], data[2:]]
 
 
@@ -23,15 +23,14 @@ class DummyExample(chains.ChainletBase):
 
     def __init__(
         self,
-        context: chains.DeploymentContext = chains.provide_context(),
-        data_generator: DummyGenerateData = chains.provide(DummyGenerateData),
-        splitter: shared_chainlet.DummySplitText = chains.provide(
+        data_generator: DummyGenerateData = chains.depends(DummyGenerateData),
+        splitter: shared_chainlet.DummySplitText = chains.depends(
             shared_chainlet.DummySplitText
         ),
+        context: chains.DeploymentContext = chains.depends_context(),
     ) -> None:
-        super().__init__(context)
         self._data_generator = data_generator
         self._data_splitter = splitter
 
-    def run(self) -> list[str]:
-        return self._data_splitter.run(self._data_generator.run())
+    def run_remote(self) -> list[str]:
+        return self._data_splitter.run_remote(self._data_generator.run_remote())

--- a/truss-chains/truss_chains/model_skeleton.py
+++ b/truss-chains/truss_chains/model_skeleton.py
@@ -37,7 +37,7 @@ class TrussChainletModel:
     #     with utils.exception_to_http_error(
     #         include_stack=True, chainlet_name="SplitText"
     #     ):
-    #         result = await self._chainlet.run(
+    #         result = await self._chainlet.run_remote(
     #             inputs=shared_chainlet.SplitTextInput.parse_obj(payload["inputs"]),
     #             extra_arg=payload["extra_arg"],
     #         )

--- a/truss-chains/truss_chains/public_api.py
+++ b/truss-chains/truss_chains/public_api.py
@@ -1,47 +1,57 @@
+import functools
 import pathlib
-from typing import Any, ContextManager, Mapping, Optional, Type, Union, final
+from typing import ContextManager, Mapping, Optional, Type, Union
 
 from truss_chains import definitions, deploy, framework
 
 
-def provide_context() -> Any:
-    """Sets a 'symbolic marker' for injecting a Context object at runtime."""
-    return framework.ContextProvisionMarker()
+def depends_context() -> definitions.DeploymentContext:
+    """Sets a 'symbolic marker' for injecting a Context object at runtime.
+
+    WARNING: Despite the type annotation, this does *not* immediately provide a
+    context instance.
+    Only when deploying remotely or using `run_local` a context instance is provided.
+    """
+    # The type error is silenced to because chains framework will at runtime inject
+    # a corresponding instance. Nonetheless, we want to use a type annotation here,
+    # to facilitate type inference, code-completion and type checking within the code
+    # of chainlets that depend on the other chainlet.
+    return framework.ContextDependencyMarker()  # type: ignore
 
 
-def provide(chainlet_cls: Type[definitions.ABCChainlet], retries: int = 1) -> Any:
-    """Sets a 'symbolic marker' for injecting a stub or local Chainlet at runtime."""
+def depends(
+    chainlet_cls: Type[framework.ChainletT], retries: int = 1
+) -> framework.ChainletT:
+    """Sets a 'symbolic marker' for injecting a stub or local Chainlet at runtime.
+
+    WARNING: Despite the type annotation, this does *not* immediately provide a
+    chainlet instance.
+    Only when deploying remotely or using `run_local` a chainlet instance is provided.
+    """
     options = definitions.RPCOptions(retries=retries)
-    return framework.ChainletProvisionMarker(chainlet_cls, options)
+    # The type error is silenced to because chains framework will at runtime inject
+    # a corresponding instance. Nonetheless, we want to use a type annotation here,
+    # to facilitate type inference, code-completion and type checking within the code
+    # of chainlets that depend on the other chainlet.
+    return framework.ChainletDependencyMarker(chainlet_cls, options)  # type: ignore
 
 
-class ChainletBase(definitions.ABCChainlet[definitions.UserConfigT]):
+class ChainletBase(definitions.ABCChainlet):
     def __init_subclass__(cls, **kwargs) -> None:
         super().__init_subclass__(**kwargs)
         framework.check_and_register_class(cls)
+        # For default init (from `object`) we don't need to check anything.
+        if cls.has_custom_init():
+            original_init = cls.__init__
 
-        original_init = cls.__init__
+            @functools.wraps(original_init)
+            def __init_with_arg_check__(self, *args, **kwargs):
+                if args:
+                    raise definitions.ChainsRuntimeError("Only kwargs are allowed.")
+                framework.ensure_args_are_injected(cls, original_init, kwargs)
+                original_init(self, *args, **kwargs)
 
-        def init_with_arg_check(self, *args, **kwargs):
-            if args:
-                raise definitions.ChainsRuntimeError("Only kwargs are allowed.")
-            framework.ensure_args_are_injected(cls, original_init, kwargs)
-            original_init(self, *args, **kwargs)
-
-        cls.__init__ = init_with_arg_check  # type: ignore[method-assign]
-
-    def __init__(
-        self,
-        context: definitions.DeploymentContext[
-            definitions.UserConfigT
-        ] = provide_context(),
-    ) -> None:
-        self._context = context
-
-    @final
-    @property
-    def user_config(self) -> definitions.UserConfigT:
-        return self._context.user_config
+            cls.__init__ = __init_with_arg_check__  # type: ignore[method-assign]
 
 
 def entrypoint(cls: Type[framework.ChainletT]) -> Type[framework.ChainletT]:
@@ -67,7 +77,8 @@ def deploy_remotely(
 def run_local(
     secrets: Optional[Mapping[str, str]] = None,
     data_dir: Optional[Union[pathlib.Path, str]] = None,
+    chainlet_to_service: Optional[Mapping[str, definitions.ServiceDescriptor]] = None,
 ) -> ContextManager[None]:
     """Context manager for using in-process instantiations of Chainlet dependencies."""
     data_dir = pathlib.Path(data_dir) if data_dir else None
-    return framework.run_local(secrets, data_dir)
+    return framework.run_local(secrets, data_dir, chainlet_to_service)

--- a/truss-chains/truss_chains/stub.py
+++ b/truss-chains/truss_chains/stub.py
@@ -17,7 +17,7 @@ class BasetenSession:
         api_key: str,
     ) -> None:
         logging.info(
-            f"Creating stub for `{service_descriptor.name}` "
+            f"Creating BasetenSession (HTTP) for `{service_descriptor.name}` "
             f"({service_descriptor.options.retries} retries) with predict URL:\n"
             f"    `{service_descriptor.predict_url}`"
         )

--- a/truss-chains/truss_chains/utils.py
+++ b/truss-chains/truss_chains/utils.py
@@ -240,7 +240,6 @@ def handle_response(response: httpx.Response, remote_name: str) -> Any:
     #     raise fastapi.HTTPException(
     #         status_code=response.status_code, detail=response.content
     #     )
-
     if response.is_server_error or response.is_client_error:
         try:
             response_json = response.json()


### PR DESCRIPTION
* Make context argument optional and, if used, trailing.
* Rename `run` -> `run_remote`, `provide` -> `depends`.
* Configurable predict concurrency.
* Better detection of invalid chainelt instatiations.
* Add more unittests - covering chainlet instatiations warnings.

<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
