### PR TITLE
Don't import python_on_whales at top-level.

### DIFF
--- a/truss/truss_handle.py
+++ b/truss/truss_handle.py
@@ -77,17 +77,19 @@ if is_notebook_or_ipython():
     logger.setLevel(logging.INFO)
     logger.addHandler(logging.StreamHandler(sys.stdout))
 
-from python_on_whales import Container, docker
-
 
 class RunningContainer:
-    def __init__(self, container: Container):
+    def __init__(self, container):
         self.container = container
 
     def logs(self):
+        from python_on_whales import docker
+
         return docker.logs(self.container, follow=True, stream=True)
 
     def wait(self):
+        from python_on_whales import docker
+
         return docker.wait(self.container)
 
 


### PR DESCRIPTION

## :rocket: What

Follow-up from https://github.com/basetenlabs/truss/pull/1059, that broke the ITs because python_on_whales is not available in the context builder, so the module needs to imported in each of these modules.

## Follow-up

It's not good that we have to keep track of each method and which deps are available. We should have a separate package for the correct deps that can be used in the context builder.

## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing

Tested that this still works:

```
$ poetry run truss run-python sidscript.py truss/test_data/test_basic_truss
```