### PR TITLE
Error out locally when using FP8 quant with non-compatible hardware

### DIFF
--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -13,9 +13,8 @@ import rich.live
 import rich.spinner
 import rich.table
 import rich_click as click
-from InquirerPy import inquirer
-
 import truss
+from InquirerPy import inquirer
 from truss.cli.console import console
 from truss.cli.create import ask_name
 from truss.constants import TRTLLM_MIN_MEMORY_REQUEST_GI
@@ -34,6 +33,7 @@ from truss.remote.remote_factory import USER_TRUSSRC_PATH, RemoteFactory
 from truss.truss_config import Build, ModelServer
 from truss.util.config_checks import (
     check_and_update_memory_for_trt_llm_builder,
+    check_fp8_hardware_compat,
     check_secrets_for_trt_llm_builder,
 )
 from truss.util.errors import RemoteNetworkError
@@ -826,6 +826,12 @@ def push(
         console.print(
             f"Automatically increasing memory for trt-llm builder to {TRTLLM_MIN_MEMORY_REQUEST_GI}Gi."
         )
+    if not check_fp8_hardware_compat(tr):
+        incompatible_hardware_text = (
+            "FP8 quantization is only compatible with H100 accelerator."
+        )
+        console.print(incompatible_hardware_text, style="red")
+        sys.exit(1)
 
     # TODO(Abu): This needs to be refactored to be more generic
     service = remote_provider.push(

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -33,7 +33,7 @@ from truss.remote.remote_factory import USER_TRUSSRC_PATH, RemoteFactory
 from truss.truss_config import Build, ModelServer
 from truss.util.config_checks import (
     check_and_update_memory_for_trt_llm_builder,
-    check_fp8_hardware_compat,
+    check_quantization_and_hardware_compat,
     check_secrets_for_trt_llm_builder,
 )
 from truss.util.errors import RemoteNetworkError
@@ -826,7 +826,7 @@ def push(
         console.print(
             f"Automatically increasing memory for trt-llm builder to {TRTLLM_MIN_MEMORY_REQUEST_GI}Gi."
         )
-    if not check_fp8_hardware_compat(tr):
+    if not check_quantization_and_hardware_compat(tr):
         incompatible_hardware_text = (
             "FP8 quantization is only compatible with H100 accelerator."
         )

--- a/truss/util/config_checks.py
+++ b/truss/util/config_checks.py
@@ -38,8 +38,8 @@ def check_and_update_memory_for_trt_llm_builder(tr: TrussHandle) -> bool:
     return True
 
 
-def check_fp8_hardware_compat(tr: TrussHandle) -> bool:
-    """Check if quantization type is compatible with"""
+def check_quantization_and_hardware_compat(tr: TrussHandle) -> bool:
+    """Check if quantization type is compatible with hardware"""
     if tr.spec.config.trt_llm and tr.spec.config.trt_llm.build:
         user_defined_quantization_type = tr.spec.config.trt_llm.build.quantization_type
         user_defined_accelerator = tr.spec.config.resources.accelerator.accelerator


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
We want to error out locally when trying to build with FP8 but with non-FP8 compatible architecture. 
<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
