### PR TITLE
Fix older Truss CLI versions

### DIFF
--- a/truss-chains/truss_chains/definitions.py
+++ b/truss-chains/truss_chains/definitions.py
@@ -75,7 +75,6 @@ class SafeModel(pydantic.BaseModel):
         arbitrary_types_allowed=False,
         strict=True,
         validate_assignment=True,
-        extra="forbid",
     )
 
 

--- a/truss-chains/truss_chains/utils.py
+++ b/truss-chains/truss_chains/utils.py
@@ -177,6 +177,22 @@ def populate_chainlet_service_predict_urls(
     return chainlet_to_deployed_service
 
 
+# NOTE: This needs to be available in the Context Builder
+# so that older Truss CLI versions that generate code that
+# expects this function to be available continue to work.
+def override_chainlet_to_service_metadata(
+    chainlet_to_service: Dict[
+        str, Union[definitions.ServiceDescriptor, definitions.DeployedServiceDescriptor]
+    ],
+) -> None:
+    chainlet_to_deployed_service = populate_chainlet_service_predict_urls(
+        chainlet_to_service
+    )
+
+    for chainlet_name in chainlet_to_service.keys():
+        chainlet_to_service[chainlet_name] = chainlet_to_deployed_service[chainlet_name]
+
+
 # Error Propagation Utils. #############################################################
 
 


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
- Re-add the `override_chainlet_to_service_metadata` function expected by model code generated by older Truss CLI versions. Unfortunately this code needs to be part of the model server image so that older Truss CLI versions generating code that imports this function continue to work.
- Note that the types are kind of messed up because this function overwrites `ServiceDescriptor` values with `DeployedServiceDescriptor` values.

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
