### PR TITLE
add kv cache free gpu mem fraction support to engine builder flow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.17dev3"
+version = "0.9.17rc2"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.17dev1"
+version = "0.9.17dev3"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.17rc1"
+version = "0.9.17dev1"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/config/trt_llm.py
+++ b/truss/config/trt_llm.py
@@ -62,6 +62,7 @@ class TrussTRTLLMBuildConfiguration(BaseModel):
         TrussTRTLLMPluginConfiguration()
     )
     use_fused_mlp: bool = False
+    kv_cache_free_gpu_mem_fraction: float = 0.9
 
     class Config:
         json_encoders = {
@@ -72,11 +73,10 @@ class TrussTRTLLMBuildConfiguration(BaseModel):
 
 
 class TrussTRTLLMServingConfiguration(BaseModel):
-    engine_repository: Optional[str] = None
-    tokenizer_repository: Optional[str] = None
+    engine_repository: str
+    tokenizer_repository: str
     tensor_parallel_count: int = 1
     pipeline_parallel_count: int = 1
-    kv_cache_free_gpu_mem_fraction: float = 0.9
 
 
 class TRTLLMConfiguration(BaseModel):

--- a/truss/config/trt_llm.py
+++ b/truss/config/trt_llm.py
@@ -72,10 +72,11 @@ class TrussTRTLLMBuildConfiguration(BaseModel):
 
 
 class TrussTRTLLMServingConfiguration(BaseModel):
-    engine_repository: str
-    tokenizer_repository: str
+    engine_repository: Optional[str] = None
+    tokenizer_repository: Optional[str] = None
     tensor_parallel_count: int = 1
     pipeline_parallel_count: int = 1
+    kv_cache_free_gpu_mem_fraction: float = 0.9
 
 
 class TRTLLMConfiguration(BaseModel):

--- a/truss/constants.py
+++ b/truss/constants.py
@@ -118,6 +118,6 @@ BRITON_BASE_TRTLLM_REQUIREMENTS = [
     "grpcio==1.64.0",
     "grpcio-tools==1.64.0",
     "transformers==4.41.0",
-    "truss==0.9.17dev3",
+    "truss==0.9.17rc2",
 ]
 OPENAI_COMPATIBLE_TAG = "openai-compatible"

--- a/truss/constants.py
+++ b/truss/constants.py
@@ -118,6 +118,6 @@ BRITON_BASE_TRTLLM_REQUIREMENTS = [
     "grpcio==1.64.0",
     "grpcio-tools==1.64.0",
     "transformers==4.41.0",
-    "truss==0.9.12",
+    "truss==0.9.17dev3",
 ]
 OPENAI_COMPATIBLE_TAG = "openai-compatible"

--- a/truss/templates/trtllm-briton/model/model.py
+++ b/truss/templates/trtllm-briton/model/model.py
@@ -10,10 +10,7 @@ import briton_pb2
 import briton_pb2_grpc
 import grpc
 from transformers import AutoTokenizer
-from truss.config.trt_llm import (
-    TrussTRTLLMBuildConfiguration,
-    TrussTRTLLMServingConfiguration,
-)
+from truss.config.trt_llm import TrussTRTLLMBuildConfiguration
 from truss.constants import OPENAI_COMPATIBLE_TAG
 
 BRITON_PORT = 50051
@@ -74,15 +71,12 @@ class Model:
         truss_trtllm_build_config = TrussTRTLLMBuildConfiguration(
             **trtllm_config.get("build")
         )
-        truss_trtllm_serving_config = TrussTRTLLMServingConfiguration(
-            **trtllm_config.get("serve")
-        )
         self._tp_count = truss_trtllm_build_config.tensor_parallel_count
         self._tokenizer_repository = (
             truss_trtllm_build_config.checkpoint_repository.repo
         )
         self._kv_cache_free_gpu_mem_fraction = (
-            truss_trtllm_serving_config.kv_cache_free_gpu_mem_fraction
+            truss_trtllm_build_config.kv_cache_free_gpu_mem_fraction
         )
 
         self._hf_token = None


### PR DESCRIPTION
At very high batch sizes the default of 0.9 is not sufficient because it doesn't leave enough gpu memory for non-kv cache use cases, we need to be able to lower it.

Testing: Tested manually on dev.