### PR TITLE
Smallish Chains Improvements, fixes BT-11981, BT-11430, BT-11907

### DIFF
--- a/truss-chains/tests/chains_test.py
+++ b/truss-chains/tests/chains_test.py
@@ -1,7 +1,9 @@
 import logging
 import re
 from pathlib import Path
+from typing import List
 
+import pydantic
 import pytest
 import requests
 from truss.tests.test_testing_utilities_for_other_tests import ensure_kill_all
@@ -213,3 +215,23 @@ def test_raises_depends_usage():
         with chains.run_local():
             chain = InlinedDepends()
             chain.run_remote()
+
+
+class SomeModel(pydantic.BaseModel):
+    foo: int
+
+
+def test_raises_unsupported_arg_type_list_object():
+    with pytest.raises(definitions.ChainsUsageError, match="Unsupported I/O type"):
+
+        class UnsupportedArgType(chains.ChainletBase):
+            def run_remote(self) -> list[pydantic.BaseModel]:
+                return [SomeModel(foo=0)]
+
+
+def test_raises_unsupported_arg_type_list_object_legacy():
+    with pytest.raises(definitions.ChainsUsageError, match="Unsupported I/O type"):
+
+        class UnsupportedArgType(chains.ChainletBase):
+            def run_remote(self) -> List[pydantic.BaseModel]:
+                return [SomeModel(foo=0)]

--- a/truss-chains/truss_chains/framework.py
+++ b/truss-chains/truss_chains/framework.py
@@ -133,7 +133,7 @@ def _instantiation_error_msg(cls_name: str):
     )
 
 
-def _validate_io_type(param: inspect.Parameter) -> None:
+def _validate_io_type(annotation: Any, name: str) -> None:
     """
     For Chainlet I/O (both data or parameters), we allow simple types
     (int, str, float...) and `list` or `dict` containers of these.
@@ -142,29 +142,29 @@ def _validate_io_type(param: inspect.Parameter) -> None:
     containers_str = [c.__name__ for c in _SIMPLE_CONTAINERS]
     types_str = [c.__name__ if c is not None else "None" for c in _SIMPLE_TYPES]
     error_msg = (
-        f"Unsupported I/O type `{param}`. Supported are:\n"
+        f"Unsupported I/O type `{name}` of type `{annotation}`. Supported are:\n"
         f"\t* simple types: {types_str}\n"
         f"\t* containers of these simple types, with annotated items: {containers_str}"
         ", e.g. `dict[str, int]` (use built-in types, not `typing.Dict`).\n"
         "\t* For complicated / nested data structures: `pydantic` models."
     )
-    anno = param.annotation
-    if isinstance(anno, str):
+    if isinstance(annotation, str):
         raise definitions.ChainsUsageError(
-            f"A string-valued type annotation was found: `{param}`. Use only actual "
-            "types and avoid `from __future__ import annotations` (upgrade python)."
+            f"A string-valued type annotation was found for `{name}` of type "
+            f"`{annotation}`. Use only actual types and avoid `from __future__ import "
+            "annotations` (upgrade python)."
         )
-    if anno in _SIMPLE_TYPES:
+    if annotation in _SIMPLE_TYPES:
         return
-    if isinstance(anno, types.GenericAlias):
-        if get_origin(anno) not in _SIMPLE_CONTAINERS:
+    if isinstance(annotation, types.GenericAlias):
+        if get_origin(annotation) not in _SIMPLE_CONTAINERS:
             raise definitions.ChainsUsageError(error_msg)
-        args = get_args(anno)
+        args = get_args(annotation)
         for arg in args:
             if arg not in _SIMPLE_TYPES:
                 raise definitions.ChainsUsageError(error_msg)
         return
-    if utils.issubclass_safe(anno, pydantic.BaseModel):
+    if utils.issubclass_safe(annotation, pydantic.BaseModel):
         return
 
     raise definitions.ChainsUsageError(error_msg)
@@ -191,7 +191,7 @@ def _validate_endpoint_params(
                 f"`{cls_name}.{definitions.ENDPOINT_METHOD_NAME}` parameter "
                 f"`{param.name}` has no type annotation."
             )
-        _validate_io_type(param)
+        _validate_io_type(param.annotation, param.name)
         type_descriptor = definitions.TypeDescriptor(raw=param.annotation)
         is_optional = param.default != inspect.Parameter.empty
         input_args.append(
@@ -200,6 +200,25 @@ def _validate_endpoint_params(
             )
         )
     return input_args
+
+
+def _validate_endpoint_output_types(
+    annotation: Any, cls_name: str, signature
+) -> list[definitions.TypeDescriptor]:
+    if annotation == inspect.Parameter.empty:
+        raise definitions.ChainsUsageError(
+            "Return values of endpoints must be type annotated. Got:\n"
+            f"{cls_name}.{definitions.ENDPOINT_METHOD_NAME}{signature} -> !MISSING!"
+        )
+    if get_origin(annotation) is tuple:
+        output_types = []
+        for i, arg in enumerate(get_args(annotation)):
+            _validate_io_type(arg, f"return_type[{i}]")
+            output_types.append(definitions.TypeDescriptor(raw=arg))
+    else:
+        _validate_io_type(annotation, "return_type")
+        output_types = [definitions.TypeDescriptor(raw=annotation)]
+    return output_types
 
 
 def _validate_and_describe_endpoint(
@@ -234,18 +253,10 @@ def _validate_and_describe_endpoint(
     input_args = _validate_endpoint_params(
         list(signature.parameters.values()), cls.name
     )
-    if signature.return_annotation == inspect.Parameter.empty:
-        raise definitions.ChainsUsageError(
-            "Return values of endpoints must be type annotated. Got:\n"
-            f"{cls.name}.{definitions.ENDPOINT_METHOD_NAME}{signature} -> !MISSING!"
-        )
-    if get_origin(signature.return_annotation) is tuple:
-        output_types = list(
-            definitions.TypeDescriptor(raw=arg)
-            for arg in get_args(signature.return_annotation)
-        )
-    else:
-        output_types = [definitions.TypeDescriptor(raw=signature.return_annotation)]
+
+    output_types = _validate_endpoint_output_types(
+        signature.return_annotation, cls.name, signature
+    )
 
     if inspect.isasyncgenfunction(endpoint_method):
         is_async = True

--- a/truss-chains/truss_chains/remote.py
+++ b/truss-chains/truss_chains/remote.py
@@ -6,6 +6,7 @@ import pathlib
 import re
 import tempfile
 import textwrap
+import traceback
 import uuid
 from typing import (
     TYPE_CHECKING,
@@ -452,6 +453,7 @@ class _Watcher:
     _watch_filter: Callable[[watchfiles.Change, str], bool]
     _console: "rich_console.Console"
     _error_console: "rich_console.Console"
+    _show_stack_trace: bool
 
     def __init__(
         self,
@@ -461,11 +463,13 @@ class _Watcher:
         remote: Optional[str],
         console: "rich_console.Console",
         error_console: "rich_console.Console",
+        show_stack_trace: bool,
     ) -> None:
         self._source = source
         self._entrypoint = entrypoint
         self._console = console
         self._error_console = error_console
+        self._show_stack_trace = show_stack_trace
         if not remote:
             remote = remote_cli.inquire_remote_name(
                 remote_factory.RemoteFactory.get_available_config_names()
@@ -569,6 +573,7 @@ class _Watcher:
         user_env: Optional[Mapping[str, str]],
     ) -> None:
         exception_raised = None
+        stack_trace = ""
         with log_utils.LogInterceptor() as log_interceptor, self._console.status(
             " Live Patching Chain.\n", spinner="arrow3"
         ):
@@ -601,6 +606,7 @@ class _Watcher:
                     }
             except Exception as e:
                 exception_raised = e
+                stack_trace = traceback.format_exc()
             finally:
                 logs = log_interceptor.get_logs()
 
@@ -618,6 +624,9 @@ class _Watcher:
                 "Try to fix the issue and save the file. Error:\n"
                 f"{textwrap.indent(str(exception_raised), ' ' * 4)}"
             )
+            if self._show_stack_trace:
+                self._error_console.print(stack_trace)
+
             self._console.print(
                 "The watcher will continue and if you can resolve the "
                 "issue, subsequent patches might succeed.",
@@ -690,6 +699,7 @@ def watch(
     user_env: Optional[Mapping[str, str]],
     console: "rich_console.Console",
     error_console: "rich_console.Console",
+    show_stack_trace: bool,
 ) -> None:
     console.print(
         (
@@ -698,5 +708,7 @@ def watch(
         ),
         style="blue",
     )
-    patcher = _Watcher(source, entrypoint, name, remote, console, error_console)
+    patcher = _Watcher(
+        source, entrypoint, name, remote, console, error_console, show_stack_trace
+    )
     patcher.watch(user_env)

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -632,6 +632,7 @@ def push_chain(
                     user_env_parsed,
                     console,
                     error_console,
+                    show_stack_trace=not is_humanfriendly_log_level,
                 )
         else:
             console.print(f"Deployment failed ({num_failed} failures).", style="red")
@@ -705,7 +706,14 @@ def watch_chains(
         user_env_parsed = {}
 
     chains_remote.watch(
-        source, entrypoint, name, remote, user_env_parsed, console, error_console
+        source,
+        entrypoint,
+        name,
+        remote,
+        user_env_parsed,
+        console,
+        error_console,
+        show_stack_trace=not is_humanfriendly_log_level,
     )
 
 

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -582,12 +582,12 @@ def push_chain(
             remote=remote,
         )
         service = chains_remote.push(entrypoint_cls, options)
-        assert isinstance(service, chains_remote.BasetenChainService)
 
     console.print("\n")
     if dryrun:
         return
 
+    assert isinstance(service, chains_remote.BasetenChainService)
     curl_snippet = _make_chains_curl_snippet(service.run_remote_url)
 
     table, statuses = _create_chains_table(service)

--- a/truss/util/.truss_ignore
+++ b/truss/util/.truss_ignore
@@ -141,6 +141,9 @@ venv.bak/
 .dmypy.json
 dmypy.json
 
+# ruff
+.ruff_cache/
+
 # Pyre type checker
 .pyre/
 


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
* Raise on invalid python source file names (contain `-` or `model.py`).
* Close loophole on unvalidated output types.
* Fix codegen bug for no return value.
* Optionally show stack trace in watch loop.
* Special case handling to support repeated import of `torch`.

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
