### PR TITLE
Add truss login and truss.login().

### DIFF
--- a/truss/__init__.py
+++ b/truss/__init__.py
@@ -9,7 +9,7 @@ def version():
     return __version__
 
 
-from truss.api import push
+from truss.api import login, push
 from truss.build import from_directory, init, kill_all, load
 
-__all__ = ["from_directory", "init", "kill_all", "load", "push"]
+__all__ = ["from_directory", "init", "kill_all", "load", "push", "login"]

--- a/truss/api/__init__.py
+++ b/truss/api/__init__.py
@@ -4,6 +4,26 @@ import truss
 from truss.api import definitions
 from truss.remote.baseten.service import BasetenService
 from truss.remote.remote_factory import RemoteFactory
+from truss.remote.truss_remote import RemoteConfig
+
+
+def login(api_key: str):
+    """
+    Logs user into Baseten account. Persists information to ~/.trussrc file,
+    so only needs to be invoked once.
+    Args:
+        api_key: Baseten API Key
+    """
+    remote_url = "https://app.baseten.co"
+    remote_config = RemoteConfig(
+        name="baseten",
+        configs={
+            "remote_provider": "baseten",
+            "api_key": api_key,
+            "remote_url": remote_url,
+        },
+    )
+    RemoteFactory.update_remote_config(remote_config)
 
 
 def push(

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -29,7 +29,11 @@ from truss.remote.baseten.core import (
 )
 from truss.remote.baseten.service import BasetenService
 from truss.remote.baseten.utils.status import get_displayable_status
-from truss.remote.remote_cli import inquire_model_name, inquire_remote_name
+from truss.remote.remote_cli import (
+    inquire_model_name,
+    inquire_remote_config,
+    inquire_remote_name,
+)
 from truss.remote.remote_factory import USER_TRUSSRC_PATH, RemoteFactory
 from truss.truss_config import Build, ModelServer
 from truss.util.config_checks import (
@@ -282,6 +286,24 @@ def run(target_directory: str, build_dir: Path, tag, port, attach) -> None:
             f"Container already exists at {urls}. Are you sure you want to continue?"
         )
     tr.docker_run(build_dir=build_dir, tag=tag, local_port=port, detach=not attach)
+
+
+@truss_cli.command()
+@click.option(
+    "--api-key",
+    type=str,
+    required=False,
+    help="Name of the remote in .trussrc to patch changes to",
+)
+@error_handling
+def login(api_key: Optional[str]):
+    from truss.api import login
+
+    if not api_key:
+        remote_config = inquire_remote_config()
+        RemoteFactory.update_remote_config(remote_config)
+    else:
+        login(api_key)
 
 
 @truss_cli.command()


### PR DESCRIPTION

## :rocket: What

Adds:
* New `truss login` CLI command
* New `truss.login` python function

To make authentication easier with the CLI. Currently, there is no way of adding credentials non-interactively, which is annoying if you want to use `truss` in CI/CD systems. Additionally, if you mess up when typing in your API key during truss push, you have to no easy way to correct it outside of using `truss configure` to manually edit the ~/.trussrc file, which feels quite heavyweight & not super intuitive. This is a complaint we've gotten a couple times.

### Truss Login CLI

`truss login` can used either interactively or non-interactively. To use the non-interactive mode, you can pass the baseten api key on the command line, like `truss login --api-key $BASTEN_API_KEY`. Otherwise, you can use `truss login`, and interactively use it similarly to `truss push` today.


## Follow-ups

After this is merged, I'll follow up with docs

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing

Tried both of these out successfully, ensured ~/.trussrc file is updated correctly.
