### PR TITLE
Use new cli links

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.15rc40"
+version = "0.9.16rc2"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.15rc22"
+version = "0.9.15rc40"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.16rc2"
+version = "0.9.16rc3"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss-chains/truss_chains/deploy.py
+++ b/truss-chains/truss_chains/deploy.py
@@ -147,9 +147,12 @@ def _get_ordered_dependencies(
 
 
 def _chainlet_logs_url(
-    chain_id: str, chain_deployment_id: str, chainlet_id: str
+    chain_id: str,
+    chain_deployment_id: str,
+    chainlet_id: str,
+    remote: b10_remote.BasetenRemote,
 ) -> str:
-    return ""
+    return f"{remote._remote_url}/chains/{chain_id}/logs/{chain_deployment_id}/{chainlet_id}"
 
 
 class RemoteChainService:
@@ -175,7 +178,10 @@ class RemoteChainService:
                 chainlet["name"],
                 chainlet["oracle_version"]["current_model_deployment_status"]["status"],
                 _chainlet_logs_url(
-                    self._chain_id, self._chain_deployment_id, chainlet["id"]
+                    self._chain_id,
+                    self._chain_deployment_id,
+                    chainlet["id"],
+                    self._remote,
                 ),
             )
             for chainlet in chainlets

--- a/truss-chains/truss_chains/deploy.py
+++ b/truss-chains/truss_chains/deploy.py
@@ -189,6 +189,8 @@ class RemoteChainService:
 
 
 class ChainService:
+    # TODO: This class needs to be refactored It's very tateful right now
+    # and bug-prone as a consequence, as it has to deal with both the local & remote flows.
     name: str
     _entrypoint: str
     _services: MutableMapping[str, b10_service.TrussService]
@@ -315,12 +317,14 @@ def deploy_remotely(
                 )
             )
 
-        chain_id, chain_deployment_id = options.remote_provider.create_chain(
+        chain_deployment_handle = options.remote_provider.create_chain(
             chain_name=chain_service.name, chainlets=chainlets, publish=options.publish
         )
 
         chain_service.set_remote_chain_service(
-            chain_id, chain_deployment_id, options.remote_provider
+            chain_deployment_handle.chain_id,
+            chain_deployment_handle.chain_deployment_id,
+            options.remote_provider,
         )
 
     return chain_service

--- a/truss-chains/truss_chains/deploy.py
+++ b/truss-chains/truss_chains/deploy.py
@@ -16,6 +16,7 @@ from typing import (
 )
 
 import truss
+from truss.remote.baseten import remote as b10_remote
 from truss.remote.baseten import service as b10_service
 from truss.remote.baseten import types as b10_types
 from truss_chains import code_gen, definitions, framework, utils
@@ -145,11 +146,48 @@ def _get_ordered_dependencies(
     ]
 
 
+def _chainlet_logs_url(
+    chain_id: str, chain_deployment_id: str, chainlet_id: str
+) -> str:
+    return ""
+
+
+class RemoteChainService:
+    _remote: b10_remote.BasetenRemote  # TODO, make this a generic TypeVar for this calss
+    _chain_id: str
+    _chain_deployment_id: str
+
+    def __init__(
+        self, chain_id: str, chain_deployment_id: str, remote: b10_remote.BasetenRemote
+    ) -> None:
+        self._remote = remote
+        self._chain_id = chain_id
+        self._chain_deployment_id = chain_deployment_id
+
+    def get_info(self) -> list[tuple[str, str, str]]:
+        """Return list with elements (name, status, logs_url) for each chainlet."""
+        chainlets = self._remote.get_chainlets(
+            chain_deployment_id=self._chain_deployment_id
+        )
+
+        return [
+            (
+                chainlet["name"],
+                chainlet["oracle_version"]["current_model_deployment_status"]["status"],
+                _chainlet_logs_url(
+                    self._chain_id, self._chain_deployment_id, chainlet["id"]
+                ),
+            )
+            for chainlet in chainlets
+        ]
+
+
 class ChainService:
     name: str
     _entrypoint: str
     _services: MutableMapping[str, b10_service.TrussService]
     _entrypoint_fake_json_data = Any
+    _remote_chain_service: Optional[RemoteChainService]
 
     def __init__(self, entrypoint: str, name: str) -> None:
         self.name = name
@@ -159,6 +197,13 @@ class ChainService:
 
     def add_service(self, name: str, service: b10_service.TrussService) -> None:
         self._services[name] = service
+
+    def set_remote_chain_service(
+        self, chain_id: str, chain_deployment_id: str, remote: b10_remote.BasetenRemote
+    ) -> None:
+        self._remote_chain_service = RemoteChainService(
+            chain_id, chain_deployment_id, remote
+        )
 
     @property
     def entrypoint_fake_json_data(self) -> Any:
@@ -195,11 +240,10 @@ class ChainService:
         return self.get_entrypoint.predict(json)
 
     def get_info(self) -> list[tuple[str, str, str]]:
-        """Return list with elements (name, status, logs_url) for each chainlet."""
-        return list(
-            (name, next(service.poll_deployment_status(sleep_secs=0)), service.logs_url)
-            for name, service in self._services.items()
-        )
+        if not self._remote_chain_service:
+            raise ValueError("Chain was not deployed remotely.")
+
+        return self._remote_chain_service.get_info()
 
 
 def deploy_remotely(
@@ -265,10 +309,12 @@ def deploy_remotely(
                 )
             )
 
-        chain_id = options.remote_provider.create_chain(
+        chain_id, chain_deployment_id = options.remote_provider.create_chain(
             chain_name=chain_service.name, chainlets=chainlets, publish=options.publish
         )
 
-        print(f"Newly Created Chain: {chain_id}")
+        chain_service.set_remote_chain_service(
+            chain_id, chain_deployment_id, options.remote_provider
+        )
 
     return chain_service

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -351,7 +351,6 @@ def _create_chains_table(service) -> Tuple[rich.table.Table, List[str]]:
     required=False,
     help="Name of the remote in .trussrc to push to.",
 )
-@error_handling
 def deploy(
     source: Path,
     entrypoint: Optional[str],

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -353,6 +353,7 @@ def _create_chains_table(service) -> Tuple[rich.table.Table, List[str]]:
     required=False,
     help="Name of the remote in .trussrc to push to.",
 )
+@error_handling
 def deploy(
     source: Path,
     entrypoint: Optional[str],

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -26,6 +26,7 @@ from truss.remote.baseten.core import (
     ModelVersionId,
 )
 from truss.remote.baseten.service import BasetenService
+from truss.remote.baseten.utils.status import get_displayable_status
 from truss.remote.remote_cli import inquire_model_name, inquire_remote_name
 from truss.remote.remote_factory import USER_TRUSSRC_PATH, RemoteFactory
 from truss.truss_config import Build, ModelServer
@@ -284,18 +285,19 @@ def _create_chains_table(service) -> Tuple[rich.table.Table, List[str]]:
     statuses = []
     # After reversing, the first one is the entrypoint (per order in service).
     for i, (name, status, logs_url) in enumerate(reversed(service.get_info())):
-        if status == ACTIVE_STATUS:
+        displayable_status = get_displayable_status(status)
+        if displayable_status == ACTIVE_STATUS:
             spinner_name = "active"
-        elif status in DEPLOYING_STATUSES:
-            if status == "BUILDING":
+        elif displayable_status in DEPLOYING_STATUSES:
+            if displayable_status == "BUILDING":
                 spinner_name = "building"
-            elif status == "LOADING":
+            elif displayable_status == "LOADING":
                 spinner_name = "loading"
             else:
                 spinner_name = "deploying"
         else:
             spinner_name = "failed"
-        spinner = rich.spinner.Spinner(spinner_name, text=status)
+        spinner = rich.spinner.Spinner(spinner_name, text=displayable_status)
         if i == 0:
             display_name = f"{name} (entrypoint)"
         else:
@@ -304,7 +306,7 @@ def _create_chains_table(service) -> Tuple[rich.table.Table, List[str]]:
         table.add_row(spinner, display_name, logs_url)
         if i == 0:  # Add section divider after entrypoint.
             table.add_section()
-        statuses.append(status)
+        statuses.append(displayable_status)
     return table, statuses
 
 

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -205,6 +205,8 @@ class BasetenApi:
             chainlets: [{chainlets_string}]
         ) {{
             id
+            chain_id
+            chain_deployment_id
         }}
         }}
         """
@@ -225,6 +227,7 @@ class BasetenApi:
             chainlets: [{chainlets_string}]
         ) {{
             chain_id
+            chain_deployment_id
         }}
         }}
         """
@@ -252,11 +255,6 @@ class BasetenApi:
         resp = self._post_graphql_query(query_string)
         return resp["data"]["deploy_chain_deployment"]
 
-    def get_chain_by_id(self, id: str):
-
-        # TODO: Implement
-        pass
-
     def get_chains(self):
         query_string = """
         {
@@ -269,6 +267,25 @@ class BasetenApi:
 
         resp = self._post_graphql_query(query_string)
         return resp["data"]["chains"]
+
+    def get_chainlets_by_deployment_id(self, chain_deployment_id: str):
+        query_string = f"""
+        {{
+            chain_deployment(id:"{chain_deployment_id}") {{
+                chainlets{{
+                    name
+                    id
+                    oracle_version {{
+                        current_model_deployment_status {{
+                            status
+                        }}
+                    }}
+                 }}
+            }}
+        }}
+        """
+        resp = self._post_graphql_query(query_string)
+        return resp["data"]["chain_deployment"]["chainlets"]
 
     def models(self):
         query_string = """

--- a/truss/remote/baseten/core.py
+++ b/truss/remote/baseten/core.py
@@ -1,4 +1,5 @@
 import logging
+import typing
 from typing import IO, List, Optional, Tuple
 
 import truss
@@ -15,6 +16,11 @@ logger = logging.getLogger(__name__)
 
 DEPLOYING_STATUSES = ["BUILDING", "DEPLOYING", "LOADING_MODEL", "UPDATING"]
 ACTIVE_STATUS = "ACTIVE"
+
+
+class ChainDeploymentHandle(typing.NamedTuple):
+    chain_id: str
+    chain_deployment_id: str
 
 
 class ModelIdentifier:
@@ -84,14 +90,18 @@ def create_chain(
     chain_name: str,
     chainlets: List[b10_types.ChainletData],
     is_draft: bool = False,
-) -> Tuple[str, str]:
+) -> ChainDeploymentHandle:
     if is_draft:
         response = api.deploy_draft_chain(chain_name, chainlets)
     elif chain_id:
         response = api.deploy_chain_deployment(chain_id, chainlets)
     else:
         response = api.deploy_chain(chain_name, chainlets)
-    return (response["chain_id"], response["chain_deployment_id"])
+
+    return ChainDeploymentHandle(
+        chain_id=response["chain_id"],
+        chain_deployment_id=response["chain_deployment_id"],
+    )
 
 
 def get_model_versions(api: BasetenApi, model_name: ModelName) -> Tuple[str, List]:

--- a/truss/remote/baseten/core.py
+++ b/truss/remote/baseten/core.py
@@ -84,14 +84,14 @@ def create_chain(
     chain_name: str,
     chainlets: List[b10_types.ChainletData],
     is_draft: bool = False,
-) -> str:
+) -> Tuple[str, str]:
     if is_draft:
-        return api.deploy_draft_chain(chain_name, chainlets)["chain_id"]
-
-    if chain_id:
-        return api.deploy_chain_deployment(chain_id, chainlets)["chain_id"]
-
-    return api.deploy_chain(chain_name, chainlets)["id"]
+        response = api.deploy_draft_chain(chain_name, chainlets)
+    elif chain_id:
+        response = api.deploy_chain_deployment(chain_id, chainlets)
+    else:
+        response = api.deploy_chain(chain_name, chainlets)
+    return (response["chain_id"], response["chain_deployment_id"])
 
 
 def get_model_versions(api: BasetenApi, model_name: ModelName) -> Tuple[str, List]:

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -12,6 +12,7 @@ from truss.remote.baseten import types as b10_types
 from truss.remote.baseten.api import BasetenApi
 from truss.remote.baseten.auth import AuthService
 from truss.remote.baseten.core import (
+    ChainDeploymentHandle,
     ModelId,
     ModelIdentifier,
     ModelName,
@@ -52,7 +53,7 @@ class BasetenRemote(TrussRemote):
         chain_name: str,
         chainlets: List[b10_types.ChainletData],
         publish: bool = False,
-    ) -> Tuple[str, str]:
+    ) -> ChainDeploymentHandle:
         # Returns tuple of (chain_id, chain_deployment_id)
         chain_id = get_chain_id_by_name(self._api, chain_name)
         return create_chain(

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -52,8 +52,8 @@ class BasetenRemote(TrussRemote):
         chain_name: str,
         chainlets: List[b10_types.ChainletData],
         publish: bool = False,
-    ) -> str:
-
+    ) -> Tuple[str, str]:
+        # Returns tuple of (chain_id, chain_deployment_id)
         chain_id = get_chain_id_by_name(self._api, chain_name)
         return create_chain(
             self._api,
@@ -62,6 +62,9 @@ class BasetenRemote(TrussRemote):
             chainlets=chainlets,
             is_draft=not publish,
         )
+
+    def get_chainlets(self, chain_deployment_id: str) -> List[dict]:
+        return self._api.get_chainlets_by_deployment_id(chain_deployment_id)
 
     def push(  # type: ignore
         self,

--- a/truss/remote/baseten/utils/status.py
+++ b/truss/remote/baseten/utils/status.py
@@ -1,0 +1,29 @@
+STATUS_TO_DISPLAYABLE = {
+    "BUILDING_MODEL": "BUILDING",
+    "DEPLOYING_MODEL": "DEPLOYING",
+    "MODEL_DEPLOY_FAILED": "DEPLOY_FAILED",
+    "MODEL_LOADING": "LOADING_MODEL",
+    "MODEL_READY": "ACTIVE",
+    "MODEL_UNHEALTHY": "UNHEALTHY",
+    "BUILDING_MODEL_FAILED": "BUILD_FAILED",
+    "BUILDING_MODEL_STOPPED": "BUILD_STOPPED",
+    "DEACTIVATING_MODEL": "DEACTIVATING",
+    "DEACTIVATED_MODEL": "INACTIVE",
+    "MODEL_DNE_ERROR": "FAILED",
+    "UPDATING": "UPDATING",
+    "MIGRATING_WORKLOAD_PLANES": "UPDATING",
+    "SCALED_TO_ZERO": "SCALED_TO_ZERO",
+    "SCALING_FROM_ZERO": "WAKING_UP",
+}
+
+
+def get_displayable_status(status: str) -> str:
+    """
+    TODO: Remove this method once Chains is supported in the REST API
+
+    This is used by the `truss chains deploy` command right now to
+    print the right status. Once Chains are supported by the REST API, the
+    Baseten REST API will return status strings matching the ones here, so we don't
+    need to do any mapping.
+    """
+    return STATUS_TO_DISPLAYABLE[status]

--- a/truss/remote/baseten/utils/status.py
+++ b/truss/remote/baseten/utils/status.py
@@ -26,4 +26,4 @@ def get_displayable_status(status: str) -> str:
     Baseten REST API will return status strings matching the ones here, so we don't
     need to do any mapping.
     """
-    return STATUS_TO_DISPLAYABLE[status]
+    return STATUS_TO_DISPLAYABLE.get(status, "UNKNOWN")


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What

Now that we have new chainlet links available in the UI for going to logs, we can link them properly in the CLI. We do that here.


## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing

<img width="939" alt="status_py_—_truss__Codespaces__zany_happiness_" src="https://github.com/basetenlabs/truss/assets/850115/3b7740f0-00fc-4062-a62f-8bb2205e1357">


