### PR TITLE
Adding initial code to implement build commands

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.14"
+version = "0.9.15rc16"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/contexts/image_builder/serving_image_builder.py
+++ b/truss/contexts/image_builder/serving_image_builder.py
@@ -383,6 +383,12 @@ class ServingImageBuilder(ImageBuilder):
                     )
                 )
 
+        # User specified build commands
+        build_commands: list = []
+        if self._spec.build_commands is not None:
+            for command in self._spec.build_commands:
+                build_commands.append(command)
+
         # Download from HuggingFace
         model_files, cached_files = update_config_and_gather_files(
             config, truss_dir, build_dir
@@ -450,6 +456,7 @@ class ServingImageBuilder(ImageBuilder):
             use_hf_secret,
             cached_files,
             external_data_files,
+            build_commands,
         )
 
     def _render_dockerfile(
@@ -460,6 +467,7 @@ class ServingImageBuilder(ImageBuilder):
         use_hf_secret: bool,
         cached_files: List[str],
         external_data_files: List[Tuple[str, str]],
+        build_commands: List[str],
     ):
         config = self._spec.config
         data_dir = build_dir / config.data_dir
@@ -512,6 +520,7 @@ class ServingImageBuilder(ImageBuilder):
             hf_access_token=hf_access_token,
             hf_access_token_file_name=HF_ACCESS_TOKEN_FILE_NAME,
             external_data_files=external_data_files,
+            build_commands=build_commands,
             **FILENAME_CONSTANTS_MAP,
         )
         docker_file_path = build_dir / MODEL_DOCKERFILE_NAME

--- a/truss/contexts/image_builder/serving_image_builder.py
+++ b/truss/contexts/image_builder/serving_image_builder.py
@@ -385,9 +385,8 @@ class ServingImageBuilder(ImageBuilder):
 
         # User specified build commands
         build_commands: list = []
-        if self._spec.build_commands is not None:
-            for command in self._spec.build_commands:
-                build_commands.append(command)
+        for command in self._spec.build_commands:
+            build_commands.append(command)
 
         # Download from HuggingFace
         model_files, cached_files = update_config_and_gather_files(

--- a/truss/contexts/image_builder/serving_image_builder.py
+++ b/truss/contexts/image_builder/serving_image_builder.py
@@ -383,11 +383,6 @@ class ServingImageBuilder(ImageBuilder):
                     )
                 )
 
-        # User specified build commands
-        build_commands: list = []
-        for command in self._spec.build_commands:
-            build_commands.append(command)
-
         # Download from HuggingFace
         model_files, cached_files = update_config_and_gather_files(
             config, truss_dir, build_dir
@@ -455,7 +450,7 @@ class ServingImageBuilder(ImageBuilder):
             use_hf_secret,
             cached_files,
             external_data_files,
-            build_commands,
+            self._spec.build_commands,
         )
 
     def _render_dockerfile(

--- a/truss/templates/server.Dockerfile.jinja
+++ b/truss/templates/server.Dockerfile.jinja
@@ -62,6 +62,13 @@ RUN mkdir -p {{ dst.parent }}; curl -L "{{ url }}" -o {{ dst }}
 {% endfor %}
 {%- endif  %}
 
+
+{%- if build_commands %}
+{% for command in build_commands %}
+RUN {{ command }}
+{% endfor %}
+{%- endif  %}
+
 # Copy data before code for better caching
 {%- if data_dir_exists %}
 COPY ./{{config.data_dir}} /app/data

--- a/truss/test_data/test_build_commands/config.yaml
+++ b/truss/test_data/test_build_commands/config.yaml
@@ -1,0 +1,13 @@
+build_commands:
+  - mkdir example_dir
+  - cd example_dir && touch testing.py
+model_metadata: {}
+model_name: null
+model_type: custom
+python_version: py39
+requirements: []
+resources:
+  accelerator: null
+  cpu: 500m
+  memory: 512Mi
+  use_gpu: false

--- a/truss/test_data/test_build_commands/model/model.py
+++ b/truss/test_data/test_build_commands/model/model.py
@@ -1,0 +1,17 @@
+from typing import Any, Dict, List
+
+
+class Model:
+    def __init__(self, **kwargs) -> None:
+        self._data_dir = kwargs["data_dir"]
+        self._config = kwargs["config"]
+        self._secrets = kwargs["secrets"]
+        self._model = None
+
+    def load(self):
+        # Load model here and assign to self._model.
+        pass
+
+    def predict(self, model_input: Any) -> Dict[str, List]:
+        # Invoke model on model_input and calculate predictions here.
+        return {"predictions": [1, 2]}

--- a/truss/test_data/test_build_commands_failure/config.yaml
+++ b/truss/test_data/test_build_commands_failure/config.yaml
@@ -1,0 +1,14 @@
+build_commands:
+  - mkdir example_dir
+  - cd example_dir && touch testing.py
+  - haha lol
+model_metadata: {}
+model_name: null
+model_type: custom
+python_version: py39
+requirements: []
+resources:
+  accelerator: null
+  cpu: 500m
+  memory: 512Mi
+  use_gpu: false

--- a/truss/test_data/test_build_commands_failure/model/model.py
+++ b/truss/test_data/test_build_commands_failure/model/model.py
@@ -1,0 +1,17 @@
+from typing import Any, Dict, List
+
+
+class Model:
+    def __init__(self, **kwargs) -> None:
+        self._data_dir = kwargs["data_dir"]
+        self._config = kwargs["config"]
+        self._secrets = kwargs["secrets"]
+        self._model = None
+
+    def load(self):
+        # Load model here and assign to self._model.
+        pass
+
+    def predict(self, model_input: Any) -> Dict[str, List]:
+        # Invoke model on model_input and calculate predictions here.
+        return {"predictions": [1, 2]}

--- a/truss/tests/test_config.py
+++ b/truss/tests/test_config.py
@@ -152,6 +152,7 @@ def test_parse_base_image(input_dict, expect_base_image, output_dict):
 
 def generate_default_config():
     config = {
+        "build_commands": None,
         "environment_variables": {},
         "external_package_dirs": [],
         "model_metadata": {},
@@ -176,7 +177,8 @@ def test_default_config_not_crowded_end_to_end():
         requirements=[],
     )
 
-    config_yaml = """environment_variables: {}
+    config_yaml = """build_commands: null
+environment_variables: {}
 external_package_dirs: []
 model_metadata: {}
 model_name: null

--- a/truss/tests/test_config.py
+++ b/truss/tests/test_config.py
@@ -152,7 +152,7 @@ def test_parse_base_image(input_dict, expect_base_image, output_dict):
 
 def generate_default_config():
     config = {
-        "build_commands": None,
+        "build_commands": [],
         "environment_variables": {},
         "external_package_dirs": [],
         "model_metadata": {},
@@ -177,7 +177,7 @@ def test_default_config_not_crowded_end_to_end():
         requirements=[],
     )
 
-    config_yaml = """build_commands: null
+    config_yaml = """build_commands: []
 environment_variables: {}
 external_package_dirs: []
 model_metadata: {}

--- a/truss/tests/test_truss_handle.py
+++ b/truss/tests/test_truss_handle.py
@@ -821,7 +821,7 @@ def _read_readme(filename: str) -> str:
 
 def generate_default_config():
     config = {
-        "build_commands": None,
+        "build_commands": [],
         "environment_variables": {},
         "external_package_dirs": [],
         "model_metadata": {},

--- a/truss/tests/test_truss_handle.py
+++ b/truss/tests/test_truss_handle.py
@@ -800,6 +800,7 @@ def _read_readme(filename: str) -> str:
 
 def generate_default_config():
     config = {
+        "build_commands": None,
         "environment_variables": {},
         "external_package_dirs": [],
         "model_metadata": {},

--- a/truss/tests/test_truss_handle.py
+++ b/truss/tests/test_truss_handle.py
@@ -458,6 +458,27 @@ def test_add_environment_variable(custom_model_truss_dir_with_pre_and_post):
         Docker.client().kill(container)
 
 
+@pytest.mark.integration
+def test_build_commands():
+    truss_root = Path(__file__).parent.parent.parent.resolve() / "truss"
+    truss_dir = truss_root / "test_data" / "test_build_commands"
+    tr = TrussHandle(truss_dir)
+    with ensure_kill_all():
+        r1 = tr.docker_predict([1, 2])
+        assert r1 == {"predictions": [1, 2]}
+
+
+@pytest.mark.integration
+def test_build_commands_failure():
+    truss_root = Path(__file__).parent.parent.parent.resolve() / "truss"
+    truss_dir = truss_root / "test_data" / "test_build_commands_failure"
+    tr = TrussHandle(truss_dir)
+    try:
+        tr.docker_run(local_port=8090, detach=True, wait_for_server_ready=True)
+    except DockerException as exc:
+        assert "It returned with code 1" in str(exc)
+
+
 def test_add_data_file(custom_model_truss_dir_with_pre_and_post, tmp_path):
     th = TrussHandle(custom_model_truss_dir_with_pre_and_post)
     data_filepath = tmp_path / "test_data.txt"

--- a/truss/truss_config.py
+++ b/truss/truss_config.py
@@ -498,6 +498,7 @@ class TrussConfig:
     base_image: Optional[BaseImage] = None
     model_cache: ModelCache = field(default_factory=ModelCache)
     trt_llm: Optional[TRTLLMConfiguration] = None
+    build_commands: Optional[List[str]] = None
 
     @property
     def canonical_python_version(self) -> str:
@@ -553,6 +554,7 @@ class TrussConfig:
             trt_llm=transform_optional(
                 d.get("trt_llm"), lambda x: TRTLLMConfiguration(**x)
             ),
+            build_commands=d.get("build_commands", None),
         )
         config.validate()
         return config
@@ -613,6 +615,7 @@ DATACLASS_TO_REQ_KEYS_MAP = {
         "resources",
         "secrets",
         "system_packages",
+        "build_commands",
     },
     BaseImage: {"image", "python_executable_path"},
 }

--- a/truss/truss_config.py
+++ b/truss/truss_config.py
@@ -498,7 +498,7 @@ class TrussConfig:
     base_image: Optional[BaseImage] = None
     model_cache: ModelCache = field(default_factory=ModelCache)
     trt_llm: Optional[TRTLLMConfiguration] = None
-    build_commands: Optional[List[str]] = None
+    build_commands: Optional[List[str]] = field(default_factory=list)
 
     @property
     def canonical_python_version(self) -> str:
@@ -554,7 +554,7 @@ class TrussConfig:
             trt_llm=transform_optional(
                 d.get("trt_llm"), lambda x: TRTLLMConfiguration(**x)
             ),
-            build_commands=d.get("build_commands", None),
+            build_commands=d.get("build_commands", []),
         )
         config.validate()
         return config

--- a/truss/truss_spec.py
+++ b/truss/truss_spec.py
@@ -35,7 +35,7 @@ class TrussSpec:
         return self._config.external_data
 
     @property
-    def build_commands(self) -> Optional[List[str]]:
+    def build_commands(self) -> List[str]:
         return self._config.build_commands
 
     @property

--- a/truss/truss_spec.py
+++ b/truss/truss_spec.py
@@ -35,6 +35,10 @@ class TrussSpec:
         return self._config.external_data
 
     @property
+    def build_commands(self) -> Optional[List[str]]:
+        return self._config.build_commands
+
+    @property
     def model_module_dir(self) -> Path:
         return self._truss_dir / self._config.model_module_dir
 


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What

Users want to be able to run custom docker commands inside the build step. Right now they have to create a custom base image, but this is not ideal since it becomes the customers responsibility to manage these images and ultimately leads to a slower dev cycle on their end. This feature is useful for customers who want to cache things like git repos or model weights in different locations in their truss. 

<!--
  How was the change described above implemented?
-->
## :computer: How

We can allow users to specify their docker commands inside the `config.yaml` and then inject them into the Dockerfile, so that their commands get run at build time. For now, we can restrict the use to just `RUN` commands which should be enough for most use-cases.

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing

Manual tests + integration tests.
Link to integration tests: https://github.com/basetenlabs/truss/actions/runs/9470284962
