### PR TITLE
update trtllm template so ModelInput is forward compatible

### DIFF
--- a/truss/templates/trtllm/model/model.py
+++ b/truss/templates/trtllm/model/model.py
@@ -102,10 +102,10 @@ class Model:
                 yield result
 
         async def build_response():
-            text = ""
-            async for res in result_iterator:
-                text += res
-            return text
+            full_text = ""
+            async for delta in result_iterator:
+                full_text += delta
+            return full_text
 
         if model_input.stream:
             return generate()

--- a/truss/templates/trtllm/model/model.py
+++ b/truss/templates/trtllm/model/model.py
@@ -101,10 +101,17 @@ class Model:
             async for result in result_iterator:
                 yield result
 
+        async def build_response():
+            text = ""
+            async for res in result_iterator:
+                text += res
+            return text
+
         if model_input.stream:
             return generate()
         else:
+            text = await build_response()
             if self.uses_openai_api:
-                return "".join(generate())
+                return text
             else:
-                return {"text": "".join(generate())}
+                return {"text": text}

--- a/truss/templates/trtllm/packages/schema.py
+++ b/truss/templates/trtllm/packages/schema.py
@@ -22,7 +22,9 @@ class ModelInput:
         ignore_eos: bool = False,
         stream: bool = True,
         eos_token_id: int = None,  # type: ignore
-        # enables new arguments to be passed in without breaking instantiation
+        # Arguments included as part of kwargs are not passed on to the triton server.
+        # We declare **kwargs as an input to prevent erroring in the case of unexpected
+        # keyword args being passed in.
         **kwargs,
     ) -> None:
         self.stream = stream
@@ -61,7 +63,7 @@ class ModelInput:
         output_len_data = np.ones_like(prompt_data, dtype=np.int32) * self._max_tokens
         bad_words_data = np.array([self._bad_words_list], dtype=object)
         stop_words_data = np.array([self._stop_words_list], dtype=object)
-        # temporary fix to enbale non-streaming response from the truss
+        # temporary fix to enable non-streaming response from the truss
         stream_data = np.array([[True]], dtype=bool)
         beam_width_data = np.array([[self._beam_width]], dtype=np.int32)
         repetition_penalty_data = np.array(

--- a/truss/templates/trtllm/packages/schema.py
+++ b/truss/templates/trtllm/packages/schema.py
@@ -22,6 +22,7 @@ class ModelInput:
         ignore_eos: bool = False,
         stream: bool = True,
         eos_token_id: int = None,  # type: ignore
+        # enables new arguments to be passed in without breaking instantiation
         **kwargs,
     ) -> None:
         self.stream = stream
@@ -60,6 +61,7 @@ class ModelInput:
         output_len_data = np.ones_like(prompt_data, dtype=np.int32) * self._max_tokens
         bad_words_data = np.array([self._bad_words_list], dtype=object)
         stop_words_data = np.array([self._stop_words_list], dtype=object)
+        # temporary fix to enbale non-streaming response from the truss
         stream_data = np.array([[True]], dtype=bool)
         beam_width_data = np.array([[self._beam_width]], dtype=np.int32)
         repetition_penalty_data = np.array(

--- a/truss/templates/trtllm/packages/schema.py
+++ b/truss/templates/trtllm/packages/schema.py
@@ -22,6 +22,7 @@ class ModelInput:
         ignore_eos: bool = False,
         stream: bool = True,
         eos_token_id: int = None,  # type: ignore
+        **kwargs,
     ) -> None:
         self.stream = stream
         self.request_id = request_id
@@ -59,7 +60,7 @@ class ModelInput:
         output_len_data = np.ones_like(prompt_data, dtype=np.int32) * self._max_tokens
         bad_words_data = np.array([self._bad_words_list], dtype=object)
         stop_words_data = np.array([self._stop_words_list], dtype=object)
-        stream_data = np.array([[self.stream]], dtype=bool)
+        stream_data = np.array([[True]], dtype=bool)
         beam_width_data = np.array([[self._beam_width]], dtype=np.int32)
         repetition_penalty_data = np.array(
             [[self._repetition_penalty]], dtype=np.float32


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What

Modifies the existing template for trt-llm to enable forward compatibility from the bridge. Additionally, enables non-streaming responses from the truss with temporary hack on "stream" value in the TRT LLM integration

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing

Tested the instantiation with my own truss, sent it additional fields, got back 200

stream value behavior has been validated in previous work