### PR TITLE
improves trtllm example

### DIFF
--- a/truss/templates/trtllm/model/model.py
+++ b/truss/templates/trtllm/model/model.py
@@ -85,7 +85,7 @@ class Model:
         model_input.setdefault("max_tokens", DEFAULT_MAX_TOKENS)
         model_input.setdefault("max_new_tokens", DEFAULT_MAX_NEW_TOKENS)
 
-        is_oai_protocol = model_input.get("client_origin", "") == "open_ai_protocol"
+        is_oai_protocol = model_input.get("client_origin", "") == "open_ai_protocol" or self.uses_openai_api
 
         if is_oai_protocol:
             templater = lambda x: self.tokenizer.apply_chat_template(x, tokenize=False)

--- a/truss/templates/trtllm/model/model.py
+++ b/truss/templates/trtllm/model/model.py
@@ -92,8 +92,6 @@ class Model:
             model_input = ModelInput.from_bridge_oai_request(
                 model_input,
                 templater,
-                DEFAULT_MAX_TOKENS,
-                DEFAULT_MAX_NEW_TOKENS,
                 request_id,
                 self.eos_token_id,
             )

--- a/truss/templates/trtllm/model/model.py
+++ b/truss/templates/trtllm/model/model.py
@@ -79,16 +79,20 @@ class Model:
         if "messages" not in model_input and "prompt" not in model_input:
             raise ValueError("Prompt or messages must be provided")
 
-        request_id = str(os.getpid()) + str(
-            next(self._request_id_counter)
-        )
+        request_id = str(os.getpid()) + str(next(self._request_id_counter))
         model_input.setdefault("max_tokens", DEFAULT_MAX_TOKENS)
         model_input.setdefault("max_new_tokens", DEFAULT_MAX_NEW_TOKENS)
 
-        is_oai_protocol = model_input.get("client_origin", "") == "open_ai_protocol" or self.uses_openai_api
+        is_oai_protocol = (
+            model_input.get("client_origin", "") == "open_ai_protocol"
+            or self.uses_openai_api
+        )
 
         if is_oai_protocol:
-            templater = lambda x: self.tokenizer.apply_chat_template(x, tokenize=False)
+
+            def templater(msgs):
+                return self.tokenizer.apply_chat_template(msgs, tokenize=False)
+
             model_input = ModelInput.from_bridge_oai_request(
                 model_input,
                 templater,

--- a/truss/templates/trtllm/packages/schema.py
+++ b/truss/templates/trtllm/packages/schema.py
@@ -47,6 +47,24 @@ class ModelInput:
         request_id: str,
         eos_token_id: str,
     ) -> "ModelInput":
+        """
+        The BridgeCompletionRequest is input into the `from_bridge_oai_request` function.
+        This model is json-serialized as input into the `predict` endpoint. 
+        If changes are needed, reach out the Baseten Core Product team
+
+        class BridgeCompletionRequest(BaseModel):
+            messages: Union[str, List[Dict[str, str]]]
+            raw: Dict[Any, Any]
+            client_origin: str
+            repetition_penalty: Optional[float] = None
+            temperature: Optional[float] = None
+            top_p: Optional[float] = None
+            top_k: Optional[float] = None
+            stream: bool = False
+            max_tokens: Optional[int] = None
+            max_new_tokens: Optional[int] = None
+            stop_words_list: Optional[List[str]] = None
+        """
         if "messages" not in model_input:
             raise ValueError("'messages' key expected in bridge request")
 
@@ -114,24 +132,3 @@ class ModelInput:
             inputs.append(self._prepare_grpc_tensor("end_id", end_id_data))
 
         return inputs
-
-"""
-The BridgeCompletionRequest is input into the `from_bridge_request` function.
-This model is json-serialized as input into the `predict` endpoint. 
-If changes are needed, reach out the Baseten Core Product team
-
-class BridgeCompletionRequest(BaseModel):
-    messages: Union[str, List[Dict[str, str]]]
-    # raw is the incoming request with the "messages" omitted
-    # to avoid unnecessarily large request size
-    raw: Dict[Any, Any]
-    client_origin: str
-    repetition_penalty: Optional[float] = None
-    temperature: Optional[float] = None
-    top_p: Optional[float] = None
-    top_k: Optional[float] = None
-    stream: bool = False
-    max_tokens: Optional[int] = None
-    max_new_tokens: Optional[int] = None
-    stop_words_list: Optional[List[str]] = None
-"""

--- a/truss/templates/trtllm/packages/schema.py
+++ b/truss/templates/trtllm/packages/schema.py
@@ -46,7 +46,7 @@ class ModelInput:
         chat_templater: Callable[[Any], Any],
         request_id: str,
         eos_token_id: str,
-    ):
+    ) -> "ModelInput":
         if "messages" not in model_input:
             raise ValueError("'messages' key expected in bridge request")
 


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Addresses some shortcomings in the trtllm exmaple
* corrects forward incompatibility caused by `ModelInput(**model_input)` invocation
* more cleanly carves out type conversion for oai
* provides temporary fix for trt llm "stream=False" shortcomings, that results in generating nothing (cc @htrivedi99 @aspctu )
<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
Deployed this on a Llama-3-8b-trt-llm model and ran it through its paces (stream=True, False), additional params to ensure forward compatibility, printed model input from truss to verify functionality

Some Follow Ups:
- update llama-3-trt-llm example code 
- Anything else? 