### PR TITLE
Switch default for chains push to development.

### DIFF
--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -470,7 +470,7 @@ def _create_chains_table(service) -> Tuple[rich.table.Table, List[str]]:
 @click.option(
     "--publish/--no-publish",
     type=bool,
-    default=True,
+    default=False,
     help="Create chainlets as published deployments.",
 )
 @click.option(


### PR DESCRIPTION

## :rocket: What

For consistency with models, let's have `truss chains push` push development deployments by default.

There are some docs that will need to update based on this. Will take a pass and update accordingly.

## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
