### PR TITLE
Update truss config validations.

### DIFF
--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -670,6 +670,16 @@ def push(
         tr.spec.config.model_name = model_name
         tr.spec.config.write_to_yaml_file(tr.spec.config_path, verbose=False)
 
+    # Log a warning if using secrets without --trusted.
+    # TODO(helen): this could be moved to a separate function that includes more
+    #  config checks.
+    if tr.spec.config.secrets and not trusted:
+        not_trusted_text = (
+            "Warning: your Truss has secrets but was not pushed with --trusted. "
+            "Please push with --trusted to grant access to secrets."
+        )
+        console.print(not_trusted_text, style="red")
+
     # TODO(Abu): This needs to be refactored to be more generic
     service = remote_provider.push(
         tr,
@@ -697,16 +707,6 @@ def push(
 """
 
         click.echo(draft_model_text)
-
-    # Log a warning if using secrets without --trusted.
-    # TODO(helen): this could be moved to a separate function that includes more
-    #  config checks.
-    if tr.spec.config.secrets and not trusted:
-        not_trusted_text = (
-            "Warning: your Truss has secrets but was not pushed with --trusted. "
-            "Please push with --trusted to grant access to secrets."
-        )
-        console.print(not_trusted_text, style="red")
 
     if promote:
         promotion_text = (

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -635,7 +635,7 @@ def predict(
         "specifying, the command will not complete until the deployment is complete."
     ),
 )
-# @error_handling
+@error_handling
 def push(
     target_directory: str,
     remote: str,
@@ -703,7 +703,7 @@ def push(
     #  config checks.
     if tr.spec.config.secrets and not trusted:
         not_trusted_text = (
-            "Warning: your Truss has secrets but was not pushed with --trusted."
+            "Warning: your Truss has secrets but was not pushed with --trusted. "
             "Please push with --trusted to grant access to secrets."
         )
         console.print(not_trusted_text, style="red")

--- a/truss/test_data/test_basic_truss/config.yaml
+++ b/truss/test_data/test_basic_truss/config.yaml
@@ -9,5 +9,7 @@ resources:
   cpu: '1'
   memory: 2Gi
   use_gpu: false
-secrets: {}
+secrets:
+  foo: "foo"
+  bar: "bar"
 system_packages: []

--- a/truss/truss_config.py
+++ b/truss/truss_config.py
@@ -39,6 +39,8 @@ DEFAULT_USE_GPU = False
 
 DEFAULT_BLOB_BACKEND = HTTP_PUBLIC_BLOB_BACKEND
 
+VALID_PYTHON_VERSIONS = ["py39", "py310", "py311"]
+
 # Set up logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -576,6 +578,21 @@ class TrussConfig:
         return TrussConfig.from_dict(self.to_dict())
 
     def validate(self):
+        if self.python_version not in VALID_PYTHON_VERSIONS:
+
+            raise ValueError(
+                f"Please ensure that `python_version` is one of {VALID_PYTHON_VERSIONS}"
+            )
+
+        if not isinstance(self.secrets, dict):
+            raise ValueError(
+                "Please ensure that `secrets` is a mapping of the form:\n"
+                "```\n"
+                "secrets:\n"
+                '  secret1: "some default value"\n'
+                '  secret2: "some other default value"\n'
+                "```"
+            )
         for secret_name in self.secrets:
             validate_secret_name(secret_name)
 

--- a/truss/validation.py
+++ b/truss/validation.py
@@ -1,5 +1,5 @@
 import re
-from pathlib import Path
+from pathlib import PosixPath
 from typing import Pattern, Set
 
 from truss.constants import REGISTRY_BUILD_SECRET_PREFIX
@@ -81,9 +81,10 @@ def _is_numeric(number_like: str) -> bool:
 def validate_python_executable_path(path: str) -> None:
     """
     This python executable path determines the python executable
-    used to run the inference server - check to see that it is an absolute path
+    used to run the inference server - check to see that it is an absolute path.
+    We use PosixPath -- TrussServer always runs on a Posix machine.
     """
-    if path and not Path(path).is_absolute():
+    if path and not PosixPath(path).is_absolute():
         raise ValidationError(
             f"Invalid relative python executable path {path}. Provide an absolute path"
         )


### PR DESCRIPTION

## :rocket: What

Changed the following validations:
* base_image.python_executable_path -- changed this to use PosixPath so that this works on windows
* secrets -- validate that this is a dictionary and not a list (this is a common pitfall for users)
* python_version -- validate that user is using an allowed python version

## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing

```
poetry run truss push
```

with various configurations. See unit tests here. I did not test this on windows.
