### PR TITLE
Add build_arg_to_secret mapping

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.28rc1"
+version = "0.9.28rc2"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.27rc3"
+version = "0.9.27rc10"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/templates/server.Dockerfile.jinja
+++ b/truss/templates/server.Dockerfile.jinja
@@ -4,6 +4,11 @@
 
 {% extends "base.Dockerfile.jinja" %}
 
+{% for build_arg, secret in config.build.build_arg_to_secret_mapping.items() %}
+ARG {{build_arg}}=""
+
+{% endfor %}
+
 {% block base_image_patch %}
 # If user base image is supplied in config, apply build commands from truss base image
 {% if config.base_image %}

--- a/truss/truss_config.py
+++ b/truss/truss_config.py
@@ -180,15 +180,22 @@ class ModelServer(Enum):
 class Build:
     model_server: ModelServer = ModelServer.TrussServer
     arguments: Dict = field(default_factory=dict)
+    build_arg_to_secret_mapping: Dict = field(default_factory=dict)
 
     @staticmethod
     def from_dict(d):
         model_server = ModelServer[d.get("model_server", "TrussServer")]
         arguments = d.get("arguments", {})
+        build_arg_to_secret_mapping = d.get("build_arg_to_secret_mapping", {})
+        if not isinstance(build_arg_to_secret_mapping, dict):
+            raise ValueError(
+                "Please pass a valid mapping for `build_arg_to_secret_mapping`."
+            )
 
         return Build(
             model_server=model_server,
             arguments=arguments,
+            build_arg_to_secret_mapping=build_arg_to_secret_mapping,
         )
 
     def to_dict(self):


### PR DESCRIPTION
See https://linear.app/baseten/issue/BT-11623/add-support-for-installing-pip-packages-from-private-github for the context here

## :rocket: What

Here, we add build_arg_to_secret_mapping so that we can make use of secrets in `build_commands`.

We wire this into the 

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing

Pushed an RC (`pip install truss==0.9.28rc2`), and tested it against the Baseten branch (https://github.com/basetenlabs/baseten/pull/9011) on dev. Used this config:

```
description: Some test description
environment_variables: {}
build:
  build_arg_to_secret_mapping:
    FOO: wiki
build_commands:
  - "pip install $FOO"
model_name: "truss commands 9"
secrets:
  wiki: null
requirements: []
python_version: py310
```


