### PR TITLE
add --name option to init command

### DIFF
--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -191,9 +191,10 @@ def chains():
     default=ModelServer.TrussServer.value,
     type=click.Choice([server.value for server in ModelServer]),
 )
+@click.option("-n", "--name", type=click.STRING)
 @log_level_option
 @error_handling
-def init(target_directory, backend) -> None:
+def init(target_directory, backend, name) -> None:
     """Create a new truss.
 
     TARGET_DIRECTORY: A Truss is created in this directory
@@ -205,7 +206,10 @@ def init(target_directory, backend) -> None:
         )
     tr_path = Path(target_directory)
     build_config = Build(model_server=ModelServer[backend])
-    model_name = ask_name()
+    if name:
+        model_name = name
+    else:
+        model_name = ask_name()
     truss.init(
         target_directory=target_directory,
         build_config=build_config,


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What

I want to be able to initialize a Truss without tying the name in separately, like so:

```
truss init target_directory --name "My Truss"
```

This will reduce a bit of friction for following tutorials and overall make Truss a fraction more programatic.

<!--
  How was the change described above implemented?
-->
## :computer: How

Added a click option.

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing

Manually tested locally:

* Made sure it worked with no flag the same way it used to
* Made sure it worked with `-n`
* Made sure it worked with `--name`
