### PR TITLE
Adds checks to Briton inputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.25rc4"
+version = "0.9.25rc5"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.25rc2"
+version = "0.9.25rc3"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.25rc3"
+version = "0.9.25rc4"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/templates/trtllm-briton/src/engine.py
+++ b/truss/templates/trtllm-briton/src/engine.py
@@ -137,13 +137,12 @@ class Engine:
 
     def validate_input(self, model_input):
         beam_width = model_input.get("beam_width", None)
-        if beam_width:
-            # Beam width == 1.
-            # There's no need to check if streaming is passed in the input.
-            # Briton explicitly sets streaming to true in britonToTbRequest().
-            # https://github.com/basetenlabs/baseten/blob/1c2c9cbe1adafc0c736566bd012abbe7d7e2c2da/briton/src/briton.cpp#L272
-            if beam_width != 1:
-                raise ValueError("TensorRT-LLM requires beam_width to equal 1")
+        # Beam width == 1.
+        # There's no need to check if streaming is passed in the input.
+        # Briton explicitly sets streaming to true in britonToTbRequest().
+        # https://github.com/basetenlabs/baseten/blob/1c2c9cbe1adafc0c736566bd012abbe7d7e2c2da/briton/src/briton.cpp#L272
+        if beam_width is not None and beam_width != 1:
+            raise ValueError("TensorRT-LLM requires beam_width to equal 1")
 
         # If Beam width != max_beam_width, TensorRt-LLM will fail an assert.
         # Since Briton sets streaming, the max_beam_width must aslo equal 1.

--- a/truss/templates/trtllm-briton/src/engine.py
+++ b/truss/templates/trtllm-briton/src/engine.py
@@ -135,15 +135,7 @@ class Engine:
         briton_monitor_thread.start()
         self._loaded = True
 
-    def validate_input(self, prompt, model_input):
-        # Input length <= max_input_length.
-        if prompt:
-            input_length = len(prompt)
-            if input_length > self._max_input_len:
-                raise ValueError(
-                    f"Input length `{input_length}` is longer than allowed by max_input_length: {self._max_input_len}."
-                )
-
+    def validate_input(self, model_input):
         beam_width = model_input.get("beam_width", None)
         if beam_width:
             # Beam width == 1.
@@ -202,7 +194,7 @@ class Engine:
                 for word in model_input[words].split(","):
                     getattr(request, words).append(word)
 
-        self.validate_input(prompt, model_input)
+        self.validate_input(model_input)
 
         resp_iter = self._stub.Infer(request)
 

--- a/truss/templates/trtllm-briton/src/engine.py
+++ b/truss/templates/trtllm-briton/src/engine.py
@@ -87,6 +87,9 @@ class Engine:
         except:  # noqa
             pass
 
+        self._max_input_len = truss_trtllm_build_config.max_input_len
+        self._max_beam_width = truss_trtllm_build_config.max_beam_width
+
     def load(self):
         if self._loaded:
             return
@@ -132,6 +135,29 @@ class Engine:
         briton_monitor_thread.start()
         self._loaded = True
 
+    def validate_input(self, prompt, model_input):
+        # Input length <= max_input_length.
+        if prompt:
+            input_length = len(prompt)
+            if input_length > self._max_input_len:
+                raise ValueError(
+                    f"Input length `{input_length}` is longer than allowed by max_input_length: {self._max_input_len}."
+                )
+
+        beam_width = model_input.get("beam_width", None)
+        if beam_width:
+            # Beam width == 1.
+            # There's no need to check if streaming is passed in the input.
+            # Briton explicitly sets streaming to true in britonToTbRequest().
+            # https://github.com/basetenlabs/baseten/blob/1c2c9cbe1adafc0c736566bd012abbe7d7e2c2da/briton/src/briton.cpp#L272
+            if beam_width != 1:
+                raise ValueError("TensorRT-LLM requires beam_width to equal 1")
+
+        # If Beam width != max_beam_width, TensorRt-LLM will fail an assert.
+        # Since Briton sets streaming, the max_beam_width must aslo equal 1.
+        if self._max_beam_width != 1:
+            raise ValueError("TensorRT-LLM requires max_beam_width to equal 1.")
+
     async def predict(self, model_input):
         """
         Run inference
@@ -175,6 +201,8 @@ class Engine:
             if words in model_input:
                 for word in model_input[words].split(","):
                     getattr(request, words).append(word)
+
+        self.validate_input(prompt, model_input)
 
         resp_iter = self._stub.Infer(request)
 


### PR DESCRIPTION
TensorRT-LLM uses asserts to validate its inputs. This PR adds checks to ensure that Truss doesn't send values to Briton that will fail these asserts. Specifically, 
• Beam width == 1.
• max_beam_width == 1. 

For the last check, the TensorRT-LLM check is that max_beam_width == beam_width if streaming. But since Briton sets streaming for all inputs, max_beam_width = beam_width == 1.

Fixes:
• [BT-11575](https://linear.app/baseten/issue/BT-11575/error-performing-inference-with-engine-built-with-max-beam-width-1)
