### PR TITLE
Fix statuses in truss chains deploy

### DIFF
--- a/truss-chains/truss_chains/deploy.py
+++ b/truss-chains/truss_chains/deploy.py
@@ -180,7 +180,7 @@ class RemoteChainService:
         return [
             b10_types.DeployedChainlet(
                 name=chainlet["name"],
-                is_entrypoint=chainlet["oracle_version"]["is_entrypoint"],
+                is_entrypoint=chainlet["is_entrypoint"],
                 status=chainlet["oracle_version"]["current_model_deployment_status"][
                     "status"
                 ],

--- a/truss-chains/truss_chains/deploy.py
+++ b/truss-chains/truss_chains/deploy.py
@@ -17,6 +17,7 @@ from typing import (
 )
 
 import truss
+from tenacity import retry, stop_after_delay, wait_fixed
 from truss.remote.baseten import remote as b10_remote
 from truss.remote.baseten import service as b10_service
 from truss.remote.baseten import types as b10_types
@@ -170,17 +171,20 @@ class RemoteChainService:
         self._chain_id = chain_id
         self._chain_deployment_id = chain_deployment_id
 
-    def get_info(self) -> list[tuple[str, str, str]]:
+    def get_info(self) -> list[b10_types.DeployedChainlet]:
         """Return list with elements (name, status, logs_url) for each chainlet."""
         chainlets = self._remote.get_chainlets(
             chain_deployment_id=self._chain_deployment_id
         )
 
         return [
-            (
-                chainlet["name"],
-                chainlet["oracle_version"]["current_model_deployment_status"]["status"],
-                _chainlet_logs_url(
+            b10_types.DeployedChainlet(
+                name=chainlet["name"],
+                is_entrypoint=chainlet["oracle_version"]["is_entrypoint"],
+                status=chainlet["oracle_version"]["current_model_deployment_status"][
+                    "status"
+                ],
+                logs_url=_chainlet_logs_url(
                     self._chain_id,
                     self._chain_deployment_id,
                     chainlet["id"],
@@ -285,7 +289,8 @@ class ChainService:
             The JSON response."""
         return self.get_entrypoint.predict(json)
 
-    def get_info(self) -> list[tuple[str, str, str]]:
+    @retry(stop=stop_after_delay(60), wait=wait_fixed(1), reraise=True)
+    def get_info(self) -> list[b10_types.DeployedChainlet]:
         """Queries the statuses of all chainlets in the chain.
 
         Returns:

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -334,8 +334,8 @@ def _create_chains_table(service) -> Tuple[rich.table.Table, List[str]]:
     table.add_column("Logs URL")
     statuses = []
     # After reversing, the first one is the entrypoint (per order in service).
-    for i, (name, status, logs_url) in enumerate(reversed(service.get_info())):
-        displayable_status = get_displayable_status(status)
+    for i, chainlet in enumerate(reversed(service.get_info())):
+        displayable_status = get_displayable_status(chainlet.status)
         if displayable_status == ACTIVE_STATUS:
             spinner_name = "active"
         elif displayable_status in DEPLOYING_STATUSES:
@@ -348,13 +348,13 @@ def _create_chains_table(service) -> Tuple[rich.table.Table, List[str]]:
         else:
             spinner_name = "failed"
         spinner = rich.spinner.Spinner(spinner_name, text=displayable_status)
-        if i == 0:
-            display_name = f"{name} (entrypoint)"
+        if chainlet.is_entrypoint:
+            display_name = f"{chainlet.name} (entrypoint)"
         else:
-            display_name = f"{name} (dep)"
+            display_name = f"{chainlet.name} (dep)"
 
-        table.add_row(spinner, display_name, logs_url)
-        if i == 0:  # Add section divider after entrypoint.
+        table.add_row(spinner, display_name, chainlet.logs_url)
+        if chainlet.is_entrypoint:  # Add section divider after entrypoint.
             table.add_section()
         statuses.append(displayable_status)
     return table, statuses

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -275,6 +275,7 @@ class BasetenApi:
                 chainlets{{
                     name
                     id
+                    is_entrypoint
                     oracle_version {{
                         current_model_deployment_status {{
                             status

--- a/truss/remote/baseten/types.py
+++ b/truss/remote/baseten/types.py
@@ -3,6 +3,13 @@ from enum import Enum
 import pydantic
 
 
+class DeployedChainlet(pydantic.BaseModel):
+    name: str
+    is_entrypoint: bool
+    status: str
+    logs_url: str
+
+
 class ChainletData(pydantic.BaseModel):
     name: str
     oracle_version_id: str


### PR DESCRIPTION

## :rocket: What

Fix two issues here:
1. Added retries to get_info to prevent issue where we 502 and then exit
2. Issue where entrypoint assumed that it was the first chainlet listed
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing

Deployed locally, made sure it works:

```
 $ poetry run truss chains deploy hello.py 
Using chain workspace dir: `/workspaces/truss/truss-chains/examples/helloworld` (files under this dir will be included as dependencies in the remote deployments and are importable).
Generating truss chainlet model for `RandInt`.
Truss not found in pip requirements, auto-adding: `truss==0.9.17rc3`.
Deploying chainlet `HelloWorld2.RandInt` as a truss model on Baseten (publish=False, promote=False).
Compressing... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Uploading... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Service created for `RandInt` @ https://model-8w64d5q4.api.staging.baseten.co/development/predict.
Generating truss chainlet model for `HelloWorld2`.
Truss not found in pip requirements, auto-adding: `truss==0.9.17rc3`.
Deploying chainlet `HelloWorld2.HelloWorld2` as a truss model on Baseten (publish=False, promote=False).
Compressing... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Uploading... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Service created for `HelloWorld2` @ https://model-4w5o8pq2.api.staging.baseten.co/development/predict.


                                              ⛓️   HelloWorld2 - Chainlets  ⛓️                                               
╭──────────────────────┬──────────────────────────┬───────────────────────────────────────────────────────────────────────╮
│ Status               │ Name                     │ Logs URL                                                              │
├──────────────────────┼──────────────────────────┼───────────────────────────────────────────────────────────────────────┤
│ 💚  ACTIVE           │ HelloWorld2 (entrypoint) │ https://app.staging.baseten.co/chains/j8w62345/logs/j8w672q4/62qj7lqd │
├──────────────────────┼──────────────────────────┼───────────────────────────────────────────────────────────────────────┤
│ 💚  ACTIVE           │ RandInt (dep)            │ https://app.staging.baseten.co/chains/j8w62345/logs/j8w672q4/1lqzrp34 │
╰──────────────────────┴──────────────────────────┴───────────────────────────────────────────────────────────────────────╯
Deployment succeeded.
You can run the chain with:
curl -X POST 'https://model-4w5o8pq2.api.staging.baseten.co/development/predict' \
    -H "Authorization: Api-Key $BASETEN_API_KEY" \
    -d '<JSON_INPUT>'
```
