### PR TITLE
add validation for trt-llm HF repo

### DIFF
--- a/truss/config/trt_llm.py
+++ b/truss/config/trt_llm.py
@@ -99,7 +99,7 @@ class TRTLLMConfiguration(BaseModel):
         super().__init__(**data)
         self._validate_minimum_required_configuration()
         self._validate_kv_cache_flags()
-        if self.build.checkpoint_repository.source == "HF":
+        if self.build.checkpoint_repository.source == CheckpointSource.HF:
             self._validate_hf_repo_id()
 
     # In pydantic v2 this would be `@model_validator(mode="after")` and
@@ -139,7 +139,9 @@ class TRTLLMConfiguration(BaseModel):
         try:
             validate_repo_id(self.build.checkpoint_repository.repo)
         except HFValidationError as e:
-            raise ValueError(f"Validation failed: {str(e)}") from e
+            raise ValueError(
+                f"HuggingFace repository validation failed: {str(e)}"
+            ) from e
 
     @property
     def requires_build(self):

--- a/truss/tests/test_config.py
+++ b/truss/tests/test_config.py
@@ -468,6 +468,24 @@ def test_plugin_paged_context_fmha_check(trtllm_config):
         TrussConfig.from_dict(trtllm_config)
 
 
+@pytest.mark.parametrize(
+    "repo",
+    [
+        "./llama-3.1-8b",
+        "../my-model-is-in-parent-directory",
+        "~/.huggingface/my--model--cache/model",
+        "foo.git",
+        "datasets/foo/bar",
+        ".repo_id" "other..repo..id",
+    ],
+)
+def test_invalid_hf_repo(trtllm_config, repo):
+    trtllm_config["trt_llm"]["build"]["checkpoint_repository"]["source"] = "HF"
+    trtllm_config["trt_llm"]["build"]["checkpoint_repository"]["repo"] = repo
+    with pytest.raises(ValueError):
+        TrussConfig.from_dict(trtllm_config)
+
+
 def test_plugin_paged_fp8_context_fmha_check(trtllm_config):
     trtllm_config["trt_llm"]["build"]["plugin_configuration"] = {
         "paged_kv_cache": False,


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Added validation for TrussTRTLLMBuildConfiguration.checkpoint_repository.repo to make sure it is a valid repo name. It doesn't confirm if the model exists since the model might be private, it only checks if the name is valid.
<!--
  How was the change described above implemented?
-->
## :computer: How
Added a validation method to TRTLLMConfiguration as a part of __init__() 
<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
Added a parameterized test to test_config.py for the repo id.