### PR TITLE
fix initialization from pydantic models

### DIFF
--- a/truss/base/trt_llm_config.py
+++ b/truss/base/trt_llm_config.py
@@ -208,27 +208,28 @@ class TRTLLMConfiguration(BaseModel):
     def migrate_runtime_fields(cls, data: Any) -> Any:
         extra_runtime_fields = {}
         valid_build_fields = {}
-        for key, value in data.get("build").items():
-            if key in TrussTRTLLMBuildConfiguration.__annotations__:
-                valid_build_fields[key] = value
-            else:
-                if key in TrussTRTLLMRuntimeConfiguration.__annotations__:
-                    logger.warning(f"Found runtime.{key}: {value} in build config")
-                    extra_runtime_fields[key] = value
-        if extra_runtime_fields:
-            logger.warning(
-                f"Found extra fields {list(extra_runtime_fields.keys())} in build configuration, unspecified runtime fields will be configured using these values."
-                " This configuration of deprecated fields is scheduled for removal, please upgrade to the latest truss version and update configs according to https://docs.baseten.co/performance/engine-builder-config."
-            )
-            data.get("runtime").update(
-                {
-                    k: v
-                    for k, v in extra_runtime_fields.items()
-                    if k not in data.get("runtime")
-                }
-            )
-
-        data.update({"build": valid_build_fields})
+        if isinstance(data.get("build"), dict):
+            for key, value in data.get("build").items():
+                if key in TrussTRTLLMBuildConfiguration.__annotations__:
+                    valid_build_fields[key] = value
+                else:
+                    if key in TrussTRTLLMRuntimeConfiguration.__annotations__:
+                        logger.warning(f"Found runtime.{key}: {value} in build config")
+                        extra_runtime_fields[key] = value
+            if extra_runtime_fields:
+                logger.warning(
+                    f"Found extra fields {list(extra_runtime_fields.keys())} in build configuration, unspecified runtime fields will be configured using these values."
+                    " This configuration of deprecated fields is scheduled for removal, please upgrade to the latest truss version and update configs according to https://docs.baseten.co/performance/engine-builder-config."
+                )
+                data.get("runtime").update(
+                    {
+                        k: v
+                        for k, v in extra_runtime_fields.items()
+                        if k not in data.get("runtime")
+                    }
+                )
+            data.update({"build": valid_build_fields})
+            return data
         return data
 
     @property

--- a/truss/tests/trt_llm/test_trt_llm_config.py
+++ b/truss/tests/trt_llm/test_trt_llm_config.py
@@ -1,7 +1,14 @@
 from truss.base.trt_llm_config import (
     TRTLLMConfiguration,
     TrussTRTLLMBatchSchedulerPolicy,
+    TrussTRTLLMBuildConfiguration,
+    TrussTRTLLMRuntimeConfiguration,
 )
+
+
+def test_trt_llm_config_init_from_pydantic_models(trtllm_config):
+    build_config = TrussTRTLLMBuildConfiguration(**trtllm_config["trt_llm"]["build"])
+    TRTLLMConfiguration(build=build_config, runtime=TrussTRTLLMRuntimeConfiguration())
 
 
 def test_trt_llm_configuration_init_and_migrate_deprecated_runtime_fields(


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
- Added validation of TRTLLM configuration was failing when using pydantic models in constructor – this PR adds a check to only apply the validation in ambiguous cases when constructing from a dictionary.
<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
- Added unit test coverage for this case
