### PR TITLE
Deprecate --trusted.

### DIFF
--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -1134,9 +1134,7 @@ def push(
         tr.spec.config.model_name = model_name
         tr.spec.config.write_to_yaml_file(tr.spec.config_path, verbose=False)
 
-    # Log a warning if using secrets without --trusted.
-    # TODO(helen): this could be moved to a separate function that includes more
-    #  config checks.
+    # Log a warning if using --trusted.
     if trusted:
         trusted_deprecation_notice = (
             "[DEPRECATED] `--trusted` optionsis deprecated and no longer needed"

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -1137,7 +1137,7 @@ def push(
     # Log a warning if using --trusted.
     if trusted:
         trusted_deprecation_notice = (
-            "[DEPRECATED] `--trusted` optionsis deprecated and no longer needed"
+            "[DEPRECATED] `--trusted` option is deprecated and no longer needed"
         )
         console.print(trusted_deprecation_notice, style="yellow")
 

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -1054,7 +1054,7 @@ def run_python(script, target_directory):
     is_flag=True,
     required=False,
     default=False,
-    help="Trust truss with hosted secrets.",
+    help="[DEPRECATED]Trust truss with hosted secrets.",
 )
 @click.option(
     "--disable-truss-download",
@@ -1137,12 +1137,11 @@ def push(
     # Log a warning if using secrets without --trusted.
     # TODO(helen): this could be moved to a separate function that includes more
     #  config checks.
-    if tr.spec.config.secrets and not trusted:
-        not_trusted_text = (
-            "Warning: your Truss has secrets but was not pushed with --trusted. "
-            "Please push with --trusted to grant access to secrets."
+    if trusted:
+        trusted_deprecation_notice = (
+            "[DEPRECATED] `--trusted` optionsis deprecated and no longer needed"
         )
-        console.print(not_trusted_text, style="red")
+        console.print(trusted_deprecation_notice, style="yellow")
 
     # trt-llm engine builder checks
     if uses_trt_llm_builder(tr):
@@ -1182,7 +1181,7 @@ def push(
         tr,
         model_name=model_name,
         publish=publish,
-        trusted=trusted,
+        trusted=True,
         promote=promote,
         preserve_previous_prod_deployment=preserve_previous_production_deployment,
         deployment_name=deployment_name,

--- a/truss/templates/shared/secrets_resolver.py
+++ b/truss/templates/shared/secrets_resolver.py
@@ -62,7 +62,6 @@ def _secret_missing_error_message(key: str) -> str:
     return f"""
 Secret '{key}' not found. Please ensure that:
   * Secret '{key}' is defined in the 'secrets' section of the Truss config file
-  * The model was pushed with the --trusted flag
   * Secret '{key}' is defined in the secret manager
  Read more about secrets here: {SECRETS_DOC_LINK}.
     """

--- a/truss/tests/test_model_inference.py
+++ b/truss/tests/test_model_inference.py
@@ -397,8 +397,7 @@ secrets:
 
     config_with_no_secret = "model_name: secrets-truss"
     missing_secret_error_message = """Secret 'secret' not found. Please ensure that:
-  * Secret 'secret' is defined in the 'secrets' section of the Truss config file
-  * The model was pushed with the --trusted flag"""
+  * Secret 'secret' is defined in the 'secrets' section of the Truss config file"""
 
     with ensure_kill_all(), _temp_truss(inspect.getsource(Model), config) as tr:
         LocalConfigHandler.set_secret("secret", "secret_value")


### PR DESCRIPTION

## :rocket: What

See [thread](https://basetenlabs.slack.com/archives/C04NM3YA2DT/p1732246642551419) for context:

* The `--trusted` flag is quite confusing for users, almost all of the time, you want to set it to true, but the default is false. At this point, from how people have been using Truss, there is not really a need for at all, and it serves as a major source of confusion.
* We have already essentially deprecated the `--trusted` flag for Chains and never supported it.

The behavior for secrets will now be that secrets will be mounted on the Truss. You still need to declare which secrets you want to access in the `config.yaml` file to access them. We throw a nice error in Truss if you try to access a secret that is not there.

## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing

![cli_py_—_truss__Codespaces__zany_happiness_](https://github.com/user-attachments/assets/a6558bbf-d2b3-4c85-9346-69ac38fdadbf)
