### PR TITLE
Increase threadpool limit to match predict_concurrency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.14"
+version = "0.9.15dev1"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/test_data/test_concurrency_truss/config.yaml
+++ b/truss/test_data/test_concurrency_truss/config.yaml
@@ -1,2 +1,2 @@
 runtime:
-  predict_concurrency: 2
+  predict_concurrency: 50


### PR DESCRIPTION

## :rocket: What

While load testing Async, we discovered a bug with Truss where if you try to send more than 40 requests concurrently, anything beyond the 40 get stuck behind those first 40, no matter how high the predict concurrency.

After some digging, we noticed that this was due to the fact that `anyio` has a limit of 40 on the number of threads that get spawned. For trusses where the `predict` function is synchronous, they will be bound by this 40 number.

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing

Wrote integration test to test this.
