### PR TITLE
Unified error handling in truss server and adding baseten error headers to response

### DIFF
--- a/truss/templates/server/common/errors.py
+++ b/truss/templates/server/common/errors.py
@@ -71,13 +71,6 @@ def _make_baseten_response(
     )
 
 
-async def generic_exception_handler(_, exc):
-    return JSONResponse(
-        status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
-        content={"error": f"{type(exc).__name__} : {str(exc)}"},
-    )
-
-
 async def exception_handler(_: fastapi.Request, exc: Exception) -> fastapi.Response:
     if isinstance(exc, ModelMissingError):
         return _make_baseten_response(HTTPStatus.NOT_FOUND.value, exc)

--- a/truss/templates/server/common/errors.py
+++ b/truss/templates/server/common/errors.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Optional
+from typing import Mapping, Optional
 
 from fastapi.responses import JSONResponse
 
@@ -57,14 +57,24 @@ class ModelNotReady(RuntimeError):
         return self.error_msg
 
 
+def _make_baseten_error_headers(error_code: int) -> Mapping[str, str]:
+    # The source of truth for these constants is in
+    # go/beefeater/shared/error_propagated.go
+    TrussServerServiceID = "04"
+    return {
+        "X-BASETEN-ERROR-SOURCE": TrussServerServiceID,
+        "X-BASETEN-ERROR-CODE": str(error_code),
+    }
+
+
 async def exception_handler(_, exc):
     return JSONResponse(
         status_code=HTTPStatus.INTERNAL_SERVER_ERROR, content={"error": str(exc)}
     )
 
 
-async def invalid_input_handler(_, exc):
-    return JSONResponse(status_code=HTTPStatus.BAD_REQUEST, content={"error": str(exc)})
+# async def invalid_input_handler(_, exc):
+#     return JSONResponse(status_code=HTTPStatus.BAD_REQUEST, content={"error": str(exc)})
 
 
 async def inference_error_handler(_, exc):

--- a/truss/templates/server/common/errors.py
+++ b/truss/templates/server/common/errors.py
@@ -1,7 +1,21 @@
+import asyncio
+import logging
 from http import HTTPStatus
-from typing import Mapping, Optional
+from typing import (
+    Callable,
+    Coroutine,
+    Mapping,
+    NoReturn,
+    Optional,
+    TypeVar,
+    Union,
+    overload,
+)
 
+import fastapi
+from fastapi import HTTPException
 from fastapi.responses import JSONResponse
+from typing_extensions import ParamSpec
 
 
 class ModelMissingError(Exception):
@@ -10,40 +24,6 @@ class ModelMissingError(Exception):
 
     def __str__(self):
         return self.path
-
-
-class InferenceError(RuntimeError):
-    def __init__(self, reason):
-        self.reason = reason
-
-    def __str__(self):
-        return self.reason
-
-
-class InvalidInput(ValueError):
-    """
-    Exception class indicating invalid input arguments.
-    HTTP Servers should return HTTP_400 (Bad Request).
-    """
-
-    def __init__(self, reason):
-        self.reason = reason
-
-    def __str__(self):
-        return self.reason
-
-
-class ModelNotFound(Exception):
-    """
-    Exception class indicating requested model does not exist.
-    HTTP Servers should return HTTP_404 (Not Found).
-    """
-
-    def __init__(self, model_name=None):
-        self.reason = f"Model with name {model_name} does not exist."
-
-    def __str__(self):
-        return self.reason
 
 
 class ModelNotReady(RuntimeError):
@@ -57,29 +37,32 @@ class ModelNotReady(RuntimeError):
         return self.error_msg
 
 
+class InputParsingError(ValueError):
+    pass
+
+
+class UserCodeError(Exception):
+    pass
+
+
 def _make_baseten_error_headers(error_code: int) -> Mapping[str, str]:
     # The source of truth for these constants is in
     # go/beefeater/shared/error_propagated.go
-    TrussServerServiceID = "04"
+    truss_server_service_id = "04"
     return {
-        "X-BASETEN-ERROR-SOURCE": TrussServerServiceID,
+        "X-BASETEN-ERROR-SOURCE": truss_server_service_id,
         "X-BASETEN-ERROR-CODE": str(error_code),
     }
 
 
-async def exception_handler(_, exc):
+def _make_baseten_response(
+    http_status: int, info: Union[str, Exception]
+) -> fastapi.Response:
+    msg = str(info) if isinstance(info, Exception) else info
     return JSONResponse(
-        status_code=HTTPStatus.INTERNAL_SERVER_ERROR, content={"error": str(exc)}
-    )
-
-
-# async def invalid_input_handler(_, exc):
-#     return JSONResponse(status_code=HTTPStatus.BAD_REQUEST, content={"error": str(exc)})
-
-
-async def inference_error_handler(_, exc):
-    return JSONResponse(
-        status_code=HTTPStatus.INTERNAL_SERVER_ERROR, content={"error": str(exc)}
+        status_code=http_status,
+        content={"error": msg},
+        headers=_make_baseten_error_headers(http_status),
     )
 
 
@@ -90,21 +73,75 @@ async def generic_exception_handler(_, exc):
     )
 
 
-async def model_not_found_handler(_, exc):
-    return JSONResponse(status_code=HTTPStatus.NOT_FOUND, content={"error": str(exc)})
+async def exception_handler(
+    request: fastapi.Request, exc: Exception
+) -> fastapi.Response:
+    if isinstance(exc, ModelMissingError):
+        return _make_baseten_response(HTTPStatus.NOT_FOUND, exc)
+    if isinstance(exc, ModelNotReady):
+        return _make_baseten_response(HTTPStatus.SERVICE_UNAVAILABLE, exc)
+    if isinstance(exc, NotImplementedError):
+        return _make_baseten_response(HTTPStatus.NOT_IMPLEMENTED, exc)
+    if isinstance(exc, InputParsingError):
+        return _make_baseten_response(HTTPStatus.BAD_REQUEST, exc)
+    if isinstance(exc, UserCodeError):
+        return _make_baseten_response(
+            HTTPStatus.INTERNAL_SERVER_ERROR, "Internal Server Error"
+        )
+    if isinstance(exc, fastapi.HTTPException):
+        # This is a pass through, but still adds our headers.
+        return _make_baseten_response(exc.status_code, exc.detail)
+    # Any other exceptions will be turned into internal server errors.
+    return _make_baseten_response(HTTPStatus.INTERNAL_SERVER_ERROR, exc)
 
 
-async def model_not_ready_handler(_, exc):
-    return JSONResponse(
-        status_code=HTTPStatus.SERVICE_UNAVAILABLE, content={"error": str(exc)}
-    )
+def _handle_exception(exc: Exception, logger: logging.Logger) -> NoReturn:
+    # Note that logger.exception logs the stacktrace, such that the user can
+    # debug this error from the logs.
+    if isinstance(exc, HTTPException):
+        logger.exception("Model raised HTTPException")
+        raise exc
+    else:
+        logger.exception("Internal Server Error")
+        raise UserCodeError(str(exc))
 
 
-async def not_implemented_error_handler(_, exc):
-    return JSONResponse(
-        status_code=HTTPStatus.NOT_IMPLEMENTED, content={"error": str(exc)}
-    )
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
+_R_async = TypeVar("_R_async", bound=Coroutine)  # Return type for async functions
 
 
-async def http_exception_handler(_, exc):
-    return JSONResponse(status_code=exc.status_code, content={"error": exc.detail})
+@overload
+def intercept_exceptions(
+    func: Callable[_P, _R], logger: logging.Logger
+) -> Callable[_P, _R]: ...
+@overload
+def intercept_exceptions(
+    func: Callable[_P, _R_async], logger: logging.Logger
+) -> Callable[_P, _R_async]: ...
+
+
+def intercept_exceptions(
+    func: Callable[_P, _R], logger: logging.Logger
+) -> Callable[_P, _R]:
+    """Converts all exceptions to 500-`HTTPException` and logs them.
+    If exception is already `HTTPException`, re-raises exception as is.
+    """
+    if asyncio.iscoroutinefunction(func):
+        # Handle asynchronous function
+        async def inner_async(*args: _P.args, **kwargs: _P.kwargs) -> _R:
+            try:
+                return await func(*args, **kwargs)
+            except Exception as e:
+                _handle_exception(e, logger)
+
+        return inner_async  # type: ignore[return-value]
+    else:
+        # Handle synchronous function
+        def inner_sync(*args: _P.args, **kwargs: _P.kwargs) -> _R:
+            try:
+                return func(*args, **kwargs)
+            except Exception as e:
+                _handle_exception(e, logger)
+
+        return inner_sync

--- a/truss/templates/server/common/truss_server.py
+++ b/truss/templates/server/common/truss_server.py
@@ -307,6 +307,9 @@ class TrussServer:
                 exc: errors.exception_handler for exc in errors.HANDLED_EXCEPTIONS
             },
         )
+        # Above `exception_handlers` only triggers on exact exception classes.
+        # This here is a fallback to add our custom headers in all other cases.
+        app.add_exception_handler(Exception, errors.exception_handler)
 
         def exit_self():
             # Note that this kills the current process, the worker process, not

--- a/truss/templates/server/common/truss_server.py
+++ b/truss/templates/server/common/truss_server.py
@@ -148,7 +148,7 @@ class BasetenEndpoints:
                     except pydantic.ValidationError as e:
                         raise errors.InputParsingError(
                             f"Could not parse pydantic: {str(e)}"
-                        )
+                        ) from e
             else:
                 if model.truss_schema:
                     if model.truss_schema:
@@ -158,7 +158,7 @@ class BasetenEndpoints:
                         except pydantic.ValidationError as e:
                             raise errors.InputParsingError(
                                 f"Could not parse pydantic: {str(e)}"
-                            )
+                            ) from e
                 else:
                     try:
                         with tracing.section_as_event(span, "json-deserialize"):
@@ -166,9 +166,10 @@ class BasetenEndpoints:
                     except json.JSONDecodeError as e:
                         raise errors.InputParsingError(
                             f"Invalid JSON payload: {str(e)}"
-                        )
+                        ) from e
 
-            # calls ModelWrapper.__call__, which runs validate, preprocess, predict, and postprocess
+            # Calls ModelWrapper.__call__, which runs validate, preprocess, predict,
+            # and postprocess.
             with tracing.section_as_event(span, "model-call"):
                 response: Union[Dict, Generator] = await model(
                     body,
@@ -302,7 +303,7 @@ class TrussServer:
                     methods=["POST"],
                 ),
             ],
-            exception_handlers={Exception: errors.error_handler},
+            exception_handlers={Exception: errors.exception_handler},
         )
 
         def exit_self():

--- a/truss/templates/server/common/truss_server.py
+++ b/truss/templates/server/common/truss_server.py
@@ -144,7 +144,7 @@ class BasetenEndpoints:
                 if model.truss_schema:
                     try:
                         with tracing.section_as_event(span, "parse-pydantic"):
-                            body = model.truss_schema.input_type.parse(**body)
+                            body = model.truss_schema.input_type.parse_obj(body)
                     except pydantic.ValidationError as e:
                         raise errors.InputParsingError(
                             f"Request Validation Error, {str(e)}"

--- a/truss/templates/server/common/truss_server.py
+++ b/truss/templates/server/common/truss_server.py
@@ -147,7 +147,7 @@ class BasetenEndpoints:
                             body = model.truss_schema.input_type.parse(**body)
                     except pydantic.ValidationError as e:
                         raise errors.InputParsingError(
-                            f"Could not parse pydantic: {str(e)}"
+                            f"Request Validation Error, {str(e)}"
                         ) from e
             else:
                 if model.truss_schema:
@@ -157,7 +157,7 @@ class BasetenEndpoints:
                                 body = model.truss_schema.input_type.parse_raw(body_raw)
                         except pydantic.ValidationError as e:
                             raise errors.InputParsingError(
-                                f"Could not parse pydantic: {str(e)}"
+                                f"Request Validation Error, {str(e)}"
                             ) from e
                 else:
                     try:
@@ -303,7 +303,9 @@ class TrussServer:
                     methods=["POST"],
                 ),
             ],
-            exception_handlers={Exception: errors.exception_handler},
+            exception_handlers={
+                exc: errors.exception_handler for exc in errors.HANDLED_EXCEPTIONS
+            },
         )
 
         def exit_self():

--- a/truss/test_data/test_streaming_truss_with_tracing/config.yaml
+++ b/truss/test_data/test_streaming_truss_with_tracing/config.yaml
@@ -1,4 +1,42 @@
-model_name: Test Streaming
-python_version: py39
+apply_library_patches: true
+base_image: null
+build:
+  arguments: {}
+  model_server: TrussServer
+  secret_to_path_mapping: {}
+build_commands: []
+bundled_packages_dir: packages
+data_dir: data
+description: null
 environment_variables:
-  OTEL_TRACING_NDJSON_FILE: "/tmp/otel_traces.ndjson"
+  OTEL_TRACING_NDJSON_FILE: /tmp/otel_traces.ndjson
+examples_filename: examples.yaml
+external_data: null
+external_package_dirs: []
+input_type: Any
+live_reload: false
+model_cache: []
+model_class_filename: model.py
+model_class_name: Model
+model_framework: custom
+model_metadata: {}
+model_module_dir: model
+model_name: Test Streaming
+model_type: Model
+python_version: py39
+requirements: []
+requirements_file: null
+resources:
+  accelerator: null
+  cpu: '1'
+  memory: 2Gi
+  use_gpu: false
+runtime:
+  enable_tracing_data: false
+  num_workers: 1
+  predict_concurrency: 1
+  streaming_read_timeout: 60
+secrets: {}
+spec_version: '2.0'
+system_packages: []
+trt_llm: null

--- a/truss/test_data/test_streaming_truss_with_tracing/config.yaml
+++ b/truss/test_data/test_streaming_truss_with_tracing/config.yaml
@@ -1,42 +1,4 @@
-apply_library_patches: true
-base_image: null
-build:
-  arguments: {}
-  model_server: TrussServer
-  secret_to_path_mapping: {}
-build_commands: []
-bundled_packages_dir: packages
-data_dir: data
-description: null
-environment_variables:
-  OTEL_TRACING_NDJSON_FILE: /tmp/otel_traces.ndjson
-examples_filename: examples.yaml
-external_data: null
-external_package_dirs: []
-input_type: Any
-live_reload: false
-model_cache: []
-model_class_filename: model.py
-model_class_name: Model
-model_framework: custom
-model_metadata: {}
-model_module_dir: model
 model_name: Test Streaming
-model_type: Model
 python_version: py39
-requirements: []
-requirements_file: null
-resources:
-  accelerator: null
-  cpu: '1'
-  memory: 2Gi
-  use_gpu: false
-runtime:
-  enable_tracing_data: false
-  num_workers: 1
-  predict_concurrency: 1
-  streaming_read_timeout: 60
-secrets: {}
-spec_version: '2.0'
-system_packages: []
-trt_llm: null
+environment_variables:
+  OTEL_TRACING_NDJSON_FILE: "/tmp/otel_traces.ndjson"

--- a/truss/tests/test_model_inference.py
+++ b/truss/tests/test_model_inference.py
@@ -476,7 +476,7 @@ secrets:
         assert_logs_contain_error(container.logs(), missing_secret_error_message)
         assert "Internal Server Error" in response.json()["error"]
         assert response.headers["x-baseten-error-source"] == "04"
-        assert response.headers["x-baseten-error-code"] == "500"
+        assert response.headers["x-baseten-error-code"] == "600"
 
 
 @pytest.mark.integration
@@ -754,7 +754,7 @@ def test_truss_with_errors():
 
         assert "Internal Server Error" in response.json()["error"]
         assert response.headers["x-baseten-error-source"] == "04"
-        assert response.headers["x-baseten-error-code"] == "500"
+        assert response.headers["x-baseten-error-code"] == "600"
 
 
 @pytest.mark.integration

--- a/truss/tests/test_model_inference.py
+++ b/truss/tests/test_model_inference.py
@@ -454,6 +454,8 @@ secrets:
 
         assert_logs_contain_error(container.logs(), missing_secret_error_message)
         assert "Internal Server Error" in response.json()["error"]
+        assert response.headers["x-baseten-error-source"] == "04"
+        assert response.headers["x-baseten-error-code"] == "500"
 
     with ensure_kill_all(), tempfile.TemporaryDirectory(dir=".") as tmp_work_dir:
         # Case where the secret is not mounted
@@ -473,6 +475,8 @@ secrets:
 
         assert_logs_contain_error(container.logs(), missing_secret_error_message)
         assert "Internal Server Error" in response.json()["error"]
+        assert response.headers["x-baseten-error-source"] == "04"
+        assert response.headers["x-baseten-error-code"] == "500"
 
 
 @pytest.mark.integration
@@ -662,6 +666,8 @@ def test_truss_with_errors():
         assert_logs_contain_error(container.logs(), "ValueError: error")
 
         assert "Internal Server Error" in response.json()["error"]
+        assert response.headers["x-baseten-error-source"] == "04"
+        assert response.headers["x-baseten-error-code"] == "500"
 
     model_preprocess_error = """
     class Model:
@@ -690,6 +696,8 @@ def test_truss_with_errors():
 
         assert_logs_contain_error(container.logs(), "ValueError: error")
         assert "Internal Server Error" in response.json()["error"]
+        assert response.headers["x-baseten-error-source"] == "04"
+        assert response.headers["x-baseten-error-code"] == "500"
 
     model_postprocess_error = """
     class Model:
@@ -717,6 +725,8 @@ def test_truss_with_errors():
         assert "error" in response.json()
         assert_logs_contain_error(container.logs(), "ValueError: error")
         assert "Internal Server Error" in response.json()["error"]
+        assert response.headers["x-baseten-error-source"] == "04"
+        assert response.headers["x-baseten-error-code"] == "500"
 
     model_async = """
     class Model:
@@ -743,6 +753,8 @@ def test_truss_with_errors():
         assert_logs_contain_error(container.logs(), "ValueError: error")
 
         assert "Internal Server Error" in response.json()["error"]
+        assert response.headers["x-baseten-error-source"] == "04"
+        assert response.headers["x-baseten-error-code"] == "500"
 
 
 @pytest.mark.integration
@@ -773,6 +785,8 @@ def test_truss_with_user_errors():
         response = requests.post(full_url, json={})
         assert response.status_code == 500
         assert "error" in response.json()
+        assert response.headers["x-baseten-error-source"] == "04"
+        assert response.headers["x-baseten-error-code"] == "500"
 
         assert_logs_contain_error(
             container.logs(),
@@ -781,6 +795,8 @@ def test_truss_with_user_errors():
         )
 
         assert "My custom message." in response.json()["error"]
+        assert response.headers["x-baseten-error-source"] == "04"
+        assert response.headers["x-baseten-error-code"] == "500"
 
 
 @pytest.mark.integration

--- a/truss/tests/test_model_inference.py
+++ b/truss/tests/test_model_inference.py
@@ -455,7 +455,7 @@ secrets:
         assert_logs_contain_error(container.logs(), missing_secret_error_message)
         assert "Internal Server Error" in response.json()["error"]
         assert response.headers["x-baseten-error-source"] == "04"
-        assert response.headers["x-baseten-error-code"] == "500"
+        assert response.headers["x-baseten-error-code"] == "600"
 
     with ensure_kill_all(), tempfile.TemporaryDirectory(dir=".") as tmp_work_dir:
         # Case where the secret is not mounted
@@ -667,7 +667,7 @@ def test_truss_with_errors():
 
         assert "Internal Server Error" in response.json()["error"]
         assert response.headers["x-baseten-error-source"] == "04"
-        assert response.headers["x-baseten-error-code"] == "500"
+        assert response.headers["x-baseten-error-code"] == "600"
 
     model_preprocess_error = """
     class Model:
@@ -697,7 +697,7 @@ def test_truss_with_errors():
         assert_logs_contain_error(container.logs(), "ValueError: error")
         assert "Internal Server Error" in response.json()["error"]
         assert response.headers["x-baseten-error-source"] == "04"
-        assert response.headers["x-baseten-error-code"] == "500"
+        assert response.headers["x-baseten-error-code"] == "600"
 
     model_postprocess_error = """
     class Model:
@@ -726,7 +726,7 @@ def test_truss_with_errors():
         assert_logs_contain_error(container.logs(), "ValueError: error")
         assert "Internal Server Error" in response.json()["error"]
         assert response.headers["x-baseten-error-source"] == "04"
-        assert response.headers["x-baseten-error-code"] == "500"
+        assert response.headers["x-baseten-error-code"] == "600"
 
     model_async = """
     class Model:
@@ -786,7 +786,7 @@ def test_truss_with_user_errors():
         assert response.status_code == 500
         assert "error" in response.json()
         assert response.headers["x-baseten-error-source"] == "04"
-        assert response.headers["x-baseten-error-code"] == "500"
+        assert response.headers["x-baseten-error-code"] == "600"
 
         assert_logs_contain_error(
             container.logs(),
@@ -796,7 +796,7 @@ def test_truss_with_user_errors():
 
         assert "My custom message." in response.json()["error"]
         assert response.headers["x-baseten-error-source"] == "04"
-        assert response.headers["x-baseten-error-code"] == "500"
+        assert response.headers["x-baseten-error-code"] == "600"
 
 
 @pytest.mark.integration

--- a/truss/tests/test_model_schema.py
+++ b/truss/tests/test_model_schema.py
@@ -35,6 +35,8 @@ def test_truss_with_no_annotations():
         assert schema_response.status_code == 404
 
         assert schema_response.json()["error"] == "No schema found"
+        assert response.headers["x-baseten-error-source"] == "04"
+        assert response.headers["x-baseten-error-code"] == "404"
 
 
 @pytest.mark.integration
@@ -58,8 +60,9 @@ class Model:
 
         schema_response = requests.get(SCHEMA_URL)
         assert schema_response.status_code == 404
-
         assert schema_response.json()["error"] == "No schema found"
+        assert response.headers["x-baseten-error-source"] == "04"
+        assert response.headers["x-baseten-error-code"] == "404"
 
 
 @pytest.mark.integration
@@ -120,6 +123,9 @@ def test_truss_with_annotated_inputs_outputs():
             "\nprompt\n  Field required [type=missing, input_value={'bad_key': 'value'}, input_type=dict]\n"
             in response.json()["error"]
         )
+
+        assert response.headers["x-baseten-error-source"] == "04"
+        assert response.headers["x-baseten-error-code"] == "400"
 
         schema_response = requests.get(SCHEMA_URL)
 

--- a/truss/tests/test_model_schema.py
+++ b/truss/tests/test_model_schema.py
@@ -106,14 +106,14 @@ def test_truss_with_annotated_inputs_outputs():
 
     with ensure_kill_all():
         _ = tr.docker_run(local_port=8090, detach=True, wait_for_server_ready=True)
-        # Valid JSON input
+        # Valid JSON input.
         json_input = {"prompt": "value"}
         response = requests.post(INFERENCE_URL, json=json_input)
         assert response.json() == {
             "generated_text": "value",
         }
 
-        # Valid binary input
+        # Valid binary input.
         byte_input = serialization.truss_msgpack_serialize(json_input)
         print(byte_input)
         response = requests.post(
@@ -135,7 +135,7 @@ def test_truss_with_annotated_inputs_outputs():
         assert response.headers["x-baseten-error-source"] == "04"
         assert response.headers["x-baseten-error-code"] == "700"
 
-        # Schema response
+        # Schema response.
         schema_response = requests.get(SCHEMA_URL)
         schema = schema_response.json()
         assert schema["input_schema"] == {

--- a/truss/tests/test_model_schema.py
+++ b/truss/tests/test_model_schema.py
@@ -36,8 +36,8 @@ def test_truss_with_no_annotations():
         assert schema_response.status_code == 404
 
         assert schema_response.json()["error"] == "No schema found"
-        assert response.headers["x-baseten-error-source"] == "04"
-        assert response.headers["x-baseten-error-code"] == "404"
+        assert schema_response.headers["x-baseten-error-source"] == "04"
+        assert schema_response.headers["x-baseten-error-code"] == "600"
 
 
 @pytest.mark.integration
@@ -62,8 +62,8 @@ class Model:
         schema_response = requests.get(SCHEMA_URL)
         assert schema_response.status_code == 404
         assert schema_response.json()["error"] == "No schema found"
-        assert response.headers["x-baseten-error-source"] == "04"
-        assert response.headers["x-baseten-error-code"] == "404"
+        assert schema_response.headers["x-baseten-error-source"] == "04"
+        assert schema_response.headers["x-baseten-error-code"] == "600"
 
 
 @pytest.mark.integration
@@ -133,7 +133,7 @@ def test_truss_with_annotated_inputs_outputs():
             in response.json()["error"]
         )
         assert response.headers["x-baseten-error-source"] == "04"
-        assert response.headers["x-baseten-error-code"] == "400"
+        assert response.headers["x-baseten-error-code"] == "700"
 
         # Schema response
         schema_response = requests.get(SCHEMA_URL)


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
* Unify error handling and add baseten custom error headers to responses [spec](https://www.notion.so/ml-infra/End-to-end-Error-code-Propagation-698daa6d2c3a4d10b55056b1a892cdfb).
* Remove dead code (unused exceptions and error handlers).
* Fuse optional parsing of pydantic models ("truss schema") with top-level input deserialization. This allows to parse json with pydantic directly (`Model(**json.loads(x))` => `Model.parse_raw(x)`), which is more performant than using `json.loads` first.

See also: https://github.com/basetenlabs/baseten/pull/9258

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
