### PR TITLE
requirements file handling respects comments

### DIFF
--- a/truss/patch/calc_patch.py
+++ b/truss/patch/calc_patch.py
@@ -72,7 +72,6 @@ def calc_truss_patch(
     )
 
     new_config = TrussConfig.from_yaml(truss_dir / CONFIG_FILE)
-    print(new_config)
     prev_config = TrussConfig.from_dict(yaml.safe_load(previous_truss_signature.config))
 
     truss_spec = TrussSpec(truss_dir)

--- a/truss/patch/calc_patch.py
+++ b/truss/patch/calc_patch.py
@@ -72,6 +72,7 @@ def calc_truss_patch(
     )
 
     new_config = TrussConfig.from_yaml(truss_dir / CONFIG_FILE)
+    print(new_config)
     prev_config = TrussConfig.from_dict(yaml.safe_load(previous_truss_signature.config))
 
     truss_spec = TrussSpec(truss_dir)

--- a/truss/patch/custom_types.py
+++ b/truss/patch/custom_types.py
@@ -26,10 +26,16 @@ class TrussSignature:
 
     @staticmethod
     def from_dict(d) -> "TrussSignature":
+        requirements_file_requirements = d.get("requirements_file_requirements", [])
+        filtered_requirements = []
+        for req in requirements_file_requirements:
+            stripped = req.strip()
+            if stripped and not stripped.startswith("#"):
+                filtered_requirements.append(req)
         return TrussSignature(
             content_hashes_by_path=d["content_hashes_by_path"],
             config=d["config"],
-            requirements_file_requirements=d.get("requirements_file_requirements", []),
+            requirements_file_requirements=filtered_requirements,
         )
 
 

--- a/truss/tests/patch/test_calc_patch.py
+++ b/truss/tests/patch/test_calc_patch.py
@@ -304,6 +304,46 @@ def test_calc_truss_patch_handles_requirements_file_name_change(
     ]
 
 
+def test_calc_truss_patch_handles_requirements_comments(
+    custom_model_truss_dir: Path,
+):
+    def pre_config_op(config: TrussConfig):
+        requirements_contents = """xformers\n#torch==2.0.1"""
+        filename = "./requirements.txt"
+        config.requirements_file = filename
+        with (custom_model_truss_dir / filename).open("w") as req_file:
+            req_file.write(requirements_contents)
+
+    def config_op(config: TrussConfig):
+        requirements_contents = """#xformers\ntorch==2.3.1\n"""
+        filename = "requirements.txt"
+        with (custom_model_truss_dir / filename).open("w") as req_file:
+            req_file.write(requirements_contents)
+
+    patches = _apply_config_change_and_calc_patches(
+        custom_model_truss_dir,
+        config_op=config_op,
+        config_pre_op=pre_config_op,
+    )
+    assert len(patches) == 2
+    assert patches == [
+        Patch(
+            type=PatchType.PYTHON_REQUIREMENT,
+            body=PythonRequirementPatch(
+                action=Action.REMOVE,
+                requirement="xformers",
+            ),
+        ),
+        Patch(
+            type=PatchType.PYTHON_REQUIREMENT,
+            body=PythonRequirementPatch(
+                action=Action.ADD,
+                requirement="torch==2.3.1",
+            ),
+        ),
+    ]
+
+
 def test_calc_truss_patch_handles_requirements_file_changes(
     custom_model_truss_dir: Path,
 ):
@@ -315,7 +355,7 @@ def test_calc_truss_patch_handles_requirements_file_changes(
             req_file.write(requirements_contents)
 
     def config_op(config: TrussConfig):
-        requirements_contents = """requests\ntorch==2.3.1"""
+        requirements_contents = """requests\ntorch==2.3.1\n"""
         filename = "requirements.txt"
         with (custom_model_truss_dir / filename).open("w") as req_file:
             req_file.write(requirements_contents)

--- a/truss/truss_config.py
+++ b/truss/truss_config.py
@@ -613,8 +613,14 @@ class TrussConfig:
         if self.requirements_file:
             requirements_path = truss_dir / self.requirements_file
             try:
+                requirement_lines = []
                 with open(requirements_path) as f:
-                    return [x for x in f.read().split("\n") if x]
+                    for line in f.readlines():
+                        stripped_line = line.strip()
+                        if stripped_line and not stripped_line.startswith("#"):
+                            print(f"appending line: {line.strip()}")
+                            requirement_lines.append(line.strip())
+                return requirement_lines
             except Exception as e:
                 logger.exception(
                     f"failed to read requirements file: {self.requirements_file}"


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
* Ensure that loading requirements from file respects comments
<!--
  How was the change described above implemented?
-->
## :computer: How
* upon load of the config, leave out lines that start with a `#`
* do this in a couple places to account for 
  * the truss signature (upon push) storing requirements with the `#`
  * loading the requirements from local file during truss watch
<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
