### PR TITLE
[BT-10657] Wire up truss chains deploy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.14"
+version = "0.9.15rc20"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss-chains/truss_chains/deploy.py
+++ b/truss-chains/truss_chains/deploy.py
@@ -32,6 +32,12 @@ def _deploy_to_baseten(
         f"Deploying chainlet `{model_name}` as truss model on Baseten "
         f"(publish={options.publish}, promote={options.promote})."
     )
+
+    # Since we are deploying a model independently of the chain, we add a random prefix to
+    # prevent us from running into issues with existing models with the same name.
+    #
+    # This is a bit of a hack for now. Once we support model_origin for Chains models, we
+    # can drop the requirement for names on models.
     model_prefix = "".join(random.choices(string.ascii_uppercase + string.digits, k=9))
 
     # Models must be trusted to use the API KEY secret.

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -344,6 +344,12 @@ def _create_chains_table(service) -> Tuple[rich.table.Table, List[str]]:
     is_flag=True,
     help="Produces only generated files, but doesn't deploy anything.",
 )
+@click.option(
+    "--remote",
+    type=str,
+    required=False,
+    help="Name of the remote in .trussrc to push to.",
+)
 @error_handling
 def deploy(
     source: Path,
@@ -353,6 +359,7 @@ def deploy(
     promote: bool,
     wait: bool,
     dryrun: bool,
+    remote: Optional[str],
 ) -> None:
     """
     Deploys a chain remotely.
@@ -374,6 +381,7 @@ def deploy(
             promote=promote,
             publish=publish,
             only_generate_trusses=dryrun,
+            remote=remote,
         )
         service = chains_deploy.deploy_remotely(entrypoint_cls, options)
 

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -3,9 +3,9 @@ from enum import Enum
 from typing import Any, List, Optional
 
 import requests
+from truss.remote.baseten import types as b10_types
 from truss.remote.baseten.auth import ApiKey, AuthService
 from truss.remote.baseten.error import ApiError
-from truss.remote.baseten.types import ChainletData
 from truss.remote.baseten.utils.transfer import base64_encoded_json_str
 
 logger = logging.getLogger(__name__)
@@ -23,7 +23,7 @@ API_URL_MAPPING = {
 DEFAULT_API_DOMAIN = "https://api.baseten.co"
 
 
-def _chainlet_data_to_graphql_mutation(chainlet: ChainletData):
+def _chainlet_data_to_graphql_mutation(chainlet: b10_types.ChainletData):
     return f"""
         {{
             name: "{chainlet.name}",
@@ -186,7 +186,7 @@ class BasetenApi:
         resp = self._post_graphql_query(query_string)
         return resp["data"]["deploy_draft_truss"]
 
-    def deploy_chain(self, name: str, chainlet_data: List[ChainletData]):
+    def deploy_chain(self, name: str, chainlet_data: List[b10_types.ChainletData]):
         chainlet_data_strings = [
             _chainlet_data_to_graphql_mutation(chainlet) for chainlet in chainlet_data
         ]
@@ -205,7 +205,9 @@ class BasetenApi:
         resp = self._post_graphql_query(query_string)
         return resp["data"]["deploy_chain"]
 
-    def deploy_draft_chain(self, name: str, chainlet_data: List[ChainletData]):
+    def deploy_draft_chain(
+        self, name: str, chainlet_data: List[b10_types.ChainletData]
+    ):
         chainlet_data_strings = [
             _chainlet_data_to_graphql_mutation(chainlet) for chainlet in chainlet_data
         ]
@@ -223,7 +225,9 @@ class BasetenApi:
         resp = self._post_graphql_query(query_string)
         return resp["data"]["deploy_draft_chain"]
 
-    def deploy_chain_deployment(self, chain_id: str, chainlet_data: List[ChainletData]):
+    def deploy_chain_deployment(
+        self, chain_id: str, chainlet_data: List[b10_types.ChainletData]
+    ):
         chainlet_data_strings = [
             _chainlet_data_to_graphql_mutation(chainlet) for chainlet in chainlet_data
         ]

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -1,10 +1,11 @@
 import logging
 from enum import Enum
-from typing import Any, Optional
+from typing import Any, List, Optional
 
 import requests
 from truss.remote.baseten.auth import ApiKey, AuthService
 from truss.remote.baseten.error import ApiError
+from truss.remote.baseten.types import ChainletData
 from truss.remote.baseten.utils.transfer import base64_encoded_json_str
 
 logger = logging.getLogger(__name__)
@@ -20,6 +21,16 @@ API_URL_MAPPING = {
 # If a non-standard domain is used with the baseten remote, default to
 # using the production api routes
 DEFAULT_API_DOMAIN = "https://api.baseten.co"
+
+
+def _chainlet_data_to_graphql_mutation(chainlet: ChainletData):
+    return f"""
+        {{
+            name: "{chainlet.name}",
+            oracle_version_id: "{chainlet.oracle_version_id}",
+            is_entrypoint: {'true' if chainlet.is_entrypoint else 'false'}
+        }}
+        """
 
 
 class BasetenApi:
@@ -51,6 +62,7 @@ class BasetenApi:
 
     def _post_graphql_query(self, query_string: str) -> dict:
         headers = self._auth_token.header()
+
         resp = requests.post(
             self._graphql_api_url,
             data={"query": query_string},
@@ -173,6 +185,80 @@ class BasetenApi:
         """
         resp = self._post_graphql_query(query_string)
         return resp["data"]["deploy_draft_truss"]
+
+    def deploy_chain(self, name: str, chainlet_data: List[ChainletData]):
+        chainlet_data_strings = [
+            _chainlet_data_to_graphql_mutation(chainlet) for chainlet in chainlet_data
+        ]
+
+        chainlets_string = ", ".join(chainlet_data_strings)
+        query_string = f"""
+        mutation {{
+        deploy_chain(
+            name: "{name}",
+            chainlets: [{chainlets_string}]
+        ) {{
+            id
+        }}
+        }}
+        """
+        resp = self._post_graphql_query(query_string)
+        return resp["data"]["deploy_chain"]
+
+    def deploy_draft_chain(self, name: str, chainlet_data: List[ChainletData]):
+        chainlet_data_strings = [
+            _chainlet_data_to_graphql_mutation(chainlet) for chainlet in chainlet_data
+        ]
+        chainlets_string = ", ".join(chainlet_data_strings)
+        query_string = f"""
+        mutation {{
+        deploy_draft_chain(
+            name: "{name}",
+            chainlets: [{chainlets_string}]
+        ) {{
+            chain_id
+        }}
+        }}
+        """
+        resp = self._post_graphql_query(query_string)
+        return resp["data"]["deploy_draft_chain"]
+
+    def deploy_chain_deployment(self, chain_id: str, chainlet_data: List[ChainletData]):
+        chainlet_data_strings = [
+            _chainlet_data_to_graphql_mutation(chainlet) for chainlet in chainlet_data
+        ]
+        chainlets_string = ", ".join(chainlet_data_strings)
+        query_string = f"""
+        mutation {{
+        deploy_chain_deployment(
+            chain_id: "{chain_id}",
+            chainlets: [{chainlets_string}]
+        ) {{
+            chain_id
+            chain_deployment_id
+        }}
+        }}
+        """
+        resp = self._post_graphql_query(query_string)
+        return resp["data"]["deploy_chain_deployment"]
+
+    def get_chain_by_id(self, id: str):
+
+        # TODO: Implement
+        pass
+
+    def get_chains(self):
+        query_string = """
+        {
+            chains {
+                id
+                name
+            }
+        }
+        """
+
+        resp = self._post_graphql_query(query_string)
+        return resp["data"]["chains"]
 
     def models(self):
         query_string = """

--- a/truss/remote/baseten/core.py
+++ b/truss/remote/baseten/core.py
@@ -4,6 +4,7 @@ from typing import IO, List, Optional, Tuple
 import truss
 from truss.remote.baseten.api import BasetenApi
 from truss.remote.baseten.error import ApiError
+from truss.remote.baseten.types import ChainletData
 from truss.remote.baseten.utils.tar import create_tar_with_progress_bar
 from truss.remote.baseten.utils.transfer import multipart_upload_boto3
 from truss.truss_handle import TrussHandle
@@ -35,6 +36,23 @@ class ModelVersionId(ModelIdentifier):
         self.value = model_version_id
 
 
+def exists_chain(api: BasetenApi, chain_name: str) -> Optional[str]:
+    """
+    Check if a chain with the given name exists in the Baseten remote.
+
+    Args:
+        api: BasetenApi instance
+        chain_name: Name of the chain to check for existence
+
+    Returns:
+        chain_id if present, otherwise None
+    """
+    chains = api.get_chains()
+
+    chain_name_id_mapping = {chain["name"]: chain["id"] for chain in chains}
+    return chain_name_id_mapping.get(chain_name)
+
+
 def exists_model(api: BasetenApi, model_name: str) -> Optional[str]:
     """
     Check if a model with the given name exists in the Baseten remote.
@@ -58,6 +76,22 @@ def exists_model(api: BasetenApi, model_name: str) -> Optional[str]:
         raise e
 
     return model["model"]["id"]
+
+
+def create_chain(
+    api: BasetenApi,
+    chain_id: Optional[str],
+    chain_name: str,
+    chainlets: List[ChainletData],
+    is_draft: bool = False,
+) -> str:
+    if is_draft:
+        return api.deploy_draft_chain(chain_name, chainlets)["chain_id"]
+
+    if chain_id:
+        return api.deploy_chain_deployment(chain_id, chainlets)["chain_id"]
+
+    return api.deploy_chain(chain_name, chainlets)["id"]
 
 
 def get_model_versions(api: BasetenApi, model_name: ModelName) -> Tuple[str, List]:

--- a/truss/remote/baseten/core.py
+++ b/truss/remote/baseten/core.py
@@ -2,9 +2,9 @@ import logging
 from typing import IO, List, Optional, Tuple
 
 import truss
+from truss.remote.baseten import types as b10_types
 from truss.remote.baseten.api import BasetenApi
 from truss.remote.baseten.error import ApiError
-from truss.remote.baseten.types import ChainletData
 from truss.remote.baseten.utils.tar import create_tar_with_progress_bar
 from truss.remote.baseten.utils.transfer import multipart_upload_boto3
 from truss.truss_handle import TrussHandle
@@ -36,7 +36,7 @@ class ModelVersionId(ModelIdentifier):
         self.value = model_version_id
 
 
-def exists_chain(api: BasetenApi, chain_name: str) -> Optional[str]:
+def get_chain_id_by_name(api: BasetenApi, chain_name: str) -> Optional[str]:
     """
     Check if a chain with the given name exists in the Baseten remote.
 
@@ -82,7 +82,7 @@ def create_chain(
     api: BasetenApi,
     chain_id: Optional[str],
     chain_name: str,
-    chainlets: List[ChainletData],
+    chainlets: List[b10_types.ChainletData],
     is_draft: bool = False,
 ) -> str:
     if is_draft:

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -18,8 +18,8 @@ from truss.remote.baseten.core import (
     archive_truss,
     create_chain,
     create_truss_service,
-    exists_chain,
     exists_model,
+    get_chain_id_by_name,
     get_dev_version,
     get_dev_version_from_versions,
     get_model_versions,
@@ -50,7 +50,7 @@ class BasetenRemote(TrussRemote):
     def create_chain(
         self, chain_name: str, chainlets: List[ChainletData], publish: bool = False
     ) -> str:
-        chain_id = exists_chain(self._api, chain_name)
+        chain_id = get_chain_id_by_name(self._api, chain_name)
         return create_chain(
             self._api,
             chain_id=chain_id,

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -16,7 +16,9 @@ from truss.remote.baseten.core import (
     ModelName,
     ModelVersionId,
     archive_truss,
+    create_chain,
     create_truss_service,
+    exists_chain,
     exists_model,
     get_dev_version,
     get_dev_version_from_versions,
@@ -26,6 +28,7 @@ from truss.remote.baseten.core import (
 )
 from truss.remote.baseten.error import ApiError
 from truss.remote.baseten.service import BasetenService
+from truss.remote.baseten.types import ChainletData
 from truss.remote.baseten.utils.transfer import base64_encoded_json_str
 from truss.remote.truss_remote import TrussRemote
 from truss.truss_config import ModelServer
@@ -43,6 +46,18 @@ class BasetenRemote(TrussRemote):
     @property
     def api(self) -> BasetenApi:
         return self._api
+
+    def create_chain(
+        self, chain_name: str, chainlets: List[ChainletData], publish: bool = False
+    ) -> str:
+        chain_id = exists_chain(self._api, chain_name)
+        return create_chain(
+            self._api,
+            chain_id=chain_id,
+            chain_name=chain_name,
+            chainlets=chainlets,
+            is_draft=not publish,
+        )
 
     def push(  # type: ignore
         self,

--- a/truss/remote/baseten/types.py
+++ b/truss/remote/baseten/types.py
@@ -1,0 +1,7 @@
+import pydantic
+
+
+class ChainletData(pydantic.BaseModel):
+    name: str
+    oracle_version_id: str
+    is_entrypoint: bool


### PR DESCRIPTION

## :rocket: What

Wired up `truss chains deploy` to create the new chains objects on the backend using the new mutations.

```
$ pip install truss==0.9.15rc20
```

### Follow-ups

* We need to change the links in the `truss chains deploy` output to link to the new Chains pages -- we'll do this once the UI is out and ready.
* Start sending model_origin to the create_truss so that we can treat these differently in the DB (do this first), this will allow us to hide these models from the Chains section

## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing

Ran:

```
poetry run truss chains deploy --remote baseten-staging --publish
```

on my codespace, and confirmed that it worked and created chains objects.
