### PR TITLE
truss watch requirements file

### DIFF
--- a/truss/patch/calc_patch.py
+++ b/truss/patch/calc_patch.py
@@ -152,7 +152,7 @@ def calc_truss_patch(
         elif path == requirements_path:
             requirement_config_patches = _calc_python_requirements_patches(
                 previous_truss_signature.requirements_file_requirements,
-                new_config.load_requirements_from_file(),
+                new_config.load_requirements_from_file(truss_dir),
             )
             if requirement_config_patches:
                 logger.info("Created patch for requirements changes")

--- a/truss/patch/calc_patch.py
+++ b/truss/patch/calc_patch.py
@@ -95,6 +95,7 @@ def calc_truss_patch(
     )
     if patches:
         print("created patches for requirements")
+        print(patches)
         logger.info("Created patches for requirements")
     for path in changed_paths["removed"]:
         if _strictly_under(path, [model_module_path]):

--- a/truss/patch/calc_patch.py
+++ b/truss/patch/calc_patch.py
@@ -58,6 +58,7 @@ def calc_truss_patch(
         ignored. E.g. at the root level, only changes to config.yaml are
         checked, any other changes are ignored.
     """
+    print("calc_truss_patch")
 
     def _relative_to_root(path: Path) -> str:
         return str(path.relative_to(truss_dir))
@@ -73,6 +74,7 @@ def calc_truss_patch(
 
     new_config = TrussConfig.from_yaml(truss_dir / CONFIG_FILE)
     prev_config = TrussConfig.from_dict(yaml.safe_load(previous_truss_signature.config))
+    print("loaded configs")
     if new_config.requirements_file != prev_config.requirements_file:
         # TODO(rcano)
         logger.info("Changing requirement files not supported yet")

--- a/truss/patch/calc_patch.py
+++ b/truss/patch/calc_patch.py
@@ -72,14 +72,12 @@ def calc_truss_patch(
     )
 
     new_config = TrussConfig.from_yaml(truss_dir / CONFIG_FILE)
-    prev_config = TrussConfig.from_dict(
-        yaml.safe_load(previous_truss_signature.config)
-    )
+    prev_config = TrussConfig.from_dict(yaml.safe_load(previous_truss_signature.config))
     if new_config.requirements_file != prev_config.requirements_file:
         # TODO(rcano)
         logger.info("Changing requirement files not supported yet")
         return None
-    
+
     requirements_path = prev_config.requirements_file
 
     truss_spec = TrussSpec(truss_dir)
@@ -150,9 +148,12 @@ def calc_truss_patch(
                 )
             )
         elif path == requirements_path:
-            requirement_config_patches = _calc_python_requirements_patches(prev_config._requirements_file_requirements, new_config._requirements_file_requirements)
+            requirement_config_patches = _calc_python_requirements_patches(
+                prev_config._requirements_file_requirements,
+                new_config._requirements_file_requirements,
+            )
             if requirement_config_patches:
-                logger.info(f"Created patch for requirements changes")
+                logger.info("Created patch for requirements changes")
                 patches.extend(requirement_config_patches)
         elif path == CONFIG_FILE:
             config_patches = calc_config_patches(prev_config, new_config)
@@ -331,7 +332,7 @@ def _calc_external_data_patches(
 
 
 def _calc_python_requirements_patches(
-    prev_raw_reqs: List[str],new_raw_reqs: List[str]
+    prev_raw_reqs: List[str], new_raw_reqs: List[str]
 ) -> List[Patch]:
     """Calculate patch based on changes to python requirements.
 

--- a/truss/patch/calc_patch.py
+++ b/truss/patch/calc_patch.py
@@ -149,8 +149,8 @@ def calc_truss_patch(
             )
         elif path == requirements_path:
             requirement_config_patches = _calc_python_requirements_patches(
-                prev_config._requirements_file_requirements,
-                new_config._requirements_file_requirements,
+                previous_truss_signature.requirements_file_requirements,
+                new_config.load_requirements_from_file(),
             )
             if requirement_config_patches:
                 logger.info("Created patch for requirements changes")

--- a/truss/patch/calc_patch.py
+++ b/truss/patch/calc_patch.py
@@ -58,7 +58,6 @@ def calc_truss_patch(
         ignored. E.g. at the root level, only changes to config.yaml are
         checked, any other changes are ignored.
     """
-    print("calc_truss_patch")
 
     def _relative_to_root(path: Path) -> str:
         return str(path.relative_to(truss_dir))
@@ -74,7 +73,6 @@ def calc_truss_patch(
 
     new_config = TrussConfig.from_yaml(truss_dir / CONFIG_FILE)
     prev_config = TrussConfig.from_dict(yaml.safe_load(previous_truss_signature.config))
-    print("loaded configs")
 
     truss_spec = TrussSpec(truss_dir)
     model_module_path = _relative_to_root(truss_spec.model_module_dir)
@@ -94,8 +92,6 @@ def calc_truss_patch(
         truss_dir, previous_truss_signature, prev_config, new_config
     )
     if patches:
-        print("created patches for requirements")
-        print(patches)
         logger.info("Created patches for requirements")
     for path in changed_paths["removed"]:
         if _strictly_under(path, [model_module_path]):

--- a/truss/patch/signature.py
+++ b/truss/patch/signature.py
@@ -1,5 +1,3 @@
-import json 
-
 from pathlib import Path
 from typing import List, Optional
 
@@ -7,7 +5,6 @@ from truss.constants import CONFIG_FILE
 from truss.patch.dir_signature import directory_content_signature
 from truss.patch.types import TrussSignature
 from truss.truss_config import TrussConfig
-
 
 
 def calc_truss_signature(

--- a/truss/patch/signature.py
+++ b/truss/patch/signature.py
@@ -1,16 +1,20 @@
+import json 
+
 from pathlib import Path
 from typing import List, Optional
 
+from truss.constants import CONFIG_FILE
 from truss.patch.dir_signature import directory_content_signature
 from truss.patch.types import TrussSignature
+from truss.truss_config import TrussConfig
+
 
 
 def calc_truss_signature(
     truss_dir: Path, ignore_patterns: Optional[List[str]] = None
 ) -> TrussSignature:
     content_signature = directory_content_signature(truss_dir, ignore_patterns)
-    with (truss_dir / "config.yaml").open("r") as config_file:
-        config = config_file.read()
+    config = TrussConfig.to_signature_config(truss_dir / CONFIG_FILE)
     return TrussSignature(
         content_hashes_by_path=content_signature,
         config=config,

--- a/truss/patch/signature.py
+++ b/truss/patch/signature.py
@@ -15,8 +15,13 @@ def calc_truss_signature(
     with (config_path).open("r") as config_file:
         config = config_file.read()
     requirements = TrussConfig.load_requirements_file_from_filepath(config_path)
-    return TrussSignature(
+    s = TrussSignature(
         content_hashes_by_path=content_signature,
         config=config,
         requirements_file_requirements=requirements,
     )
+    print("calculating truss signature")
+    import json
+
+    print(json.dumps(s.to_dict()))
+    return s

--- a/truss/patch/signature.py
+++ b/truss/patch/signature.py
@@ -15,13 +15,8 @@ def calc_truss_signature(
     with (config_path).open("r") as config_file:
         config = config_file.read()
     requirements = TrussConfig.load_requirements_file_from_filepath(config_path)
-    s = TrussSignature(
+    return TrussSignature(
         content_hashes_by_path=content_signature,
         config=config,
         requirements_file_requirements=requirements,
     )
-    print("calculating truss signature")
-    import json
-
-    print(json.dumps(s.to_dict()))
-    return s

--- a/truss/patch/signature.py
+++ b/truss/patch/signature.py
@@ -11,8 +11,12 @@ def calc_truss_signature(
     truss_dir: Path, ignore_patterns: Optional[List[str]] = None
 ) -> TrussSignature:
     content_signature = directory_content_signature(truss_dir, ignore_patterns)
-    config = TrussConfig.to_signature_config(truss_dir / CONFIG_FILE)
+    config_path = truss_dir / CONFIG_FILE
+    with (config_path).open("r") as config_file:
+        config = config_file.read()
+    requirements = TrussConfig.load_requirements_file_from_filepath(config_path)
     return TrussSignature(
         content_hashes_by_path=content_signature,
         config=config,
+        requirements_file_requirements=requirements,
     )

--- a/truss/patch/types.py
+++ b/truss/patch/types.py
@@ -31,3 +31,6 @@ class TrussSignature:
             config=d["config"],
             requirements_file_requirements=d.get("requirements_file_requirements", []),
         )
+
+
+ChangedPaths = Dict[str, List[str]]

--- a/truss/patch/types.py
+++ b/truss/patch/types.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Dict
+from typing import Dict, List
 
 
 @dataclass
@@ -15,11 +15,13 @@ class TrussSignature:
 
     content_hashes_by_path: Dict[str, str]
     config: str
+    requirements_file_requirements: List[str] = []
 
     def to_dict(self) -> dict:
         return {
             "content_hashes_by_path": self.content_hashes_by_path,
             "config": self.config,
+            "requirements_file_requirements": self.requirements_file_requirements,
         }
 
     @staticmethod
@@ -27,4 +29,5 @@ class TrussSignature:
         return TrussSignature(
             content_hashes_by_path=d["content_hashes_by_path"],
             config=d["config"],
+            requirements_file_requirements=d.get("requirements_file_requirements", []),
         )

--- a/truss/patch/types.py
+++ b/truss/patch/types.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Dict, List
 
 
@@ -15,7 +15,7 @@ class TrussSignature:
 
     content_hashes_by_path: Dict[str, str]
     config: str
-    requirements_file_requirements: List[str] = []
+    requirements_file_requirements: List[str] = field(default_factory=list)
 
     def to_dict(self) -> dict:
         return {

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -7,7 +7,6 @@ import click
 import rich
 import yaml
 from requests import ReadTimeout
-from truss.constants import CONFIG_FILE
 from truss.local.local_config_handler import LocalConfigHandler
 from truss.remote.baseten import types as b10_types
 from truss.remote.baseten.api import BasetenApi
@@ -33,8 +32,7 @@ from truss.remote.baseten.error import ApiError
 from truss.remote.baseten.service import BasetenService
 from truss.remote.baseten.utils.transfer import base64_encoded_json_str
 from truss.remote.truss_remote import TrussRemote
-from truss.truss_config import ModelServer, TrussConfig
-from truss.truss_handle import TrussSignature
+from truss.truss_config import ModelServer
 from truss.truss_handle import TrussHandle
 from truss.util.path import is_ignored, load_trussignore_patterns
 from watchfiles import watch

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -291,10 +291,8 @@ class BasetenRemote(TrussRemote):
                 "attempting to watch for changes"
             )
             return
-        print("adding signature")
         LocalConfigHandler.add_signature(truss_hash, truss_signature)
         try:
-            print("calc patch")
             patch_request = truss_handle.calc_patch(truss_hash, truss_ignore_patterns)
         except Exception:
             error_console.print("Failed to calculate patch, bailing on patching")

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -291,8 +291,10 @@ class BasetenRemote(TrussRemote):
                 "attempting to watch for changes"
             )
             return
+        print("adding signature")
         LocalConfigHandler.add_signature(truss_hash, truss_signature)
         try:
+            print("calc patch")
             patch_request = truss_handle.calc_patch(truss_hash, truss_ignore_patterns)
         except Exception:
             error_console.print("Failed to calculate patch, bailing on patching")

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -7,6 +7,7 @@ import click
 import rich
 import yaml
 from requests import ReadTimeout
+from truss.constants import CONFIG_FILE
 from truss.local.local_config_handler import LocalConfigHandler
 from truss.remote.baseten import types as b10_types
 from truss.remote.baseten.api import BasetenApi
@@ -32,7 +33,8 @@ from truss.remote.baseten.error import ApiError
 from truss.remote.baseten.service import BasetenService
 from truss.remote.baseten.utils.transfer import base64_encoded_json_str
 from truss.remote.truss_remote import TrussRemote
-from truss.truss_config import ModelServer
+from truss.truss_config import ModelServer, TrussConfig
+from truss.truss_handle import TrussSignature
 from truss.truss_handle import TrussHandle
 from truss.util.path import is_ignored, load_trussignore_patterns
 from watchfiles import watch

--- a/truss/tests/patch/test_calc_patch.py
+++ b/truss/tests/patch/test_calc_patch.py
@@ -273,7 +273,6 @@ def test_calc_truss_patch_handles_requirements_file_name_change(
         filename = "requirement.txt"
         config.requirements.clear()
         config.requirements_file = filename
-        config.requirements.append(requirements_contents)
         with (custom_model_truss_dir / filename).open("w") as req_file:
             req_file.write(requirements_contents)
 
@@ -372,6 +371,7 @@ def test_calc_truss_patch_handles_requirements_file_removal(
 
     def config_op(config: TrussConfig):
         config.requirements.append(requirements_contents)
+        config.requirements_file = ""
         os.remove(custom_model_truss_dir / filename)
 
     patches = _apply_config_change_and_calc_patches(

--- a/truss/tests/test_config.py
+++ b/truss/tests/test_config.py
@@ -399,3 +399,16 @@ def test_to_dict_trtllm(verbose, expect_equal, trtllm_config):
     assert (
         TrussConfig.from_dict(trtllm_config).to_dict(verbose=verbose) == trtllm_config
     ) == expect_equal
+
+
+def test_from_yaml_invalid_requirements_configuration():
+    invalid_requirements = {
+        "requirements_file": "requirements.txt",
+        "requirements": ["requests"],
+    }
+    with tempfile.NamedTemporaryFile(mode="w", delete=False) as yaml_file:
+        yaml_path = Path(yaml_file.name)
+        yaml.safe_dump(invalid_requirements, yaml_file)
+
+        with pytest.raises(ValueError):
+            TrussConfig.from_yaml(yaml_path)

--- a/truss/truss_config.py
+++ b/truss/truss_config.py
@@ -564,7 +564,7 @@ class TrussConfig:
         if self.requirements_file:
             requirements_path = truss_dir / self.requirements_file
             with open(requirements_path) as f:
-                return [x for x in f.read().split("\n")]
+                return [x for x in f.read().split("\n") if x]
         return []
 
     @staticmethod

--- a/truss/truss_config.py
+++ b/truss/truss_config.py
@@ -563,8 +563,14 @@ class TrussConfig:
     def load_requirements_from_file(self, truss_dir: Path) -> List[str]:
         if self.requirements_file:
             requirements_path = truss_dir / self.requirements_file
-            with open(requirements_path) as f:
-                return [x for x in f.read().split("\n") if x]
+            try:
+                with open(requirements_path) as f:
+                    return [x for x in f.read().split("\n") if x]
+            except Exception as e:
+                logger.exception(
+                    f"failed to read requirements file: {self.requirements_file}"
+                )
+                raise e
         return []
 
     @staticmethod

--- a/truss/truss_config.py
+++ b/truss/truss_config.py
@@ -1,14 +1,14 @@
+import json
 import logging
 from dataclasses import _MISSING_TYPE, dataclass, field, fields
 from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Optional
-import json
 
 import yaml
 
 from truss.config.trt_llm import TRTLLMConfiguration
-from truss.constants import HTTP_PUBLIC_BLOB_BACKEND, CONFIG_FILE
+from truss.constants import HTTP_PUBLIC_BLOB_BACKEND
 from truss.errors import ValidationError
 from truss.types import ModelFrameworkType
 from truss.util.data_structures import transform_optional
@@ -529,7 +529,9 @@ class TrussConfig:
             input_type=d.get("input_type", DEFAULT_MODEL_INPUT_TYPE),
             model_metadata=d.get("model_metadata", {}),
             requirements_file=d.get("requirements_file", None),
-            _requirements_file_requirements=d.get("_requirements_file_requirements", []),
+            _requirements_file_requirements=d.get(
+                "_requirements_file_requirements", []
+            ),
             requirements=d.get("requirements", []),
             system_packages=d.get("system_packages", []),
             environment_variables=d.get("environment_variables", {}),
@@ -572,15 +574,17 @@ class TrussConfig:
         """
         from_yaml_with_requirements_file_requirements loads the yaml file with the
         appropriate requirements attached. This method injects the requirements
-        into the config's object. 
+        into the config's object.
         """
         config = TrussConfig._from_yaml(yaml_path)
-        if config.requirements_file and not config._requirements_file_requirements: 
+        if config.requirements_file and not config._requirements_file_requirements:
             requirements_path = yaml_path.parent / config.requirements_file
             with open(requirements_path) as f:
-                config._requirements_file_requirements = [x for x in f.read().split('\n')]
+                config._requirements_file_requirements = [
+                    x for x in f.read().split("\n")
+                ]
         return config
-    
+
     @staticmethod
     def _from_yaml(yaml_path: Path):
         with yaml_path.open() as yaml_file:
@@ -598,8 +602,7 @@ class TrussConfig:
             yaml.dump(self.to_dict(verbose=verbose), config_file)
 
     def to_dict(self, verbose: bool = True):
-        val =obj_to_dict(self, verbose=verbose)
-        return val
+        return obj_to_dict(self, verbose=verbose)
 
     def clone(self):
         return TrussConfig.from_dict(self.to_dict())

--- a/truss/truss_config.py
+++ b/truss/truss_config.py
@@ -560,9 +560,9 @@ class TrussConfig:
         config.validate()
         return config
 
-    def load_requirements_from_file(self, config_path: Path) -> List[str]:
+    def load_requirements_from_file(self, truss_dir: Path) -> List[str]:
         if self.requirements_file:
-            requirements_path = config_path.parent / self.requirements_file
+            requirements_path = truss_dir / self.requirements_file
             with open(requirements_path) as f:
                 return [x for x in f.read().split("\n")]
         return []
@@ -570,7 +570,7 @@ class TrussConfig:
     @staticmethod
     def load_requirements_file_from_filepath(yaml_path: Path) -> List[str]:
         config = TrussConfig.from_yaml(yaml_path)
-        return config.load_requirements_from_file(yaml_path)
+        return config.load_requirements_from_file(yaml_path.parent)
 
     @staticmethod
     def from_yaml(yaml_path: Path):

--- a/truss/truss_config.py
+++ b/truss/truss_config.py
@@ -618,6 +618,11 @@ class TrussConfig:
         for secret_name in self.secrets:
             validate_secret_name(secret_name)
 
+        if self.requirements and self.requirements_file:
+            raise ValueError(
+                "Please ensure that only one of `requirements` and `requirements_file` is specified"
+            )
+
 
 DATACLASS_TO_REQ_KEYS_MAP = {
     Resources: {"accelerator", "cpu", "memory", "use_gpu"},

--- a/truss/truss_handle.py
+++ b/truss/truss_handle.py
@@ -770,11 +770,14 @@ class TrussHandle:
         Returns None if signature cannot be found locally for previous truss hash
         or if the change cannot be expressed with currently supported patches.
         """
+        print("in calc_patch")
         prev_sign_str = LocalConfigHandler.get_signature(prev_truss_hash)
         if prev_sign_str is None:
             logger.info(f"Signature not found for truss for hash {prev_truss_hash}")
             return None
         prev_sign = TrussSignature.from_dict(json.loads(prev_sign_str))
+        print("prev sign")
+        print(prev_sign)
         ignore_patterns = truss_ignore_patterns + self._spec.hash_ignore_patterns
         patch_ops = calc_truss_patch(self._truss_dir, prev_sign, ignore_patterns)
         if patch_ops is None:

--- a/truss/truss_handle.py
+++ b/truss/truss_handle.py
@@ -770,14 +770,11 @@ class TrussHandle:
         Returns None if signature cannot be found locally for previous truss hash
         or if the change cannot be expressed with currently supported patches.
         """
-        print("in calc_patch")
         prev_sign_str = LocalConfigHandler.get_signature(prev_truss_hash)
         if prev_sign_str is None:
             logger.info(f"Signature not found for truss for hash {prev_truss_hash}")
             return None
         prev_sign = TrussSignature.from_dict(json.loads(prev_sign_str))
-        print("prev sign")
-        print(prev_sign)
         ignore_patterns = truss_ignore_patterns + self._spec.hash_ignore_patterns
         patch_ops = calc_truss_patch(self._truss_dir, prev_sign, ignore_patterns)
         if patch_ops is None:

--- a/truss/truss_handle.py
+++ b/truss/truss_handle.py
@@ -774,7 +774,6 @@ class TrussHandle:
         if prev_sign_str is None:
             logger.info(f"Signature not found for truss for hash {prev_truss_hash}")
             return None
-
         prev_sign = TrussSignature.from_dict(json.loads(prev_sign_str))
         ignore_patterns = truss_ignore_patterns + self._spec.hash_ignore_patterns
         patch_ops = calc_truss_patch(self._truss_dir, prev_sign, ignore_patterns)


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Enables us to issue patch requests via `truss watch` when changes are made to requirements files. Overall it supports
* changing from config-based to file-based requirements (and vice versa)
* adding/removing/modifying requirements in requirements files
* changing the name of the requirements file
* Adds validation that only one of `requirements` or `requirements.txt` is populated/non-zero

<!--
  How was the change described above implemented?
-->
## :computer: How

* Adds requirements file requirements to the truss signature. 
* Expects only one of `config.requirements` or `signature.requirements_file_requirements` to be populated, but will prefer `config.requirements` if both are populated

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing

* Adds unit testing
* Tested locally the above supported flows
* Explicitly tested that pre-existing truss's signatures can be read in accurately without err'ing (this is done by putting a default on the initialization for the `TrussSignature`) 
