### PR TITLE
lazy data resolver changes to optimistically write engine build artifacts to cache volume when applicable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.50rc1"
+version = "0.9.50rc2"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.49rc201"
+version = "0.9.50rc0"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.50rc2"
+version = "0.9.50rc3"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.50rc0"
+version = "0.9.50rc1"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/templates/shared/lazy_data_resolver.py
+++ b/truss/templates/shared/lazy_data_resolver.py
@@ -9,7 +9,10 @@ import pydantic
 import requests
 import yaml
 
-from truss.templates.shared.util import BLOB_DOWNLOAD_TIMEOUT_SECS
+try:
+    from shared.util import BLOB_DOWNLOAD_TIMEOUT_SECS
+except ModuleNotFoundError:
+    from truss.templates.shared.util import BLOB_DOWNLOAD_TIMEOUT_SECS
 
 LAZY_DATA_RESOLVER_PATH = Path("/bptr/bptr-manifest")
 NUM_WORKERS = 4

--- a/truss/templates/shared/lazy_data_resolver.py
+++ b/truss/templates/shared/lazy_data_resolver.py
@@ -53,8 +53,8 @@ class LazyDataResolver:
         """Download object from URL, attempt to write to cache and symlink to data directory if applicable, data directory otherwise.
         In case of failure, write to data directory
         """
-        file_path = CACHE_DIR / hash
         if self._uses_b10_cache:
+            file_path = CACHE_DIR / hash
             if file_path.exists():
                 os.symlink(file_path, self._data_dir / file_name)
                 return
@@ -67,9 +67,10 @@ class LazyDataResolver:
             timeout=BLOB_DOWNLOAD_TIMEOUT_SECS,
         )
         resp.raise_for_status()
-        file_path.parent.mkdir(parents=True, exist_ok=True)
+
         if self._uses_b10_cache:
             try:
+                file_path.parent.mkdir(parents=True, exist_ok=True)
                 with file_path.open("wb") as file:
                     shutil.copyfileobj(resp.raw, file)
                 # symlink to data directory

--- a/truss/templates/shared/util.py
+++ b/truss/templates/shared/util.py
@@ -1,12 +1,9 @@
 import multiprocessing
 import os
-import shutil
 import sys
-from pathlib import Path
 from typing import List
 
 import psutil
-import requests
 
 BLOB_DOWNLOAD_TIMEOUT_SECS = 600  # 10 minutes
 # number of seconds to wait for truss server child processes before sending kill signal
@@ -78,17 +75,3 @@ def kill_child_processes(parent_pid: int):
     )
     for process in alive:
         process.kill()
-
-
-def download_from_url_using_requests(URL: str, download_to: Path):
-    # Streaming download to keep memory usage low
-    resp = requests.get(
-        URL,
-        allow_redirects=True,
-        stream=True,
-        timeout=BLOB_DOWNLOAD_TIMEOUT_SECS,
-    )
-    resp.raise_for_status()
-    download_to.parent.mkdir(parents=True, exist_ok=True)
-    with download_to.open("wb") as file:
-        shutil.copyfileobj(resp.raw, file)

--- a/truss/tests/templates/core/server/test_lazy_data_resolver.py
+++ b/truss/tests/templates/core/server/test_lazy_data_resolver.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import os
 from contextlib import nullcontext
 from pathlib import Path
 from typing import Callable
@@ -8,6 +9,7 @@ from unittest.mock import patch
 import pytest
 import requests_mock
 from truss.templates.shared.lazy_data_resolver import (
+    BASETEN_FS_ENABLED_ENV_VAR,
     LAZY_DATA_RESOLVER_PATH,
     LazyDataResolver,
 )
@@ -87,8 +89,8 @@ def test_lazy_data_resolution(
         with expectation:
             ldr = LazyDataResolver(Path("foo"))
             assert ldr._bptr_resolution == {
-                "foo-name": "https://foo-rl",
-                "bar-name": "https://bar-rl",
+                "foo-name": ("https://foo-rl", "foo-hash"),
+                "bar-name": ("https://bar-rl", "bar-hash"),
             }
 
 
@@ -122,11 +124,61 @@ def test_lazy_data_fetch(
         data_dir = Path(tmp_path)
         ldr = LazyDataResolver(data_dir)
         with requests_mock.Mocker() as m:
-            for file_name, url in ldr._bptr_resolution.items():
+            for file_name, (url, _) in ldr._bptr_resolution.items():
                 resp = {"file_name": file_name, "url": url}
                 m.get(url, json=resp)
             ldr.fetch()
-            for file_name, url in ldr._bptr_resolution.items():
+            for file_name, (url, _) in ldr._bptr_resolution.items():
                 assert (ldr._data_dir / file_name).read_text() == json.dumps(
                     {"file_name": file_name, "url": url}
                 )
+
+
+@pytest.mark.parametrize(
+    "foo_expiry,bar_expiry",
+    [
+        (
+            int(
+                datetime.datetime(3000, 1, 1, tzinfo=datetime.timezone.utc).timestamp()
+            ),
+            int(
+                datetime.datetime(3000, 1, 1, tzinfo=datetime.timezone.utc).timestamp()
+            ),
+        )
+    ],
+)
+def test_lazy_data_fetch_to_cache(
+    baseten_pointer_manifest_mock, foo_expiry, bar_expiry, tmp_path, monkeypatch
+):
+    monkeypatch.setenv(BASETEN_FS_ENABLED_ENV_VAR, "1")
+    baseten_pointer_manifest_mock = baseten_pointer_manifest_mock(
+        foo_expiry, bar_expiry
+    )
+    manifest_path = tmp_path / "bptr" / "bptr-manifest"
+    manifest_path.parent.mkdir()
+    manifest_path.touch()
+    manifest_path.write_text(baseten_pointer_manifest_mock)
+    cache_dir = tmp_path / "cache" / "org"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    cache_dir.touch()
+    with patch(
+        "truss.templates.shared.lazy_data_resolver.LAZY_DATA_RESOLVER_PATH",
+        manifest_path,
+    ) as _, patch(
+        "truss.templates.shared.lazy_data_resolver.CACHE_DIR",
+        cache_dir,
+    ) as CACHE_DIR:
+        data_dir = Path(tmp_path)
+        ldr = LazyDataResolver(data_dir)
+        assert ldr._uses_b10_cache
+        with requests_mock.Mocker() as m:
+            for file_name, (url, hash) in ldr._bptr_resolution.items():
+                resp = {"file_name": file_name, "url": url}
+                m.get(url, json=resp)
+            ldr.fetch()
+            for file_name, (url, hash) in ldr._bptr_resolution.items():
+                assert (CACHE_DIR / hash).read_text() == json.dumps(
+                    {"file_name": file_name, "url": url}
+                )
+                assert os.path.islink(ldr._data_dir / file_name)
+                assert os.readlink(ldr._data_dir / file_name) == str(CACHE_DIR / hash)

--- a/truss/tests/templates/core/server/test_lazy_data_resolver.py
+++ b/truss/tests/templates/core/server/test_lazy_data_resolver.py
@@ -150,7 +150,7 @@ def test_lazy_data_fetch(
 def test_lazy_data_fetch_to_cache(
     baseten_pointer_manifest_mock, foo_expiry, bar_expiry, tmp_path, monkeypatch
 ):
-    monkeypatch.setenv(BASETEN_FS_ENABLED_ENV_VAR, "1")
+    monkeypatch.setenv(BASETEN_FS_ENABLED_ENV_VAR, "True")
     baseten_pointer_manifest_mock = baseten_pointer_manifest_mock(
         foo_expiry, bar_expiry
     )
@@ -158,7 +158,7 @@ def test_lazy_data_fetch_to_cache(
     manifest_path.parent.mkdir()
     manifest_path.touch()
     manifest_path.write_text(baseten_pointer_manifest_mock)
-    cache_dir = tmp_path / "cache" / "org"
+    cache_dir = tmp_path / "cache" / "org" / "artifacts"
     cache_dir.mkdir(parents=True, exist_ok=True)
     cache_dir.touch()
     with patch(
@@ -200,7 +200,7 @@ def test_lazy_data_fetch_to_cache(
 def test_lazy_data_fetch_cached(
     baseten_pointer_manifest_mock, foo_expiry, bar_expiry, tmp_path, monkeypatch
 ):
-    monkeypatch.setenv(BASETEN_FS_ENABLED_ENV_VAR, "1")
+    monkeypatch.setenv(BASETEN_FS_ENABLED_ENV_VAR, "True")
     baseten_pointer_manifest_mock = baseten_pointer_manifest_mock(
         foo_expiry, bar_expiry
     )
@@ -208,7 +208,7 @@ def test_lazy_data_fetch_cached(
     manifest_path.parent.mkdir()
     manifest_path.touch()
     manifest_path.write_text(baseten_pointer_manifest_mock)
-    cache_dir = tmp_path / "cache" / "org"
+    cache_dir = tmp_path / "cache" / "org" / "artifacts"
     cache_dir.mkdir(parents=True, exist_ok=True)
     cache_dir.touch()
     with patch(


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
- This PR includes supports writing Baseten pointer file resolutions to cache directories, when applicable, falling back to writing to the data directory upon write failure.
<!--
  How was the change described above implemented?
-->
## :computer: How
- Write downloaded files to the cache directory and symlink them to data directory
- On subsequent deploys, check the bptr data hash for cache hits to avoid remote downloads
<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
- Added unit tests