### PR TITLE
change path to supervisord binary

### DIFF
--- a/truss/templates/server.Dockerfile.jinja
+++ b/truss/templates/server.Dockerfile.jinja
@@ -105,7 +105,7 @@ COPY ./proxy.conf {{ proxy_config_path }}
 RUN mkdir -p {{ supervisor_log_dir }}
 COPY supervisord.conf {{ supervisor_config_path }}
 ENV SUPERVISOR_SERVER_URL="{{ supervisor_server_url }}"
-ENV SERVER_START_CMD="/usr/local/bin/supervisord -c {{ supervisor_config_path }}"
+ENV SERVER_START_CMD="supervisord -c {{ supervisor_config_path }}"
 ENTRYPOINT ["/usr/local/bin/supervisord", "-c", "{{ supervisor_config_path }}"]
     {%- elif config.live_reload %}
 ENV HASH_TRUSS="{{truss_hash}}"


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
We can't rely on supervisord being at /usr/local/bin where pip installs it. For pyenv, it gets installed at ```/root/.pyenv/shims/supervisord -> /root/.pyenv/versions/3.10.14/bin/supervisord```
Fix, removes /usr/local/bin/ from supervisord binary path

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
