### PR TITLE
Added whoami command

### DIFF
--- a/truss/__init__.py
+++ b/truss/__init__.py
@@ -15,7 +15,7 @@ def version():
     return __version__
 
 
-from truss.api import login, push
+from truss.api import login, push, whoami
 from truss.build import from_directory, init, kill_all, load
 
-__all__ = ["from_directory", "init", "kill_all", "load", "push", "login"]
+__all__ = ["from_directory", "init", "kill_all", "load", "push", "login", "whoami"]

--- a/truss/api/__init__.py
+++ b/truss/api/__init__.py
@@ -26,6 +26,27 @@ def login(api_key: str):
     RemoteFactory.update_remote_config(remote_config)
 
 
+def whoami(remote: Optional[str] = None):
+    """
+    Returns account information for the current user.
+    """
+    if not remote:
+        available_remotes = RemoteFactory.get_available_config_names()
+        if len(available_remotes) == 1:
+            remote = available_remotes[0]
+        elif len(available_remotes) == 0:
+            raise ValueError(
+                "Please authenticate via truss.login and pass it as an argument."
+            )
+        else:
+            raise ValueError(
+                "Multiple remotes found. Please pass the remote as an argument."
+            )
+
+    remote_provider = RemoteFactory.create(remote=remote)
+    return remote_provider.whoami()
+
+
 def push(
     target_directory: str,
     remote: Optional[str] = None,

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -332,6 +332,25 @@ def login(api_key: Optional[str]):
 
 
 @truss_cli.command()
+@click.option(
+    "--remote",
+    type=str,
+    required=False,
+    help="Name of the remote in .trussrc to check whoami.",
+)
+@error_handling
+def whoami(remote: Optional[str]):
+    """
+    Shows user information and exit.
+    """
+    from truss.api import whoami
+
+    user = whoami(remote)
+
+    console.print(f"{user.workspace_name}\{user.user_email}")
+
+
+@truss_cli.command()
 @click.argument("target_directory", required=False, default=os.getcwd())
 @click.option(
     "--remote",

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -345,6 +345,9 @@ def whoami(remote: Optional[str]):
     """
     from truss.api import whoami
 
+    if not remote:
+        remote = inquire_remote_name(RemoteFactory.get_available_config_names())
+
     user = whoami(remote)
 
     console.print(f"{user.workspace_name}\{user.user_email}")

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -34,7 +34,7 @@ from truss.remote.baseten.core import (
 from truss.remote.baseten.error import ApiError, RemoteError
 from truss.remote.baseten.service import BasetenService, URLConfig
 from truss.remote.baseten.utils.transfer import base64_encoded_json_str
-from truss.remote.truss_remote import TrussRemote
+from truss.remote.truss_remote import RemoteUser, TrussRemote
 from truss.truss_config import ModelServer
 from truss.truss_handle import TrussHandle
 from truss.util.path import is_ignored, load_trussignore_patterns
@@ -114,6 +114,17 @@ class BasetenRemote(TrussRemote):
                 chain_deployment_id
             )
         ]
+
+    def whoami(self) -> RemoteUser:
+        resp = self._api._post_graphql_query(
+            "query{organization{workspace_name}user{email}}"
+        )
+        workspace_name = resp["data"]["organization"]["workspace_name"]
+        user_email = resp["data"]["user"]["email"]
+        return RemoteUser(
+            workspace_name,
+            user_email,
+        )
 
     def push(  # type: ignore
         self,

--- a/truss/remote/truss_remote.py
+++ b/truss/remote/truss_remote.py
@@ -9,6 +9,17 @@ if TYPE_CHECKING:
 from truss.truss_handle import TrussHandle
 
 
+class RemoteUser:
+    """Class to hold information about the remote user"""
+
+    workspace_name: str
+    user_email: str
+
+    def __init__(self, workspace_name: str, user_email: str):
+        self.workspace_name = workspace_name
+        self.user_email = user_email
+
+
 class TrussService(ABC):
     """
     Define the abstract base class for a TrussService.
@@ -206,6 +217,16 @@ class TrussRemote(ABC):
         Args:
             truss_handle: The TrussHandle to push to the remote service.
             **kwargs: Additional keyword arguments for the push operation.
+
+        """
+
+    @abstractmethod
+    def whoami(self) -> RemoteUser:
+        """
+        Returns account information for the current user.
+
+        This method should be implemented in subclasses and return a RemoteUser.
+
 
         """
 

--- a/truss/tests/remote/test_remote_factory.py
+++ b/truss/tests/remote/test_remote_factory.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 import pytest
 from truss.remote.remote_factory import RemoteFactory
-from truss.remote.truss_remote import RemoteConfig, TrussRemote
+from truss.remote.truss_remote import RemoteConfig, RemoteUser, TrussRemote
 
 SAMPLE_CONFIG = {"api_key": "test_key", "remote_url": "http://test.com"}
 
@@ -40,6 +40,9 @@ class TrussTestRemote(TrussRemote):
 
     def sync_truss_to_dev_version_by_name(self, model_name: str, target_directory: str):
         raise NotImplementedError
+
+    def whoami(self) -> RemoteUser:
+        return RemoteUser("test_user", "test_email")
 
 
 def mock_service_config():


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What

This PR adds the `truss whoami` command that returns information about the currently logged in user. This allows users that swap between accounts to easily determine which account they are using. The format of the output when using the baseten remote is `{workspace name}\{user's email}`

<!--
  How was the change described above implemented?
-->
## :computer: How

The data is returned from the baseten grapql API by passing in the API key.

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
Local testing with different baseten API keys
