### PR TITLE
Use lazy data resolver in triton engine builder flow

### DIFF
--- a/truss/templates/trtllm/model/model.py
+++ b/truss/templates/trtllm/model/model.py
@@ -18,11 +18,12 @@ DEFAULT_MAX_NEW_TOKENS = 500
 
 
 class Model:
-    def __init__(self, data_dir, config, secrets):
+    def __init__(self, data_dir, config, secrets, lazy_data_resolver):
         self._data_dir = data_dir
         self._config = config
         self._secrets = secrets
         self._request_id_counter = count(start=1)
+        self._lazy_data_resolver = lazy_data_resolver
         self.triton_client = None
         self.triton_server = None
         self.tokenizer = None


### PR DESCRIPTION
Ideally, fetch should be removed from model_wrapper, but I have decided to limit the changes for now and left a todo for it.