### PR TITLE
Atomic Chain creation client

### DIFF
--- a/docs/chains/doc_gen/generate_reference.py
+++ b/docs/chains/doc_gen/generate_reference.py
@@ -72,7 +72,7 @@ SECTION_UTILITIES = (
         "truss_chains.remote.ChainService",
         "truss_chains.make_abs_path_here",
         "truss_chains.run_local",
-        "truss_chains.ServiceDescriptor",
+        "truss_chains.DeployedServiceDescriptor",
         "truss_chains.StubBase",
         "truss_chains.RemoteErrorDetail",
         # "truss_chains.ChainsRuntimeError",

--- a/truss-chains/tests/test_utils.py
+++ b/truss-chains/tests/test_utils.py
@@ -1,4 +1,3 @@
-import copy
 import json
 
 import pytest
@@ -29,16 +28,15 @@ def test_populate_chainlet_service_predict_urls(tmp_path, dynamic_config_mount_d
     chainlet_to_service = {
         "HelloWorld": definitions.ServiceDescriptor(
             name="HelloWorld",
-            predict_url="https://model-model_id.api.baseten.co/deployments/deployment_id/predict",
             options=definitions.RPCOptions(),
         )
     }
-    original_chainlet_to_service = copy.deepcopy(chainlet_to_service)
-    populate_chainlet_service_predict_urls(chainlet_to_service)
+    new_chainlet_to_service = populate_chainlet_service_predict_urls(
+        chainlet_to_service
+    )
 
-    assert chainlet_to_service != original_chainlet_to_service
     assert (
-        chainlet_to_service["HelloWorld"].predict_url
+        new_chainlet_to_service["HelloWorld"].predict_url
         == DYNAMIC_CHAINLET_CONFIG_VALUE["HelloWorld"]["predict_url"]
     )
 
@@ -55,26 +53,12 @@ def test_no_populate_chainlet_service_predict_urls(
 
     chainlet_to_service = {
         "RandInt": definitions.ServiceDescriptor(
-            name="HelloWorld",
-            predict_url="https://model-model_id.api.baseten.co/deployments/deployment_id/predict",
+            name="RandInt",
             options=definitions.RPCOptions(),
         )
     }
-    original_chainlet_to_service = copy.deepcopy(chainlet_to_service)
-    populate_chainlet_service_predict_urls(chainlet_to_service)
 
-    assert chainlet_to_service == original_chainlet_to_service
-
-
-def test_no_config_populate_chainlet_service_predict_urls(dynamic_config_mount_dir):
-    chainlet_to_service = {
-        "HelloWorld": definitions.ServiceDescriptor(
-            name="HelloWorld",
-            predict_url="https://model-model_id.api.baseten.co/deployments/deployment_id/predict",
-            options=definitions.RPCOptions(),
-        )
-    }
-    original_chainlet_to_service = copy.deepcopy(chainlet_to_service)
-    populate_chainlet_service_predict_urls(chainlet_to_service)
-
-    assert chainlet_to_service == original_chainlet_to_service
+    with pytest.raises(
+        definitions.MissingDependencyError, match="Chainlet 'RandInt' not found"
+    ):
+        populate_chainlet_service_predict_urls(chainlet_to_service)

--- a/truss-chains/tests/test_utils.py
+++ b/truss-chains/tests/test_utils.py
@@ -4,7 +4,7 @@ import json
 import pytest
 
 from truss_chains import definitions
-from truss_chains.utils import override_chainlet_to_service_metadata
+from truss_chains.utils import populate_chainlet_service_predict_urls
 
 DYNAMIC_CHAINLET_CONFIG_VALUE = {
     "HelloWorld": {
@@ -22,7 +22,7 @@ def dynamic_config_mount_dir(tmp_path, monkeypatch: pytest.MonkeyPatch):
     yield
 
 
-def test_override_chainlet_to_service_metadata(tmp_path, dynamic_config_mount_dir):
+def test_populate_chainlet_service_predict_urls(tmp_path, dynamic_config_mount_dir):
     with (tmp_path / definitions.DYNAMIC_CHAINLET_CONFIG_KEY).open("w") as f:
         f.write(json.dumps(DYNAMIC_CHAINLET_CONFIG_VALUE))
 
@@ -34,7 +34,7 @@ def test_override_chainlet_to_service_metadata(tmp_path, dynamic_config_mount_di
         )
     }
     original_chainlet_to_service = copy.deepcopy(chainlet_to_service)
-    override_chainlet_to_service_metadata(chainlet_to_service)
+    populate_chainlet_service_predict_urls(chainlet_to_service)
 
     assert chainlet_to_service != original_chainlet_to_service
     assert (
@@ -47,7 +47,7 @@ def test_override_chainlet_to_service_metadata(tmp_path, dynamic_config_mount_di
     "config",
     [DYNAMIC_CHAINLET_CONFIG_VALUE, {}, ""],
 )
-def test_no_override_chainlet_to_service_metadata(
+def test_no_populate_chainlet_service_predict_urls(
     config, tmp_path, dynamic_config_mount_dir
 ):
     with (tmp_path / definitions.DYNAMIC_CHAINLET_CONFIG_KEY).open("w") as f:
@@ -61,12 +61,12 @@ def test_no_override_chainlet_to_service_metadata(
         )
     }
     original_chainlet_to_service = copy.deepcopy(chainlet_to_service)
-    override_chainlet_to_service_metadata(chainlet_to_service)
+    populate_chainlet_service_predict_urls(chainlet_to_service)
 
     assert chainlet_to_service == original_chainlet_to_service
 
 
-def test_no_config_override_chainlet_to_service_metadata(dynamic_config_mount_dir):
+def test_no_config_populate_chainlet_service_predict_urls(dynamic_config_mount_dir):
     chainlet_to_service = {
         "HelloWorld": definitions.ServiceDescriptor(
             name="HelloWorld",
@@ -75,6 +75,6 @@ def test_no_config_override_chainlet_to_service_metadata(dynamic_config_mount_di
         )
     }
     original_chainlet_to_service = copy.deepcopy(chainlet_to_service)
-    override_chainlet_to_service_metadata(chainlet_to_service)
+    populate_chainlet_service_predict_urls(chainlet_to_service)
 
     assert chainlet_to_service == original_chainlet_to_service

--- a/truss-chains/truss_chains/__init__.py
+++ b/truss-chains/truss_chains/__init__.py
@@ -25,12 +25,12 @@ from truss_chains.definitions import (
     ChainletOptions,
     Compute,
     CustomImage,
+    DeployedServiceDescriptor,
     DeploymentContext,
     DockerImage,
     RemoteConfig,
     RemoteErrorDetail,
     RPCOptions,
-    ServiceDescriptor,
 )
 from truss_chains.public_api import (
     ChainletBase,
@@ -55,7 +55,7 @@ __all__ = [
     "RPCOptions",
     "RemoteConfig",
     "RemoteErrorDetail",
-    "ServiceDescriptor",
+    "DeployedServiceDescriptor",
     "StubBase",
     "depends",
     "depends_context",

--- a/truss-chains/truss_chains/code_gen.py
+++ b/truss-chains/truss_chains/code_gen.py
@@ -627,9 +627,6 @@ def gen_truss_chainlet(
     # Filter needed services and customize options.
     dep_services = {}
     for dep in chainlet_descriptor.dependencies.values():
-        # NOTE(dynamic-chainlet-config): We don't set
-        # a predict URL for Chainlet services as they
-        # are auto-populated during Chain deployment.
         dep_services[dep.name] = definitions.ServiceDescriptor(
             name=dep.name,
             options=dep.options,

--- a/truss-chains/truss_chains/code_gen.py
+++ b/truss-chains/truss_chains/code_gen.py
@@ -623,14 +623,15 @@ def gen_truss_chainlet(
     chain_name: str,
     chainlet_descriptor: definitions.ChainletAPIDescriptor,
     model_name: str,
-    chainlet_display_name_to_url: Mapping[str, str],
 ) -> pathlib.Path:
     # Filter needed services and customize options.
     dep_services = {}
     for dep in chainlet_descriptor.dependencies.values():
+        # NOTE(dynamic-chainlet-config): We don't set
+        # a predict URL for Chainlet services as they
+        # are auto-populated during Chain deployment.
         dep_services[dep.name] = definitions.ServiceDescriptor(
             name=dep.name,
-            predict_url=chainlet_display_name_to_url[dep.display_name],
             options=dep.options,
         )
 

--- a/truss-chains/truss_chains/definitions.py
+++ b/truss-chains/truss_chains/definitions.py
@@ -27,6 +27,7 @@ from truss.base import truss_config
 from truss.base.constants import PRODUCTION_ENVIRONMENT_NAME
 from truss.remote import baseten as baseten_remote
 from truss.remote import remote_cli, remote_factory
+from truss.truss_handle import TrussHandle
 
 BASETEN_API_SECRET_NAME = "baseten_chain_api_key"
 SECRET_DUMMY = "***"
@@ -554,6 +555,19 @@ class ChainletAPIDescriptor(SafeModelNonSerializable):
     @property
     def display_name(self) -> str:
         return self.chainlet_cls.display_name
+
+
+class ChainletArtifact(SafeModel):
+    path: pathlib.Path
+    is_entrypoint: bool
+    descriptor: ChainletAPIDescriptor
+
+
+class ChainletPushPayload(SafeModel):
+    truss_handle: TrussHandle
+    is_entrypoint: bool
+    model_name: str
+    name: str
 
 
 class StackFrame(SafeModel):

--- a/truss-chains/truss_chains/definitions.py
+++ b/truss-chains/truss_chains/definitions.py
@@ -425,7 +425,6 @@ class DeploymentContext(SafeModelNonSerializable):
     Args:
         data_dir: The directory where the chainlet can store and access data,
           e.g. for downloading model weights.
-        user_config: User-defined configuration for the chainlet.
         chainlet_to_service: A mapping from chainlet names to service descriptors.
           This is used create RPCs sessions to dependency chainlets. It contains only
           the chainlet services that are dependencies of the current chainlet.
@@ -437,7 +436,6 @@ class DeploymentContext(SafeModelNonSerializable):
     """
 
     data_dir: Optional[pathlib.Path] = None
-    user_config: UserConfigT
     chainlet_to_service: Mapping[str, DeployedServiceDescriptor]
     secrets: MappingNoIter[str, str]
     environment: Optional[Environment] = None

--- a/truss-chains/truss_chains/definitions.py
+++ b/truss-chains/truss_chains/definitions.py
@@ -560,12 +560,6 @@ class ChainletAPIDescriptor(SafeModelNonSerializable):
         return self.chainlet_cls.display_name
 
 
-class ChainletArtifact(SafeModel):
-    truss_dir: pathlib.Path
-    is_entrypoint: bool
-    descriptor: ChainletAPIDescriptor
-
-
 class StackFrame(SafeModel):
     filename: str
     lineno: Optional[int]

--- a/truss-chains/truss_chains/framework.py
+++ b/truss-chains/truss_chains/framework.py
@@ -841,7 +841,6 @@ def _create_modified_init_for_local(
     secrets: Mapping[str, str],
     data_dir: Optional[pathlib.Path],
     chainlet_to_service: Mapping[str, definitions.DeployedServiceDescriptor],
-    user_env: Mapping[str, str],
 ):
     """Replaces the default argument values with local Chainlet instantiations.
 
@@ -1013,7 +1012,6 @@ def run_local(
     secrets: Mapping[str, str],
     data_dir: Optional[pathlib.Path],
     chainlet_to_service: Mapping[str, definitions.DeployedServiceDescriptor],
-    user_env: Mapping[str, str],
 ) -> Any:
     """Context to run Chainlets with dependency injection from local instances."""
     # TODO: support retries in local mode.

--- a/truss-chains/truss_chains/framework.py
+++ b/truss-chains/truss_chains/framework.py
@@ -840,7 +840,8 @@ def _create_modified_init_for_local(
     ],
     secrets: Mapping[str, str],
     data_dir: Optional[pathlib.Path],
-    chainlet_to_service: Mapping[str, definitions.ServiceDescriptor],
+    chainlet_to_service: Mapping[str, definitions.DeployedServiceDescriptor],
+    user_env: Mapping[str, str],
 ):
     """Replaces the default argument values with local Chainlet instantiations.
 
@@ -1011,7 +1012,8 @@ def _create_modified_init_for_local(
 def run_local(
     secrets: Mapping[str, str],
     data_dir: Optional[pathlib.Path],
-    chainlet_to_service: Mapping[str, definitions.ServiceDescriptor],
+    chainlet_to_service: Mapping[str, definitions.DeployedServiceDescriptor],
+    user_env: Mapping[str, str],
 ) -> Any:
     """Context to run Chainlets with dependency injection from local instances."""
     # TODO: support retries in local mode.

--- a/truss-chains/truss_chains/model_skeleton.py
+++ b/truss-chains/truss_chains/model_skeleton.py
@@ -4,7 +4,7 @@ from typing import Optional
 from truss.templates.shared import secrets_resolver
 
 from truss_chains import definitions
-from truss_chains.utils import override_chainlet_to_service_metadata
+from truss_chains.utils import populate_chainlet_service_predict_urls
 
 
 class TrussChainletModel:
@@ -28,7 +28,7 @@ class TrussChainletModel:
         deployment_environment: Optional[definitions.Environment] = (
             definitions.Environment.model_validate(environment) if environment else None
         )
-        chainlet_to_deployed_service = override_chainlet_to_service_metadata(
+        chainlet_to_deployed_service = populate_chainlet_service_predict_urls(
             truss_metadata.chainlet_to_service
         )
 

--- a/truss-chains/truss_chains/model_skeleton.py
+++ b/truss-chains/truss_chains/model_skeleton.py
@@ -28,10 +28,13 @@ class TrussChainletModel:
         deployment_environment: Optional[definitions.Environment] = (
             definitions.Environment.model_validate(environment) if environment else None
         )
-        override_chainlet_to_service_metadata(truss_metadata.chainlet_to_service)
+        chainlet_to_deployed_service = override_chainlet_to_service_metadata(
+            truss_metadata.chainlet_to_service
+        )
 
-        self._context = definitions.DeploymentContext(
-            chainlet_to_service=truss_metadata.chainlet_to_service,
+        self._context = definitions.DeploymentContext[UserConfigT](
+            user_config=truss_metadata.user_config,
+            chainlet_to_service=chainlet_to_deployed_service,
             secrets=secrets,
             data_dir=data_dir,
             environment=deployment_environment,

--- a/truss-chains/truss_chains/model_skeleton.py
+++ b/truss-chains/truss_chains/model_skeleton.py
@@ -32,8 +32,7 @@ class TrussChainletModel:
             truss_metadata.chainlet_to_service
         )
 
-        self._context = definitions.DeploymentContext[UserConfigT](
-            user_config=truss_metadata.user_config,
+        self._context = definitions.DeploymentContext(
             chainlet_to_service=chainlet_to_deployed_service,
             secrets=secrets,
             data_dir=data_dir,

--- a/truss-chains/truss_chains/public_api.py
+++ b/truss-chains/truss_chains/public_api.py
@@ -162,7 +162,10 @@ def push(
 def run_local(
     secrets: Optional[Mapping[str, str]] = None,
     data_dir: Optional[Union[pathlib.Path, str]] = None,
-    chainlet_to_service: Optional[Mapping[str, definitions.ServiceDescriptor]] = None,
+    chainlet_to_service: Optional[
+        Mapping[str, definitions.DeployedServiceDescriptor]
+    ] = None,
+    user_env: Optional[Mapping[str, str]] = None,
 ) -> ContextManager[None]:
     """Context manager local debug execution of a chain.
 
@@ -188,7 +191,7 @@ def run_local(
             with chains.run_local(
                 secrets={"some_token": os.environ["SOME_TOKEN"]},
                 chainlet_to_service={
-                    "SomeChainlet": chains.ServiceDescriptor(
+                    "SomeChainlet": chains.DeployedServiceDescriptor(
                         name="SomeChainlet",
                         predict_url="https://...",
                         options=chains.RPCOptions(),

--- a/truss-chains/truss_chains/public_api.py
+++ b/truss-chains/truss_chains/public_api.py
@@ -165,7 +165,6 @@ def run_local(
     chainlet_to_service: Optional[
         Mapping[str, definitions.DeployedServiceDescriptor]
     ] = None,
-    user_env: Optional[Mapping[str, str]] = None,
 ) -> ContextManager[None]:
     """Context manager local debug execution of a chain.
 

--- a/truss-chains/truss_chains/remote.py
+++ b/truss-chains/truss_chains/remote.py
@@ -380,17 +380,20 @@ def push(
             port = utils.get_free_port()
             chainlet_to_port[chainlet_artifact.name] = port
 
-            # http://localhost:{port} seems to only work *sometimes* with docker.
-            predict_url = f"http://host.docker.internal:{port}"
+            service = DockerTrussService(
+                # http://localhost:{port} seems to only work *sometimes* with docker.
+                f"http://host.docker.internal:{port}",
+                is_draft=True,
+            )
 
             chainlet_to_predict_url[chainlet_artifact.name] = {
-                "predict_url": predict_url,
+                "predict_url": service.predict_url,
             }
 
             if chainlet_artifact.is_entrypoint:
                 assert entrypoint_service is None
 
-                entrypoint_service = DockerTrussService(predict_url, is_draft=True)
+                entrypoint_service = service
 
         assert entrypoint_service is not None
 

--- a/truss-chains/truss_chains/remote.py
+++ b/truss-chains/truss_chains/remote.py
@@ -337,7 +337,7 @@ class _ChainSourceGenerator:
             model_name = f"{model_base_name}-{model_suffix}"
 
             logging.info(
-                f"Generating truss chainlet model for `{chainlet_descriptor.name}`."
+                f"Generating Truss Chainlet model for '{chainlet_descriptor.name}'."
             )
 
             chainlet_dir = code_gen.gen_truss_chainlet(

--- a/truss-chains/truss_chains/remote.py
+++ b/truss-chains/truss_chains/remote.py
@@ -301,7 +301,7 @@ def _create_chains_secret_if_missing(remote_provider: b10_remote.BasetenRemote) 
         )
 
 
-class _Generator:
+class _ChainSourceGenerator:
     def __init__(
         self,
         options: definitions.PushOptions,
@@ -358,7 +358,9 @@ def push(
     non_entrypoint_root_dir: Optional[str] = None,
     gen_root: pathlib.Path = pathlib.Path(tempfile.gettempdir()),
 ) -> Optional[ChainService]:
-    chainlet_artifacts = _Generator(options, gen_root).generate_chainlet_artifacts(
+    chainlet_artifacts = _ChainSourceGenerator(
+        options, gen_root
+    ).generate_chainlet_artifacts(
         entrypoint,
         non_entrypoint_root_dir,
     )
@@ -368,7 +370,6 @@ def push(
 
     if isinstance(options, definitions.PushOptionsBaseten):
         _create_chains_secret_if_missing(options.remote_provider)
-
         return _create_baseten_chain(options, chainlet_artifacts)
     elif isinstance(options, definitions.PushOptionsLocalDocker):
         entrypoint_service: Optional[DockerTrussService] = None

--- a/truss-chains/truss_chains/remote.py
+++ b/truss-chains/truss_chains/remote.py
@@ -27,7 +27,7 @@ import watchfiles
 
 if TYPE_CHECKING:
     from rich import console as rich_console
-from truss import validation
+from truss.base import validation
 from truss.local import local_config_handler
 from truss.remote import remote_cli, remote_factory
 from truss.remote.baseten import core as b10_core

--- a/truss-chains/truss_chains/remote.py
+++ b/truss-chains/truss_chains/remote.py
@@ -22,7 +22,6 @@ from typing import (
 )
 
 import tenacity
-import truss
 import watchfiles
 
 if TYPE_CHECKING:
@@ -33,6 +32,7 @@ from truss.remote.baseten import core as b10_core
 from truss.remote.baseten import custom_types as b10_types
 from truss.remote.baseten import remote as b10_remote
 from truss.remote.baseten import service as b10_service
+from truss.truss_handle import build as truss_build
 from truss.util import log_utils
 from truss.util import path as truss_path
 
@@ -80,7 +80,7 @@ def _push_service_docker(
 ) -> None:
     logging.info(f"Running in docker container `{chainlet_display_name}` ")
 
-    truss_handle = truss.load(str(truss_dir))
+    truss_handle = truss_build.load(str(truss_dir))
 
     truss_handle.add_secret(
         definitions.BASETEN_API_SECRET_NAME, options.baseten_chain_api_key

--- a/truss-chains/truss_chains/stub.py
+++ b/truss-chains/truss_chains/stub.py
@@ -43,13 +43,13 @@ class BasetenSession:
         max_keepalive_connections=DEFAULT_MAX_KEEPALIVE_CONNECTIONS,
     )
     _auth_header: Mapping[str, str]
-    _service_descriptor: definitions.ServiceDescriptor
+    _service_descriptor: definitions.DeployedServiceDescriptor
     _cached_sync_client: Optional[tuple[httpx.Client, int]]
     _cached_async_client: Optional[tuple[aiohttp.ClientSession, int]]
 
     def __init__(
         self,
-        service_descriptor: definitions.ServiceDescriptor,
+        service_descriptor: definitions.DeployedServiceDescriptor,
         api_key: str,
     ) -> None:
         logging.info(
@@ -220,7 +220,9 @@ class StubBase(abc.ABC):
 
     @final
     def __init__(
-        self, service_descriptor: definitions.ServiceDescriptor, api_key: str
+        self,
+        service_descriptor: definitions.DeployedServiceDescriptor,
+        api_key: str,
     ) -> None:
         """
         Args:
@@ -245,7 +247,7 @@ class StubBase(abc.ABC):
         """
         options = options or definitions.RPCOptions()
         return cls(
-            definitions.ServiceDescriptor(
+            service_descriptor=definitions.DeployedServiceDescriptor(
                 name=cls.__name__, predict_url=predict_url, options=options
             ),
             api_key=context.get_baseten_api_key(),

--- a/truss-chains/truss_chains/utils.py
+++ b/truss-chains/truss_chains/utils.py
@@ -131,6 +131,9 @@ def get_free_port() -> int:
         return port
 
 
+# NOTE(dynamic-chainlet-config): Predict URLs
+# for services that belong to a Chainlet are
+# auto-populated through dynamic config.
 def override_chainlet_to_service_metadata(
     chainlet_to_service: Mapping[str, definitions.ServiceDescriptor],
 ):

--- a/truss-chains/truss_chains/utils.py
+++ b/truss-chains/truss_chains/utils.py
@@ -141,15 +141,11 @@ def get_free_port() -> int:
         return port
 
 
-# NOTE(dynamic-chainlet-config): Predict URLs
-# for services that belong to a Chainlet are
-# auto-populated through dynamic config.
-def override_chainlet_to_service_metadata(
+def populate_chainlet_service_predict_urls(
     chainlet_to_service: Mapping[str, definitions.ServiceDescriptor],
 ) -> Mapping[str, definitions.DeployedServiceDescriptor]:
     chainlet_to_deployed_service: Dict[str, definitions.DeployedServiceDescriptor] = {}
 
-    # Override predict_urls in chainlet_to_service ServiceDescriptors if dynamic_chainlet_config exists
     dynamic_chainlet_config_str = dynamic_config_resolver.get_dynamic_config_value_sync(
         definitions.DYNAMIC_CHAINLET_CONFIG_KEY
     )
@@ -174,7 +170,9 @@ def override_chainlet_to_service_metadata(
             definitions.DeployedServiceDescriptor(
                 name=service_descriptor.name,
                 options=service_descriptor.options,
-                # We update the predict_url to be the one pulled from the dynamic_chainlet_config
+                # NOTE(dynamic-chainlet-config): Predict URLs
+                # for services that belong to a Chainlet are
+                # auto-populated through dynamic config.
                 predict_url=dynamic_chainlet_config[chainlet_name]["predict_url"],
             )
         )

--- a/truss-chains/truss_chains/utils.py
+++ b/truss-chains/truss_chains/utils.py
@@ -151,7 +151,7 @@ def populate_chainlet_service_predict_urls(
     )
 
     if not dynamic_chainlet_config_str:
-        raise RuntimeError(
+        raise definitions.MissingDependencyError(
             f"No '{definitions.DYNAMIC_CHAINLET_CONFIG_KEY}' found. Cannot override Chainlet configs."
         )
 
@@ -162,7 +162,7 @@ def populate_chainlet_service_predict_urls(
         service_descriptor,
     ) in chainlet_to_service.items():
         if chainlet_name not in dynamic_chainlet_config:
-            raise RuntimeError(
+            raise definitions.MissingDependencyError(
                 f"Chainlet '{chainlet_name}' not found in '{definitions.DYNAMIC_CHAINLET_CONFIG_KEY}'."
             )
 
@@ -170,9 +170,6 @@ def populate_chainlet_service_predict_urls(
             definitions.DeployedServiceDescriptor(
                 name=service_descriptor.name,
                 options=service_descriptor.options,
-                # NOTE(dynamic-chainlet-config): Predict URLs
-                # for services that belong to a Chainlet are
-                # auto-populated through dynamic config.
                 predict_url=dynamic_chainlet_config[chainlet_name]["predict_url"],
             )
         )

--- a/truss/base/validation.py
+++ b/truss/base/validation.py
@@ -24,6 +24,12 @@ MEMORY_UNITS: Dict[str, int] = {
     "Ei": 1024**6,
 }
 
+_MODEL_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]+-[0-9a-f]{8}$")
+
+
+def is_valid_model_name(model_name: str) -> bool:
+    return bool(_MODEL_NAME_RE.match(model_name))
+
 
 def validate_secret_to_path_mapping(secret_to_path_mapping: Dict[str, str]) -> None:
     if not isinstance(secret_to_path_mapping, dict):

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -29,7 +29,7 @@ def _oracle_data_to_graphql_mutation(oracle: b10_types.OracleData) -> str:
         f'model_name: "{oracle.model_name}"',
         f's3_key: "{oracle.s3_key}"',
         f'encoded_config_str: "{oracle.encoded_config_str}"',
-        f'is_trusted: "{str(oracle.is_trusted).lower()}"',
+        f"is_trusted: {str(oracle.is_trusted).lower()}",
     ]
 
     if oracle.semver_bump:

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -224,7 +224,6 @@ class BasetenApi:
         chain_name: Optional[str] = None,
         environment: Optional[str] = None,
         is_draft: bool = False,
-        promote_after_deploy: bool = False,
     ):
         entrypoint_str = _chainlet_data_atomic_to_graphql_mutation(entrypoint)
 
@@ -244,7 +243,6 @@ class BasetenApi:
                     is_draft: {str(is_draft).lower()}
                     entrypoint: {entrypoint_str}
                     dependencies: [{dependencies_str}]
-                    promote_after_deploy: {str(promote_after_deploy).lower()}
                     client_version: "truss=={truss.version()}"
                 ) {{
                     chain_id

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -48,7 +48,6 @@ def _chainlet_data_atomic_to_graphql_mutation(
 
     args = [
         f'name: "{chainlet.name}"',
-        f"is_entrypoint: {str(chainlet.is_entrypoint).lower()}",
         f"oracle: {oracle_data_string}",
     ]
 

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -35,26 +35,17 @@ def _chainlet_data_to_graphql_mutation(chainlet: b10_types.ChainletData):
 
 def _oracle_data_to_graphql_mutation(oracle: b10_types.OracleData):
     args = [
-        f'name: "{oracle.name}"',
+        f'model_name: "{oracle.model_name}"',
         f's3_key: "{oracle.s3_key}"',
-        f'config: "{oracle.config}"',
+        f'encoded_config_str: "{oracle.encoded_config_str}"',
         f'is_trusted: "{str(oracle.is_trusted).lower()}"',
     ]
 
     if oracle.semver_bump:
         args.append(f'semver_bump: "{oracle.semver_bump}"')
 
-    if oracle.client_version:
-        args.append(f'client_version: "{oracle.client_version}"')
-
-    if oracle.deployment_name:
-        args.append(f'version_name: "{oracle.deployment_name}"')
-
-    if oracle.origin:
-        args.append(f'model_origin: "{oracle.origin.value}"')
-
-    if oracle.environment:
-        args.append(f'environment_name: "{oracle.environment}"')
+    if oracle.version_name:
+        args.append(f'version_name: "{oracle.version_name}"')
 
     return f"""{{ {", ".join(args)} }}"""
 

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -38,7 +38,11 @@ def _oracle_data_to_graphql_mutation(oracle: b10_types.OracleData) -> str:
     if oracle.version_name:
         args.append(f'version_name: "{oracle.version_name}"')
 
-    return f"""{{ {", ".join(args)} }}"""
+    args_str = ",\n".join(args)
+
+    return f"""{{
+        {args_str}
+    }}"""
 
 
 def _chainlet_data_atomic_to_graphql_mutation(
@@ -51,7 +55,11 @@ def _chainlet_data_atomic_to_graphql_mutation(
         f"oracle: {oracle_data_string}",
     ]
 
-    return f"""{{ {", ".join(args)} }}"""
+    args_str = ",\n".join(args)
+
+    return f"""{{
+        {args_str}
+    }}"""
 
 
 class BasetenApi:

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -38,12 +38,14 @@ def _oracle_data_to_graphql_mutation(oracle: b10_types.OracleData):
         f'name: "{oracle.name}"',
         f's3_key: "{oracle.s3_key}"',
         f'config: "{oracle.config}"',
-        f'client_version: "{oracle.client_version}"',
         f'is_trusted: "{str(oracle.is_trusted).lower()}"',
     ]
 
     if oracle.semver_bump:
         args.append(f'semver_bump: "{oracle.semver_bump}"')
+
+    if oracle.client_version:
+        args.append(f'client_version: "{oracle.client_version}"')
 
     if oracle.deployment_name:
         args.append(f'version_name: "{oracle.deployment_name}"')

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -24,7 +24,7 @@ API_URL_MAPPING = {
 DEFAULT_API_DOMAIN = "https://api.baseten.co"
 
 
-def _oracle_data_to_graphql_mutation(oracle: b10_types.OracleData):
+def _oracle_data_to_graphql_mutation(oracle: b10_types.OracleData) -> str:
     args = [
         f'model_name: "{oracle.model_name}"',
         f's3_key: "{oracle.s3_key}"',
@@ -41,7 +41,9 @@ def _oracle_data_to_graphql_mutation(oracle: b10_types.OracleData):
     return f"""{{ {", ".join(args)} }}"""
 
 
-def _chainlet_data_atomic_to_graphql_mutation(chainlet: b10_types.ChainletDataAtomic):
+def _chainlet_data_atomic_to_graphql_mutation(
+    chainlet: b10_types.ChainletDataAtomic,
+) -> str:
     oracle_data_string = _oracle_data_to_graphql_mutation(chainlet.oracle)
 
     args = [

--- a/truss/remote/baseten/core.py
+++ b/truss/remote/baseten/core.py
@@ -102,7 +102,7 @@ def create_chain_atomic(
     chainlets: List[b10_types.ChainletDataAtomic],
     is_draft: bool,
     environment: Optional[str],
-):
+) -> ChainDeploymentHandleAtomic:
     entrypoints: List[b10_types.ChainletDataAtomic] = []
     dependencies: List[b10_types.ChainletDataAtomic] = []
 

--- a/truss/remote/baseten/core.py
+++ b/truss/remote/baseten/core.py
@@ -98,7 +98,8 @@ def get_dev_chain_deployment(api: BasetenApi, chain_id: str):
 def create_chain_atomic(
     api: BasetenApi,
     chain_name: str,
-    chainlets: List[b10_types.ChainletDataAtomic],
+    entrypoint: b10_types.ChainletDataAtomic,
+    dependencies: List[b10_types.ChainletDataAtomic],
     is_draft: bool,
     environment: Optional[str],
 ) -> ChainDeploymentHandleAtomic:
@@ -110,16 +111,10 @@ def create_chain_atomic(
 
     chain_id = get_chain_id_by_name(api, chain_name)
 
-    entrypoints: List[b10_types.ChainletDataAtomic] = []
-    dependencies: List[b10_types.ChainletDataAtomic] = []
-
-    for chainlet in chainlets:
-        (dependencies, entrypoints)[chainlet.is_entrypoint].append(chainlet)
-
-    assert len(entrypoints) == 1
-
-    entrypoint = entrypoints[0]
-
+    # TODO(Tyron): Refactor for better readability:
+    # 1. Prepare all arguments for `deploy_chain_atomic`.
+    # 2. Validate argument combinations.
+    # 3. Make a single invocation to `deploy_chain_atomic`.
     if is_draft:
         res = api.deploy_chain_atomic(
             chain_name=chain_name,

--- a/truss/remote/baseten/core.py
+++ b/truss/remote/baseten/core.py
@@ -97,12 +97,19 @@ def get_dev_chain_deployment(api: BasetenApi, chain_id: str):
 
 def create_chain_atomic(
     api: BasetenApi,
-    chain_id: Optional[str],
     chain_name: str,
     chainlets: List[b10_types.ChainletDataAtomic],
     is_draft: bool,
     environment: Optional[str],
 ) -> ChainDeploymentHandleAtomic:
+    if environment and is_draft:
+        logging.info(
+            f"Automatically publishing Chain '{chain_name}' based on environment setting."
+        )
+        is_draft = False
+
+    chain_id = get_chain_id_by_name(api, chain_name)
+
     entrypoints: List[b10_types.ChainletDataAtomic] = []
     dependencies: List[b10_types.ChainletDataAtomic] = []
 

--- a/truss/remote/baseten/custom_types.py
+++ b/truss/remote/baseten/custom_types.py
@@ -17,7 +17,6 @@ class DeployedChainlet(pydantic.BaseModel):
 
 class ChainletArtifact(pydantic.BaseModel):
     truss_dir: pathlib.Path
-    is_entrypoint: bool
     display_name: str
     name: str
 
@@ -36,7 +35,7 @@ class OracleData(pydantic.BaseModel):
     version_name: Optional[str] = None
 
 
+# This corresponds to `ChainletInputAtomicGraphene` in the backend.
 class ChainletDataAtomic(pydantic.BaseModel):
     name: str
-    is_entrypoint: bool
     oracle: OracleData

--- a/truss/remote/baseten/custom_types.py
+++ b/truss/remote/baseten/custom_types.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Optional
 
 import pydantic
 
@@ -22,3 +23,21 @@ class ChainletData(pydantic.BaseModel):
 class ModelOrigin(Enum):
     BASETEN = "BASETEN"
     CHAINS = "CHAINS"
+
+
+class OracleData(pydantic.BaseModel):
+    name: str
+    s3_key: str
+    config: str
+    semver_bump: Optional[str] = "MINOR"
+    client_version: str
+    is_trusted: bool
+    deployment_name: Optional[str] = None
+    origin: Optional[ModelOrigin] = None
+    environment: Optional[str] = None
+
+
+class ChainletDataAtomic(pydantic.BaseModel):
+    name: str
+    is_entrypoint: bool
+    oracle: OracleData

--- a/truss/remote/baseten/custom_types.py
+++ b/truss/remote/baseten/custom_types.py
@@ -15,12 +15,6 @@ class DeployedChainlet(pydantic.BaseModel):
     oracle_name: str
 
 
-class ChainletData(pydantic.BaseModel):
-    name: str
-    oracle_version_id: str
-    is_entrypoint: bool
-
-
 class ChainletArtifact(pydantic.BaseModel):
     truss_dir: pathlib.Path
     is_entrypoint: bool

--- a/truss/remote/baseten/custom_types.py
+++ b/truss/remote/baseten/custom_types.py
@@ -1,3 +1,4 @@
+import pathlib
 from enum import Enum
 from typing import Optional
 
@@ -20,21 +21,25 @@ class ChainletData(pydantic.BaseModel):
     is_entrypoint: bool
 
 
+class ChainletArtifact(pydantic.BaseModel):
+    truss_dir: pathlib.Path
+    is_entrypoint: bool
+    display_name: str
+    name: str
+
+
 class ModelOrigin(Enum):
     BASETEN = "BASETEN"
     CHAINS = "CHAINS"
 
 
 class OracleData(pydantic.BaseModel):
-    name: str
+    model_name: str
     s3_key: str
-    config: str
+    encoded_config_str: str
     semver_bump: Optional[str] = "MINOR"
-    client_version: Optional[str]
     is_trusted: bool
-    deployment_name: Optional[str] = None
-    origin: Optional[ModelOrigin] = None
-    environment: Optional[str] = None
+    version_name: Optional[str] = None
 
 
 class ChainletDataAtomic(pydantic.BaseModel):

--- a/truss/remote/baseten/custom_types.py
+++ b/truss/remote/baseten/custom_types.py
@@ -30,7 +30,7 @@ class OracleData(pydantic.BaseModel):
     s3_key: str
     config: str
     semver_bump: Optional[str] = "MINOR"
-    client_version: str
+    client_version: Optional[str]
     is_trusted: bool
     deployment_name: Optional[str] = None
     origin: Optional[ModelOrigin] = None

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -62,6 +62,7 @@ class FinalPushData(custom_types.OracleData):
     preserve_previous_prod_deployment: bool
     origin: Optional[custom_types.ModelOrigin] = None
     environment: Optional[str] = None
+    allow_truss_download: bool
 
 
 class BasetenRemote(TrussRemote):
@@ -221,6 +222,7 @@ class BasetenRemote(TrussRemote):
         trusted: bool = False,
         promote: bool = False,
         preserve_previous_prod_deployment: bool = False,
+        disable_truss_download: bool = False,
         deployment_name: Optional[str] = None,
         origin: Optional[custom_types.ModelOrigin] = None,
         environment: Optional[str] = None,
@@ -235,6 +237,7 @@ class BasetenRemote(TrussRemote):
             trusted=trusted,
             promote=promote,
             preserve_previous_prod_deployment=preserve_previous_prod_deployment,
+            disable_truss_download=disable_truss_download,
             deployment_name=deployment_name,
             origin=origin,
             environment=environment,
@@ -249,6 +252,7 @@ class BasetenRemote(TrussRemote):
             model_id=push_data.model_id,
             is_trusted=push_data.is_trusted,
             preserve_previous_prod_deployment=push_data.preserve_previous_prod_deployment,
+            allow_truss_download=push_data.allow_truss_download,
             deployment_name=push_data.version_name,
             origin=push_data.origin,
             environment=push_data.environment,

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -18,6 +18,7 @@ from truss.remote.baseten import custom_types
 from truss.remote.baseten.api import BasetenApi
 from truss.remote.baseten.auth import AuthService
 from truss.remote.baseten.core import (
+    ChainDeploymentHandleAtomic,
     ModelId,
     ModelIdentifier,
     ModelName,
@@ -247,7 +248,7 @@ class BasetenRemote(TrussRemote):
         chainlet_artifacts: List[custom_types.ChainletArtifact],
         publish: bool = False,
         environment: Optional[str] = None,
-    ):
+    ) -> Tuple[ChainDeploymentHandleAtomic, BasetenService]:
         # If we are promoting a model to an environment after deploy, it must be published.
         # Draft models cannot be promoted.
         if environment and not publish:

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -290,7 +290,7 @@ class BasetenRemote(TrussRemote):
                 )
             )
             logging.info(
-                f"Pushing chainlet `{model_name}` as a truss model on Baseten (publish={publish})"
+                f"Pushing Chainlet '{model_name}' as a Truss model on Baseten (publish={publish})."
             )
 
         chain_deployment_handle = create_chain_atomic(
@@ -308,7 +308,7 @@ class BasetenRemote(TrussRemote):
         entrypoint_service = BasetenService(
             model_id=model_id,
             model_version_id=model_version_id,
-            is_draft=push_data.is_draft,
+            is_draft=not publish,
             api_key=self._auth_service.authenticate().value,
             service_url=f"{self._remote_url}/model_versions/{model_version_id}",
             truss_handle=truss_build.load(str(entrypoint_artifact.truss_dir)),

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -18,13 +18,11 @@ from truss.remote.baseten import custom_types
 from truss.remote.baseten.api import BasetenApi
 from truss.remote.baseten.auth import AuthService
 from truss.remote.baseten.core import (
-    ChainDeploymentHandle,
     ModelId,
     ModelIdentifier,
     ModelName,
     ModelVersionId,
     archive_truss,
-    create_chain,
     create_chain_atomic,
     create_truss_service,
     exists_model,
@@ -74,28 +72,6 @@ class BasetenRemote(TrussRemote):
     @property
     def api(self) -> BasetenApi:
         return self._api
-
-    def create_chain(
-        self,
-        chain_name: str,
-        chainlets: List[custom_types.ChainletData],
-        publish: bool = False,
-        environment: Optional[str] = None,
-    ) -> ChainDeploymentHandle:
-        if environment:
-            # If we are promoting a model to an environment after deploy, it must be published.
-            # Draft models cannot be promoted.
-            publish = True
-        # Returns tuple of (chain_id, chain_deployment_id)
-        chain_id = get_chain_id_by_name(self._api, chain_name)
-        return create_chain(
-            self._api,
-            chain_id=chain_id,
-            chain_name=chain_name,
-            chainlets=chainlets,
-            is_draft=not publish,
-            environment=environment,
-        )
 
     def get_chainlets(
         self, chain_deployment_id: str
@@ -226,9 +202,6 @@ class BasetenRemote(TrussRemote):
         deployment_name: Optional[str] = None,
         origin: Optional[custom_types.ModelOrigin] = None,
         environment: Optional[str] = None,
-        chain_environment: Optional[str] = None,
-        chainlet_name: Optional[str] = None,
-        chain_name: Optional[str] = None,
     ) -> BasetenService:
         push_data = self._prepare_push(
             truss_handle=truss_handle,
@@ -256,9 +229,6 @@ class BasetenRemote(TrussRemote):
             deployment_name=push_data.version_name,
             origin=push_data.origin,
             environment=push_data.environment,
-            chain_environment=chain_environment,
-            chainlet_name=chainlet_name,
-            chain_name=chain_name,
         )
 
         return BasetenService(

--- a/truss/tests/remote/baseten/test_api.py
+++ b/truss/tests/remote/baseten/test_api.py
@@ -286,7 +286,6 @@ def test_deploy_chain_deployment(mock_post, baseten_api):
         dependencies=[],
         entrypoint=ChainletDataAtomic(
             name="chainlet-1",
-            is_entrypoint=True,
             oracle=OracleData(
                 model_name="model-1",
                 s3_key="s3-key-1",
@@ -311,7 +310,6 @@ def test_deploy_chain_deployment_no_environment(mock_post, baseten_api):
         dependencies=[],
         entrypoint=ChainletDataAtomic(
             name="chainlet-1",
-            is_entrypoint=True,
             oracle=OracleData(
                 model_name="model-1",
                 s3_key="s3-key-1",

--- a/truss/tests/remote/baseten/test_api.py
+++ b/truss/tests/remote/baseten/test_api.py
@@ -209,34 +209,6 @@ def test_create_model_from_truss(mock_post, baseten_api):
 
 
 @mock.patch("requests.post", return_value=mock_create_model_response())
-def test_create_model_from_truss_forwards_chainlet_data(mock_post, baseten_api):
-    baseten_api.create_model_from_truss(
-        "model_name",
-        "s3key",
-        "config_str",
-        "semver_bump",
-        "client_version",
-        is_trusted=False,
-        deployment_name="deployment_name",
-        chain_environment="chainstaging",
-        chain_name="chainchain",
-        chainlet_name="chainlet-1",
-    )
-
-    gql_mutation = mock_post.call_args[1]["data"]["query"]
-    assert 'name: "model_name"' in gql_mutation
-    assert 's3_key: "s3key"' in gql_mutation
-    assert 'config: "config_str"' in gql_mutation
-    assert 'semver_bump: "semver_bump"' in gql_mutation
-    assert 'client_version: "client_version"' in gql_mutation
-    assert "is_trusted: false" in gql_mutation
-    assert 'version_name: "deployment_name"' in gql_mutation
-    assert 'chain_environment: "chainstaging"' in gql_mutation
-    assert 'chain_name: "chainchain"' in gql_mutation
-    assert 'chainlet_name: "chainlet-1"' in gql_mutation
-
-
-@mock.patch("requests.post", return_value=mock_create_model_response())
 def test_create_model_from_truss_does_not_send_deployment_name_if_not_specified(
     mock_post, baseten_api
 ):

--- a/truss/tests/remote/baseten/test_remote.py
+++ b/truss/tests/remote/baseten/test_remote.py
@@ -340,18 +340,16 @@ def test_create_chain_with_no_publish():
         deployment_handle = create_chain_atomic(
             api=remote.api,
             chain_name="draft_chain",
-            chainlets=[
-                ChainletDataAtomic(
-                    name="chainlet-1",
-                    is_entrypoint=True,
-                    oracle=OracleData(
-                        model_name="model-1",
-                        s3_key="s3-key-1",
-                        encoded_config_str="encoded-config-str-1",
-                        is_trusted=True,
-                    ),
-                )
-            ],
+            entrypoint=ChainletDataAtomic(
+                name="chainlet-1",
+                oracle=OracleData(
+                    model_name="model-1",
+                    s3_key="s3-key-1",
+                    encoded_config_str="encoded-config-str-1",
+                    is_trusted=True,
+                ),
+            ),
+            dependencies=[],
             is_draft=True,
             environment=None,
         )
@@ -438,18 +436,16 @@ def test_create_chain_no_existing_chain():
         deployment_handle = create_chain_atomic(
             api=remote.api,
             chain_name="new_chain",
-            chainlets=[
-                ChainletDataAtomic(
-                    name="chainlet-1",
-                    is_entrypoint=True,
-                    oracle=OracleData(
-                        model_name="model-1",
-                        s3_key="s3-key-1",
-                        encoded_config_str="encoded-config-str-1",
-                        is_trusted=True,
-                    ),
-                )
-            ],
+            entrypoint=ChainletDataAtomic(
+                name="chainlet-1",
+                oracle=OracleData(
+                    model_name="model-1",
+                    s3_key="s3-key-1",
+                    encoded_config_str="encoded-config-str-1",
+                    is_trusted=True,
+                ),
+            ),
+            dependencies=[],
             is_draft=False,
             environment=None,
         )
@@ -540,18 +536,16 @@ def test_create_chain_with_existing_chain_promote_to_environment_publish_false()
         deployment_handle = create_chain_atomic(
             api=remote.api,
             chain_name="old_chain",
-            chainlets=[
-                ChainletDataAtomic(
-                    name="chainlet-1",
-                    is_entrypoint=True,
-                    oracle=OracleData(
-                        model_name="model-1",
-                        s3_key="s3-key-1",
-                        encoded_config_str="encoded-config-str-1",
-                        is_trusted=True,
-                    ),
-                )
-            ],
+            entrypoint=ChainletDataAtomic(
+                name="chainlet-1",
+                oracle=OracleData(
+                    model_name="model-1",
+                    s3_key="s3-key-1",
+                    encoded_config_str="encoded-config-str-1",
+                    is_trusted=True,
+                ),
+            ),
+            dependencies=[],
             is_draft=True,
             environment="production",
         )
@@ -645,18 +639,16 @@ def test_create_chain_existing_chain_publish_true_no_promotion():
         deployment_handle = create_chain_atomic(
             api=remote.api,
             chain_name="old_chain",
-            chainlets=[
-                ChainletDataAtomic(
-                    name="chainlet-1",
-                    is_entrypoint=True,
-                    oracle=OracleData(
-                        model_name="model-1",
-                        s3_key="s3-key-1",
-                        encoded_config_str="encoded-config-str-1",
-                        is_trusted=True,
-                    ),
-                )
-            ],
+            entrypoint=ChainletDataAtomic(
+                name="chainlet-1",
+                oracle=OracleData(
+                    model_name="model-1",
+                    s3_key="s3-key-1",
+                    encoded_config_str="encoded-config-str-1",
+                    is_trusted=True,
+                ),
+            ),
+            dependencies=[],
             is_draft=False,
             environment=None,
         )


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What

- Refactor Truss Chains logic so that generating Truss files, uploading to S3, and creating Oracle and Chain objects are well-separated. This way, files can be uploaded to S3 in parallel and all DB objects can be created atomically in a single transaction.
- Better separation between deploying Chains locally using Docker and to Baseten remote.

<!--
  How was the change described above implemented?
-->
## :computer: How

- Assumes that Oracle Versions belonging to a Chainlet will automatically receive a predict URL (even if it wasn't previously specified in the Truss config) through dynamic configs.
- Refer to this [Notion doc](https://www.notion.so/ml-infra/Atomic-Chain-Creation-13091d24727380c3b289da7e9fddef36?pvs=4) for more information.

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing

- Updated unit tests.
- Manual test against staging which has changes from https://github.com/basetenlabs/baseten/pull/9701.