### PR TITLE
Inspect enable chunked context configuration in Briton

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.42rc010"
+version = "0.9.42rc011"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.41"
+version = "0.9.42rc010"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/config/trt_llm.py
+++ b/truss/config/trt_llm.py
@@ -61,7 +61,7 @@ class TrussTRTLLMBuildConfiguration(BaseModel):
     max_input_len: int
     max_output_len: int
     max_batch_size: int
-    max_num_tokens: Optional[int]
+    max_num_tokens: Optional[int] = None
     max_beam_width: int = 1
     max_prompt_embedding_table_size: int = 0
     checkpoint_repository: CheckpointRepository

--- a/truss/config/trt_llm.py
+++ b/truss/config/trt_llm.py
@@ -61,6 +61,7 @@ class TrussTRTLLMBuildConfiguration(BaseModel):
     max_input_len: int
     max_output_len: int
     max_batch_size: int
+    max_num_tokens: Optional[int]
     max_beam_width: int = 1
     max_prompt_embedding_table_size: int = 0
     checkpoint_repository: CheckpointRepository
@@ -77,6 +78,7 @@ class TrussTRTLLMBuildConfiguration(BaseModel):
     use_fused_mlp: bool = False
     kv_cache_free_gpu_mem_fraction: float = 0.9
     num_builder_gpus: Optional[int] = None
+    enable_chunked_context: bool = False
 
     @validator("max_beam_width")
     def check_max_beam_width(cls, v: int):

--- a/truss/constants.py
+++ b/truss/constants.py
@@ -112,7 +112,7 @@ BASE_TRTLLM_REQUIREMENTS = [
     "grpcio==1.62.3",
     "grpcio-tools==1.62.3",
     "transformers==4.44.2",
-    "truss==0.9.31",
+    "truss==0.9.42rc010",
     "outlines==0.0.46",
     "torch==2.4.0",
     "sentencepiece==0.2.0",

--- a/truss/templates/trtllm-briton/src/engine.py
+++ b/truss/templates/trtllm-briton/src/engine.py
@@ -108,6 +108,7 @@ class Engine:
         self._enable_kv_cache_reuse = (
             truss_trtllm_build_config.plugin_configuration.use_paged_context_fmha
         )
+        self._enable_chunked_context = truss_trtllm_build_config.enable_chunked_context
 
         self._hf_token = None
         try:
@@ -154,6 +155,7 @@ engine_path: "{self._data_dir.resolve()}"
 hf_tokenizer: "{tokenizer_file.resolve()}"
 kv_cache_free_gpu_mem_fraction: {self._kv_cache_free_gpu_mem_fraction}
 enable_kv_cache_reuse: {"true" if self._enable_kv_cache_reuse else "false"}
+enable_chunked_context: {"true" if self._enable_chunked_context else "false"}
 fsm_cache_dir: "{FSM_CACHE_DIR}"
 """
 


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
- Inspect `enable_chunked_context` configuration to populate protobuf config for Briton server
<!--
  How was the change described above implemented?
-->
## :computer: How
- Bumps truss dependency to get new configuration field
<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
- Tested deployment e2e with this context builder `0.9.42rc011` with chunked context enabled and disabled