### PR TITLE
Fix non-promotion flow

### DIFF
--- a/truss/remote/baseten/core.py
+++ b/truss/remote/baseten/core.py
@@ -79,8 +79,8 @@ def create_chain(
     chain_id: Optional[str],
     chain_name: str,
     chainlets: List[b10_types.ChainletData],
-    is_draft: bool = False,
-    promote: bool = True,
+    is_draft: bool,
+    promote: bool,
 ) -> ChainDeploymentHandle:
     if is_draft:
         response = api.deploy_draft_chain(chain_name, chainlets)

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -80,6 +80,7 @@ class BasetenRemote(TrussRemote):
             chain_name=chain_name,
             chainlets=chainlets,
             is_draft=not publish,
+            promote=promote,
         )
 
     def get_chainlets(


### PR DESCRIPTION

## :rocket: What

Found a pretty bad bug after releasing the promotion flow, where we were not properly wiring the `promote` flag through. We didn't catch this because there were defaults set on the underlying api method, I've removed these to force callers to provide these.

We should do a new release to get this out quickly.
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
