### PR TITLE
Support returning StarletteResponses

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.30rc4"
+version = "0.9.30rc11"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/templates/server/common/truss_server.py
+++ b/truss/templates/server/common/truss_server.py
@@ -148,6 +148,9 @@ class BasetenEndpoints:
             headers=utils.transform_keys(request.headers, lambda key: key.lower()),
         )
 
+        if isinstance(response, Response):
+            return response
+
         # In the case that the model returns a Generator object, return a
         # StreamingResponse instead.
         if isinstance(response, (AsyncGenerator, Generator)):


### PR DESCRIPTION
## :rocket: What

Support returning starlette responses in Truss. This buys us:
* Server-sent events
* Custom content type
* Custom Status codes

See integration tests for what truss looks like, copied here:


```
    from fastapi.responses import Response
    from fastapi import status


    class Model:
        def predict(self, request):
            return Response(status_code=status.HTTP_204_NO_CONTENT)
```

Will post an example of server-sent events later.

## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing

Need to write an integration test for server-sent events, but included one for custom status codes
