### PR TITLE
Automatic migration of TRTLLM runtime configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.56rc1"
+version = "0.9.56rc2"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/base/trt_llm_config.py
+++ b/truss/base/trt_llm_config.py
@@ -213,14 +213,20 @@ class TRTLLMConfiguration(BaseModel):
                 valid_build_fields[key] = value
             else:
                 if key in TrussTRTLLMRuntimeConfiguration.__annotations__:
-                    logger.warning(f"Setting runtime.{key}: {value}")
+                    logger.warning(f"Found runtime.{key}: {value} in build config")
                     extra_runtime_fields[key] = value
         if extra_runtime_fields:
             logger.warning(
-                f"Found extra fields {list(extra_runtime_fields.keys())} in build configuration, fields were migrated to runtime configuration."
-                " This migration of deprecated fields is scheduled for removal, please upgrade to the latest truss version and update configs according to https://docs.baseten.co/performance/engine-builder-config."
+                f"Found extra fields {list(extra_runtime_fields.keys())} in build configuration, unspecified runtime fields will be configured using these values."
+                " This configuration of deprecated fields is scheduled for removal, please upgrade to the latest truss version and update configs according to https://docs.baseten.co/performance/engine-builder-config."
             )
-            data.update({"runtime": extra_runtime_fields})
+            data.get("runtime").update(
+                {
+                    k: v
+                    for k, v in extra_runtime_fields.items()
+                    if k not in data.get("runtime")
+                }
+            )
 
         data.update({"build": valid_build_fields})
         return data

--- a/truss/tests/conftest.py
+++ b/truss/tests/conftest.py
@@ -839,7 +839,7 @@ def trtllm_spec_dec_config_full(trtllm_config) -> Dict[str, Any]:
                 "use_paged_context_fmha": True,
             },
             "speculator": {
-                "speculative_decoding_mode": TrussSpecDecMode.DRAFT_EXTERNAL,
+                "speculative_decoding_mode": TrussSpecDecMode.DRAFT_EXTERNAL.value,
                 "num_draft_tokens": 4,
                 "build": {
                     "base_model": "llama",
@@ -874,7 +874,7 @@ def trtllm_spec_dec_config(trtllm_config) -> Dict[str, Any]:
                 "use_paged_context_fmha": True,
             },
             "speculator": {
-                "speculative_decoding_mode": TrussSpecDecMode.DRAFT_EXTERNAL,
+                "speculative_decoding_mode": TrussSpecDecMode.DRAFT_EXTERNAL.value,
                 "num_draft_tokens": 4,
                 "checkpoint_repository": {
                     "source": "HF",

--- a/truss/tests/conftest.py
+++ b/truss/tests/conftest.py
@@ -808,7 +808,7 @@ def deprecated_trtllm_config(default_config) -> Dict[str, Any]:
             "enable_chunked_context": True,
             "batch_scheduler_policy": TrussTRTLLMBatchSchedulerPolicy.MAX_UTILIZATION.value,
             "request_default_max_tokens": 10,
-            "total_token_limit": 100,
+            "total_token_limit": 50,
             # end deprecated fields
             "checkpoint_repository": {
                 "source": "HF",
@@ -816,7 +816,7 @@ def deprecated_trtllm_config(default_config) -> Dict[str, Any]:
             },
             "gather_all_token_logits": False,
         },
-        "runtime": {},
+        "runtime": {"total_token_limit": 100},
     }
     return trtllm_config
 

--- a/truss/tests/conftest.py
+++ b/truss/tests/conftest.py
@@ -1,4 +1,5 @@
 import contextlib
+import copy
 import importlib
 import os
 import shutil
@@ -6,14 +7,18 @@ import subprocess
 import sys
 import time
 from pathlib import Path
+from typing import Any, Dict
 
 import pytest
 import requests
 import yaml
 
 from truss.base.custom_types import Example
-from truss.base.trt_llm_config import TrussTRTLLMBatchSchedulerPolicy
-from truss.base.truss_config import DEFAULT_BUNDLED_PACKAGES_DIR
+from truss.base.trt_llm_config import (
+    TrussSpecDecMode,
+    TrussTRTLLMBatchSchedulerPolicy,
+)
+from truss.base.truss_config import DEFAULT_BUNDLED_PACKAGES_DIR, Accelerator
 from truss.contexts.image_builder.serving_image_builder import (
     ServingImageBuilderContext,
 )
@@ -736,3 +741,146 @@ def _modify_yaml(yaml_path: Path):
     yield content
     with yaml_path.open("w") as yaml_file:
         yaml.dump(content, yaml_file)
+
+
+@pytest.fixture
+def default_config() -> Dict[str, Any]:
+    return {
+        "build_commands": [],
+        "environment_variables": {},
+        "external_package_dirs": [],
+        "model_metadata": {},
+        "model_name": None,
+        "python_version": "py39",
+        "requirements": [],
+        "resources": {
+            "accelerator": None,
+            "cpu": "1",
+            "memory": "2Gi",
+            "use_gpu": False,
+        },
+        "secrets": {},
+        "system_packages": [],
+    }
+
+
+@pytest.fixture
+def trtllm_config(default_config) -> Dict[str, Any]:
+    trtllm_config = default_config
+    trtllm_config["resources"] = {
+        "accelerator": Accelerator.L4.value,
+        "cpu": "1",
+        "memory": "24Gi",
+        "use_gpu": True,
+    }
+    trtllm_config["trt_llm"] = {
+        "build": {
+            "base_model": "llama",
+            "max_seq_len": 2048,
+            "max_batch_size": 512,
+            "checkpoint_repository": {
+                "source": "HF",
+                "repo": "meta/llama4-500B",
+            },
+            "gather_all_token_logits": False,
+        },
+        "runtime": {},
+    }
+    return trtllm_config
+
+
+@pytest.fixture
+def deprecated_trtllm_config(default_config) -> Dict[str, Any]:
+    trtllm_config = default_config
+    trtllm_config["resources"] = {
+        "accelerator": Accelerator.L4.value,
+        "cpu": "1",
+        "memory": "24Gi",
+        "use_gpu": True,
+    }
+    trtllm_config["trt_llm"] = {
+        "build": {
+            "base_model": "llama",
+            "max_seq_len": 2048,
+            "max_batch_size": 512,
+            # start deprecated fields
+            "kv_cache_free_gpu_mem_fraction": 0.1,
+            "enable_chunked_context": True,
+            "batch_scheduler_policy": TrussTRTLLMBatchSchedulerPolicy.MAX_UTILIZATION.value,
+            "request_default_max_tokens": 10,
+            "total_token_limit": 100,
+            # end deprecated fields
+            "checkpoint_repository": {
+                "source": "HF",
+                "repo": "meta/llama4-500B",
+            },
+            "gather_all_token_logits": False,
+        },
+        "runtime": {},
+    }
+    return trtllm_config
+
+
+@pytest.fixture
+def trtllm_spec_dec_config_full(trtllm_config) -> Dict[str, Any]:
+    spec_dec_config = copy.deepcopy(trtllm_config)
+    spec_dec_config["trt_llm"] = {
+        "build": {
+            "base_model": "llama",
+            "max_seq_len": 2048,
+            "max_batch_size": 512,
+            "checkpoint_repository": {
+                "source": "HF",
+                "repo": "meta/llama4-500B",
+            },
+            "plugin_configuration": {
+                "paged_kv_cache": True,
+                "gemm_plugin": "auto",
+                "use_paged_context_fmha": True,
+            },
+            "speculator": {
+                "speculative_decoding_mode": TrussSpecDecMode.DRAFT_EXTERNAL,
+                "num_draft_tokens": 4,
+                "build": {
+                    "base_model": "llama",
+                    "max_seq_len": 2048,
+                    "max_batch_size": 512,
+                    "checkpoint_repository": {
+                        "source": "HF",
+                        "repo": "meta/llama4-500B",
+                    },
+                },
+            },
+        },
+    }
+    return spec_dec_config
+
+
+@pytest.fixture
+def trtllm_spec_dec_config(trtllm_config) -> Dict[str, Any]:
+    spec_dec_config = copy.deepcopy(trtllm_config)
+    spec_dec_config["trt_llm"] = {
+        "build": {
+            "base_model": "llama",
+            "max_seq_len": 2048,
+            "max_batch_size": 512,
+            "checkpoint_repository": {
+                "source": "HF",
+                "repo": "meta/llama4-500B",
+            },
+            "plugin_configuration": {
+                "paged_kv_cache": True,
+                "gemm_plugin": "auto",
+                "use_paged_context_fmha": True,
+            },
+            "speculator": {
+                "speculative_decoding_mode": TrussSpecDecMode.DRAFT_EXTERNAL,
+                "num_draft_tokens": 4,
+                "checkpoint_repository": {
+                    "source": "HF",
+                    "repo": "meta/llama4-500B",
+                },
+            },
+        },
+    }
+    return spec_dec_config

--- a/truss/tests/test_config.py
+++ b/truss/tests/test_config.py
@@ -2,14 +2,12 @@ import copy
 import tempfile
 from contextlib import nullcontext as does_not_raise
 from pathlib import Path
-from typing import Any, Dict
 
 import pytest
 import yaml
 
 from truss.base.custom_types import ModelFrameworkType
 from truss.base.trt_llm_config import (
-    TrussSpecDecMode,
     TrussTRTLLMQuantizationType,
 )
 from truss.base.truss_config import (
@@ -27,117 +25,6 @@ from truss.base.truss_config import (
     TrussConfig,
 )
 from truss.truss_handle.truss_handle import TrussHandle
-
-
-@pytest.fixture
-def default_config() -> Dict[str, Any]:
-    return {
-        "build_commands": [],
-        "environment_variables": {},
-        "external_package_dirs": [],
-        "model_metadata": {},
-        "model_name": None,
-        "python_version": "py39",
-        "requirements": [],
-        "resources": {
-            "accelerator": None,
-            "cpu": "1",
-            "memory": "2Gi",
-            "use_gpu": False,
-        },
-        "secrets": {},
-        "system_packages": [],
-    }
-
-
-@pytest.fixture
-def trtllm_config(default_config) -> Dict[str, Any]:
-    trtllm_config = default_config
-    trtllm_config["resources"] = {
-        "accelerator": Accelerator.L4.value,
-        "cpu": "1",
-        "memory": "24Gi",
-        "use_gpu": True,
-    }
-    trtllm_config["trt_llm"] = {
-        "build": {
-            "base_model": "llama",
-            "max_seq_len": 2048,
-            "max_batch_size": 512,
-            "checkpoint_repository": {
-                "source": "HF",
-                "repo": "meta/llama4-500B",
-            },
-            "gather_all_token_logits": False,
-        },
-        "runtime": {},
-    }
-    return trtllm_config
-
-
-@pytest.fixture
-def trtllm_spec_dec_config_full(trtllm_config) -> Dict[str, Any]:
-    spec_dec_config = copy.deepcopy(trtllm_config)
-    spec_dec_config["trt_llm"] = {
-        "build": {
-            "base_model": "llama",
-            "max_seq_len": 2048,
-            "max_batch_size": 512,
-            "checkpoint_repository": {
-                "source": "HF",
-                "repo": "meta/llama4-500B",
-            },
-            "plugin_configuration": {
-                "paged_kv_cache": True,
-                "gemm_plugin": "auto",
-                "use_paged_context_fmha": True,
-            },
-            "speculator": {
-                "speculative_decoding_mode": TrussSpecDecMode.DRAFT_EXTERNAL,
-                "num_draft_tokens": 4,
-                "build": {
-                    "base_model": "llama",
-                    "max_seq_len": 2048,
-                    "max_batch_size": 512,
-                    "checkpoint_repository": {
-                        "source": "HF",
-                        "repo": "meta/llama4-500B",
-                    },
-                },
-            },
-        },
-    }
-    return spec_dec_config
-
-
-@pytest.fixture
-def trtllm_spec_dec_config(trtllm_config) -> Dict[str, Any]:
-    spec_dec_config = copy.deepcopy(trtllm_config)
-    spec_dec_config["trt_llm"] = {
-        "build": {
-            "base_model": "llama",
-            "max_seq_len": 2048,
-            "max_batch_size": 512,
-            "checkpoint_repository": {
-                "source": "HF",
-                "repo": "meta/llama4-500B",
-            },
-            "plugin_configuration": {
-                "paged_kv_cache": True,
-                "gemm_plugin": "auto",
-                "use_paged_context_fmha": True,
-            },
-            "speculator": {
-                "speculative_decoding_mode": TrussSpecDecMode.DRAFT_EXTERNAL,
-                "num_draft_tokens": 4,
-                "checkpoint_repository": {
-                    "source": "HF",
-                    "repo": "meta/llama4-500B",
-                },
-            },
-        },
-    }
-    return spec_dec_config
 
 
 @pytest.mark.parametrize(

--- a/truss/tests/trt_llm/test_trt_llm_config.py
+++ b/truss/tests/trt_llm/test_trt_llm_config.py
@@ -1,0 +1,17 @@
+from truss.base.trt_llm_config import (
+    TRTLLMConfiguration,
+    TrussTRTLLMBatchSchedulerPolicy,
+)
+
+
+def test_trt_llm_configuration_init_and_migrate_deprecated_runtime_fields(
+    deprecated_trtllm_config,
+):
+    trt_llm_config = TRTLLMConfiguration(**deprecated_trtllm_config["trt_llm"])
+    assert trt_llm_config.runtime.model_dump() == {
+        "kv_cache_free_gpu_mem_fraction": 0.1,
+        "enable_chunked_context": True,
+        "batch_scheduler_policy": TrussTRTLLMBatchSchedulerPolicy.MAX_UTILIZATION.value,
+        "request_default_max_tokens": 10,
+        "total_token_limit": 100,
+    }


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
- This PR improves the breaking change rollout experience for users that have previously configured runtime configs in the `trt_llm.build` key.

For example the following config:
```
trt_llm:
  build:
    base_model: llama
    checkpoint_repository:
      repo: meta-llama/Llama-3.1-8B-Instruct
      source: HF
    max_seq_len: 8192
    enable_chunked_context: False
    kv_cache_free_gpu_mem_fraction: 0.6
```
will have runtime configs migrated to the proper runtime key:
```
trt_llm:
  build:
    base_model: llama
    checkpoint_repository:
      repo: meta-llama/Llama-3.1-8B-Instruct
      source: HF
    max_seq_len: 8192
  runtime:
    enable_chunked_context: False
    kv_cache_free_gpu_mem_fraction: 0.6
```
with the following CLI logging:
```
Found extra fields ['enable_chunked_context', 'kv_cache_free_gpu_mem_fraction'] in build configuration, attempting to migrate valid fields to runtime configuration. This migration of deprecated fields is scheduled for        
removal, please upgrade to the latest truss version and update configs according to https://docs.baseten.co/performance/engine-builder-config.                                                                                   
Setting runtime.enable_chunked_context: False                                                                                                                                                                                    
Setting runtime.kv_cache_free_gpu_mem_fraction: 0.6
```
<!--
  How was the change described above implemented?
-->
## :computer: How
- During config initialization, we look for extra build fields and attempt to patch matching runtime configuration with a deprecation notice and callout to update the truss client version. 
- We will rollout this config change to the backend with `0.9.56rc2` and follow up with a full patch release of the client package.
<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
- Added unit tests
