### PR TITLE
avoid erring on empty lines in requirement files

### DIFF
--- a/truss/patch/calc_patch.py
+++ b/truss/patch/calc_patch.py
@@ -89,6 +89,7 @@ def calc_truss_patch(
         return _strictly_under(path, [data_dir_path])
 
     patches = []
+
     for path in changed_paths["removed"]:
         if _strictly_under(path, [model_module_path]):
             logger.info(f"Created patch to remove model code file: {path}")

--- a/truss/templates/control/control/helpers/truss_patch/requirement_name_identifier.py
+++ b/truss/templates/control/control/helpers/truss_patch/requirement_name_identifier.py
@@ -13,4 +13,4 @@ def identify_requirement_name(req: str) -> str:
 
 
 def reqs_by_name(reqs: List[str]) -> Dict[str, str]:
-    return {identify_requirement_name(req): req for req in reqs}
+    return {identify_requirement_name(req): req for req in reqs if req.strip()}

--- a/truss/tests/templates/control/control/helpers/test_requirement_name_identifier.py
+++ b/truss/tests/templates/control/control/helpers/test_requirement_name_identifier.py
@@ -29,6 +29,7 @@ def test_identify_requirement_name(req, expected_name):
 def test_reqs_by_name():
     reqs = [
         "pytorch",
+
         "jinja==1.0",
     ]
     assert reqs_by_name(reqs) == {"pytorch": "pytorch", "jinja": "jinja==1.0"}

--- a/truss/tests/templates/control/control/helpers/test_requirement_name_identifier.py
+++ b/truss/tests/templates/control/control/helpers/test_requirement_name_identifier.py
@@ -29,7 +29,7 @@ def test_identify_requirement_name(req, expected_name):
 def test_reqs_by_name():
     reqs = [
         "pytorch",
-
+        " ",
         "jinja==1.0",
     ]
     assert reqs_by_name(reqs) == {"pytorch": "pytorch", "jinja": "jinja==1.0"}

--- a/truss/truss_config.py
+++ b/truss/truss_config.py
@@ -499,7 +499,7 @@ class TrussConfig:
     base_image: Optional[BaseImage] = None
     model_cache: ModelCache = field(default_factory=ModelCache)
     trt_llm: Optional[TRTLLMConfiguration] = None
-    build_commands: Optional[List[str]] = field(default_factory=list)
+    build_commands: List[str] = field(default_factory=list)
 
     @property
     def canonical_python_version(self) -> str:


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
right now adding a new line in a requirements file will cause the server to error

Note - we can also make the server more robust to something like this
<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
