### PR TITLE
Support promote to `--environment` in chains

### DIFF
--- a/truss-chains/truss_chains/definitions.py
+++ b/truss-chains/truss_chains/definitions.py
@@ -610,6 +610,7 @@ class PushOptions(SafeModelNonSerializable):
 class PushOptionsBaseten(PushOptions):
     remote_provider: baseten_remote.BasetenRemote
     publish: bool
+    environment: Optional[str]
 
     @classmethod
     def create(

--- a/truss-chains/truss_chains/definitions.py
+++ b/truss-chains/truss_chains/definitions.py
@@ -24,6 +24,7 @@ from typing import (  # type: ignore[attr-defined]  # Chains uses Python >=3.9.
 
 import pydantic
 from truss import truss_config
+from truss.constants import PRODUCTION_ENVIRONMENT_NAME
 from truss.remote import baseten as baseten_remote
 from truss.remote import remote_cli, remote_factory
 
@@ -625,6 +626,8 @@ class PushOptionsBaseten(PushOptions):
             remote = remote_cli.inquire_remote_name(
                 remote_factory.RemoteFactory.get_available_config_names()
             )
+        if promote and not environment:
+            environment = PRODUCTION_ENVIRONMENT_NAME
         remote_provider = cast(
             baseten_remote.BasetenRemote,
             remote_factory.RemoteFactory.create(remote=remote),

--- a/truss-chains/truss_chains/definitions.py
+++ b/truss-chains/truss_chains/definitions.py
@@ -609,17 +609,17 @@ class PushOptions(SafeModelNonSerializable):
 class PushOptionsBaseten(PushOptions):
     remote_provider: baseten_remote.BasetenRemote
     publish: bool
-    promote: bool
 
     @classmethod
     def create(
         cls,
         chain_name: str,
         publish: bool,
-        promote: bool,
+        promote: Optional[bool],
         only_generate_trusses: bool,
         user_env: Mapping[str, str],
         remote: Optional[str] = None,
+        environment: Optional[str] = None,
     ) -> "PushOptionsBaseten":
         if not remote:
             remote = remote_cli.inquire_remote_name(
@@ -633,9 +633,9 @@ class PushOptionsBaseten(PushOptions):
             remote_provider=remote_provider,
             chain_name=chain_name,
             publish=publish,
-            promote=promote,
             only_generate_trusses=only_generate_trusses,
             user_env=user_env,
+            environment=environment,
         )
 
 

--- a/truss-chains/truss_chains/definitions.py
+++ b/truss-chains/truss_chains/definitions.py
@@ -629,6 +629,8 @@ class PushOptionsBaseten(PushOptions):
             )
         if promote and not environment:
             environment = PRODUCTION_ENVIRONMENT_NAME
+        if environment:
+            publish = True
         remote_provider = cast(
             baseten_remote.BasetenRemote,
             remote_factory.RemoteFactory.create(remote=remote),

--- a/truss-chains/truss_chains/public_api.py
+++ b/truss-chains/truss_chains/public_api.py
@@ -125,6 +125,7 @@ def push(
     user_env: Optional[Mapping[str, str]] = None,
     only_generate_trusses: bool = False,
     remote: Optional[str] = None,
+    environment: Optional[str] = None,
 ) -> chains_remote.BasetenChainService:
     """
     Deploys a chain remotely (with all dependent chainlets).
@@ -144,6 +145,7 @@ def push(
           ``/tmp/.chains_generated``.
         remote: name of a remote config in `.trussrc`. If not provided, it will be
           inquired.
+        environment: The name of an environment to promote deployment into.
 
     Returns:
         A chain service handle to the deployed chain.
@@ -156,6 +158,7 @@ def push(
         user_env=user_env or {},
         only_generate_trusses=only_generate_trusses,
         remote=remote,
+        environment=environment,
     )
     service = chains_remote.push(entrypoint, options)
     assert isinstance(service, chains_remote.BasetenChainService)  # Per options above.

--- a/truss-chains/truss_chains/remote.py
+++ b/truss-chains/truss_chains/remote.py
@@ -49,11 +49,8 @@ def _push_to_baseten(
     model_name = truss_handle.spec.config.model_name
     assert model_name is not None
     assert bool(_MODEL_NAME_RE.match(model_name))
-    if options.promote and not options.publish:
-        logging.info("`promote=True` overrides `publish` to `True`.")
     logging.info(
-        f"Pushing chainlet `{model_name}` as a truss model on Baseten "
-        f"(publish={options.publish}, promote={options.promote})."
+        f"Pushing chainlet `{model_name}` as a truss model on Baseten (publish={options.publish})"
     )
     # Models must be trusted to use the API KEY secret.
     service = options.remote_provider.push(
@@ -61,7 +58,6 @@ def _push_to_baseten(
         model_name=model_name,
         trusted=True,
         publish=options.publish,
-        promote=options.promote,
         origin=b10_types.ModelOrigin.CHAINS,
     )
     return cast(b10_service.BasetenService, service)
@@ -327,7 +323,7 @@ def _create_baseten_chain(
         chain_name=baseten_options.chain_name,
         chainlets=chainlet_data,
         publish=baseten_options.publish,
-        promote=baseten_options.promote,
+        environment=baseten_options.environment,
     )
     return BasetenChainService(
         baseten_options.chain_name,

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -2,7 +2,6 @@ import inspect
 import json
 import logging
 import os
-import re
 import sys
 import time
 import warnings
@@ -413,9 +412,11 @@ def chains():
 
 def _make_chains_curl_snippet(run_remote_url: str, environment: Optional[str]) -> str:
     if environment:
-        run_remote_url = re.sub(
-            r"/deployment/[^/]+/", f"/environments/{environment}/", run_remote_url
-        )
+        idx = run_remote_url.find("deployment")
+        if idx != -1:
+            run_remote_url = (
+                run_remote_url[:idx] + f"environments/{environment}/run_remote"
+            )
     return (
         f"curl -X POST '{run_remote_url}' \\\n"
         '    -H "Authorization: Api-Key $BASETEN_API_KEY" \\\n'

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -411,7 +411,7 @@ def chains():
     """Subcommands for truss chains"""
 
 
-def _make_chains_curl_snippet(run_remote_url: str, environment: str) -> str:
+def _make_chains_curl_snippet(run_remote_url: str, environment: Optional[str]) -> str:
     if environment:
         run_remote_url = re.sub(
             r"/deployment/[^/]+/", f"/environments/{environment}/", run_remote_url
@@ -669,13 +669,10 @@ def push_chain(
             for log in intercepted_logs:
                 console.print(f"\t{log}")
         if success:
+            deploy_success_text = "Deployment succeeded."
             if environment:
-                console.print(
-                    f"Your chain has been deployed into the {options.environment} environment.",
-                    style="green",
-                )
-            else:
-                console.print("Deployment succeeded.", style="bold green")
+                deploy_success_text = f"Your chain has been deployed into the {options.environment} environment."
+            console.print(deploy_success_text, style="bold green")
             console.print(f"You can run the chain with:\n{curl_snippet}")
             if watch:  # Note that this command will print a startup message.
                 chains_remote.watch(

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -610,13 +610,12 @@ def push_chain(
     if promote and environment:
         promote_warning = "`promote` flag and `environment` flag were both specified. Ignoring the value of `promote`"
         console.print(promote_warning, style="yellow")
-    if promote and not environment:
-        environment = PRODUCTION_ENVIRONMENT_NAME
 
     with framework.import_target(source, entrypoint) as entrypoint_cls:
         chain_name = name or entrypoint_cls.__name__
         options = chains_def.PushOptionsBaseten.create(
             chain_name=chain_name,
+            promote=promote,
             publish=publish,
             only_generate_trusses=dryrun,
             user_env=user_env_parsed,

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -235,7 +235,10 @@ class BasetenApi:
         return resp["data"]["deploy_draft_chain"]
 
     def deploy_chain_deployment(
-        self, chain_id: str, chainlet_data: List[b10_types.ChainletData], promote: bool
+        self,
+        chain_id: str,
+        chainlet_data: List[b10_types.ChainletData],
+        environment: Optional[str] = None,
     ):
         chainlet_data_strings = [
             _chainlet_data_to_graphql_mutation(chainlet) for chainlet in chainlet_data
@@ -246,7 +249,7 @@ class BasetenApi:
         deploy_chain_deployment(
             chain_id: "{chain_id}",
             chainlets: [{chainlets_string}],
-            promote_after_deploy: {'true' if promote else 'false'},
+            {f'environment_name: "{environment}"' if environment else ""}
         ) {{
             chain_id
             chain_deployment_id

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -246,14 +246,14 @@ class BasetenApi:
         chainlets_string = ", ".join(chainlet_data_strings)
         query_string = f"""
         mutation {{
-        deploy_chain_deployment(
-            chain_id: "{chain_id}",
-            chainlets: [{chainlets_string}],
-            {f'environment_name: "{environment}"' if environment else ""}
-        ) {{
-            chain_id
-            chain_deployment_id
-        }}
+            deploy_chain_deployment(
+                chain_id: "{chain_id}",
+                chainlets: [{chainlets_string}],
+                {f'environment_name: "{environment}"' if environment else ""}
+            ) {{
+                chain_id
+                chain_deployment_id
+            }}
         }}
         """
         resp = self._post_graphql_query(query_string)

--- a/truss/remote/baseten/core.py
+++ b/truss/remote/baseten/core.py
@@ -96,7 +96,10 @@ def create_chain(
         try:
             response = api.deploy_chain_deployment(chain_id, chainlets, environment)
         except ApiError as e:
-            if "Environment matching query does not exist" in e.message:
+            if (
+                e.graphql_error_code
+                == BasetenApi.GraphQLErrorCodes.RESOURCE_NOT_FOUND.value
+            ):
                 raise ValueError(
                     f'Environment "{environment}" does not exist. You can create environments in the Chains UI.'
                 ) from e
@@ -308,7 +311,10 @@ def create_truss_service(
             environment=environment,
         )
     except ApiError as e:
-        if "Environment matching query does not exist" in e.message:
+        if (
+            e.graphql_error_code
+            == BasetenApi.GraphQLErrorCodes.RESOURCE_NOT_FOUND.value
+        ):
             raise ValueError(
                 f'Environment "{environment}" does not exist. You can create environments in the Baseten UI.'
             ) from e

--- a/truss/remote/baseten/core.py
+++ b/truss/remote/baseten/core.py
@@ -98,12 +98,10 @@ def create_chain(
         except ApiError as e:
             if "Environment matching query does not exist" in e.message:
                 raise ValueError(
-                    f'Environment "{environment}" does not exist. You can create environments in the Baseten UI.'
+                    f'Environment "{environment}" does not exist. You can create environments in the Chains UI.'
                 ) from e
             raise e
     else:
-        if environment:
-            raise ValueError(NO_ENVIRONMENTS_EXIST_ERROR_MESSAGING)
         response = api.deploy_chain(chain_name, chainlets)
 
     return ChainDeploymentHandle(

--- a/truss/remote/baseten/core.py
+++ b/truss/remote/baseten/core.py
@@ -102,6 +102,8 @@ def create_chain(
                 ) from e
             raise e
     else:
+        if environment and environment != PRODUCTION_ENVIRONMENT_NAME:
+            raise ValueError(NO_ENVIRONMENTS_EXIST_ERROR_MESSAGING)
         response = api.deploy_chain(chain_name, chainlets)
 
     return ChainDeploymentHandle(

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -67,10 +67,10 @@ class BasetenRemote(TrussRemote):
         chain_name: str,
         chainlets: List[custom_types.ChainletData],
         publish: bool = False,
-        promote: bool = False,
+        environment: Optional[str] = None,
     ) -> ChainDeploymentHandle:
-        if promote:
-            # If we are promoting a model after deploy, it must be published.
+        if environment:
+            # If we are promoting a model to an environment after deploy, it must be published.
             # Draft models cannot be promoted.
             publish = True
         # Returns tuple of (chain_id, chain_deployment_id)
@@ -81,7 +81,7 @@ class BasetenRemote(TrussRemote):
             chain_name=chain_name,
             chainlets=chainlets,
             is_draft=not publish,
-            promote=promote,
+            environment=environment,
         )
 
     def get_chainlets(

--- a/truss/tests/remote/baseten/test_remote.py
+++ b/truss/tests/remote/baseten/test_remote.py
@@ -488,23 +488,24 @@ def test_create_chain_with_existing_chain_promote_to_environment_publish_false()
         match_graphql_request(get_chains_graphql_request, expected_get_chains_query)
         # Note that if publish=False and environment!=None, we set publish to True and create
         # a non-draft deployment
-        expected_create_chain_mutation = """
-        mutation {
-        deploy_chain_deployment(
-            chain_id: "old-chain-id",
-            chainlets: [
+        chainlets_string = """
         {
             name: "chainlet-1",
             oracle_version_id: "some-ov-id",
             is_entrypoint: true
         }
-        ],
-            environment_name: "production"
-        ) {
-            chain_id
-            chain_deployment_id
-        }
-        }
+        """
+        expected_create_chain_mutation = f"""
+        mutation {{
+            deploy_chain_deployment(
+                chain_id: "old-chain-id",
+                chainlets: [{chainlets_string}],
+                environment_name: "production"
+            ) {{
+                chain_id
+                chain_deployment_id
+            }}
+        }}
         """.strip()
 
         match_graphql_request(
@@ -568,24 +569,25 @@ def test_create_chain_existing_chain_publish_true_no_promotion():
         """.strip()
 
         match_graphql_request(get_chains_graphql_request, expected_get_chains_query)
-        # Note environment_name is omitted
-        expected_create_chain_mutation = """
-        mutation {
-        deploy_chain_deployment(
-            chain_id: "old-chain-id",
-            chainlets: [
+        chainlets_string = """
         {
             name: "chainlet-1",
             oracle_version_id: "some-ov-id",
             is_entrypoint: true
         }
-        ],
-
-        ) {
-            chain_id
-            chain_deployment_id
-        }
-        }
+        """
+        environment = None
+        expected_create_chain_mutation = f"""
+        mutation {{
+            deploy_chain_deployment(
+                chain_id: "old-chain-id",
+                chainlets: [{chainlets_string}],
+                {f'environment_name: "{environment}"' if environment else ""}
+            ) {{
+                chain_id
+                chain_deployment_id
+            }}
+        }}
         """.strip()
 
         match_graphql_request(

--- a/truss/tests/remote/baseten/test_remote.py
+++ b/truss/tests/remote/baseten/test_remote.py
@@ -314,7 +314,6 @@ def test_create_chain_with_no_publish():
                 )
             ],
             publish=False,
-            promote=False,
         )
 
         get_chains_graphql_request = m.request_history[0]
@@ -433,7 +432,7 @@ def test_create_chain_no_existing_chain():
         assert deployment_handle.chain_deployment_id == "new-chain-deployment-id"
 
 
-def test_create_chain_with_existing_chain_promote_true_publish_false():
+def test_create_chain_with_existing_chain_promote_to_environment_publish_false():
     remote = BasetenRemote(_TEST_REMOTE_URL, "api_key")
 
     with requests_mock.Mocker() as m:
@@ -471,7 +470,7 @@ def test_create_chain_with_existing_chain_promote_true_publish_false():
                 )
             ],
             publish=False,
-            promote=True,
+            environment="production",
         )
 
         get_chains_graphql_request = m.request_history[0]
@@ -487,7 +486,7 @@ def test_create_chain_with_existing_chain_promote_true_publish_false():
         """.strip()
 
         match_graphql_request(get_chains_graphql_request, expected_get_chains_query)
-        # Note that if publish=False and promote=True, we set publish to True and create
+        # Note that if publish=False and environment!=None, we set publish to True and create
         # a non-draft deployment
         expected_create_chain_mutation = """
         mutation {
@@ -500,7 +499,7 @@ def test_create_chain_with_existing_chain_promote_true_publish_false():
             is_entrypoint: true
         }
         ],
-            promote_after_deploy: true,
+            environment_name: "production"
         ) {
             chain_id
             chain_deployment_id
@@ -516,7 +515,7 @@ def test_create_chain_with_existing_chain_promote_true_publish_false():
         assert deployment_handle.chain_deployment_id == "new-chain-deployment-id"
 
 
-def test_create_chain_existing_chain_publish_true_promote_false():
+def test_create_chain_existing_chain_publish_true_no_promotion():
     remote = BasetenRemote(_TEST_REMOTE_URL, "api_key")
 
     with requests_mock.Mocker() as m:
@@ -554,7 +553,6 @@ def test_create_chain_existing_chain_publish_true_promote_false():
                 )
             ],
             publish=True,
-            promote=False,
         )
 
         get_chains_graphql_request = m.request_history[0]
@@ -570,7 +568,7 @@ def test_create_chain_existing_chain_publish_true_promote_false():
         """.strip()
 
         match_graphql_request(get_chains_graphql_request, expected_get_chains_query)
-        # Note promote_after_deploy is false
+        # Note environment_name is omitted
         expected_create_chain_mutation = """
         mutation {
         deploy_chain_deployment(
@@ -582,7 +580,7 @@ def test_create_chain_existing_chain_publish_true_promote_false():
             is_entrypoint: true
         }
         ],
-            promote_after_deploy: false,
+
         ) {
             chain_id
             chain_deployment_id


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Adds the `--environment` flag in favor of `--promote` for pushing chains.

<!--
  How was the change described above implemented?
-->
## :computer: How
`truss push my_chain.py --environment production` will act the same as `truss push my_chain.py --promote`
and we will now support `truss push my_chain.py --environment environment_name`

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
Tested the following scenarios on dev

#### Promoting to production using `--environment`
```
truss chains push hello_chain/hello.py --name 10_11_chain --environment production

? 🎮 Which remote do you want to connect to? baseten-dev-10-2
Using chain workspace dir: `/Users/sam/hello_chain` (files under this dir will be included as dependencies in the remote deployments and are importable).
Generating truss chainlet model for `AnotherDependency`.
Truss not found in pip requirements, auto-adding: `truss==0.9.44`.
Pushing chainlet `AnotherDependency-836b5b01` as a truss model on Baseten (publish=True)
Compressing... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Uploading... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Pushed `AnotherDependency`
Generating truss chainlet model for `RandInt`.
Truss not found in pip requirements, auto-adding: `truss==0.9.44`.
Pushing chainlet `RandInt-8f7ded29` as a truss model on Baseten (publish=True)
Compressing... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Uploading... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Pushed `RandInt`
Generating truss chainlet model for `HelloWorld_10_11`.
Truss not found in pip requirements, auto-adding: `truss==0.9.44`.
Pushing chainlet `HelloWorld_10_11-03a8853f` as a truss model on Baseten (publish=True)
Compressing... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Uploading... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Pushed `HelloWorld_10_11`


                                                 ⛓️   10_11_chain - Chain  ⛓️
                                                 ⛓️   10_11_chain - Chain  ⛓️

                             🌐 Status page: https://app.dev.baseten.co/chains/j7wl7qdm/overview
╭──────────────────────┬───────────────────────────────┬───────────────────────────────────────────────────────────────────╮
│ Status               │ Chainlet                      │ Logs URL                                                          │
├──────────────────────┼───────────────────────────────┼───────────────────────────────────────────────────────────────────┤
│  💚 ACTIVE           │ HelloWorld_10_11 (entrypoint) │ https://app.dev.baseten.co/chains/j7wl7qdm/logs/903yve3z/97qkpdwr │
├──────────────────────┼───────────────────────────────┼───────────────────────────────────────────────────────────────────┤
│  💚 ACTIVE           │ AnotherDependency (internal)  │ https://app.dev.baseten.co/chains/j7wl7qdm/logs/903yve3z/j8w6ygq4 │
│  💚 ACTIVE           │ RandInt (internal)            │ https://app.dev.baseten.co/chains/j7wl7qdm/logs/903yve3z/o4w5yv32 │
╰──────────────────────┴───────────────────────────────┴───────────────────────────────────────────────────────────────────╯
Your chain has been deployed into the production environment.
You can run the chain with:
curl -X POST 'https://chain-j7wl7qdm.api.mc-dev.baseten.co/environments/production/run_remote' \
    -H "Authorization: Api-Key $BASETEN_API_KEY" \
    -d '<JSON_INPUT>'
```

#### Promoting to production using `--promote`
```
truss chains push hello_chain/hello.py --name 10_11_chain --promote

? 🎮 Which remote do you want to connect to? baseten-dev-10-2
Using chain workspace dir: `/Users/sam/hello_chain` (files under this dir will be included as dependencies in the remote deployments and are importable).
Generating truss chainlet model for `AnotherDependency`.
Truss not found in pip requirements, auto-adding: `truss==0.9.44`.
Pushing chainlet `AnotherDependency-130cea35` as a truss model on Baseten (publish=True)
Compressing... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Uploading... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Pushed `AnotherDependency`
Generating truss chainlet model for `RandInt`.
Truss not found in pip requirements, auto-adding: `truss==0.9.44`.
Pushing chainlet `RandInt-4e13ceb1` as a truss model on Baseten (publish=True)
Compressing... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Uploading... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Pushed `RandInt`
Generating truss chainlet model for `HelloWorld_10_11`.
Truss not found in pip requirements, auto-adding: `truss==0.9.44`.
Pushing chainlet `HelloWorld_10_11-11aa2725` as a truss model on Baseten (publish=True)
Compressing... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Uploading... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Pushed `HelloWorld_10_11`


                                                 ⛓️   10_11_chain - Chain  ⛓️

                             🌐 Status page: https://app.dev.baseten.co/chains/j7wl7qdm/overview
╭──────────────────────┬───────────────────────────────┬───────────────────────────────────────────────────────────────────╮
│ Status               │ Chainlet                      │ Logs URL                                                          │
├──────────────────────┼───────────────────────────────┼───────────────────────────────────────────────────────────────────┤
│  💚 ACTIVE           │ HelloWorld_10_11 (entrypoint) │ https://app.dev.baseten.co/chains/j7wl7qdm/logs/n4q925w5/x5qek5qo │
├──────────────────────┼───────────────────────────────┼───────────────────────────────────────────────────────────────────┤
│ 💚  ACTIVE           │ AnotherDependency (internal)  │ https://app.dev.baseten.co/chains/j7wl7qdm/logs/n4q925w5/gnwxy6qy │
│ 💚  ACTIVE           │ RandInt (internal)            │ https://app.dev.baseten.co/chains/j7wl7qdm/logs/n4q925w5/n4q9e9w5 │
╰──────────────────────┴───────────────────────────────┴───────────────────────────────────────────────────────────────────╯
Deployment succeeded.
You can run the chain with:
curl -X POST 'https://chain-j7wl7qdm.api.mc-dev.baseten.co/environments/production/run_remote' \
    -H "Authorization: Api-Key $BASETEN_API_KEY" \
    -d '<JSON_INPUT>'
```

#### Promoting to a nonexistent environment using `--environment`
```
truss chains push hello_chain/hello.py --name 10_11_chain --environment staging

? 🎮 Which remote do you want to connect to? baseten-dev-10-2
Using chain workspace dir: `/Users/sam/hello_chain` (files under this dir will
be included as dependencies in the remote deployments and are importable).
Generating truss chainlet model for `AnotherDependency`.
Truss not found in pip requirements, auto-adding: `truss==0.9.44`.
Pushing chainlet `AnotherDependency-16d8a729` as a truss model on Baseten
(publish=True)
Compressing... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Uploading... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Pushed `AnotherDependency`
Generating truss chainlet model for `RandInt`.
Truss not found in pip requirements, auto-adding: `truss==0.9.44`.
Pushing chainlet `RandInt-776c9062` as a truss model on Baseten (publish=True)
Compressing... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Uploading... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Pushed `RandInt`
Generating truss chainlet model for `HelloWorld_10_11`.
Truss not found in pip requirements, auto-adding: `truss==0.9.44`.
Pushing chainlet `HelloWorld_10_11-91490dc3` as a truss model on Baseten
(publish=True)
Compressing... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Uploading... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Pushed `HelloWorld_10_11`
ERROR: ApiError: No stable environment with name staging found for chain id j7wl7qdm.
```

#### Promoting to staging using `--environment`
```
truss chains push hello_chain/hello.py --name 10_11_chain --environment staging

? 🎮 Which remote do you want to connect to? baseten-dev-10-2
Using chain workspace dir: `/Users/sam/hello_chain` (files under this dir will
be included as dependencies in the remote deployments and are importable).
Generating truss chainlet model for `AnotherDependency`.
Truss not found in pip requirements, auto-adding: `truss==0.9.44`.
Pushing chainlet `AnotherDependency-8447609e` as a truss model on Baseten
(publish=True)
Compressing... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Uploading... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Pushed `AnotherDependency`
Generating truss chainlet model for `RandInt`.
Truss not found in pip requirements, auto-adding: `truss==0.9.44`.
Pushing chainlet `RandInt-708e77d7` as a truss model on Baseten (publish=True)
Compressing... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Uploading... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Pushed `RandInt`
Generating truss chainlet model for `HelloWorld_10_11`.
Truss not found in pip requirements, auto-adding: `truss==0.9.44`.
Pushing chainlet `HelloWorld_10_11-e637113f` as a truss model on Baseten
(publish=True)
Compressing... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Uploading... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Pushed `HelloWorld_10_11`
                           ⛓️   10_11_chain - Chain  ⛓️

       🌐 Status page: https://app.dev.baseten.co/chains/j7wl7qdm/overview
╭──────────────────────┬───────────────────────────┬───────────────────────────╮
│ Status               │ Chainlet                  │ Logs URL                  │
├──────────────────────┼───────────────────────────┼───────────────────────────┤
│  💚 ACTIVE           │ HelloWorld_10_11          │ https://app.dev.baseten.… │
│                      │ (entrypoint)              │                           │
├──────────────────────┼───────────────────────────┼───────────────────────────┤
│  💚 ACTIVE           │ AnotherDependency         │ https://app.dev.baseten.… │
│                      │ (internal)                │                           │
│  💚 ACTIVE           │ RandInt (internal)        │ https://app.dev.baseten.… │
╰──────────────────────┴───────────────────────────┴───────────────────────────╯
Your chain has been deployed into the staging environment.
You can run the chain with:
curl -X POST
'https://chain-j7wl7qdm.api.mc-dev.baseten.co/environments/staging/run_remote' \
    -H "Authorization: Api-Key $BASETEN_API_KEY" \
    -d '<JSON_INPUT>'
```

#### Promote to an environment using both `--promote` and `--environment`
```
truss chains push hello_chain/hello.py --name 10_11_chain --promote --environment staging

`promote` flag and `environment` flag were both specified. Ignoring the value of `promote`
? 🎮 Which remote do you want to connect to? baseten-dev-10-2
Using chain workspace dir: `/Users/sam/hello_chain` (files under this dir will be included as dependencies in the remote deployments and are importable).
Generating truss chainlet model for `AnotherDependency`.
Truss not found in pip requirements, auto-adding: `truss==0.9.44`.
Pushing chainlet `AnotherDependency-9713b234` as a truss model on Baseten (publish=True)
Compressing... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Uploading... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Pushed `AnotherDependency`
Generating truss chainlet model for `RandInt`.
Truss not found in pip requirements, auto-adding: `truss==0.9.44`.
Pushing chainlet `RandInt-3e298f73` as a truss model on Baseten (publish=True)
Compressing... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Uploading... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Pushed `RandInt`
Generating truss chainlet model for `HelloWorld_10_11`.
Truss not found in pip requirements, auto-adding: `truss==0.9.44`.
Pushing chainlet `HelloWorld_10_11-11f84e99` as a truss model on Baseten (publish=True)
Compressing... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Uploading... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Pushed `HelloWorld_10_11`
                                                 ⛓️   10_11_chain - Chain  ⛓️

                             🌐 Status page: https://app.dev.baseten.co/chains/j7wl7qdm/overview
╭──────────────────────┬───────────────────────────────┬───────────────────────────────────────────────────────────────────╮
│ Status               │ Chainlet                      │ Logs URL                                                          │
├──────────────────────┼───────────────────────────────┼───────────────────────────────────────────────────────────────────┤
│  💚 ACTIVE           │ HelloWorld_10_11 (entrypoint) │ https://app.dev.baseten.co/chains/j7wl7qdm/logs/x5qe923o/n4q9ejw5 │
├──────────────────────┼───────────────────────────────┼───────────────────────────────────────────────────────────────────┤
│  💚 ACTIVE           │ AnotherDependency (internal)  │ https://app.dev.baseten.co/chains/j7wl7qdm/logs/x5qe923o/gyqv1gq8 │
│  💚 ACTIVE           │ RandInt (internal)            │ https://app.dev.baseten.co/chains/j7wl7qdm/logs/x5qe923o/gnwxyyqy │
╰──────────────────────┴───────────────────────────────┴───────────────────────────────────────────────────────────────────╯
Your chain has been deployed into the staging environment.
You can run the chain with:
curl -X POST 'https://chain-j7wl7qdm.api.mc-dev.baseten.co/environments/staging/run_remote' \
    -H "Authorization: Api-Key $BASETEN_API_KEY" \
    -d '<JSON_INPUT>'
```

#### Publishing a deployment using `--publish`
```
truss chains push hello_chain/hello.py --name 10_11_chain --publish

? 🎮 Which remote do you want to connect to? baseten-dev-10-2
Using chain workspace dir: `/Users/sam/hello_chain` (files under this dir will be included as dependencies in the remote deployments and are importable).
Generating truss chainlet model for `AnotherDependency`.
Truss not found in pip requirements, auto-adding: `truss==0.9.44`.
Pushing chainlet `AnotherDependency-45778eee` as a truss model on Baseten (publish=True)
Compressing... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Uploading... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Pushed `AnotherDependency`
Generating truss chainlet model for `RandInt`.
Truss not found in pip requirements, auto-adding: `truss==0.9.44`.
Pushing chainlet `RandInt-04f4fb49` as a truss model on Baseten (publish=True)
Compressing... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Uploading... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Pushed `RandInt`
Generating truss chainlet model for `HelloWorld_10_11`.
Truss not found in pip requirements, auto-adding: `truss==0.9.44`.
Pushing chainlet `HelloWorld_10_11-12607a40` as a truss model on Baseten (publish=True)
Compressing... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Uploading... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
                                                 ⛓️   10_11_chain - Chain  ⛓️

                             🌐 Status page: https://app.dev.baseten.co/chains/j7wl7qdm/overview
╭──────────────────────┬───────────────────────────────┬───────────────────────────────────────────────────────────────────╮
│ Status               │ Chainlet                      │ Logs URL                                                          │
├──────────────────────┼───────────────────────────────┼───────────────────────────────────────────────────────────────────┤
│  💚 ACTIVE           │ HelloWorld_10_11 (entrypoint) │ https://app.dev.baseten.co/chains/j7wl7qdm/logs/p7qrm93v/p7qrv03v │
├──────────────────────┼───────────────────────────────┼───────────────────────────────────────────────────────────────────┤
│  💚 ACTIVE           │ AnotherDependency (internal)  │ https://app.dev.baseten.co/chains/j7wl7qdm/logs/p7qrm93v/x5qekpqo │
│  💚 ACTIVE           │ RandInt (internal)            │ https://app.dev.baseten.co/chains/j7wl7qdm/logs/p7qrm93v/gyqv1rq8 │
╰──────────────────────┴───────────────────────────────┴───────────────────────────────────────────────────────────────────╯
Deployment succeeded.
You can run the chain with:
curl -X POST 'https://chain-j7wl7qdm.api.mc-dev.baseten.co/deployment/p7qrm93v/run_remote' \
    -H "Authorization: Api-Key $BASETEN_API_KEY" \
    -d '<JSON_INPUT>'
```

#### Pushing a development deployment
```
truss chains push hello_chain/hello.py --name 10_11_chain

? 🎮 Which remote do you want to connect to? baseten-dev-10-2
Using chain workspace dir: `/Users/sam/hello_chain` (files under this dir will be included as dependencies in the remote deployments and are importable).
Generating truss chainlet model for `AnotherDependency`.
Truss not found in pip requirements, auto-adding: `truss==0.9.44`.
Pushing chainlet `AnotherDependency-2141b20b` as a truss model on Baseten (publish=False)
Compressing... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Uploading... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Pushed `AnotherDependency`
Generating truss chainlet model for `RandInt`.
Truss not found in pip requirements, auto-adding: `truss==0.9.44`.
Pushing chainlet `RandInt-7763c4fd` as a truss model on Baseten (publish=False)
Compressing... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Uploading... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Pushed `RandInt`
Generating truss chainlet model for `HelloWorld_10_11`.
Truss not found in pip requirements, auto-adding: `truss==0.9.44`.
Pushing chainlet `HelloWorld_10_11-acc6eccf` as a truss model on Baseten (publish=False)
Compressing... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Uploading... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Pushed `HelloWorld_10_11`


                                                 ⛓️   10_11_chain - Chain  ⛓️

                             🌐 Status page: https://app.dev.baseten.co/chains/j7wl7qdm/overview
╭──────────────────────┬───────────────────────────────┬───────────────────────────────────────────────────────────────────╮
│ Status               │ Chainlet                      │ Logs URL                                                          │
├──────────────────────┼───────────────────────────────┼───────────────────────────────────────────────────────────────────┤
│ 💚  ACTIVE           │ HelloWorld_10_11 (entrypoint) │ https://app.dev.baseten.co/chains/j7wl7qdm/logs/1lqzrp34/xv31e1wz │
├──────────────────────┼───────────────────────────────┼───────────────────────────────────────────────────────────────────┤
│ 💚  ACTIVE           │ AnotherDependency (internal)  │ https://app.dev.baseten.co/chains/j7wl7qdm/logs/1lqzrp34/1lqzyxw4 │
│ 💚  ACTIVE           │ RandInt (internal)            │ https://app.dev.baseten.co/chains/j7wl7qdm/logs/1lqzrp34/62qjkp3d │
╰──────────────────────┴───────────────────────────────┴───────────────────────────────────────────────────────────────────╯
Deployment succeeded.
You can run the chain with:
curl -X POST 'https://chain-j7wl7qdm.api.mc-dev.baseten.co/development/run_remote' \
    -H "Authorization: Api-Key $BASETEN_API_KEY" \
    -d '<JSON_INPUT>'
```
## Release notes:
* **Pre-release: https://github.com/basetenlabs/baseten/pull/9505 needs to make it to `production` first**

