### PR TITLE
Fix name/display_name discrepancy

### DIFF
--- a/truss-chains/truss_chains/code_gen.py
+++ b/truss-chains/truss_chains/code_gen.py
@@ -631,7 +631,7 @@ def gen_truss_chainlet(
     dep_services = {}
     for dep in chainlet_descriptor.dependencies.values():
         dep_services[dep.name] = definitions.ServiceDescriptor(
-            name=dep.name,
+            name=dep.display_name,
             options=dep.options,
         )
     chainlet_dir = _make_chainlet_dir(chain_name, chainlet_descriptor, gen_root)

--- a/truss/remote/baseten/custom_types.py
+++ b/truss/remote/baseten/custom_types.py
@@ -18,7 +18,6 @@ class DeployedChainlet(pydantic.BaseModel):
 class ChainletArtifact(pydantic.BaseModel):
     truss_dir: pathlib.Path
     display_name: str
-    name: str
 
 
 class ModelOrigin(Enum):


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
- Use `display_name` when creating Chainlets so that there's no discrepancy between Chainlet names in the dynamic Chainlet configs and Truss metadata. This causes Chain deployments to fail.

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
