### PR TITLE
Better chains error propagation (+various fixes).

### DIFF
--- a/truss-chains/tests/test_e2e.py
+++ b/truss-chains/tests/test_e2e.py
@@ -1,5 +1,6 @@
 import logging
 import re
+import time
 from pathlib import Path
 
 import pytest
@@ -24,6 +25,7 @@ def test_chain():
             service = deployment_client.push(entrypoint, options)
 
         url = service.run_remote_url.replace("host.docker.internal", "localhost")
+        time.sleep(1.0)  # Wait for models to be ready.
 
         # Call without providing values for default arguments.
         response = requests.post(
@@ -100,7 +102,8 @@ ValueError: \(showing chained remote errors, root error at the bottom\)
 │   │       raise ValueError\(f\"This input is too long: \{len\(data\)\}\.\"\)
 ╰   ╰   ValueError: This input is too long: \d+\.
                 """
-        assert re.match(error_regex.strip(), error_str.strip(), re.MULTILINE)
+
+        assert re.match(error_regex.strip(), error_str.strip(), re.MULTILINE), error_str
 
 
 @pytest.mark.asyncio

--- a/truss-chains/truss_chains/definitions.py
+++ b/truss-chains/truss_chains/definitions.py
@@ -633,7 +633,6 @@ class RemoteErrorDetail(SafeModel):
     error response.
     """
 
-    remote_name: str
     exception_cls_name: str
     exception_module_name: Optional[str]
     exception_message: str
@@ -654,8 +653,7 @@ class RemoteErrorDetail(SafeModel):
             else ""
         )
         error = (
-            f"{RemoteErrorDetail.__name__} in `{self.remote_name}`\n"
-            f"Traceback (most recent call last):\n"
+            f"Chainlet-Traceback (most recent call last):\n"
             f"{stack}{self.exception_cls_name}: {self.exception_message}{exc_info}"
         )
         return error

--- a/truss-chains/truss_chains/deployment/code_gen.py
+++ b/truss-chains/truss_chains/deployment/code_gen.py
@@ -452,10 +452,7 @@ def _gen_predict_src(chainlet_descriptor: definitions.ChainletAPIDescriptor) -> 
     )
     # Add error handling context manager:
     parts.append(
-        _indent(
-            f"with stub.trace_parent(request), utils.exception_to_http_error("
-            f'chainlet_name="{chainlet_descriptor.name}"):'
-        )
+        _indent("with stub.trace_parent(request), utils.exception_to_http_error():")
     )
     # Invoke Chainlet.
     if (

--- a/truss-chains/truss_chains/streaming.py
+++ b/truss-chains/truss_chains/streaming.py
@@ -173,7 +173,6 @@ class _StreamReader(_Streamer[ItemT, HeaderTT, FooterTT]):
         if not length:
             return delimiter, b""
         data_bytes = await self._stream.readexactly(length)
-        print(f"Read Delimiter: {delimiter}")
         return delimiter, data_bytes
 
     async def read_items(self) -> AsyncIterator[ItemT]:


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
* Skip pre-/post-process (and tracing span) if not defined on model.
* Remove left-over print statememtn in chains streaming.
* Add some helper functions to integration test chain (for more interesting stack traces).
* Improve chainlet error chaining by filtering out all non-user code and making the formatting nicer.
* Add test with regex to assert that this filtering is matching in case functions are renamed.
* Simplify code gen by avoiding chainlet name in `exception_to_http_error`.

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
