### PR TITLE
[Chains] Fixes from bug-bash

### DIFF
--- a/truss-chains/truss_chains/__init__.py
+++ b/truss-chains/truss_chains/__init__.py
@@ -11,8 +11,9 @@ import pydantic
 pydantic_major_version = int(pydantic.VERSION.split(".")[0])
 if pydantic_major_version < 2:
     raise RuntimeError(
-        f"Pydantic v2 is not supported for `Truss-Chains`. Please upgrade to v2. "
-        "You can still use other Truss functionality."
+        f"Pydantic version {pydantic.VERSION} is not supported for Truss-Chains."
+        "Please upgrade to pydantic v2. With v1, you can still use all 'classical' "
+        "(non-Chains) Truss features."
     )
 
 del pydantic, pydantic_major_version

--- a/truss-chains/truss_chains/cli.py
+++ b/truss-chains/truss_chains/cli.py
@@ -5,6 +5,7 @@ from InquirerPy import inquirer
 def inquire_copy_confirm(msg: str) -> bool:
     rich.print(msg)
     return inquirer.confirm(
-        "Do you want to proceed deploying and copy all data (⚠️ proceed with cation)?",
+        "Do you want to proceed with deploying and copying "
+        "all data (⚠️ proceed with cation)?",
         default=False,
     ).execute()

--- a/truss-chains/truss_chains/cli.py
+++ b/truss-chains/truss_chains/cli.py
@@ -1,0 +1,10 @@
+import rich
+from InquirerPy import inquirer
+
+
+def inquire_copy_confirm(msg: str) -> bool:
+    rich.print(msg)
+    return inquirer.confirm(
+        "Do you want to proceed deploying and copy all data (⚠️ proceed with cation)?",
+        default=False,
+    ).execute()

--- a/truss-chains/truss_chains/code_gen.py
+++ b/truss-chains/truss_chains/code_gen.py
@@ -31,13 +31,14 @@ import shutil
 import subprocess
 import sys
 import textwrap
+import time
 from typing import Any, Iterable, Mapping, Optional
 
 import libcst
 import truss
 from truss import truss_config
 from truss.contexts.image_builder import serving_image_builder
-from truss_chains import definitions, model_skeleton, utils
+from truss_chains import cli, definitions, model_skeleton, utils
 
 INDENT = " " * 4
 _REQUIREMENTS_FILENAME = "pip_requirements.txt"
@@ -326,6 +327,8 @@ def _make_chainlet_dir(
     chainlet_name = chainlet_descriptor.name
     dir_name = f"chainlet_{chainlet_name}"
     chainlet_dir = root / definitions.GENERATED_CODE_DIR / chain_name / dir_name
+    if chainlet_dir.exists():
+        shutil.rmtree(chainlet_dir)
     chainlet_dir.mkdir(exist_ok=True, parents=True)
     return chainlet_dir
 
@@ -511,13 +514,74 @@ def _gen_truss_chainlet_file(
 # Truss Gen ############################################################################
 
 
-def _copy_python_source_files(root_dir: pathlib.Path, dest_dir: pathlib.Path) -> None:
+def _copy_python_source_files(
+    root_dir: pathlib.Path,
+    dest_dir: pathlib.Path,
+    max_files: int = 1000,
+    max_size_mb: int = 100,
+    time_limit_seconds: int = 3,
+) -> None:
     """Copy all python files under root recursively, but skips pycache."""
 
-    def python_files_only(_, names):
-        return [name for name in names if name == "__pycache__"]
+    def exclude_filter(_, names):
+        return [name for name in names if name in ("__pycache__", ".mypy_cache")]
 
-    shutil.copytree(root_dir, dest_dir, ignore=python_files_only, dirs_exist_ok=True)
+    start_time = time.time()
+    total_size = 0
+    total_files = 0
+    max_size_bytes = max_size_mb * 1024 * 1024
+    limit_issue = False
+
+    for dir_path, dir_names, filenames in os.walk(root_dir):
+        # In-place modification affects `os.walk` iterator intentionally.
+        dir_names[:] = [
+            d for d in dir_names if d not in exclude_filter(dir_path, dir_names)
+        ]
+        filenames = [
+            f for f in filenames if f not in exclude_filter(dir_path, filenames)
+        ]
+        for filename in filenames:
+            total_files += 1
+            filepath = pathlib.Path(dir_path) / filename
+            total_size += filepath.stat().st_size
+            if total_files > max_files or total_size > max_size_bytes:
+                limit_issue = True
+                break
+            if (time.time() - start_time) > time_limit_seconds:
+                limit_issue = True
+                break
+
+        if limit_issue:
+            break
+
+    if limit_issue:
+        if total_files > max_files:
+            issue_msg = f"found a large number of files (>{max_files})"
+        elif total_size > max_size_bytes:
+            issue_msg = (
+                f"found a large amount of data (>{total_size / (1024 * 1024):.2f} MB)"
+            )
+        else:
+            issue_msg = f"it took longer than {time_limit_seconds} seconds to scan"
+
+        msg = (
+            f"All files nested in the chains workspace directory are included in the "
+            "remote deployment. To prevent accidental inclusion of more files than "
+            "intended we scanned \n"
+            f"📁 {root_dir} \nand {issue_msg}. Please ensure the following:\n"
+            "✅ A chain should always be defined in a sub-dir to prevent including "
+            "unwanted content from your dev env. Use `truss chains init` or "
+            "refer to the docs for creating a new chain.\n"
+            "✅ Don't nest large data files and assets inside your chain directory. "
+            "Keep them in a directory next to the chain directory and use the "
+            "'remote_config.docker_image.data_dir' option to include them in the "
+            "remote deployment.\n"
+        )
+        confirmed = cli.inquire_copy_confirm(msg)
+        if not confirmed:
+            raise definitions.ChainsUsageError("User aborted copying files.")
+
+    shutil.copytree(root_dir, dest_dir, ignore=exclude_filter, dirs_exist_ok=True)
 
 
 def _make_requirements(image: definitions.DockerImage) -> list[str]:

--- a/truss-chains/truss_chains/code_gen.py
+++ b/truss-chains/truss_chains/code_gen.py
@@ -567,7 +567,7 @@ def _copy_python_source_files(
         msg = (
             f"All files nested in the chains workspace directory are included in the "
             "remote deployment. To prevent accidental inclusion of more files than "
-            "intended we scanned \n"
+            "intended, we scanned \n"
             f"📁 {root_dir} \nand {issue_msg}. Please ensure the following:\n"
             "✅ A chain should always be defined in a sub-dir to prevent including "
             "unwanted content from your dev env. Use `truss chains init` or "

--- a/truss-chains/truss_chains/framework.py
+++ b/truss-chains/truss_chains/framework.py
@@ -722,15 +722,16 @@ def import_target(
     module_name = module_path.stem  # Use the file's name as the module name
     if not os.path.isfile(module_path):
         raise ImportError(
-            f"`{module_path}` is not a file. You must point to a file where the entrypoint is defined."
+            f"`{module_path}` is not a file. You must point to a python file where "
+            "the entrypoint chainlet is defined."
         )
 
-    error_msg = f"Could not import `{target_name}` from `{module_path}`. Check path."
+    import_error_msg = f"Could not import `{module_path}`. Check path."
     spec = importlib.util.spec_from_file_location(module_name, module_path)
     if not spec:
-        raise ImportError(error_msg)
+        raise ImportError(import_error_msg)
     if not spec.loader:
-        raise ImportError(error_msg)
+        raise ImportError(import_error_msg)
 
     module = importlib.util.module_from_spec(spec)
     module.__file__ = str(module_path)
@@ -740,9 +741,9 @@ def import_target(
     # registration has to stay at least until the deployment command has finished.
     if module_name in sys.modules:
         raise ImportError(
-            f"{error_msg}. There is already a module in `sys.modules` "
-            f"with name {module_name}. Overwriting that value is unsafe. "
-            "Try renaming your file."
+            f"{import_error_msg}. There is already a module in `sys.modules` "
+            f"with name `{module_name}`. Overwriting that value is unsafe. "
+            "Try renaming your source file."
         )
     modules_before = set(sys.modules.keys())
     sys.modules[module_name] = module

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -53,7 +53,12 @@ class BasetenRemote(TrussRemote):
         chain_name: str,
         chainlets: List[b10_types.ChainletData],
         publish: bool = False,
+        promote: bool = False,
     ) -> ChainDeploymentHandle:
+        if promote:
+            # If we are promoting a model after deploy, it must be published.
+            # Draft models cannot be promoted.
+            publish = True
         # Returns tuple of (chain_id, chain_deployment_id)
         chain_id = get_chain_id_by_name(self._api, chain_name)
         return create_chain(


### PR DESCRIPTION
* Configurable logging level in truss CLI, default to more humanfriendly format.
* Fix pydantic v1/v2 error message.
* Clear temp gen directories.
* Check before copying suspiciously many files.
* Improved some error messages.
* Override fix publish options for `create_chain`.
* Don't create chains in `dryrun` / `only_generate_trusses` case.
* Chain as model name prefix, since now we have chains organized directly

Fixes BT-11213, BT-11219

<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
