### PR TITLE
Add unary default value and validation for max_beam_width configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.27rc1"
+version = "0.9.27rc2"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.26"
+version = "0.9.27rc1"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.27rc2"
+version = "0.9.27rc3"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/config/trt_llm.py
+++ b/truss/config/trt_llm.py
@@ -76,6 +76,7 @@ class TrussTRTLLMBuildConfiguration(BaseModel):
         if isinstance(v, int):
             if v != 1:
                 raise ValueError("max_beam_width must be unary")
+        return v
 
 
 class TrussTRTLLMServingConfiguration(BaseModel):

--- a/truss/config/trt_llm.py
+++ b/truss/config/trt_llm.py
@@ -3,7 +3,7 @@ import logging
 from enum import Enum
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 from rich.console import Console
 
 logging.basicConfig(level=logging.INFO)
@@ -53,7 +53,7 @@ class TrussTRTLLMBuildConfiguration(BaseModel):
     max_input_len: int
     max_output_len: int
     max_batch_size: int
-    max_beam_width: int
+    max_beam_width: int = 1
     max_prompt_embedding_table_size: int = 0
     checkpoint_repository: CheckpointRepository
     gather_all_token_logits: bool = False
@@ -69,6 +69,13 @@ class TrussTRTLLMBuildConfiguration(BaseModel):
     use_fused_mlp: bool = False
     kv_cache_free_gpu_mem_fraction: float = 0.9
     num_builder_gpus: Optional[int] = None
+
+    @field_validator("max_beam_width", mode="after")
+    @classmethod
+    def check_max_beam_width(cls, v: int):
+        if isinstance(v, int):
+            if v != 1:
+                raise ValueError("max_beam_width must be unary")
 
 
 class TrussTRTLLMServingConfiguration(BaseModel):
@@ -125,4 +132,4 @@ class TRTLLMConfiguration(BaseModel):
     # TODO(Abu): Replace this with model_dump(json=True)
     # when pydantic v2 is used here
     def to_json_dict(self, verbose=True):
-        return json.loads(self.json(exclude_unset=not verbose))
+        return json.loads(self.model_dump_json(exclude_unset=not verbose))

--- a/truss/constants.py
+++ b/truss/constants.py
@@ -109,7 +109,7 @@ BASE_TRTLLM_REQUIREMENTS = [
     "grpcio==1.64.0",
     "grpcio-tools==1.64.0",
     "transformers==4.43.2",
-    "truss==0.9.27rc1",
+    "truss==0.9.27rc2",
 ]
 AUDIO_MODEL_TRTLLM_REQUIREMENTS = [
     "--extra-index-url https://pypi.nvidia.com",

--- a/truss/constants.py
+++ b/truss/constants.py
@@ -109,7 +109,7 @@ BASE_TRTLLM_REQUIREMENTS = [
     "grpcio==1.64.0",
     "grpcio-tools==1.64.0",
     "transformers==4.43.2",
-    "truss==0.9.25rc2",
+    "truss==0.9.27rc1",
 ]
 AUDIO_MODEL_TRTLLM_REQUIREMENTS = [
     "--extra-index-url https://pypi.nvidia.com",

--- a/truss/tests/conftest.py
+++ b/truss/tests/conftest.py
@@ -392,7 +392,6 @@ def custom_model_trt_llm(tmp_path):
                     "max_input_len": 1024,
                     "max_output_len": 1024,
                     "max_batch_size": 512,
-                    "max_beam_width": 1,
                     "checkpoint_repository": {
                         "source": "HF",
                         "repo": "meta/llama4-500B",

--- a/truss/tests/test_config.py
+++ b/truss/tests/test_config.py
@@ -55,7 +55,6 @@ def trtllm_config(default_config) -> Dict[str, Any]:
             "max_input_len": 1024,
             "max_output_len": 1024,
             "max_batch_size": 512,
-            "max_beam_width": 1,
             "checkpoint_repository": {
                 "source": "HF",
                 "repo": "meta/llama4-500B",
@@ -397,6 +396,12 @@ def test_from_yaml_python_version():
         assert result.python_version == "py39"
 
 
+def test_max_beam_width_check(trtllm_config):
+    trtllm_config["trt_llm"]["build"]["max_beam_width"] = 2
+    with pytest.raises(ValueError):
+        TrussConfig.from_dict(trtllm_config)
+
+
 @pytest.mark.parametrize("verbose, expect_equal", [(False, True), (True, False)])
 def test_to_dict_trtllm(verbose, expect_equal, trtllm_config):
     assert (
@@ -443,4 +448,4 @@ def test_validate_quant_format_and_accelerator_for_trt_llm_builder(
     config.trt_llm.build.quantization_type = quant_format
     config.resources.accelerator.accelerator = accelerator
     with expectation:
-        config.clone()
+        TrussConfig.from_dict(config.to_dict())


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What

- Adds unary default value and field validator to `trt_llm.build.max_beam_width` as support is limited to this case for the time being.
- Bumps truss version for briton requirements to leverage this config change.
<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
- Added unit test for field validation