### PR TITLE
Fix/Improve integration tests

### DIFF
--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -5,7 +5,7 @@ description: "setups python, poetry and associated cache"
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.9.9'
 
@@ -22,7 +22,7 @@ runs:
       shell: bash
 
     - name: Set up cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cache
       with:
         path: .venv

--- a/.github/workflows/build-context-builder-image.yml
+++ b/.github/workflows/build-context-builder-image.yml
@@ -9,7 +9,7 @@ jobs:
     outputs:
       version: ${{ steps.versions.outputs.version }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # We need to use a different github token because GITHUB_TOKEN cannot trigger a workflow from another
           token: ${{secrets.BASETENBOT_GITHUB_TOKEN}}
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-20.04
     needs: [detect-version]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1

--- a/.github/workflows/commit_new_release_to_main.yml
+++ b/.github/workflows/commit_new_release_to_main.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         token: ${{ secrets.BASETENBOT_GITHUB_TOKEN }}
 

--- a/.github/workflows/create_release_pr.yml
+++ b/.github/workflows/create_release_pr.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Install poetry
       run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -18,7 +18,7 @@ jobs:
       release_version: ${{ steps.versions.outputs.release_version }}
       is_prerelease_version: ${{ steps.versions.outputs.is_prerelease_version }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # We need to use a different github token because GITHUB_TOKEN cannot trigger a workflow from another
           token: ${{secrets.BASETENBOT_GITHUB_TOKEN}}
@@ -44,7 +44,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-python/
       - run: poetry install
       - shell: bash
@@ -63,14 +63,27 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        split_group: ["1", "2", "3", "4", "5"]
+        split_group: [ "1", "2", "3", "4", "5" ]
     steps:
-      - name: Purge Docker cache
-        run: docker builder prune -af
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-python/
       - run: poetry install
-      - run: poetry run pytest truss/tests --durations=0 -m 'integration' --splits 5 --group ${{ matrix.split_group }}
+      - run: poetry run pytest truss/tests --durations=0 -m 'integration' --splits 5 --group ${{ matrix.split_group }} -k "not test_requirements_pydantic[1]"
+
+  # Running `test_requirements_pydantic[1]` started failing when running together with the other tests.
+  # We could pin down the issue to the fact that the built image had v2 installed, despite v1 in `requirements.txt`
+  # The test passes locally and when running in its own env, suggesting that there is a bug in docker caching / hash
+  # computation that makes the test falsely run with the wrong version in the image. As a stop gap solution, separating
+  # this particular test in its own job made it pass again.
+  integration-tests-pydantic-v1:
+    needs: [detect-version-changed, build-and-push-truss-base-images-if-needed]
+    if: ${{ !failure() && !cancelled() && (needs.build-and-push-truss-base-images-if-needed.result == 'success' || needs.build-and-push-truss-base-images-if-needed.result == 'skipped') }}
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-python/
+      - run: poetry install
+      - run: poetry run pytest truss/tests/test_model_inference.py::test_requirements_pydantic[1]
 
   chain-integration-tests:
     needs: [detect-version-changed, build-and-push-truss-base-images-if-needed]
@@ -79,9 +92,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - name: Purge Docker cache
-        run: docker builder prune -af
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-python/
       - run: poetry install
       - run: poetry run pytest truss-chains/tests -s --log-cli-level=INFO  --durations=0 -m 'integration'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
       release_version: ${{ steps.versions.outputs.release_version }}
       is_prerelease_version: ${{ steps.versions.outputs.is_prerelease_version }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # We need to use a different github token because GITHUB_TOKEN cannot trigger a workflow from another
           token: ${{secrets.BASETENBOT_GITHUB_TOKEN}}
@@ -47,7 +47,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-python/
       - run: poetry install
       - shell: bash
@@ -66,12 +66,39 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        split_group: ["1", "2", "3", "4", "5"]
+        split_group: [ "1", "2", "3", "4", "5" ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-python/
       - run: poetry install
-      - run: poetry run pytest truss/tests  -m 'integration' --splits 5 --group ${{ matrix.split_group }}
+      - run: poetry run pytest truss/tests --durations=0 -m 'integration' --splits 5 --group ${{ matrix.split_group }} -k "not test_requirements_pydantic[1]"
+
+  # Running `test_requirements_pydantic[1]` started failing when running together with the other tests.
+  # We could pin down the issue to the fact that the built image had v2 installed, despite v1 in `requirements.txt`
+  # The test passes locally and when running in its own env, suggesting that there is a bug in docker caching / hash
+  # computation that makes the test falsely run with the wrong version in the image. As a stop gap solution, separating
+  # this particular test in its own job made it pass again.
+  integration-tests-pydantic-v1:
+    needs: [detect-version-changed, build-and-push-truss-base-images-if-needed]
+    if: ${{ !failure() && !cancelled() && (needs.build-and-push-truss-base-images-if-needed.result == 'success' || needs.build-and-push-truss-base-images-if-needed.result == 'skipped') }}
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-python/
+      - run: poetry install
+      - run: poetry run pytest truss/tests/test_model_inference.py::test_requirements_pydantic[1]
+
+  chain-integration-tests:
+    needs: [detect-version-changed, build-and-push-truss-base-images-if-needed]
+    if: ${{ !failure() && !cancelled() && (needs.build-and-push-truss-base-images-if-needed.result == 'success' || needs.build-and-push-truss-base-images-if-needed.result == 'skipped') }}
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-python/
+      - run: poetry install
+      - run: poetry run pytest truss-chains/tests -s --log-cli-level=INFO  --durations=0 -m 'integration'integration-tests
 
   publish-to-pypi:
     needs: [detect-version-changed]
@@ -79,7 +106,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: "Git tag release"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{secrets.BASETENBOT_GITHUB_TOKEN}}
       - run: |

--- a/.github/workflows/release-truss-utils.yml
+++ b/.github/workflows/release-truss-utils.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: "Git tag release"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{secrets.BASETENBOT_GITHUB_TOKEN}}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       release_version: ${{ steps.versions.outputs.release_version }}
       is_prerelease_version: ${{ steps.versions.outputs.is_prerelease_version }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         # We need to use a different github token because GITHUB_TOKEN cannot trigger a workflow from another
         token: ${{secrets.BASETENBOT_GITHUB_TOKEN}}
@@ -33,7 +33,7 @@ jobs:
     if: ${{ !failure() && !cancelled() && needs.detect-version-changed.outputs.release_version == 'true' }}
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: "Git tag release"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{secrets.BASETENBOT_GITHUB_TOKEN}}
       - run: |


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
* Add chains test to Main (was missing because integration tests are not defined centrally).
* Separate problematic pydnatic v1 test in its own env (there were some really strange docker caching issues going on when running it all in the same env before).
* Update github action versions to get rid of deprecation warnings.


<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing

https://github.com/basetenlabs/truss/actions/runs/9812634718/job/27097097653