### PR TITLE
`truss watch` doesn't ignore directory-level `.trussignore`

### DIFF
--- a/truss/patch/calc_patch.py
+++ b/truss/patch/calc_patch.py
@@ -198,6 +198,7 @@ def _calc_changed_paths(
     root_relative_new_paths = set(
         (str(path.relative_to(root)) for path in root.glob("**/*"))
     )
+    print(ignore_patterns)
     unignored_new_paths = calc_unignored_paths(root_relative_new_paths, ignore_patterns)
     previous_root_relative_paths = set(previous_root_path_content_hashes.keys())
     unignored_prev_paths = calc_unignored_paths(
@@ -231,6 +232,8 @@ def calc_unignored_paths(
     ignored_paths = set(
         get_ignored_relative_paths(root_relative_paths, ignore_patterns)
     )
+    print('ignore paths')
+    print(ignored_paths)
     return root_relative_paths - ignored_paths  # type: ignore
 
 

--- a/truss/patch/calc_patch.py
+++ b/truss/patch/calc_patch.py
@@ -198,7 +198,6 @@ def _calc_changed_paths(
     root_relative_new_paths = set(
         (str(path.relative_to(root)) for path in root.glob("**/*"))
     )
-    print(ignore_patterns)
     unignored_new_paths = calc_unignored_paths(root_relative_new_paths, ignore_patterns)
     previous_root_relative_paths = set(previous_root_path_content_hashes.keys())
     unignored_prev_paths = calc_unignored_paths(
@@ -232,8 +231,6 @@ def calc_unignored_paths(
     ignored_paths = set(
         get_ignored_relative_paths(root_relative_paths, ignore_patterns)
     )
-    print('ignore paths')
-    print(ignored_paths)
     return root_relative_paths - ignored_paths  # type: ignore
 
 

--- a/truss/remote/baseten/core.py
+++ b/truss/remote/baseten/core.py
@@ -11,7 +11,7 @@ from truss.remote.baseten.error import ApiError
 from truss.remote.baseten.utils.tar import create_tar_with_progress_bar
 from truss.remote.baseten.utils.transfer import multipart_upload_boto3
 from truss.truss_handle import TrussHandle
-from truss.util.path import load_trussignore_patterns
+from truss.util.path import load_trussignore_patterns_from_truss_dir
 
 logger = logging.getLogger(__name__)
 
@@ -189,11 +189,7 @@ def archive_truss(truss_handle: TrussHandle) -> IO:
     truss_dir = truss_handle._spec.truss_dir
 
     # check for a truss_ignore file and read the ignore patterns if it exists
-    truss_ignore_file = truss_dir / ".truss_ignore"
-    if truss_ignore_file.exists():
-        ignore_patterns = load_trussignore_patterns(truss_ignore_file=truss_ignore_file)
-    else:
-        ignore_patterns = load_trussignore_patterns()
+    ignore_patterns = load_trussignore_patterns_from_truss_dir(truss_dir)
 
     try:
         temp_file = create_tar_with_progress_bar(truss_dir, ignore_patterns)

--- a/truss/remote/baseten/core.py
+++ b/truss/remote/baseten/core.py
@@ -194,6 +194,9 @@ def archive_truss(truss_handle: TrussHandle) -> IO:
         ignore_patterns = load_trussignore_patterns(truss_ignore_file=truss_ignore_file)
     else:
         ignore_patterns = load_trussignore_patterns()
+    print('from archive_truss')
+    print(truss_handle._spec.truss_dir)
+    print(ignore_patterns)
 
     try:
         temp_file = create_tar_with_progress_bar(truss_dir, ignore_patterns)

--- a/truss/remote/baseten/core.py
+++ b/truss/remote/baseten/core.py
@@ -194,9 +194,6 @@ def archive_truss(truss_handle: TrussHandle) -> IO:
         ignore_patterns = load_trussignore_patterns(truss_ignore_file=truss_ignore_file)
     else:
         ignore_patterns = load_trussignore_patterns()
-    print('from archive_truss')
-    print(truss_handle._spec.truss_dir)
-    print(ignore_patterns)
 
     try:
         temp_file = create_tar_with_progress_bar(truss_dir, ignore_patterns)

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -288,13 +288,13 @@ class BasetenRemote(TrussRemote):
                 "No development model found. Run `truss push` then try again."
             )
 
-        print('target directory')
-        # assuming this becomes truss_dir
-        print(target_directory)
         watch_path = Path(target_directory)
+        # assuming this becomes truss_dir
         truss_ignore_file = watch_path / ".truss_ignore"
         if truss_ignore_file.exists():
-            truss_ignore_patterns = load_trussignore_patterns(truss_ignore_file=truss_ignore_file)
+            truss_ignore_patterns = load_trussignore_patterns(
+                truss_ignore_file=truss_ignore_file
+            )
         else:
             truss_ignore_patterns = load_trussignore_patterns()
 

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -37,7 +37,7 @@ from truss.remote.baseten.utils.transfer import base64_encoded_json_str
 from truss.remote.truss_remote import TrussRemote
 from truss.truss_config import ModelServer
 from truss.truss_handle import TrussHandle
-from truss.util.path import is_ignored, load_trussignore_patterns
+from truss.util.path import is_ignored, load_trussignore_patterns_from_truss_dir
 from watchfiles import watch
 
 
@@ -289,14 +289,7 @@ class BasetenRemote(TrussRemote):
             )
 
         watch_path = Path(target_directory)
-        # assuming this becomes truss_dir
-        truss_ignore_file = watch_path / ".truss_ignore"
-        if truss_ignore_file.exists():
-            truss_ignore_patterns = load_trussignore_patterns(
-                truss_ignore_file=truss_ignore_file
-            )
-        else:
-            truss_ignore_patterns = load_trussignore_patterns()
+        truss_ignore_patterns = load_trussignore_patterns_from_truss_dir(watch_path)
 
         def watch_filter(_, path):
             return not is_ignored(

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -288,8 +288,15 @@ class BasetenRemote(TrussRemote):
                 "No development model found. Run `truss push` then try again."
             )
 
+        print('target directory')
+        # assuming this becomes truss_dir
+        print(target_directory)
         watch_path = Path(target_directory)
-        truss_ignore_patterns = load_trussignore_patterns()
+        truss_ignore_file = watch_path / ".truss_ignore"
+        if truss_ignore_file.exists():
+            truss_ignore_patterns = load_trussignore_patterns(truss_ignore_file=truss_ignore_file)
+        else:
+            truss_ignore_patterns = load_trussignore_patterns()
 
         def watch_filter(_, path):
             return not is_ignored(

--- a/truss/util/path.py
+++ b/truss/util/path.py
@@ -84,6 +84,14 @@ def build_truss_target_directory(stub: str) -> Path:
     return target_directory_path
 
 
+def load_trussignore_patterns_from_truss_dir(truss_dir: Path) -> List[str]:
+    truss_ignore_file = truss_dir / ".truss_ignore"
+    if truss_ignore_file.exists():
+        return load_trussignore_patterns(truss_ignore_file)
+    # default to the truss-defined ignore patterns
+    return load_trussignore_patterns()
+
+
 def load_trussignore_patterns(
     truss_ignore_file: Path = FIXED_TRUSS_IGNORE_PATH,
 ) -> List[str]:

--- a/truss/util/path.py
+++ b/truss/util/path.py
@@ -88,10 +88,14 @@ def load_trussignore_patterns(
     truss_ignore_file: Path = FIXED_TRUSS_IGNORE_PATH,
 ) -> List[str]:
     """Load patterns from a .truss_ignore file"""
+    print('truss ignore file')
+    print(truss_ignore_file)
     patterns = []
 
     with truss_ignore_file.open() as f:
         lines = f.readlines()
+        print('lines')
+        print(lines)
 
     for line in lines:
         line = line.strip()

--- a/truss/util/path.py
+++ b/truss/util/path.py
@@ -88,14 +88,10 @@ def load_trussignore_patterns(
     truss_ignore_file: Path = FIXED_TRUSS_IGNORE_PATH,
 ) -> List[str]:
     """Load patterns from a .truss_ignore file"""
-    print('truss ignore file')
-    print(truss_ignore_file)
     patterns = []
 
     with truss_ignore_file.open() as f:
         lines = f.readlines()
-        print('lines')
-        print(lines)
 
     for line in lines:
         line = line.strip()

--- a/truss/util/path.py
+++ b/truss/util/path.py
@@ -11,7 +11,8 @@ import pathspec
 
 # .truss_ignore is a fixed file in the Truss library that is used to specify files
 # that should be ignored when copying a directory tree such as .git directory.
-FIXED_TRUSS_IGNORE_PATH = Path(__file__).parent / ".truss_ignore"
+TRUSS_IGNORE_FILENAME = ".truss_ignore"
+FIXED_TRUSS_IGNORE_PATH = Path(__file__).parent / TRUSS_IGNORE_FILENAME
 
 
 def copy_tree_path(src: Path, dest: Path, ignore_patterns: List[str] = []) -> None:
@@ -85,7 +86,7 @@ def build_truss_target_directory(stub: str) -> Path:
 
 
 def load_trussignore_patterns_from_truss_dir(truss_dir: Path) -> List[str]:
-    truss_ignore_file = truss_dir / ".truss_ignore"
+    truss_ignore_file = truss_dir / TRUSS_IGNORE_FILENAME
     if truss_ignore_file.exists():
         return load_trussignore_patterns(truss_ignore_file)
     # default to the truss-defined ignore patterns


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
* current logic for `truss push` uses a local `.trussignore` if it exists. `truss watch` does not. 
* This results in confusing behavior for the user (why is this file that's in my truss ignore getting sync'd), and leads to race condition-hash versions in `truss watch`
<!--
  How was the change described above implemented?
-->
## :computer: How
* check for a truss ignore before initializing truss watch in truss and in chains 
<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
