### PR TITLE
Fix lazy data resolver error handling

### DIFF
--- a/truss/templates/shared/lazy_data_resolver.py
+++ b/truss/templates/shared/lazy_data_resolver.py
@@ -49,7 +49,7 @@ class LazyDataResolver:
                     resolved_url,
                     self._data_dir / file_name,
                 )
-            for file_name, future in futures:
+            for file_name, future in futures.items():
                 if not future:
                     raise RuntimeError(f"Download failure for file {file_name}")
 

--- a/truss/templates/shared/lazy_data_resolver.py
+++ b/truss/templates/shared/lazy_data_resolver.py
@@ -42,18 +42,16 @@ class LazyDataResolver:
 
     def fetch(self):
         with ThreadPoolExecutor(NUM_WORKERS) as executor:
-            futures = []
+            futures = {}
             for file_name, resolved_url in self._bptr_resolution.items():
-                futures.append(
-                    executor.submit(
-                        download_from_url_using_requests,
-                        resolved_url,
-                        self._data_dir / file_name,
-                    )
+                futures[file_name] = executor.submit(
+                    download_from_url_using_requests,
+                    resolved_url,
+                    self._data_dir / file_name,
                 )
-            for future in futures:
+            for file_name, future in futures:
                 if not future:
-                    raise RuntimeError(f"Download failure for file: {file_name}")
+                    raise RuntimeError(f"Download failure for file {file_name}")
 
 
 def _read_bptr_resolution() -> Dict[str, str]:


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
- Previous code would throw due to undefined reference to `file_name` in present scope. Change the code to persist a mapping of file name and future 

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
