### PR TITLE
Binary and Numpy data serialization for Chains. Fixes BT-10089

### DIFF
--- a/truss-chains/examples/audio-transcription/transcribe.py
+++ b/truss-chains/examples/audio-transcription/transcribe.py
@@ -33,10 +33,7 @@ class DeployedWhisper(chains.StubBase):
     async def run_remote(
         self, whisper_input: data_types.WhisperInput
     ) -> data_types.WhisperResult:
-        resp = await self._remote.predict_async(
-            json_payload={"whisper_input": whisper_input.model_dump()},
-        )
-        return data_types.WhisperResult.parse_obj(resp)
+        return await self.predict_async(whisper_input, data_types.WhisperResult)
 
 
 class MacroChunkWorker(chains.ChainletBase):
@@ -93,7 +90,7 @@ class MacroChunkWorker(chains.ChainletBase):
         t1 = time.time()
         return data_types.SegmentList(
             segments=segments,
-            chunk_info=macro_chunk.copy(update={"processing_duration": t1 - t0}),
+            chunk_info=macro_chunk.model_copy(update={"processing_duration": t1 - t0}),
         )
 
 

--- a/truss-chains/examples/numpy_and_binary/chain.py
+++ b/truss-chains/examples/numpy_and_binary/chain.py
@@ -10,7 +10,7 @@ class DataModel(pydantic.BaseModel):
     np_array: pydantic_numpy.NumpyArrayField
 
 
-class SynChainlet(chains.ChainletBase):
+class SyncChainlet(chains.ChainletBase):
     def run_remote(self, data: DataModel) -> DataModel:
         print(data)
         return data.model_copy(update={"msg": "From sync"})
@@ -39,7 +39,7 @@ class HostJSON(chains.ChainletBase):
 
     def __init__(
         self,
-        sync_chainlet=chains.depends(SynChainlet, use_binary=False),
+        sync_chainlet=chains.depends(SyncChainlet, use_binary=False),
         async_chainlet=chains.depends(AsyncChainlet, use_binary=False),
         async_chainlet_no_output=chains.depends(
             AsyncChainletNoOutput, use_binary=False
@@ -69,7 +69,7 @@ class HostBinary(chains.ChainletBase):
 
     def __init__(
         self,
-        sync_chainlet=chains.depends(SynChainlet, use_binary=True),
+        sync_chainlet=chains.depends(SyncChainlet, use_binary=True),
         async_chainlet=chains.depends(AsyncChainlet, use_binary=True),
         async_chainlet_no_output=chains.depends(AsyncChainletNoOutput, use_binary=True),
         async_chainlet_no_input=chains.depends(AsyncChainletNoInput, use_binary=True),

--- a/truss-chains/examples/numpy_and_binary/chain.py
+++ b/truss-chains/examples/numpy_and_binary/chain.py
@@ -1,0 +1,92 @@
+import numpy as np
+import pydantic
+
+import truss_chains as chains
+from truss_chains import pydantic_numpy
+
+
+class DataModel(pydantic.BaseModel):
+    msg: str
+    np_array: pydantic_numpy.NumpyArrayField
+
+
+class SynChainlet(chains.ChainletBase):
+    def run_remote(self, data: DataModel) -> DataModel:
+        print(data)
+        return data.model_copy(update={"msg": "From sync"})
+
+
+class AsyncChainlet(chains.ChainletBase):
+    async def run_remote(self, data: DataModel) -> DataModel:
+        print(data)
+        return data.model_copy(update={"msg": "From async"})
+
+
+class AsyncChainletNoInput(chains.ChainletBase):
+    async def run_remote(self) -> DataModel:
+        data = DataModel(msg="From async no input", np_array=np.full((2, 2), 3))
+        print(data)
+        return data
+
+
+class AsyncChainletNoOutput(chains.ChainletBase):
+    async def run_remote(self, data: DataModel) -> None:
+        print(data)
+
+
+class HostJSON(chains.ChainletBase):
+    """Calls various chainlets in JSON mode."""
+
+    def __init__(
+        self,
+        sync_chainlet=chains.depends(SynChainlet, use_binary=False),
+        async_chainlet=chains.depends(AsyncChainlet, use_binary=False),
+        async_chainlet_no_output=chains.depends(
+            AsyncChainletNoOutput, use_binary=False
+        ),
+        async_chainlet_no_input=chains.depends(AsyncChainletNoInput, use_binary=False),
+    ):
+        self._sync_chainlet = sync_chainlet
+        self._async_chainlet = async_chainlet
+        self._async_chainlet_no_output = async_chainlet_no_output
+        self._async_chainlet_no_input = async_chainlet_no_input
+
+    async def run_remote(self) -> tuple[DataModel, DataModel, DataModel]:
+        a = np.ones((3, 2, 1))
+        data = DataModel(msg="From Host", np_array=a)
+        sync_result = self._sync_chainlet.run_remote(data)
+        print(sync_result)
+        async_result = await self._async_chainlet.run_remote(data)
+        print(async_result)
+        await self._async_chainlet_no_output.run_remote(data)
+        async_no_input = await self._async_chainlet_no_input.run_remote()
+        print(async_no_input)
+        return sync_result, async_result, async_no_input
+
+
+class HostBinary(chains.ChainletBase):
+    """Calls various chainlets in binary mode."""
+
+    def __init__(
+        self,
+        sync_chainlet=chains.depends(SynChainlet, use_binary=True),
+        async_chainlet=chains.depends(AsyncChainlet, use_binary=True),
+        async_chainlet_no_output=chains.depends(AsyncChainletNoOutput, use_binary=True),
+        async_chainlet_no_input=chains.depends(AsyncChainletNoInput, use_binary=True),
+    ):
+        self._sync_chainlet = sync_chainlet
+        self._async_chainlet = async_chainlet
+        self._async_chainlet_no_output = async_chainlet_no_output
+        self._async_chainlet_no_input = async_chainlet_no_input
+
+    async def run_remote(self) -> tuple[DataModel, DataModel, DataModel]:
+        a = np.ones((3, 2, 1))
+        data = DataModel(msg="From Host", np_array=a)
+        sync_result = self._sync_chainlet.run_remote(data)
+        print(sync_result)
+        async_result = await self._async_chainlet.run_remote(data)
+        print(async_result)
+        await self._async_chainlet_no_output.run_remote(data)
+        async_no_input = await self._async_chainlet_no_input.run_remote()
+        print(async_no_input)
+        return sync_result, async_result, async_no_input

--- a/truss-chains/examples/rag/rag_chain.py
+++ b/truss-chains/examples/rag/rag_chain.py
@@ -115,8 +115,8 @@ class LLMClient(chains.StubBase):
             f"{PERSON_MATCHING_PROMPT}\nPerson you're matching: {new_bio}\n"
             f"People from database: {bios_info}"
         )
-        resp = await self._remote.predict_async(
-            json_payload={
+        resp = await self.predict_async(
+            {
                 "messages": [{"role": "user", "content": prompt}],
                 "stream": False,
                 "max_new_tokens": 32,

--- a/truss-chains/truss_chains/definitions.py
+++ b/truss-chains/truss_chains/definitions.py
@@ -344,7 +344,7 @@ class Assets:
 
     def get_spec(self) -> AssetSpec:
         """Returns parsed and validated assets."""
-        return self._spec.copy(deep=True)
+        return self._spec.model_copy(deep=True)
 
 
 class ChainletOptions(SafeModelNonSerializable):
@@ -397,10 +397,23 @@ DEFAULT_TIMEOUT_SEC = 600
 
 
 class RPCOptions(SafeModel):
-    """Options to customize RPCs to dependency chainlets."""
+    """Options to customize RPCs to dependency chainlets.
 
-    timeout_sec: int = DEFAULT_TIMEOUT_SEC
+    Args:
+        retries: The number of times to retry the remote chainlet in case of failures
+          (e.g. due to transient network issues). For streaming, retries are only made
+          if the request fails before streaming any results back. Failures mid-stream
+          not retried.
+        timeout_sec: Timeout for the HTTP request to this chainlet.
+        use_binary: whether to send data data in binary format. This can give a parsing
+         speedup and message size reduction (~25%) for numpy arrays. Use
+         ``NumpyArrayField`` as a field type on pydantic models for integration and set
+         this option to ``True``. For simple text data, there is no significant benefit.
+    """
+
     retries: int = 1
+    timeout_sec: int = DEFAULT_TIMEOUT_SEC
+    use_binary: bool = False
 
 
 class ServiceDescriptor(SafeModel):

--- a/truss-chains/truss_chains/public_api.py
+++ b/truss-chains/truss_chains/public_api.py
@@ -38,6 +38,7 @@ def depends(
     chainlet_cls: Type[framework.ChainletT],
     retries: int = 1,
     timeout_sec: int = definitions.DEFAULT_TIMEOUT_SEC,
+    use_binary: bool = False,
 ) -> framework.ChainletT:
     """Sets a "symbolic marker" to indicate to the framework that a chainlet is a
     dependency of another chainlet. The return value of ``depends`` is intended to be
@@ -58,14 +59,22 @@ def depends(
     Args:
         chainlet_cls: The chainlet class of the dependency.
         retries: The number of times to retry the remote chainlet in case of failures
-          (e.g. due to transient network issues).
+          (e.g. due to transient network issues). For streaming, retries are only made
+          if the request fails before streaming any results back. Failures mid-stream
+          not retried.
         timeout_sec: Timeout for the HTTP request to this chainlet.
+        use_binary: whether to send data data in binary format. This can give a parsing
+         speedup and message size reduction (~25%) for numpy arrays. Use
+         ``NumpyArrayField`` as a field type on pydantic models for integration and set
+         this option to ``True``. For simple text data, there is no significant benefit.
 
     Returns:
         A "symbolic marker" to be used as a default argument in a chainlet's
         initializer.
     """
-    options = definitions.RPCOptions(retries=retries, timeout_sec=timeout_sec)
+    options = definitions.RPCOptions(
+        retries=retries, timeout_sec=timeout_sec, use_binary=use_binary
+    )
     # The type error is silenced to because chains framework will at runtime inject
     # a corresponding instance. Nonetheless, we want to use a type annotation here,
     # to facilitate type inference, code-completion and type checking within the code

--- a/truss-chains/truss_chains/pydantic_numpy.py
+++ b/truss-chains/truss_chains/pydantic_numpy.py
@@ -1,0 +1,131 @@
+import base64
+from typing import TYPE_CHECKING, Any, ClassVar
+
+import pydantic
+from pydantic.json_schema import JsonSchemaValue
+from pydantic_core import core_schema
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+
+class NumpyArrayField:
+    """Wrapper class to support numpy arrays as fields on pydantic models and provide
+    JSON or binary serialization implementations.
+
+    The JSON serialization exposes (data, shape, dtype), and the data is base-64
+    encoded which leads to ~33% overhead. A more compact serialization can be achieved
+    using ``msgpack_numpy`` (integrated in chains, if RPC-option ``use_binary`` is
+    enabled).
+
+    Usage example:
+
+    ```
+    import numpy as np
+
+    class MyModel(pydantic.BaseModel):
+        my_array: NumpyArrayField
+
+    m = MyModel(my_array=np.arange(4).reshape((2, 2)))
+    m.my_array.array += 10  # Work with the numpy array.
+    print(m)
+    # my_array=NumpyArrayField(
+    #   shape=(2, 2),
+    #   dtype=int64,
+    #   data=[[10 11] [12 13]])
+    m_json = m.model_dump_json()  # Serialize.
+    print(m_json)
+    # {"my_array":{"data_b64":"CgAAAAAAAAALAAAAAAAAAAwAAAAAAAAADQAAAAAAAAA=","shape":[2,2],"dtype":"int64"}}
+    m2 = MyModel.model_validate_json(m_json)  # De-serialize.
+    ```
+    """
+
+    data_key: ClassVar[str] = "data_b64"
+    shape_key: ClassVar[str] = "shape"
+    dtype_key: ClassVar[str] = "dtype"
+    array: "NDArray"
+
+    def __init__(self, array: "NDArray"):
+        self.array = array
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}(shape={self.array.shape}, "
+            f"dtype={self.array.dtype}, data={self.array})"
+        )
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls, source_type: Any, handler: pydantic.GetCoreSchemaHandler
+    ) -> core_schema.CoreSchema:
+        return core_schema.no_info_after_validator_function(
+            cls.validate_numpy_array,
+            core_schema.any_schema(),
+            serialization=core_schema.plain_serializer_function_ser_schema(
+                cls.serialize_numpy_array, info_arg=True
+            ),
+        )
+
+    @classmethod
+    def validate_numpy_array(cls, value: Any):
+        import numpy as np
+
+        keys = {cls.data_key, cls.shape_key, cls.dtype_key}
+        if isinstance(value, dict) and keys.issubset(value):
+            try:
+                data = base64.b64decode(value[cls.data_key])
+                array = np.frombuffer(data, dtype=value[cls.dtype_key]).reshape(
+                    value[cls.shape_key]
+                )
+                return cls(array)
+            except (ValueError, TypeError) as e:
+                raise TypeError(
+                    "numpy_array_validation"
+                    f"Invalid data, shape, or dtype for NumPy array: {str(e)}",
+                )
+        if isinstance(value, np.ndarray):
+            return cls(value)
+        if isinstance(value, cls):
+            return value
+
+        raise TypeError(
+            "numpy_array_validation\n"
+            f"Expected a NumPy array or a dictionary with keys {keys}.\n"
+            f"Got:\n{value}"
+        )
+
+    @classmethod
+    def serialize_numpy_array(
+        cls, obj: "NumpyArrayField", info: core_schema.SerializationInfo
+    ):
+        if info.mode == "json":
+            return {
+                cls.data_key: base64.b64encode(obj.array.tobytes()).decode("utf-8"),
+                cls.shape_key: obj.array.shape,
+                cls.dtype_key: str(obj.array.dtype),
+            }
+        return obj.array
+
+    @classmethod
+    def __get_pydantic_json_schema__(
+        cls,
+        _core_schema: core_schema.CoreSchema,
+        handler: pydantic.GetJsonSchemaHandler,
+    ) -> JsonSchemaValue:
+        json_schema = handler(_core_schema)
+        json_schema.update(
+            {
+                "type": "object",
+                "properties": {
+                    "data": {"type": "string", "format": "byte"},
+                    "shape": {
+                        "type": "array",
+                        "items": {"type": "integer"},
+                        "minItems": 1,
+                    },
+                    "dtype": {"type": "string"},
+                },
+                "required": ["data", "shape", "dtype"],
+            }
+        )
+        return json_schema

--- a/truss-chains/truss_chains/streaming.py
+++ b/truss-chains/truss_chains/streaming.py
@@ -4,14 +4,12 @@ import enum
 import struct
 import sys
 from collections.abc import AsyncIterator
-from typing import Generic, Optional, Protocol, Type, TypeVar, Union, overload
+from typing import Generic, Optional, Protocol, Type, TypeVar, overload
 
 import pydantic
 
 _TAG_SIZE = 5  # uint8 + uint32.
-_JSONType = Union[
-    str, int, float, bool, None, list["_JSONType"], dict[str, "_JSONType"]
-]
+
 _T = TypeVar("_T")
 
 if sys.version_info < (3, 10):

--- a/truss-chains/truss_chains/stub.py
+++ b/truss-chains/truss_chains/stub.py
@@ -1,32 +1,221 @@
 import abc
 import asyncio
+import builtins
 import contextlib
 import contextvars
+import json
 import logging
-import ssl
+import sys
+import textwrap
 import threading
 import time
+import traceback
 from typing import (
     Any,
     AsyncIterator,
     ClassVar,
+    Dict,
     Iterator,
     Mapping,
+    NoReturn,
     Optional,
     Type,
     TypeVar,
+    Union,
     final,
+    overload,
 )
 
 import aiohttp
+import fastapi
 import httpx
+import pydantic
 import starlette.requests
 import tenacity
+from truss.templates.shared import serialization
 
 from truss_chains import definitions, utils
 
 DEFAULT_MAX_CONNECTIONS = 1000
 DEFAULT_MAX_KEEPALIVE_CONNECTIONS = 400
+
+
+_RetryPolicyT = TypeVar("_RetryPolicyT", tenacity.AsyncRetrying, tenacity.Retrying)
+_InputT = TypeVar("_InputT", pydantic.BaseModel, Any)  # Any signifies "JSON".
+_OutputT = TypeVar("_OutputT", bound=pydantic.BaseModel)
+
+
+# Error Propagation Utils. #############################################################
+
+
+def _handle_exception(exception: Exception, chainlet_name: str) -> NoReturn:
+    """Raises `fastapi.HTTPException` with `RemoteErrorDetail` as detail."""
+    if hasattr(exception, "__module__"):
+        exception_module_name = exception.__module__
+    else:
+        exception_module_name = None
+
+    error_stack = traceback.extract_tb(exception.__traceback__)
+    # Exclude the error handling functions from the stack trace.
+    exclude_frames = {
+        exception_to_http_error.__name__,
+        response_raise_errors.__name__,
+        async_response_raise_errors.__name__,
+    }
+    final_tb = [frame for frame in error_stack if frame.name not in exclude_frames]
+    stack = list(
+        [definitions.StackFrame.from_frame_summary(frame) for frame in final_tb]
+    )
+    error = definitions.RemoteErrorDetail(
+        remote_name=chainlet_name,
+        exception_cls_name=exception.__class__.__name__,
+        exception_module_name=exception_module_name,
+        exception_message=str(exception),
+        user_stack_trace=stack,
+    )
+    raise fastapi.HTTPException(
+        status_code=500, detail=error.model_dump()
+    ) from exception
+
+
+@contextlib.contextmanager
+def exception_to_http_error(chainlet_name: str) -> Iterator[None]:
+    # TODO: move chainlet name from here to caller side.
+    try:
+        yield
+    except Exception as e:
+        _handle_exception(e, chainlet_name)
+
+
+def _resolve_exception_class(
+    error: definitions.RemoteErrorDetail,
+) -> Type[Exception]:
+    """Tries to find the exception class in builtins or imported libs,
+    falls back to `definitions.GenericRemoteError` if not found."""
+    exception_cls = None
+    if error.exception_module_name is None:
+        exception_cls = getattr(builtins, error.exception_cls_name, None)
+    else:
+        if mod := sys.modules.get(error.exception_module_name):
+            exception_cls = getattr(mod, error.exception_cls_name, None)
+
+    if exception_cls is None:
+        logging.warning(
+            f"Could not resolve exception with name `{error.exception_cls_name}` "
+            f"and module `{error.exception_module_name}` - fall back to "
+            f"`{definitions.GenericRemoteException.__name__}`."
+        )
+        exception_cls = definitions.GenericRemoteException
+
+    if issubclass(exception_cls, pydantic.ValidationError):
+        # Cannot re-raise naively.
+        # https://github.com/pydantic/pydantic/issues/6734.
+        exception_cls = definitions.GenericRemoteException
+
+    return exception_cls
+
+
+def _handle_response_error(response_json: dict, remote_name: str):
+    try:
+        error_json = response_json["error"]
+    except KeyError as e:
+        logging.error(f"response_json: {response_json}")
+        raise ValueError(
+            "Could not get `error` field from JSON from error response"
+        ) from e
+    try:
+        error = definitions.RemoteErrorDetail.model_validate(error_json)
+    except pydantic.ValidationError as e:
+        if isinstance(error_json, str):
+            msg = f"Remote error occurred in `{remote_name}`: '{error_json}'"
+            raise definitions.GenericRemoteException(msg) from None
+        raise ValueError(
+            "Could not parse error. Error details are expected to be either a "
+            "plain string (old truss models) or a serialized "
+            f"`definitions.RemoteErrorDetail.__name__`, got:\n{repr(error_json)}"
+        ) from e
+    exception_cls = _resolve_exception_class(error)
+    msg = (
+        f"(showing remote errors, root message at the bottom)\n"
+        f"--> Preceding Remote Cause:\n"
+        f"{textwrap.indent(error.format(), '    ')}"
+    )
+    raise exception_cls(msg)
+
+
+def response_raise_errors(response: httpx.Response, remote_name: str) -> None:
+    """In case of error, raise it.
+
+    If the response error contains `RemoteErrorDetail`, it tries to re-raise
+    the same exception that was raised remotely and falls back to
+    `GenericRemoteException` if the exception class could not be resolved.
+
+    Exception messages are chained to trace back to the root cause, i.e. the first
+    Chainlet that raised an exception. E.g. the message might look like this:
+
+    ```
+    RemoteChainletError in "Chain"
+    Traceback (most recent call last):
+      File "/app/model/Chainlet.py", line 112, in predict
+        result = await self._chainlet.run(
+      File "/app/model/Chainlet.py", line 79, in run
+        value += self._text_to_num.run(part)
+      File "/packages/remote_stubs.py", line 21, in run
+        json_result = self.predict_sync(json_args)
+      File "/packages/truss_chains/stub.py", line 37, in predict_sync
+        return utils.handle_response(
+    ValueError: (showing remote errors, root message at the bottom)
+    --> Preceding Remote Cause:
+        RemoteChainletError in "TextToNum"
+        Traceback (most recent call last):
+          File "/app/model/Chainlet.py", line 113, in predict
+            result = self._chainlet.run(data=payload["data"])
+          File "/app/model/Chainlet.py", line 54, in run
+            generated_text = self._replicator.run(data)
+          File "/packages/remote_stubs.py", line 7, in run
+            json_result = self.predict_sync(json_args)
+          File "/packages/truss_chains/stub.py", line 37, in predict_sync
+            return utils.handle_response(
+        ValueError: (showing remote errors, root message at the bottom)
+        --> Preceding Remote Cause:
+            RemoteChainletError in "TextReplicator"
+            Traceback (most recent call last):
+              File "/app/model/Chainlet.py", line 112, in predict
+                result = self._chainlet.run(data=payload["data"])
+              File "/app/model/Chainlet.py", line 36, in run
+                raise ValueError(f"This input is too long: {len(data)}.")
+            ValueError: This input is too long: 100.
+
+    ```
+    """
+    if response.is_error:
+        try:
+            response_json = response.json()
+        except Exception as e:
+            raise ValueError(
+                "Could not get JSON from error response. Status: "
+                f"`{response.status_code}`."
+            ) from e
+        _handle_response_error(response_json=response_json, remote_name=remote_name)
+
+
+async def async_response_raise_errors(
+    response: aiohttp.ClientResponse, remote_name: str
+) -> None:
+    """Async version of `async_response_raise_errors`."""
+    if response.status >= 400:
+        try:
+            response_json = await response.json()
+        except Exception as e:
+            raise ValueError(
+                "Could not get JSON from error response. Status: "
+                f"`{response.status}`."
+            ) from e
+        _handle_response_error(response_json=response_json, remote_name=remote_name)
+
+
+########################################################################################
+
 
 _trace_parent_context: contextvars.ContextVar[str] = contextvars.ContextVar(
     "trace_parent"
@@ -44,8 +233,27 @@ def trace_parent(request: starlette.requests.Request) -> Iterator[None]:
         _trace_parent_context.reset(token)
 
 
+def pydantic_set_field_dict(obj: pydantic.BaseModel) -> dict[str, pydantic.BaseModel]:
+    """Like `BaseModel.model_dump(exclude_unset=True), but only top-level.
+
+    This is used to get kwargs for invoking a function, while dropping fields for which
+    there is no value explicitly set in the pydantic model. A field is considered unset
+    if the key was not present in the incoming JSON request (from which the model was
+    parsed/initialized) and the pydantic model has a default value, such as `None`.
+
+    By dropping these unset fields, the default values from the function definition
+    will be used instead. This behavior ensures correct handling of arguments where
+    the function has a default, such as in the case of `run_remote`. If the model has
+    an optional field defaulting to `None`, this approach differentiates between
+    the user explicitly passing a value of `None` and the field being unset in the
+    request.
+
+    """
+    return {name: getattr(obj, name) for name in obj.model_fields_set}
+
+
 class BasetenSession:
-    """Helper to invoke predict method on Baseten deployments."""
+    """Provides configured HTTP clients, retries rate limit warning etc."""
 
     _client_cycle_time_sec: ClassVar[int] = 3600 * 1  # 1 hour.
     _client_limits: ClassVar[httpx.Limits] = httpx.Limits(
@@ -97,7 +305,21 @@ class BasetenSession:
             or (int(time.time()) - cached_client[1]) > self._client_cycle_time_sec
         )
 
-    def _client_sync(self) -> httpx.Client:
+    def _log_retry(self, retry_state: tenacity.RetryCallState) -> None:
+        attempt_number = retry_state.attempt_number
+        if attempt_number > 1:
+            logging.info(f"Retrying `{self.name}`, attempt {attempt_number}")
+
+    def _make_retry_policy(self, retrying: Type[_RetryPolicyT]) -> _RetryPolicyT:
+        return retrying(
+            stop=tenacity.stop_after_attempt(self._service_descriptor.options.retries),
+            retry=tenacity.retry_if_exception_type(Exception),
+            reraise=True,
+            before_sleep=self._log_retry,
+        )
+
+    @contextlib.contextmanager
+    def _client_sync(self) -> Iterator[httpx.Client]:
         # Check `_client_cycle_needed` before and after locking to avoid
         # needing a lock each time the client is accessed.
         if self._client_cycle_needed(self._cached_sync_client):
@@ -112,9 +334,14 @@ class BasetenSession:
                         int(time.time()),
                     )
         assert self._cached_sync_client is not None
-        return self._cached_sync_client[0]
+        client = self._cached_sync_client[0]
 
-    async def _client_async(self) -> aiohttp.ClientSession:
+        with self._sync_num_requests as num_requests:
+            self._maybe_warn_for_overload(num_requests)
+            yield client
+
+    @contextlib.asynccontextmanager
+    async def _client_async(self) -> AsyncIterator[aiohttp.ClientSession]:
         # Check `_client_cycle_needed` before and after locking to avoid
         # needing a lock each time the client is accessed.
         if self._client_cycle_needed(self._cached_async_client):
@@ -134,102 +361,18 @@ class BasetenSession:
                         int(time.time()),
                     )
         assert self._cached_async_client is not None
-        return self._cached_async_client[0]
+        client = self._cached_async_client[0]
 
-    def predict_sync(self, json_payload):
-        headers = {
-            definitions.OTEL_TRACE_PARENT_HEADER_KEY: _trace_parent_context.get()
-        }
-        retrying = tenacity.Retrying(
-            stop=tenacity.stop_after_attempt(self._service_descriptor.options.retries),
-            retry=tenacity.retry_if_exception_type(Exception),
-            reraise=True,
-        )
-        for attempt in retrying:
-            with attempt:
-                if (num := attempt.retry_state.attempt_number) > 1:
-                    logging.info(f"Retrying `{self.name}`, " f"attempt {num}")
-                try:
-                    with self._sync_num_requests as num_requests:
-                        self._maybe_warn_for_overload(num_requests)
-                        response = self._client_sync().post(
-                            self._service_descriptor.predict_url,
-                            json=json_payload,
-                            headers=headers,
-                        )
-                    utils.response_raise_errors(response, self.name)
-                    return response.json()
-
-                # As a special case we invalidate the client in case of certificate
-                # errors. This has happened in the past and is a defensive measure.
-                except ssl.SSLError:
-                    self._cached_sync_client = None
-                    raise
-
-    async def predict_async(self, json_payload):
-        headers = {
-            definitions.OTEL_TRACE_PARENT_HEADER_KEY: _trace_parent_context.get()
-        }
-        retrying = tenacity.AsyncRetrying(
-            stop=tenacity.stop_after_attempt(self._service_descriptor.options.retries),
-            retry=tenacity.retry_if_exception_type(Exception),
-            reraise=True,
-        )
-        async for attempt in retrying:
-            with attempt:
-                if (num := attempt.retry_state.attempt_number) > 1:
-                    logging.info(f"Retrying `{self.name}`, " f"attempt {num}")
-                try:
-                    client = await self._client_async()
-                    async with self._async_num_requests as num_requests:
-                        self._maybe_warn_for_overload(num_requests)
-                        async with client.post(
-                            self._service_descriptor.predict_url,
-                            json=json_payload,
-                            headers=headers,
-                        ) as response:
-                            await utils.async_response_raise_errors(response, self.name)
-                            return await response.json()
-                # As a special case we invalidate the client in case of certificate
-                # errors. This has happened in the past and is a defensive measure.
-                except ssl.SSLError:
-                    self._cached_async_client = None
-                    raise
-
-    async def predict_async_stream(self, json_payload) -> AsyncIterator[bytes]:  # type: ignore[return]  # Handled by retries.
-        headers = {
-            definitions.OTEL_TRACE_PARENT_HEADER_KEY: _trace_parent_context.get()
-        }
-        retrying = tenacity.AsyncRetrying(
-            stop=tenacity.stop_after_attempt(self._service_descriptor.options.retries),
-            retry=tenacity.retry_if_exception_type(Exception),
-            reraise=True,
-        )
-        async for attempt in retrying:
-            with attempt:
-                if (num := attempt.retry_state.attempt_number) > 1:
-                    logging.info(f"Retrying `{self.name}`, " f"attempt {num}")
-                try:
-                    client = await self._client_async()
-                    async with self._async_num_requests as num_requests:
-                        self._maybe_warn_for_overload(num_requests)
-                        response = await client.post(
-                            self._service_descriptor.predict_url,
-                            json=json_payload,
-                            headers=headers,
-                        )
-                        await utils.async_response_raise_errors(response, self.name)
-                        return response.content.iter_any()
-
-                # As a special case we invalidate the client in case of certificate
-                # errors. This has happened in the past and is a defensive measure.
-                except ssl.SSLError:
-                    self._cached_async_client = None
-                    raise
+        async with self._async_num_requests as num_requests:
+            self._maybe_warn_for_overload(num_requests)
+            yield client
 
 
-class StubBase(abc.ABC):
+class StubBase(BasetenSession, abc.ABC):
     """Base class for stubs that invoke remote chainlets.
+
+    Extends ``BasetenSession`` with methods for data serialization, de-serialization
+    and invoking other endpoints.
 
     It is used internally for RPCs to dependency chainlets, but it can also be used
     in user-code for wrapping a deployed truss model into the chains framework, e.g.
@@ -245,7 +388,7 @@ class StubBase(abc.ABC):
         class DeployedWhisper(chains.StubBase):
 
             async def run_remote(self, audio_b64: str) -> WhisperOutput:
-                resp = await self._remote.predict_async(
+                resp = await self.predict_async(
                     json_payload={"audio": audio_b64})
                 return WhisperOutput(text=resp["text"], language=resp["language"])
 
@@ -262,8 +405,6 @@ class StubBase(abc.ABC):
 
     """
 
-    _remote: BasetenSession
-
     @final
     def __init__(
         self,
@@ -275,7 +416,7 @@ class StubBase(abc.ABC):
             service_descriptor: Contains the URL and other configuration.
             api_key: A baseten API key to authorize requests.
         """
-        self._remote = BasetenSession(service_descriptor, api_key)
+        super().__init__(service_descriptor, api_key)
 
     @classmethod
     def from_url(
@@ -301,6 +442,117 @@ class StubBase(abc.ABC):
             ),
             api_key=context.get_baseten_api_key(),
         )
+
+    def _make_request_params(
+        self, inputs: _InputT, for_httpx: bool = False
+    ) -> Mapping[str, Any]:
+        kwargs: Dict[str, Any] = {}
+        headers = {
+            definitions.OTEL_TRACE_PARENT_HEADER_KEY: _trace_parent_context.get()
+        }
+        if isinstance(inputs, pydantic.BaseModel):
+            if self._service_descriptor.options.use_binary:
+                data_dict = inputs.model_dump(mode="python")
+                kwargs["data"] = serialization.truss_msgpack_serialize(data_dict)
+                headers["Content-Type"] = "application/octet-stream"
+            else:
+                data_key = "content" if for_httpx else "data"
+                kwargs[data_key] = inputs.model_dump_json()
+                headers["Content-Type"] = "application/json"
+        else:  # inputs is JSON dict.
+            if self._service_descriptor.options.use_binary:
+                kwargs["data"] = serialization.truss_msgpack_serialize(inputs)
+                headers["Content-Type"] = "application/octet-stream"
+            else:
+                kwargs["json"] = inputs
+                headers["Content-Type"] = "application/json"
+
+        kwargs["headers"] = headers
+        return kwargs
+
+    def _response_to_pydantic(
+        self, response: bytes, output_model: Type[_OutputT]
+    ) -> _OutputT:
+        if self._service_descriptor.options.use_binary:
+            data_dict = serialization.truss_msgpack_deserialize(response)
+            return output_model.model_validate(data_dict)
+        return output_model.model_validate_json(response)
+
+    def _response_to_json(self, response: bytes) -> Any:
+        if self._service_descriptor.options.use_binary:
+            return serialization.truss_msgpack_deserialize(response)
+        return json.loads(response)
+
+    @overload
+    def predict_sync(
+        self, inputs: _InputT, output_model: Type[_OutputT]
+    ) -> _OutputT: ...
+
+    @overload  # Returns JSON
+    def predict_sync(self, inputs: _InputT, output_model: None = None) -> Any: ...
+
+    def predict_sync(
+        self, inputs: _InputT, output_model: Optional[Type[_OutputT]] = None
+    ) -> Union[_OutputT, Any]:
+        retry = self._make_retry_policy(tenacity.Retrying)
+        params = self._make_request_params(inputs, for_httpx=True)
+
+        def _rpc() -> bytes:
+            client: httpx.Client
+            with self._client_sync() as client:
+                response = client.post(self._service_descriptor.predict_url, **params)
+            response_raise_errors(response, self.name)
+            return response.content
+
+        response_bytes = retry(_rpc)
+        if output_model:
+            return self._response_to_pydantic(response_bytes, output_model)
+        return self._response_to_json(response_bytes)
+
+    @overload
+    async def predict_async(
+        self, inputs: _InputT, output_model: Type[_OutputT]
+    ) -> _OutputT: ...
+
+    @overload  # Returns JSON.
+    async def predict_async(
+        self, inputs: _InputT, output_model: None = None
+    ) -> Any: ...
+
+    async def predict_async(
+        self, inputs: _InputT, output_model: Optional[Type[_OutputT]] = None
+    ) -> Union[_OutputT, Any]:
+        retry = self._make_retry_policy(tenacity.AsyncRetrying)
+        params = self._make_request_params(inputs)
+
+        async def _rpc() -> bytes:
+            client: aiohttp.ClientSession
+            async with self._client_async() as client:
+                async with client.post(
+                    self._service_descriptor.predict_url, **params
+                ) as response:
+                    await async_response_raise_errors(response, self.name)
+                    return await response.read()
+
+        response_bytes: bytes = await retry(_rpc)
+        if output_model:
+            return self._response_to_pydantic(response_bytes, output_model)
+        return self._response_to_json(response_bytes)
+
+    async def predict_async_stream(self, inputs: _InputT) -> AsyncIterator[bytes]:
+        retry = self._make_retry_policy(tenacity.AsyncRetrying)
+        params = self._make_request_params(inputs)
+
+        async def _rpc() -> AsyncIterator[bytes]:
+            client: aiohttp.ClientSession
+            async with self._client_async() as client:
+                response = await client.post(
+                    self._service_descriptor.predict_url, **params
+                )
+                await async_response_raise_errors(response, self.name)
+                return response.content.iter_any()
+
+        return await retry(_rpc)
 
 
 StubT = TypeVar("StubT", bound=StubBase)

--- a/truss-chains/truss_chains/utils.py
+++ b/truss-chains/truss_chains/utils.py
@@ -1,5 +1,4 @@
 import asyncio
-import builtins
 import contextlib
 import enum
 import inspect
@@ -8,26 +7,17 @@ import logging
 import os
 import random
 import socket
-import sys
-import textwrap
 import threading
-import traceback
 from typing import (
     Any,
     Dict,
     Iterable,
     Iterator,
     Mapping,
-    NoReturn,
-    Type,
     TypeVar,
     Union,
 )
 
-import aiohttp
-import fastapi
-import httpx
-import pydantic
 from truss.templates.shared import dynamic_config_resolver
 
 from truss_chains import definitions
@@ -185,171 +175,6 @@ def populate_chainlet_service_predict_urls(
     return chainlet_to_deployed_service
 
 
-# Error Propagation Utils. #############################################################
-# TODO: move request related code into `stub.py`.
-
-
-def _handle_exception(exception: Exception, chainlet_name: str) -> NoReturn:
-    """Raises `fastapi.HTTPException` with `RemoteErrorDetail` as detail."""
-    if hasattr(exception, "__module__"):
-        exception_module_name = exception.__module__
-    else:
-        exception_module_name = None
-
-    error_stack = traceback.extract_tb(exception.__traceback__)
-    # Exclude the error handling functions from the stack trace.
-    exclude_frames = {
-        exception_to_http_error.__name__,
-        response_raise_errors.__name__,
-        async_response_raise_errors.__name__,
-    }
-    final_tb = [frame for frame in error_stack if frame.name not in exclude_frames]
-    stack = list(
-        [definitions.StackFrame.from_frame_summary(frame) for frame in final_tb]
-    )
-    error = definitions.RemoteErrorDetail(
-        remote_name=chainlet_name,
-        exception_cls_name=exception.__class__.__name__,
-        exception_module_name=exception_module_name,
-        exception_message=str(exception),
-        user_stack_trace=stack,
-    )
-    raise fastapi.HTTPException(
-        status_code=500, detail=error.model_dump()
-    ) from exception
-
-
-@contextlib.contextmanager
-def exception_to_http_error(chainlet_name: str) -> Iterator[None]:
-    # TODO: move chainlet name from here to caller side.
-    try:
-        yield
-    except Exception as e:
-        _handle_exception(e, chainlet_name)
-
-
-def _resolve_exception_class(
-    error: definitions.RemoteErrorDetail,
-) -> Type[Exception]:
-    """Tries to find the exception class in builtins or imported libs,
-    falls back to `definitions.GenericRemoteError` if not found."""
-    exception_cls = None
-    if error.exception_module_name is None:
-        exception_cls = getattr(builtins, error.exception_cls_name, None)
-    else:
-        if mod := sys.modules.get(error.exception_module_name):
-            exception_cls = getattr(mod, error.exception_cls_name, None)
-
-    if exception_cls is None:
-        logging.warning(
-            f"Could not resolve exception with name `{error.exception_cls_name}` "
-            f"and module `{error.exception_module_name}` - fall back to "
-            f"`{definitions.GenericRemoteException.__name__}`."
-        )
-        exception_cls = definitions.GenericRemoteException
-
-    return exception_cls
-
-
-def _handle_response_error(response_json: dict, remote_name: str):
-    try:
-        error_json = response_json["error"]
-    except KeyError as e:
-        logging.error(f"response_json: {response_json}")
-        raise ValueError(
-            "Could not get `error` field from JSON from error response"
-        ) from e
-    try:
-        error = definitions.RemoteErrorDetail.model_validate(error_json)
-    except pydantic.ValidationError as e:
-        if isinstance(error_json, str):
-            msg = f"Remote error occurred in `{remote_name}`: '{error_json}'"
-            raise definitions.GenericRemoteException(msg) from None
-        raise ValueError(
-            "Could not parse error. Error details are expected to be either a "
-            "plain string (old truss models) or a serialized "
-            f"`definitions.RemoteErrorDetail.__name__`, got:\n{repr(error_json)}"
-        ) from e
-    exception_cls = _resolve_exception_class(error)
-    msg = (
-        f"(showing remote errors, root message at the bottom)\n"
-        f"--> Preceding Remote Cause:\n"
-        f"{textwrap.indent(error.format(), '    ')}"
-    )
-    raise exception_cls(msg)
-
-
-def response_raise_errors(response: httpx.Response, remote_name: str) -> None:
-    """In case of error, raise it.
-
-    If the response error contains `RemoteErrorDetail`, it tries to re-raise
-    the same exception that was raised remotely and falls back to
-    `GenericRemoteException` if the exception class could not be resolved.
-
-    Exception messages are chained to trace back to the root cause, i.e. the first
-    Chainlet that raised an exception. E.g. the message might look like this:
-
-    ```
-    RemoteChainletError in "Chain"
-    Traceback (most recent call last):
-      File "/app/model/Chainlet.py", line 112, in predict
-        result = await self._chainlet.run(
-      File "/app/model/Chainlet.py", line 79, in run
-        value += self._text_to_num.run(part)
-      File "/packages/remote_stubs.py", line 21, in run
-        json_result = self._remote.predict_sync(json_args)
-      File "/packages/truss_chains/stub.py", line 37, in predict_sync
-        return utils.handle_response(
-    ValueError: (showing remote errors, root message at the bottom)
-    --> Preceding Remote Cause:
-        RemoteChainletError in "TextToNum"
-        Traceback (most recent call last):
-          File "/app/model/Chainlet.py", line 113, in predict
-            result = self._chainlet.run(data=payload["data"])
-          File "/app/model/Chainlet.py", line 54, in run
-            generated_text = self._replicator.run(data)
-          File "/packages/remote_stubs.py", line 7, in run
-            json_result = self._remote.predict_sync(json_args)
-          File "/packages/truss_chains/stub.py", line 37, in predict_sync
-            return utils.handle_response(
-        ValueError: (showing remote errors, root message at the bottom)
-        --> Preceding Remote Cause:
-            RemoteChainletError in "TextReplicator"
-            Traceback (most recent call last):
-              File "/app/model/Chainlet.py", line 112, in predict
-                result = self._chainlet.run(data=payload["data"])
-              File "/app/model/Chainlet.py", line 36, in run
-                raise ValueError(f"This input is too long: {len(data)}.")
-            ValueError: This input is too long: 100.
-
-    ```
-    """
-    if response.is_error:
-        try:
-            response_json = response.json()
-        except Exception as e:
-            raise ValueError(
-                "Could not get JSON from error response. Status: "
-                f"`{response.status_code}`."
-            ) from e
-        _handle_response_error(response_json=response_json, remote_name=remote_name)
-
-
-async def async_response_raise_errors(
-    response: aiohttp.ClientResponse, remote_name: str
-) -> None:
-    """Async version of `async_response_raise_errors`."""
-    if response.status >= 400:
-        try:
-            response_json = await response.json()
-        except Exception as e:
-            raise ValueError(
-                "Could not get JSON from error response. Status: "
-                f"`{response.status}`."
-            ) from e
-        _handle_response_error(response_json=response_json, remote_name=remote_name)
-
-
 ########################################################################################
 
 
@@ -408,25 +233,6 @@ class StrEnum(str, enum.Enum):
 def issubclass_safe(x: Any, cls: type) -> bool:
     """Like built-in `issubclass`, but works on non-type objects."""
     return isinstance(x, type) and issubclass(x, cls)
-
-
-def pydantic_set_field_dict(obj: pydantic.BaseModel) -> dict[str, pydantic.BaseModel]:
-    """Like `BaseModel.model_dump(exclude_unset=True), but only top-level.
-
-    This is used to get kwargs for invoking a function, while dropping fields for which
-    there is no value explicitly set in the pydantic model. A field is considered unset
-    if the key was not present in the incoming JSON request (from which the model was
-    parsed/initialized) and the pydantic model has a default value, such as `None`.
-
-    By dropping these unset fields, the default values from the function definition
-    will be used instead. This behavior ensures correct handling of arguments where
-    the function has a default, such as in the case of `run_remote`. If the model has
-    an optional field defaulting to `None`, this approach differentiates between
-    the user explicitly passing a value of `None` and the field being unset in the
-    request.
-
-    """
-    return {name: getattr(obj, name) for name in obj.__fields_set__}
 
 
 class AsyncSafeCounter:

--- a/truss/templates/server/requirements.txt
+++ b/truss/templates/server/requirements.txt
@@ -7,7 +7,7 @@ fastapi==0.114.1
 joblib==1.2.0
 loguru==0.7.2
 msgpack-numpy==0.4.8
-msgpack==1.0.2
+msgpack==1.1.0  # Numpy/msgpack versions are finniky (1.0.2 breaks), double check when changing.
 numpy>=1.23.5
 opentelemetry-api>=1.25.0
 opentelemetry-sdk>=1.25.0

--- a/truss/tests/test_testing_utilities_for_other_tests.py
+++ b/truss/tests/test_testing_utilities_for_other_tests.py
@@ -52,10 +52,11 @@ def _show_container_logs_if_raised():
             print("An exception was raised, showing logs of all containers.")
             containers = get_containers({TRUSS: True})
             new_containers = [c for c in containers if c.id not in initial_ids]
-            parts = []
+            parts = ["\n"]
             for container in new_containers:
                 parts.append(f"Logs for container {container.name} ({container.id}):")
                 parts.append(_human_readable_json_logs(container.logs()))
+                parts.append("\n")
             logging.warning("\n".join(parts))
 
 


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
* Add a pydantic field wrapper for numpy arrays `NumpyArrayField`.
  * Implement magic methods for pydantic to understand the data type and schema.
  * For JSON (`model_dump_json`, `model_dump(mode="json")`, the data array is represented as (data [base-64 encoded buffer], shape, dtype). This is also the "externally facing" schema, of the truss server.
  * In the python runtime the array object is accessible and manipulatable by the wrapper's attribute `array`.
  * For binary serialization, the model's can dumped to a dict of objects `model_dump(mode="python")` (this mode is default!) and then packed with `msgpack` + numpy extension.
* Remove the nesting of `BasetenSession` in `StubBase`. `BasetenSession` is for HTTP config, retries and rate limits, `StubBase` is for data (de-)serialization and invoking endpoints.
  * Now `StubBase` does more of the parsing and dumping of pydantic models (in particular handling binary/JSON mode flexibly). This is good because, less variable code needs to be produced by the code generation, since the methods do more of the work.
 * Move all HTTP and error propagation stuff from `utils` to `stub` (this leaves fewer lib dependencies in `utils`).
* Fix broken msgpack versions in server requirements.
* Move truss model result serialization from `model_wrapper` to `model_server`. That's more akin to how the input/request is handled.
* TODO (in follow up PR): update documentation.

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
