### PR TITLE
Fix name/display_name discrepancy

### DIFF
--- a/truss-chains/tests/test_utils.py
+++ b/truss-chains/tests/test_utils.py
@@ -61,4 +61,6 @@ def test_no_populate_chainlet_service_predict_urls(
     with pytest.raises(
         definitions.MissingDependencyError, match="Chainlet 'RandInt' not found"
     ):
-        populate_chainlet_service_predict_urls(chainlet_to_service)
+        populate_chainlet_service_predict_urls(
+            chainlet_to_service, raise_on_missing_key=True
+        )

--- a/truss-chains/truss_chains/code_gen.py
+++ b/truss-chains/truss_chains/code_gen.py
@@ -631,7 +631,7 @@ def gen_truss_chainlet(
     dep_services = {}
     for dep in chainlet_descriptor.dependencies.values():
         dep_services[dep.name] = definitions.ServiceDescriptor(
-            name=dep.name,
+            name=dep.display_name,
             options=dep.options,
         )
     chainlet_dir = _make_chainlet_dir(chain_name, chainlet_descriptor, gen_root)

--- a/truss-chains/truss_chains/definitions.py
+++ b/truss-chains/truss_chains/definitions.py
@@ -75,6 +75,7 @@ class SafeModel(pydantic.BaseModel):
         arbitrary_types_allowed=False,
         strict=True,
         validate_assignment=True,
+        extra="allow",
     )
 
 

--- a/truss-chains/truss_chains/model_skeleton.py
+++ b/truss-chains/truss_chains/model_skeleton.py
@@ -29,7 +29,8 @@ class TrussChainletModel:
             definitions.Environment.model_validate(environment) if environment else None
         )
         chainlet_to_deployed_service = populate_chainlet_service_predict_urls(
-            truss_metadata.chainlet_to_service
+            truss_metadata.chainlet_to_service,
+            raise_on_missing_key=True,
         )
 
         self._context = definitions.DeploymentContext(

--- a/truss-chains/truss_chains/remote.py
+++ b/truss-chains/truss_chains/remote.py
@@ -331,16 +331,25 @@ class _ChainSourceGenerator:
         chain_root = _get_chain_root(entrypoint, non_entrypoint_root_dir)
         entrypoint_artifact: Optional[b10_types.ChainletArtifact] = None
         dependency_artifacts: list[b10_types.ChainletArtifact] = []
+        chainlet_display_names: set[str] = set()
 
         for chainlet_descriptor in _get_ordered_dependencies([entrypoint]):
-            model_base_name = chainlet_descriptor.display_name
+            chainlet_display_name = chainlet_descriptor.display_name
+
+            if chainlet_display_name in chainlet_display_names:
+                raise definitions.ChainsUsageError(
+                    f"Chainlet names must be unique. Found multiple Chainlets with the name: '{chainlet_display_name}'."
+                )
+
+            chainlet_display_names.add(chainlet_display_name)
+
             # Since we are creating a distinct model for each deployment of the chain,
             # we add a random suffix.
             model_suffix = str(uuid.uuid4()).split("-")[0]
-            model_name = f"{model_base_name}-{model_suffix}"
+            model_name = f"{chainlet_display_name}-{model_suffix}"
 
             logging.info(
-                f"Generating Truss Chainlet model for '{chainlet_descriptor.display_name}'."
+                f"Generating Truss Chainlet model for '{chainlet_display_name}'."
             )
 
             chainlet_dir = code_gen.gen_truss_chainlet(
@@ -353,7 +362,7 @@ class _ChainSourceGenerator:
             )
             artifact = b10_types.ChainletArtifact(
                 truss_dir=chainlet_dir,
-                display_name=chainlet_descriptor.display_name,
+                display_name=chainlet_display_name,
             )
 
             is_entrypoint = chainlet_descriptor.chainlet_cls == entrypoint

--- a/truss-chains/truss_chains/remote.py
+++ b/truss-chains/truss_chains/remote.py
@@ -338,6 +338,11 @@ class _ChainSourceGenerator:
             # we add a random suffix.
             model_suffix = str(uuid.uuid4()).split("-")[0]
             model_name = f"{model_base_name}-{model_suffix}"
+
+            logging.info(
+                f"Generating Truss Chainlet model for '{chainlet_descriptor.display_name}'."
+            )
+
             chainlet_dir = code_gen.gen_truss_chainlet(
                 chain_root,
                 self._gen_root,
@@ -348,7 +353,6 @@ class _ChainSourceGenerator:
             )
             artifact = b10_types.ChainletArtifact(
                 truss_dir=chainlet_dir,
-                name=chainlet_descriptor.name,
                 display_name=chainlet_descriptor.display_name,
             )
 
@@ -401,10 +405,10 @@ def push(
                 is_draft=True,
                 port=port,
             )
-            chainlet_to_predict_url[chainlet_artifact.name] = {
+            chainlet_to_predict_url[chainlet_artifact.display_name] = {
                 "predict_url": service.predict_url,
             }
-            chainlet_to_service[chainlet_artifact.name] = service
+            chainlet_to_service[chainlet_artifact.display_name] = service
 
         local_config_handler.LocalConfigHandler.set_dynamic_config(
             definitions.DYNAMIC_CHAINLET_CONFIG_KEY,
@@ -427,17 +431,17 @@ def push(
                 truss_dir,
                 chainlet_artifact.display_name,
                 options,
-                chainlet_to_service[chainlet_artifact.name].port,
+                chainlet_to_service[chainlet_artifact.display_name].port,
             )
             logging.info(
                 f"Pushed Chainlet `{chainlet_artifact.display_name}` as docker container."
             )
             logging.debug(
-                f"Internal model endpoint: `{chainlet_to_predict_url[chainlet_artifact.name]}`"
+                f"Internal model endpoint: `{chainlet_to_predict_url[chainlet_artifact.display_name]}`"
             )
 
         return DockerChainService(
-            options.chain_name, chainlet_to_service[entrypoint_artifact.name]
+            options.chain_name, chainlet_to_service[entrypoint_artifact.display_name]
         )
     else:
         raise NotImplementedError(options)

--- a/truss-chains/truss_chains/utils.py
+++ b/truss-chains/truss_chains/utils.py
@@ -162,9 +162,10 @@ def populate_chainlet_service_predict_urls(
         service_descriptor,
     ) in chainlet_to_service.items():
         if chainlet_name not in dynamic_chainlet_config:
-            raise definitions.MissingDependencyError(
+            logging.warning(
                 f"Chainlet '{chainlet_name}' not found in '{definitions.DYNAMIC_CHAINLET_CONFIG_KEY}'."
             )
+            continue
 
         chainlet_to_deployed_service[chainlet_name] = (
             definitions.DeployedServiceDescriptor(

--- a/truss-chains/truss_chains/utils.py
+++ b/truss-chains/truss_chains/utils.py
@@ -143,6 +143,7 @@ def get_free_port() -> int:
 
 def populate_chainlet_service_predict_urls(
     chainlet_to_service: Mapping[str, definitions.ServiceDescriptor],
+    raise_on_missing_key=False,
 ) -> Mapping[str, definitions.DeployedServiceDescriptor]:
     chainlet_to_deployed_service: Dict[str, definitions.DeployedServiceDescriptor] = {}
 
@@ -162,9 +163,12 @@ def populate_chainlet_service_predict_urls(
         service_descriptor,
     ) in chainlet_to_service.items():
         if chainlet_name not in dynamic_chainlet_config:
-            logging.warning(
-                f"Chainlet '{chainlet_name}' not found in '{definitions.DYNAMIC_CHAINLET_CONFIG_KEY}'."
-            )
+            err_msg = f"Chainlet '{chainlet_name}' not found in '{definitions.DYNAMIC_CHAINLET_CONFIG_KEY}'."
+
+            if raise_on_missing_key:
+                raise definitions.MissingDependencyError(err_msg)
+
+            logging.warning(err_msg)
             continue
 
         chainlet_to_deployed_service[chainlet_name] = (

--- a/truss-chains/truss_chains/utils.py
+++ b/truss-chains/truss_chains/utils.py
@@ -191,7 +191,9 @@ def override_chainlet_to_service_metadata(
     )
 
     for chainlet_name in chainlet_to_service.keys():
-        chainlet_to_service[chainlet_name] = chainlet_to_deployed_service[chainlet_name]
+        chainlet_to_service[chainlet_name] = chainlet_to_deployed_service.get(
+            chainlet_name, chainlet_to_service[chainlet_name]
+        )
 
 
 # Error Propagation Utils. #############################################################

--- a/truss/remote/baseten/custom_types.py
+++ b/truss/remote/baseten/custom_types.py
@@ -18,7 +18,6 @@ class DeployedChainlet(pydantic.BaseModel):
 class ChainletArtifact(pydantic.BaseModel):
     truss_dir: pathlib.Path
     display_name: str
-    name: str
 
 
 class ModelOrigin(Enum):


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
- The Chains mutation was sending `display_name` to create Chainlets and using `name` for metadata in Truss files. This causes the `predict_url` look-up on deployment to fail. Unfortunately, older Truss CLI versions will continue to have this discrepancy.
- We use `display_name` in the metadata as well to eliminate this discrepancy.

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
