### PR TITLE
Ignore local aws config

### DIFF
--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -86,10 +86,6 @@ error_console = Console(stderr=True, style="bold red")
 
 is_humanfriendly_log_level = True
 
-# In the CLI flow, ignore any local ~/.aws/config files,
-# which can interfere with uploading the Truss to S3.
-os.environ["AWS_CONFIG_FILE"] = ""
-
 
 def error_handling(f: Callable[..., object]):
     @wraps(f)

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -86,6 +86,10 @@ error_console = Console(stderr=True, style="bold red")
 
 is_humanfriendly_log_level = True
 
+# In the CLI flow, ignore any local ~/.aws/config files,
+# which can interfere with uploading the Truss to S3.
+os.environ["AWS_CONFIG_FILE"] = ""
+
 
 def error_handling(f: Callable[..., object]):
     @wraps(f)

--- a/truss/remote/baseten/utils/transfer.py
+++ b/truss/remote/baseten/utils/transfer.py
@@ -5,6 +5,7 @@ import os
 import boto3
 from boto3.s3.transfer import TransferConfig
 from rich.progress import Progress
+from truss.util.env_vars import override_env_vars
 
 
 def base64_encoded_json_str(obj):
@@ -12,26 +13,29 @@ def base64_encoded_json_str(obj):
 
 
 def multipart_upload_boto3(file_path, bucket_name, key, credentials):
-    s3_resource = boto3.resource("s3", **credentials)
-    filesize = os.stat(file_path).st_size
+    # In the CLI flow, ignore any local ~/.aws/config files,
+    # which can interfere with uploading the Truss to S3.
+    with override_env_vars({"AWS_CONFIG_FILE": ""}):
+        s3_resource = boto3.resource("s3", **credentials)
+        filesize = os.stat(file_path).st_size
 
-    # Create a new progress bar
-    progress = Progress()
+        # Create a new progress bar
+        progress = Progress()
 
-    # Add a new task to the progress bar
-    task_id = progress.add_task("[cyan]Uploading...", total=filesize)
+        # Add a new task to the progress bar
+        task_id = progress.add_task("[cyan]Uploading...", total=filesize)
 
-    with progress:
+        with progress:
 
-        def callback(bytes_transferred):
-            # Update the progress bar
-            progress.update(task_id, advance=bytes_transferred)
+            def callback(bytes_transferred):
+                # Update the progress bar
+                progress.update(task_id, advance=bytes_transferred)
 
-        s3_resource.Object(bucket_name, key).upload_file(
-            file_path,
-            Config=TransferConfig(
-                max_concurrency=10,
-                use_threads=True,
-            ),
-            Callback=callback,
-        )
+            s3_resource.Object(bucket_name, key).upload_file(
+                file_path,
+                Config=TransferConfig(
+                    max_concurrency=10,
+                    use_threads=True,
+                ),
+                Callback=callback,
+            )

--- a/truss/remote/baseten/utils/transfer.py
+++ b/truss/remote/baseten/utils/transfer.py
@@ -6,8 +6,6 @@ import boto3
 from boto3.s3.transfer import TransferConfig
 from rich.progress import Progress
 
-os.environ["AWS_CONFIG_FILE"] = ""
-
 
 def base64_encoded_json_str(obj):
     return base64.b64encode(str.encode(json.dumps(obj))).decode("utf-8")

--- a/truss/remote/baseten/utils/transfer.py
+++ b/truss/remote/baseten/utils/transfer.py
@@ -6,6 +6,8 @@ import boto3
 from boto3.s3.transfer import TransferConfig
 from rich.progress import Progress
 
+os.environ["AWS_CONFIG_FILE"] = ""
+
 
 def base64_encoded_json_str(obj):
     return base64.b64encode(str.encode(json.dumps(obj))).decode("utf-8")

--- a/truss/tests/util/test_env_vars.py
+++ b/truss/tests/util/test_env_vars.py
@@ -1,0 +1,14 @@
+import os
+
+from truss.util.env_vars import override_env_vars
+
+
+def test_override_env_vars():
+    os.environ["API_KEY"] = "original_key"
+
+    with override_env_vars({"API_KEY": "new_key", "DEBUG": "true"}):
+        assert os.environ["API_KEY"] == "new_key"
+        assert os.environ["DEBUG"] == "true"
+
+    assert os.environ["API_KEY"] == "original_key"
+    assert "DEBUG" not in os.environ

--- a/truss/util/env_vars.py
+++ b/truss/util/env_vars.py
@@ -21,7 +21,8 @@ class override_env_vars:
         self.original_vars: Dict[str, Optional[str]] = {}
 
     def __enter__(self):
-        self.original_vars = dict(os.environ)
+        for key in self.env_vars:
+            self.original_vars[key] = os.environ.get(key)
 
         for key, value in self.env_vars.items():
             os.environ[key] = value

--- a/truss/util/env_vars.py
+++ b/truss/util/env_vars.py
@@ -21,8 +21,8 @@ class override_env_vars:
         self.original_vars: Dict[str, Optional[str]] = {}
 
     def __enter__(self):
-        for key in self.env_vars:
-            self.original_vars[key] = os.environ.get(key)
+        self.original_vars = dict(os.environ)
+
         for key, value in self.env_vars.items():
             os.environ[key] = value
 

--- a/truss/util/env_vars.py
+++ b/truss/util/env_vars.py
@@ -1,0 +1,40 @@
+import os
+from typing import Dict, Optional
+
+
+class override_env_vars:
+    """A context manager for temporarily overwriting environment variables.
+
+    Usage:
+        with override_env_vars({'API_KEY': 'test_key', 'DEBUG': 'true'}):
+            # Environment variables are modified here
+            ...
+        # Original environment is restored here
+    """
+
+    def __init__(self, env_vars: Dict[str, str]):
+        """
+        Args:
+            env_vars: Dictionary of environment variables to set
+        """
+        self.env_vars = env_vars
+        self.original_vars: Dict[str, Optional[str]] = {}
+
+    def __enter__(self):
+        for key in self.env_vars:
+            self.original_vars[key] = os.environ.get(key)
+        for key, value in self.env_vars.items():
+            os.environ[key] = value
+
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        # Restore original environment
+        for key, value in self.original_vars.items():
+            if value is None:
+                # Variable didn't exist originally
+                if key in os.environ:
+                    del os.environ[key]
+            else:
+                # Restore original value
+                os.environ[key] = value


### PR DESCRIPTION

## :rocket: What

Right now, if you have stuff in your ~/.aws/config file, boto3 tries to use this. To avoid this for the CLI actions, let's just ignore the fle in the CLI.

## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing

Add the following to an ~/.aws/config file:

```
[default]
s3 = 
  use_accelerate_endpoint = true
```

```
$ poetry run truss push --publish                                                                                                                                                                                                                                                                        -- INSERT --
Warning: your Truss has secrets but was not pushed with --trusted. Please push with --trusted to grant access to secrets.
Compressing... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Uploading... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
ERROR S3UploadFailedError: Failed to upload /tmp/tmpa37i1tn5.tgz to baseten-user-models-2971lo7k/organizations/P8LkRjP/models/2a1846c7-d329-423e-bf95-b488110f58ad/model.tgz: An error occurred (InvalidRequest) when calling the PutObject operation: S3 Transfer Acceleration is not configured on this bucket
```

and then try truss push. You'll see that it fails. With this change it does not fail
