### PR TITLE
update briton server version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.16"
+version = "0.9.17"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.17"
+version = "0.9.17rc1"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/constants.py
+++ b/truss/constants.py
@@ -106,7 +106,7 @@ HTTP_PUBLIC_BLOB_BACKEND = "http_public"
 REGISTRY_BUILD_SECRET_PREFIX = "DOCKER_REGISTRY_"
 
 TRTLLM_BASE_IMAGE = "baseten/triton_trt_llm:v0.9.0"
-BRITON_TRTLLM_BASE_IMAGE = "baseten/briton-server:v0.0.1"
+BRITON_TRTLLM_BASE_IMAGE = "baseten/briton-server:250d9c29_v0.0.2"
 TRTLLM_PYTHON_EXECUTABLE = "/usr/bin/python3"
 BASE_TRTLLM_REQUIREMENTS = [
     "tritonclient[all]==2.42.0",


### PR DESCRIPTION
Updates the Briton server version to:
```
BRITON_TRTLLM_BASE_IMAGE = "baseten/briton-server:250d9c29_v0.0.2"
```

The version string uses the first 8 characters of the TensorRT-LLM commit hash and appends the Briton version string.