### PR TITLE
Fix name/display_name discrepancy

### DIFF
--- a/truss-chains/tests/test_utils.py
+++ b/truss-chains/tests/test_utils.py
@@ -28,6 +28,7 @@ def test_populate_chainlet_service_predict_urls(tmp_path, dynamic_config_mount_d
     chainlet_to_service = {
         "HelloWorld": definitions.ServiceDescriptor(
             name="HelloWorld",
+            display_name="HelloWorld",
             options=definitions.RPCOptions(),
         )
     }
@@ -54,6 +55,7 @@ def test_no_populate_chainlet_service_predict_urls(
     chainlet_to_service = {
         "RandInt": definitions.ServiceDescriptor(
             name="RandInt",
+            display_name="RandInt",
             options=definitions.RPCOptions(),
         )
     }

--- a/truss-chains/tests/test_utils.py
+++ b/truss-chains/tests/test_utils.py
@@ -6,7 +6,7 @@ from truss_chains import definitions
 from truss_chains.utils import populate_chainlet_service_predict_urls
 
 DYNAMIC_CHAINLET_CONFIG_VALUE = {
-    "HelloWorld": {
+    "Hello World!": {
         "predict_url": "https://model-diff_id.api.baseten.co/deployment/diff_deployment_id/predict"
     }
 }
@@ -28,7 +28,7 @@ def test_populate_chainlet_service_predict_urls(tmp_path, dynamic_config_mount_d
     chainlet_to_service = {
         "HelloWorld": definitions.ServiceDescriptor(
             name="HelloWorld",
-            display_name="HelloWorld",
+            display_name="Hello World!",
             options=definitions.RPCOptions(),
         )
     }
@@ -38,7 +38,7 @@ def test_populate_chainlet_service_predict_urls(tmp_path, dynamic_config_mount_d
 
     assert (
         new_chainlet_to_service["HelloWorld"].predict_url
-        == DYNAMIC_CHAINLET_CONFIG_VALUE["HelloWorld"]["predict_url"]
+        == DYNAMIC_CHAINLET_CONFIG_VALUE["Hello World!"]["predict_url"]
     )
 
 

--- a/truss-chains/truss_chains/code_gen.py
+++ b/truss-chains/truss_chains/code_gen.py
@@ -632,6 +632,7 @@ def gen_truss_chainlet(
     for dep in chainlet_descriptor.dependencies.values():
         dep_services[dep.name] = definitions.ServiceDescriptor(
             name=dep.name,
+            display_name=dep.display_name,
             options=dep.options,
         )
     chainlet_dir = _make_chainlet_dir(chain_name, chainlet_descriptor, gen_root)

--- a/truss-chains/truss_chains/definitions.py
+++ b/truss-chains/truss_chains/definitions.py
@@ -408,6 +408,7 @@ class ServiceDescriptor(SafeModel):
     specifically with ``StubBase``."""
 
     name: str
+    display_name: str
     options: RPCOptions
 
 

--- a/truss-chains/truss_chains/public_api.py
+++ b/truss-chains/truss_chains/public_api.py
@@ -197,6 +197,7 @@ def run_local(
                 chainlet_to_service={
                     "SomeChainlet": chains.DeployedServiceDescriptor(
                         name="SomeChainlet",
+                        display_name="SomeChainlet",
                         predict_url="https://...",
                         options=chains.RPCOptions(),
                     )

--- a/truss-chains/truss_chains/stub.py
+++ b/truss-chains/truss_chains/stub.py
@@ -248,7 +248,10 @@ class StubBase(abc.ABC):
         options = options or definitions.RPCOptions()
         return cls(
             service_descriptor=definitions.DeployedServiceDescriptor(
-                name=cls.__name__, predict_url=predict_url, options=options
+                name=cls.__name__,
+                display_name=cls.__name__,
+                predict_url=predict_url,
+                options=options,
             ),
             api_key=context.get_baseten_api_key(),
         )

--- a/truss-chains/truss_chains/utils.py
+++ b/truss-chains/truss_chains/utils.py
@@ -161,16 +161,19 @@ def populate_chainlet_service_predict_urls(
         chainlet_name,
         service_descriptor,
     ) in chainlet_to_service.items():
-        if chainlet_name not in dynamic_chainlet_config:
+        display_name = service_descriptor.display_name
+
+        if display_name not in dynamic_chainlet_config:
             raise definitions.MissingDependencyError(
-                f"Chainlet '{chainlet_name}' not found in '{definitions.DYNAMIC_CHAINLET_CONFIG_KEY}'."
+                f"Chainlet '{display_name}' not found in '{definitions.DYNAMIC_CHAINLET_CONFIG_KEY}'. Dynamic Chainlet config keys: {list(dynamic_chainlet_config)}."
             )
 
         chainlet_to_deployed_service[chainlet_name] = (
             definitions.DeployedServiceDescriptor(
+                display_name=display_name,
                 name=service_descriptor.name,
                 options=service_descriptor.options,
-                predict_url=dynamic_chainlet_config[chainlet_name]["predict_url"],
+                predict_url=dynamic_chainlet_config[display_name]["predict_url"],
             )
         )
 

--- a/truss-chains/truss_chains/utils.py
+++ b/truss-chains/truss_chains/utils.py
@@ -163,6 +163,11 @@ def populate_chainlet_service_predict_urls(
     ) in chainlet_to_service.items():
         display_name = service_descriptor.display_name
 
+        # NOTE: The Chainlet `display_name` in the Truss CLI
+        # corresponds to Chainlet `name` in the backend. As
+        # the dynamic Chainlet config is keyed on the backend
+        # Chainlet name, we have to look up config values by
+        # using the `display_name` in the service descriptor.
         if display_name not in dynamic_chainlet_config:
             raise definitions.MissingDependencyError(
                 f"Chainlet '{display_name}' not found in '{definitions.DYNAMIC_CHAINLET_CONFIG_KEY}'. Dynamic Chainlet config keys: {list(dynamic_chainlet_config)}."

--- a/truss-chains/truss_chains/utils.py
+++ b/truss-chains/truss_chains/utils.py
@@ -180,22 +180,6 @@ def populate_chainlet_service_predict_urls(
     return chainlet_to_deployed_service
 
 
-# NOTE: This needs to be available in the Context Builder
-# so that older Truss CLI versions that generate code that
-# expects this function to be available continue to work.
-def override_chainlet_to_service_metadata(
-    chainlet_to_service: Dict[
-        str, Union[definitions.ServiceDescriptor, definitions.DeployedServiceDescriptor]
-    ],
-) -> None:
-    chainlet_to_deployed_service = populate_chainlet_service_predict_urls(
-        chainlet_to_service
-    )
-
-    for chainlet_name in chainlet_to_service.keys():
-        chainlet_to_service[chainlet_name] = chainlet_to_deployed_service[chainlet_name]
-
-
 # Error Propagation Utils. #############################################################
 
 


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
- Add `display_name` to `ServiceDescriptor` so we can key on it when looking up `predict_url`s in the dynamic Chainlet configs.

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
- Tested using `ItestChain` with custom name Chainlet.
