### PR TITLE
Add `environment` to truss `__init__`

### DIFF
--- a/truss/templates/server/model_wrapper.py
+++ b/truss/templates/server/model_wrapper.py
@@ -835,4 +835,12 @@ def _prepare_init_args(klass, config, data_dir, secrets, lazy_data_resolver):
         model_init_params["secrets"] = secrets
     if _signature_accepts_keyword_arg(signature, "lazy_data_resolver"):
         model_init_params["lazy_data_resolver"] = lazy_data_resolver.fetch()
+    if _signature_accepts_keyword_arg(signature, "environment"):
+        environment = None
+        environment_str = dynamic_config_resolver.get_dynamic_config_value_sync(
+            dynamic_config_resolver.ENVIRONMENT_DYNAMIC_CONFIG_KEY
+        )
+        if environment_str:
+            environment = json.loads(environment_str)
+        model_init_params["environment"] = environment
     return model_init_params

--- a/truss/tests/test_model_inference.py
+++ b/truss/tests/test_model_inference.py
@@ -761,12 +761,15 @@ def test_slow_truss():
 
 
 @pytest.mark.integration
-def test_init_with_environment():
+def test_init_environment_parameter():
+    # Test a truss deployment that is associated with an environment
     model = """
     from typing import Optional
     class Model:
-        def __init__(self, environment: Optional[dict]):
-            self.environment_name = environment.get("name") if environment else None
+        def __init__(self, **kwargs):
+            self._config = kwargs["config"]
+            self._environment = kwargs["environment"]
+            self.environment_name = self._environment.get("name") if self._environment else None
 
         def load(self):
             print(f"Executing model.load with environment: {self.environment_name}")
@@ -796,6 +799,19 @@ def test_init_with_environment():
                 "rm -f /etc/b10_dynamic_config/environment",
             ]
         )
+
+    # Test a truss deployment with no associated environment
+    config = "model_name: init-no-environment-truss"
+    with ensure_kill_all(), temp_truss(model, config) as tr:
+        container = tr.docker_run(
+            local_port=8090,
+            detach=True,
+            wait_for_server_ready=True,
+        )
+        assert "Executing model.load with environment: None" in container.logs()
+        response = requests.post(PREDICT_URL, json={})
+        assert response.json() is None
+        assert response.status_code == 200
 
 
 @pytest.mark.integration


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Adds an `environment` parameter to the truss `__init__`.
This can now be accessed by doing the following:
```
def __init__(self, **kwargs):
    self._environment = kwargs["environment"]
    self.environment_name = self._environment.get("name") if self._environment else None
```
or
```
def __init__(self, environment: Optional[dict]):
    self.environment_name = environment.get("name") if environment else None
```
<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
Added a test to `test_model_inference.py`
from local test where load prints out `self._environment`:
<img width="712" alt="image" src="https://github.com/user-attachments/assets/baa8cb25-0389-4bae-9468-4e61ff524792">
and predict prints out `self.environment_name`:
```
curl -X POST http://localhost:9090/environments/staging/predict \
  -H "Authorization: Api-Key <api_key>" \
  -H 'Host: model-n4q95w5d.api.dev.baseten.co' \
  -d '"MODEL_INPUT"'
"staging"
```

