### PR TITLE
Implement promote_after_deploy for chain deployments

### DIFF
--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -235,7 +235,7 @@ class BasetenApi:
         return resp["data"]["deploy_draft_chain"]
 
     def deploy_chain_deployment(
-        self, chain_id: str, chainlet_data: List[b10_types.ChainletData]
+        self, chain_id: str, chainlet_data: List[b10_types.ChainletData], promote: bool
     ):
         chainlet_data_strings = [
             _chainlet_data_to_graphql_mutation(chainlet) for chainlet in chainlet_data
@@ -245,7 +245,8 @@ class BasetenApi:
         mutation {{
         deploy_chain_deployment(
             chain_id: "{chain_id}",
-            chainlets: [{chainlets_string}]
+            chainlets: [{chainlets_string}],
+            promote_after_deploy: {'true' if promote else 'false'},
         ) {{
             chain_id
             chain_deployment_id

--- a/truss/remote/baseten/core.py
+++ b/truss/remote/baseten/core.py
@@ -80,11 +80,16 @@ def create_chain(
     chain_name: str,
     chainlets: List[b10_types.ChainletData],
     is_draft: bool = False,
+    promote: bool = True,
 ) -> ChainDeploymentHandle:
     if is_draft:
         response = api.deploy_draft_chain(chain_name, chainlets)
     elif chain_id:
-        response = api.deploy_chain_deployment(chain_id, chainlets)
+        # This is the only case where promote has relevance, since
+        # if there is no chain already, the first deployment will
+        # already be production, and only published deployments can
+        # be promoted.
+        response = api.deploy_chain_deployment(chain_id, chainlets, promote)
     else:
         response = api.deploy_chain(chain_name, chainlets)
 


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What

Wires in the `promote_after_deploy` parameter in chain deployments.

We should only merge this once https://github.com/basetenlabs/baseten/pull/9192 is fully deployed & the frontend is implemented.

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing

See https://github.com/basetenlabs/baseten/pull/9192 for details here