### PR TITLE
error loudly for development pushes for TRT-LLM built trusses

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.25rc6"
+version = "0.9.25rc10"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -36,6 +36,7 @@ from truss.util.config_checks import (
     check_and_update_memory_for_trt_llm_builder,
     check_live_reload_for_trt_llm_builder,
     check_secrets_for_trt_llm_builder,
+    uses_trt_llm_builder,
 )
 from truss.util.errors import RemoteNetworkError
 
@@ -861,7 +862,9 @@ def push(
         console.print(
             f"Automatically increasing memory for trt-llm builder to {TRTLLM_MIN_MEMORY_REQUEST_GI}Gi."
         )
-    if check_live_reload_for_trt_llm_builder(tr):
+    if check_live_reload_for_trt_llm_builder(tr) or (
+        uses_trt_llm_builder(tr) and not publish
+    ):
         live_reload_disabled_text = "Development mode is currently not supported for trusses using TRT-LLM build flow, push as a published model using --publish"
         console.print(live_reload_disabled_text, style="red")
         sys.exit(1)

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -35,6 +35,7 @@ from truss.truss_config import Build, ModelServer
 from truss.util.config_checks import (
     check_and_update_memory_for_trt_llm_builder,
     check_secrets_for_trt_llm_builder,
+    disable_live_reload_for_trt_llm_builder,
 )
 from truss.util.errors import RemoteNetworkError
 
@@ -860,6 +861,9 @@ def push(
         console.print(
             f"Automatically increasing memory for trt-llm builder to {TRTLLM_MIN_MEMORY_REQUEST_GI}Gi."
         )
+    if disable_live_reload_for_trt_llm_builder(tr):
+        live_reload_disabled_text = "Development mode is currently not supported for trusses using TRT-LLM build flow, deploying as a published model"
+        console.print(live_reload_disabled_text)
 
     # TODO(Abu): This needs to be refactored to be more generic
     service = remote_provider.push(

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -34,7 +34,6 @@ from truss.remote.remote_factory import USER_TRUSSRC_PATH, RemoteFactory
 from truss.truss_config import Build, ModelServer
 from truss.util.config_checks import (
     check_and_update_memory_for_trt_llm_builder,
-    check_live_reload_for_trt_llm_builder,
     check_secrets_for_trt_llm_builder,
     uses_trt_llm_builder,
 )
@@ -862,9 +861,7 @@ def push(
         console.print(
             f"Automatically increasing memory for trt-llm builder to {TRTLLM_MIN_MEMORY_REQUEST_GI}Gi."
         )
-    if check_live_reload_for_trt_llm_builder(tr) or (
-        uses_trt_llm_builder(tr) and not publish
-    ):
+    if uses_trt_llm_builder(tr) and not publish:
         live_reload_disabled_text = "Development mode is currently not supported for trusses using TRT-LLM build flow, push as a published model using --publish"
         console.print(live_reload_disabled_text, style="red")
         sys.exit(1)

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -34,8 +34,8 @@ from truss.remote.remote_factory import USER_TRUSSRC_PATH, RemoteFactory
 from truss.truss_config import Build, ModelServer
 from truss.util.config_checks import (
     check_and_update_memory_for_trt_llm_builder,
+    check_live_reload_for_trt_llm_builder,
     check_secrets_for_trt_llm_builder,
-    disable_live_reload_for_trt_llm_builder,
 )
 from truss.util.errors import RemoteNetworkError
 
@@ -861,9 +861,10 @@ def push(
         console.print(
             f"Automatically increasing memory for trt-llm builder to {TRTLLM_MIN_MEMORY_REQUEST_GI}Gi."
         )
-    if disable_live_reload_for_trt_llm_builder(tr):
-        live_reload_disabled_text = "Development mode is currently not supported for trusses using TRT-LLM build flow, deploying as a published model"
-        console.print(live_reload_disabled_text)
+    if check_live_reload_for_trt_llm_builder(tr):
+        live_reload_disabled_text = "Development mode is currently not supported for trusses using TRT-LLM build flow, push as a published model using --publish"
+        console.print(live_reload_disabled_text, style="red")
+        sys.exit(1)
 
     # TODO(Abu): This needs to be refactored to be more generic
     service = remote_provider.push(

--- a/truss/config/trt_llm.py
+++ b/truss/config/trt_llm.py
@@ -54,7 +54,7 @@ class TrussTRTLLMBuildConfiguration(BaseModel):
     max_input_len: int
     max_output_len: int
     max_batch_size: int
-    max_beam_width: int = 1
+    max_beam_width: Optional[int] = 1
     max_prompt_embedding_table_size: int = 0
     checkpoint_repository: CheckpointRepository
     gather_all_token_logits: bool = False
@@ -71,10 +71,10 @@ class TrussTRTLLMBuildConfiguration(BaseModel):
     kv_cache_free_gpu_mem_fraction: float = 0.9
     num_builder_gpus: Optional[int] = None
 
-    @field_validator("max_beam_width")
+    @field_validator("max_beam_width", mode="after")
     @classmethod
-    def ensure_unary_max_beam_width(cls, v: int):
-        if v != 1:
+    def ensure_unary_max_beam_width(cls, value):
+        if value and value != 1:
             raise ValueError("Non-unary max_beam_width not supported")
 
 

--- a/truss/config/trt_llm.py
+++ b/truss/config/trt_llm.py
@@ -54,7 +54,7 @@ class TrussTRTLLMBuildConfiguration(BaseModel):
     max_input_len: int
     max_output_len: int
     max_batch_size: int
-    max_beam_width: int
+    max_beam_width: int = 1
     max_prompt_embedding_table_size: int = 0
     checkpoint_repository: CheckpointRepository
     gather_all_token_logits: bool = False

--- a/truss/config/trt_llm.py
+++ b/truss/config/trt_llm.py
@@ -3,7 +3,7 @@ import logging
 from enum import Enum
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 from rich.console import Console
 
 logging.basicConfig(level=logging.INFO)
@@ -70,6 +70,12 @@ class TrussTRTLLMBuildConfiguration(BaseModel):
     use_fused_mlp: bool = False
     kv_cache_free_gpu_mem_fraction: float = 0.9
     num_builder_gpus: Optional[int] = None
+
+    @field_validator("max_beam_width")
+    @classmethod
+    def ensure_unary_max_beam_width(cls, v: int):
+        if v != 1:
+            raise ValueError("Non-unary max_beam_width not supported")
 
 
 class TrussTRTLLMServingConfiguration(BaseModel):

--- a/truss/contexts/image_builder/serving_image_builder.py
+++ b/truss/contexts/image_builder/serving_image_builder.py
@@ -339,9 +339,6 @@ class ServingImageBuilder(ImageBuilder):
         # Copy over truss
         copy_tree_path(truss_dir, build_dir, ignore_patterns=truss_ignore_patterns)
 
-        # Copy over template truss for TRT-LLM (we overwrite the model and packages dir)
-        # Most of the code is pulled from upstream triton-inference-server tensorrtllm_backend
-        # https://github.com/triton-inference-server/tensorrtllm_backend/tree/v0.9.0/all_models/inflight_batcher_llm
         if config.trt_llm is not None:
             is_audio_model = (
                 config.trt_llm.build.base_model == TrussTRTLLMModel.WHISPER

--- a/truss/tests/test_config.py
+++ b/truss/tests/test_config.py
@@ -55,7 +55,7 @@ def trtllm_config(default_config) -> Dict[str, Any]:
             "max_input_len": 1024,
             "max_output_len": 1024,
             "max_batch_size": 512,
-            "max_beam_width": 1,
+            "max_beam_width": None,
             "checkpoint_repository": {
                 "source": "HF",
                 "repo": "meta/llama4-500B",

--- a/truss/tests/util/test_config_checks.py
+++ b/truss/tests/util/test_config_checks.py
@@ -5,8 +5,8 @@ from truss.constants import TRTLLM_MIN_MEMORY_REQUEST_GI
 from truss.truss_handle import TrussHandle
 from truss.util.config_checks import (
     check_and_update_memory_for_trt_llm_builder,
+    check_live_reload_for_trt_llm_builder,
     check_secrets_for_trt_llm_builder,
-    disable_live_reload_for_trt_llm_builder,
 )
 
 
@@ -48,9 +48,9 @@ def test_check_and_update_memory_for_trt_llm_builder(custom_model_trt_llm):
         (True, True),
     ],
 )
-def test_disable_live_reload_for_trt_llm_builder(
+def test_check_live_reload_for_trt_llm_builder(
     live_reload, expected_result, custom_model_trt_llm
 ):
     handle = TrussHandle(custom_model_trt_llm)
     handle.spec.config.live_reload = live_reload
-    assert disable_live_reload_for_trt_llm_builder(handle) is expected_result
+    assert check_live_reload_for_trt_llm_builder(handle) is expected_result

--- a/truss/tests/util/test_config_checks.py
+++ b/truss/tests/util/test_config_checks.py
@@ -6,6 +6,7 @@ from truss.truss_handle import TrussHandle
 from truss.util.config_checks import (
     check_and_update_memory_for_trt_llm_builder,
     check_secrets_for_trt_llm_builder,
+    disable_live_reload_for_trt_llm_builder,
 )
 
 
@@ -38,3 +39,18 @@ def test_check_and_update_memory_for_trt_llm_builder(custom_model_trt_llm):
     assert not check_and_update_memory_for_trt_llm_builder(handle)
     assert handle.spec.memory == f"{TRTLLM_MIN_MEMORY_REQUEST_GI}Gi"
     assert handle.spec.memory_in_bytes == TRTLLM_MIN_MEMORY_REQUEST_GI * 1024**3
+
+
+@pytest.mark.parametrize(
+    "live_reload, expected_result",
+    [
+        (False, False),
+        (True, True),
+    ],
+)
+def test_disable_live_reload_for_trt_llm_builder(
+    live_reload, expected_result, custom_model_trt_llm
+):
+    handle = TrussHandle(custom_model_trt_llm)
+    handle.spec.config.live_reload = live_reload
+    assert disable_live_reload_for_trt_llm_builder(handle) is expected_result

--- a/truss/tests/util/test_config_checks.py
+++ b/truss/tests/util/test_config_checks.py
@@ -5,7 +5,6 @@ from truss.constants import TRTLLM_MIN_MEMORY_REQUEST_GI
 from truss.truss_handle import TrussHandle
 from truss.util.config_checks import (
     check_and_update_memory_for_trt_llm_builder,
-    check_live_reload_for_trt_llm_builder,
     check_secrets_for_trt_llm_builder,
 )
 
@@ -39,18 +38,3 @@ def test_check_and_update_memory_for_trt_llm_builder(custom_model_trt_llm):
     assert not check_and_update_memory_for_trt_llm_builder(handle)
     assert handle.spec.memory == f"{TRTLLM_MIN_MEMORY_REQUEST_GI}Gi"
     assert handle.spec.memory_in_bytes == TRTLLM_MIN_MEMORY_REQUEST_GI * 1024**3
-
-
-@pytest.mark.parametrize(
-    "live_reload, expected_result",
-    [
-        (False, False),
-        (True, True),
-    ],
-)
-def test_check_live_reload_for_trt_llm_builder(
-    live_reload, expected_result, custom_model_trt_llm
-):
-    handle = TrussHandle(custom_model_trt_llm)
-    handle.spec.config.live_reload = live_reload
-    assert check_live_reload_for_trt_llm_builder(handle) is expected_result

--- a/truss/util/config_checks.py
+++ b/truss/util/config_checks.py
@@ -30,6 +30,18 @@ def check_and_update_memory_for_trt_llm_builder(tr: TrussHandle) -> bool:
     return True
 
 
+def disable_live_reload_for_trt_llm_builder(tr: TrussHandle) -> bool:
+    """Disable live_reload for trusses with TRT-LLM builder configuration
+
+    Returns True if live_reload was disabled, False otherwise
+    """
+    if tr.spec.config.trt_llm and tr.spec.config.trt_llm.build:
+        if tr.spec.live_reload:
+            tr.spec.config.live_reload = False
+            return True
+    return False
+
+
 def _is_model_public(model_id: str) -> bool:
     """Validate that a huggingface hub model is public.
 

--- a/truss/util/config_checks.py
+++ b/truss/util/config_checks.py
@@ -8,6 +8,12 @@ from truss.constants import (
 from truss.truss_handle import TrussHandle
 
 
+def uses_trt_llm_builder(tr: TrussHandle) -> bool:
+    return (
+        tr.spec.config.trt_llm is not None and tr.spec.config.trt_llm.build is not None
+    )
+
+
 def check_secrets_for_trt_llm_builder(tr: TrussHandle) -> bool:
     if tr.spec.config.trt_llm and tr.spec.config.trt_llm.build:
         source = tr.spec.config.trt_llm.build.checkpoint_repository.source
@@ -32,7 +38,7 @@ def check_and_update_memory_for_trt_llm_builder(tr: TrussHandle) -> bool:
 
 def check_live_reload_for_trt_llm_builder(tr: TrussHandle) -> bool:
     """Check live_reload for trusses with TRT-LLM builder configuration"""
-    if tr.spec.config.trt_llm and tr.spec.config.trt_llm.build:
+    if uses_trt_llm_builder(tr):
         return tr.spec.live_reload
     return False
 

--- a/truss/util/config_checks.py
+++ b/truss/util/config_checks.py
@@ -36,13 +36,6 @@ def check_and_update_memory_for_trt_llm_builder(tr: TrussHandle) -> bool:
     return True
 
 
-def check_live_reload_for_trt_llm_builder(tr: TrussHandle) -> bool:
-    """Check live_reload for trusses with TRT-LLM builder configuration"""
-    if uses_trt_llm_builder(tr):
-        return tr.spec.live_reload
-    return False
-
-
 def _is_model_public(model_id: str) -> bool:
     """Validate that a huggingface hub model is public.
 

--- a/truss/util/config_checks.py
+++ b/truss/util/config_checks.py
@@ -30,15 +30,10 @@ def check_and_update_memory_for_trt_llm_builder(tr: TrussHandle) -> bool:
     return True
 
 
-def disable_live_reload_for_trt_llm_builder(tr: TrussHandle) -> bool:
-    """Disable live_reload for trusses with TRT-LLM builder configuration
-
-    Returns True if live_reload was disabled, False otherwise
-    """
+def check_live_reload_for_trt_llm_builder(tr: TrussHandle) -> bool:
+    """Check live_reload for trusses with TRT-LLM builder configuration"""
     if tr.spec.config.trt_llm and tr.spec.config.trt_llm.build:
-        if tr.spec.live_reload:
-            tr.spec.config.live_reload = False
-            return True
+        return tr.spec.live_reload
     return False
 
 


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
- Adds error prohibiting deployment as a development model for trusses leveraging TRT-LLM builder flow as a stopgap short of adding live reload feature support for these trusses.
- Also tacks on a unary default value for `trt_llm.build.max_beam_width`

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
- Added unit tests and checked the cli behavior