### PR TITLE
Use central URLConfig for model/chain URLs.

### DIFF
--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -321,14 +321,16 @@ def watch(
     tr = _get_truss_from_directory(target_directory=target_directory)
     model_name = tr.spec.config.model_name
     if not model_name:
-        rich.print(
+        console.print(
             "🧐 NoneType model_name provided in config.yaml. "
             "Please check that you have the correct model name in your config file."
         )
         sys.exit(1)
 
     service = remote_provider.get_service(model_identifier=ModelName(model_name))
-    rich.print(f"🪵  View logs for your deployment at {_format_link(service.logs_url)}")
+    console.print(
+        f"🪵  View logs for your deployment at {_format_link(service.logs_url)}"
+    )
     remote_provider.sync_truss_to_dev_version_by_name(
         model_name, target_directory, console, error_console
     )
@@ -718,10 +720,10 @@ def init_chain(
         default="my_chain.py",
     ).execute()
     filepath = directory / str(filename).strip()
-    rich.print(f"Creating and populating {filepath}...\n")
+    console.print(f"Creating and populating {filepath}...\n")
     source_code = _load_example_chainlet_code()
     filepath.write_text(source_code)
-    rich.print(
+    console.print(
         "Next steps:\n",
         f"💻 Run [bold green]`python {filepath}`[/bold green] for local debug "
         "execution.\n"
@@ -881,7 +883,7 @@ def predict(
 
     # Log deployment ID for Baseten models.
     if isinstance(service, BasetenService):
-        rich.print(
+        console.print(
             f"Calling predict on {'[cyan]development[/cyan] ' if service.is_draft else ''}"
             f"deployment ID {service.model_version_id}..."
         )
@@ -891,7 +893,7 @@ def predict(
         for chunk in result:
             click.echo(chunk, nl=False)
         return
-    rich.print_json(data=result)
+    console.print_json(data=result)
 
 
 @truss_cli.command()
@@ -1120,7 +1122,9 @@ def push(
         )
         console.print(promotion_text, style="green")
 
-    rich.print(f"🪵  View logs for your deployment at {_format_link(service.logs_url)}")
+    console.print(
+        f"🪵  View logs for your deployment at {_format_link(service.logs_url)}"
+    )
     if wait:
         start_time = time.time()
         with console.status("[bold green]Deploying...") as status:

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -287,7 +287,7 @@ class BasetenApi:
         query_string = f"""
         {{
             chain_deployment(id:"{chain_deployment_id}") {{
-                chainlets{{
+                chainlets {{
                     name
                     id
                     is_entrypoint
@@ -302,12 +302,18 @@ class BasetenApi:
                             status
                         }}
                     }}
-                 }}
+                }}
+                chain {{
+                  id
+                }}
             }}
         }}
         """
         resp = self._post_graphql_query(query_string)
-        return resp["data"]["chain_deployment"]["chainlets"]
+        chainlets = resp["data"]["chain_deployment"]["chainlets"]
+        for chainlet in chainlets:
+            chainlet["chain"] = {"id": resp["data"]["chain_deployment"]["chain"]["id"]}
+        return chainlets
 
     def models(self):
         query_string = """

--- a/truss/remote/baseten/custom_types.py
+++ b/truss/remote/baseten/custom_types.py
@@ -6,8 +6,11 @@ import pydantic
 class DeployedChainlet(pydantic.BaseModel):
     name: str
     is_entrypoint: bool
+    is_draft: bool
     status: str
     logs_url: str
+    oracle_predict_url: str
+    oracle_name: str
 
 
 class ChainletData(pydantic.BaseModel):

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -10,7 +10,7 @@ from requests import ReadTimeout
 if TYPE_CHECKING:
     from rich import console as rich_console
 from truss.local.local_config_handler import LocalConfigHandler
-from truss.remote.baseten import custom_types as b10_types
+from truss.remote.baseten import custom_types
 from truss.remote.baseten.api import BasetenApi
 from truss.remote.baseten.auth import AuthService
 from truss.remote.baseten.core import (
@@ -31,7 +31,7 @@ from truss.remote.baseten.core import (
     upload_truss,
 )
 from truss.remote.baseten.error import ApiError, RemoteError
-from truss.remote.baseten.service import BasetenService
+from truss.remote.baseten.service import BasetenService, URLConfig
 from truss.remote.baseten.utils.transfer import base64_encoded_json_str
 from truss.remote.truss_remote import TrussRemote
 from truss.truss_config import ModelServer
@@ -64,7 +64,7 @@ class BasetenRemote(TrussRemote):
     def create_chain(
         self,
         chain_name: str,
-        chainlets: List[b10_types.ChainletData],
+        chainlets: List[custom_types.ChainletData],
         publish: bool = False,
         promote: bool = False,
     ) -> ChainDeploymentHandle:
@@ -82,8 +82,36 @@ class BasetenRemote(TrussRemote):
             is_draft=not publish,
         )
 
-    def get_chainlets(self, chain_deployment_id: str) -> List[dict]:
-        return self._api.get_chainlets_by_deployment_id(chain_deployment_id)
+    def get_chainlets(
+        self, chain_deployment_id: str
+    ) -> List[custom_types.DeployedChainlet]:
+        return [
+            custom_types.DeployedChainlet(
+                name=chainlet["name"],
+                is_entrypoint=chainlet["is_entrypoint"],
+                is_draft=chainlet["oracle_version"]["is_draft"],
+                status=chainlet["oracle_version"]["current_model_deployment_status"][
+                    "status"
+                ],
+                logs_url=URLConfig.chainlet_logs_url(
+                    self.remote_url,
+                    chainlet["chain"]["id"],
+                    chain_deployment_id,
+                    chainlet["id"],
+                ),
+                oracle_predict_url=URLConfig.invocation_url(
+                    self.remote_url,
+                    URLConfig.MODEL,
+                    chainlet["oracle"]["id"],
+                    chainlet["oracle_version"]["id"],
+                    chainlet["oracle_version"]["is_draft"],
+                ),
+                oracle_name=chainlet["oracle"]["name"],
+            )
+            for chainlet in self._api.get_chainlets_by_deployment_id(
+                chain_deployment_id
+            )
+        ]
 
     def push(  # type: ignore
         self,
@@ -94,7 +122,7 @@ class BasetenRemote(TrussRemote):
         promote: bool = False,
         preserve_previous_prod_deployment: bool = False,
         deployment_name: Optional[str] = None,
-        origin: Optional[b10_types.ModelOrigin] = None,
+        origin: Optional[custom_types.ModelOrigin] = None,
     ) -> BasetenService:
         if model_name.isspace():
             raise ValueError("Model name cannot be empty")

--- a/truss/remote/baseten/service.py
+++ b/truss/remote/baseten/service.py
@@ -31,30 +31,61 @@ def _add_model_subdomain(rest_api_url: str, model_subdomain: str) -> str:
 class URLConfig(enum.Enum):
     class Data(NamedTuple):
         prefix: str
-        endpoint: str
+        invoke_endpoint: str
+        app_endpoint: str
 
-    MODEL = Data("model", "predict")
-    CHAIN = Data("chain", "run_remote")
+    MODEL = Data("model", "predict", "chains")
+    CHAIN = Data("chain", "run_remote", "models")
 
+    @staticmethod
+    def invocation_url(
+        api_url: str,  # E.g. https://api.baseten.co
+        config: "URLConfig",
+        entity_id: str,
+        entity_version_id: str,
+        is_draft,
+    ) -> str:
+        """Get the URL for the predict/run_remote endpoint."""
+        # E.g. `https://api.baseten.co` -> `https://model-{model_id}.api.baseten.co`
+        url = _add_model_subdomain(api_url, f"{config.value.prefix}-{entity_id}")
+        if is_draft:
+            # "https://model-{model_id}.api.baseten.co/development".
+            url = f"{url}/development/{config.value.invoke_endpoint}"
+        else:
+            # "https://model-{model_id}.api.baseten.co/deployment/{deployment_id}".
+            url = f"{url}/deployment/{entity_version_id}/{config.value.invoke_endpoint}"
+        return url
 
-# Create unified module / interface for all URLs, models, chains, logs, status page...
-def make_invocation_url(
-    api_url: str,
-    config: URLConfig,
-    entity_id: str,
-    entity_version_id: str,
-    is_draft,
-) -> str:
-    """Get the URL for the predict/run_remote endpoint."""
-    # E.g. `https://api.baseten.co` -> `https://model-{model_id}.api.baseten.co`
-    url = _add_model_subdomain(api_url, f"{config.value.prefix}-{entity_id}")
-    if is_draft:
-        # "https://model-{model_id}.api.baseten.co/development".
-        url = f"{url}/development/{config.value.endpoint}"
-    else:
-        # "https://model-{model_id}.api.baseten.co/deployment/{deployment_id}".
-        url = f"{url}/deployment/{entity_version_id}/{config.value.endpoint}"
-    return url
+    @staticmethod
+    def status_page_url(
+        app_url: str,  # E.g. https://app.baseten.co/
+        config: "URLConfig",
+        entity_id: str,
+    ) -> str:
+        return f"{app_url}/{config.value.app_endpoint}/{entity_id}/overview/"
+
+    @staticmethod
+    def model_logs_url(
+        app_url: str,  # E.g. https://app.baseten.co/
+        model_id: str,
+        model_version_id: str,
+    ) -> str:
+        return (
+            f"{app_url}/{URLConfig.MODEL.value.app_endpoint}/{model_id}/logs/"
+            f"{model_version_id}"
+        )
+
+    @staticmethod
+    def chainlet_logs_url(
+        app_url: str,  # E.g. https://app.baseten.co/
+        chain_id: str,
+        chain_deployment_id: str,
+        chainlet_id: str,
+    ) -> str:
+        return (
+            f"{app_url}/{URLConfig.CHAIN.value.app_endpoint}/{chain_id}/logs/"
+            f"{chain_deployment_id}/{chainlet_id}"
+        )
 
 
 class BasetenService(TrussService):
@@ -132,14 +163,13 @@ class BasetenService(TrussService):
 
     @property
     def logs_url(self) -> str:
-        return (
-            f"{self._api.app_url}/models/{self._model_id}/"
-            f"logs/{self._model_version_id}"
+        return URLConfig.model_logs_url(
+            self._api.app_url, self.model_id, self.model_version_id
         )
 
     @property
     def predict_url(self) -> str:
-        return make_invocation_url(
+        return URLConfig.invocation_url(
             self._api.app_url,
             URLConfig.MODEL,
             self.model_id,


### PR DESCRIPTION
Use central URLConfig for model/chain URLs, make DeployedChainlet more versatile and cleanups

<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
