### PR TITLE
Use correct exit code.

### DIFF
--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -728,8 +728,6 @@ def predict(
 @click.argument("script", required=True)
 @click.argument("target_directory", required=False, default=os.getcwd())
 def run_python(script, target_directory):
-    from python_on_whales.exceptions import DockerException
-
     if not Path(script).exists():
         raise click.BadParameter(
             f"File {script} does not exist. Please provide a valid file."
@@ -745,21 +743,18 @@ def run_python(script, target_directory):
 
     tr = _get_truss_from_directory(target_directory=target_directory)
     container = tr.run_python_script(Path(script))
-    try:
-        for output in container.logs():
-            output_type = output[0]
-            output_content = output[1]
+    for output in container.logs():
+        output_type = output[0]
+        output_content = output[1]
 
-            options = {}
+        options = {}
 
-            if output_type == "stderr":
-                options["fg"] = "red"
+        if output_type == "stderr":
+            options["fg"] = "red"
 
-            click.secho(output_content.decode("utf-8", "replace"), nl=False, **options)
-        exit_code = container.wait()
-        sys.exit(exit_code)
-    except DockerException:
-        sys.exit(1)
+        click.secho(output_content.decode("utf-8", "replace"), nl=False, **options)
+    exit_code = container.wait()
+    sys.exit(exit_code)
 
 
 @truss_cli.command()

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -744,9 +744,9 @@ def run_python(script, target_directory):
         )
 
     tr = _get_truss_from_directory(target_directory=target_directory)
-    output_stream = tr.run_python_script(Path(script))
+    container = tr.run_python_script(Path(script))
     try:
-        for output in output_stream:
+        for output in container.logs():
             output_type = output[0]
             output_content = output[1]
 
@@ -756,8 +756,10 @@ def run_python(script, target_directory):
                 options["fg"] = "red"
 
             click.secho(output_content.decode("utf-8", "replace"), nl=False, **options)
+        exit_code = container.wait()
+        sys.exit(exit_code)
     except DockerException:
-        pass
+        sys.exit(1)
 
 
 @truss_cli.command()

--- a/truss/truss_handle.py
+++ b/truss/truss_handle.py
@@ -77,6 +77,19 @@ if is_notebook_or_ipython():
     logger.setLevel(logging.INFO)
     logger.addHandler(logging.StreamHandler(sys.stdout))
 
+from python_on_whales import Container, docker
+
+
+class RunningContainer:
+    def __init__(self, container: Container):
+        self.container = container
+
+    def logs(self):
+        return docker.logs(self.container, follow=True, stream=True)
+
+    def wait(self):
+        return docker.wait(self.container)
+
 
 class TrussHandle:
     def __init__(self, truss_dir: Path, validate: bool = True) -> None:
@@ -198,7 +211,7 @@ class TrussHandle:
                 add_hosts=[("host.docker.internal", "host-gateway")],
             )
 
-            return Docker.client().logs(container, follow=True, stream=True)
+            return RunningContainer(container)
 
         try:
             return _docker_run("all" if self._spec.config.resources.use_gpu else None)


### PR DESCRIPTION

## :rocket: What

Propagate the status code of the container to the `truss run` command. I do this by calling `wait` at the end of the run to ge the status code, and then exiting appropriately.

## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing

Test with a script that throws an exception, and one that doesn't, and ensure that the status code is correct
