### PR TITLE
Add new health check configuration fields

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.59.rc003"
+version = "0.9.59rc003"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.59.rc0-013"
+version = "0.9.59.rc003"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss-chains/truss_chains/__init__.py
+++ b/truss-chains/truss_chains/__init__.py
@@ -32,7 +32,6 @@ from truss_chains.definitions import (
     RemoteConfig,
     RemoteErrorDetail,
     RPCOptions,
-    Runtime,
 )
 from truss_chains.public_api import (
     ChainletBase,
@@ -60,7 +59,6 @@ __all__ = [
     "GenericRemoteException",
     "RemoteConfig",
     "RemoteErrorDetail",
-    "Runtime",
     "DeployedServiceDescriptor",
     "StubBase",
     "depends",

--- a/truss-chains/truss_chains/__init__.py
+++ b/truss-chains/truss_chains/__init__.py
@@ -32,6 +32,7 @@ from truss_chains.definitions import (
     RemoteConfig,
     RemoteErrorDetail,
     RPCOptions,
+    Runtime,
 )
 from truss_chains.public_api import (
     ChainletBase,
@@ -59,6 +60,7 @@ __all__ = [
     "GenericRemoteException",
     "RemoteConfig",
     "RemoteErrorDetail",
+    "Runtime",
     "DeployedServiceDescriptor",
     "StubBase",
     "depends",

--- a/truss-chains/truss_chains/definitions.py
+++ b/truss-chains/truss_chains/definitions.py
@@ -352,18 +352,11 @@ class ChainletOptions(SafeModelNonSerializable):
           It is independent of a potentially user-configured tracing instrumentation.
           Turning this on, could add performance overhead.
         env_variables: static environment variables available to the deployed chainlet.
+        health_checks: Configures health checks for the chainlet.
     """
 
     enable_b10_tracing: bool = False
     env_variables: Mapping[str, str] = {}
-
-
-class Runtime(SafeModelNonSerializable):
-    """Configures runtime options for a chainlet.
-    Args:
-        health_checks: Configures health checks for the chainlet.
-    """
-
     health_checks: truss_config.HealthChecks = truss_config.HealthChecks()
 
 
@@ -397,7 +390,6 @@ class RemoteConfig(SafeModelNonSerializable):
     assets: Assets = Assets()
     name: Optional[str] = None
     options: ChainletOptions = ChainletOptions()
-    runtime: Runtime = Runtime()
 
     def get_compute_spec(self) -> ComputeSpec:
         return self.compute.get_spec()

--- a/truss-chains/truss_chains/definitions.py
+++ b/truss-chains/truss_chains/definitions.py
@@ -359,6 +359,11 @@ class ChainletOptions(SafeModelNonSerializable):
 
 
 class Runtime(SafeModelNonSerializable):
+    """Configures runtime options for a chainlet.
+    Args:
+        health_checks: Configures health checks for the chainlet.
+    """
+
     health_checks: truss_config.HealthChecks = truss_config.HealthChecks()
 
 

--- a/truss-chains/truss_chains/definitions.py
+++ b/truss-chains/truss_chains/definitions.py
@@ -359,7 +359,7 @@ class ChainletOptions(SafeModelNonSerializable):
 
 
 class Runtime(SafeModelNonSerializable):
-    health_checks: truss_config.HealthCheck = truss_config.HealthCheck()
+    health_checks: truss_config.HealthChecks = truss_config.HealthChecks()
 
 
 class ChainletMetadata(SafeModelNonSerializable):

--- a/truss-chains/truss_chains/definitions.py
+++ b/truss-chains/truss_chains/definitions.py
@@ -358,6 +358,10 @@ class ChainletOptions(SafeModelNonSerializable):
     env_variables: Mapping[str, str] = {}
 
 
+class Runtime(SafeModelNonSerializable):
+    health_checks: truss_config.HealthCheck = truss_config.HealthCheck()
+
+
 class ChainletMetadata(SafeModelNonSerializable):
     is_entrypoint: bool = False
     chain_name: Optional[str] = None
@@ -388,6 +392,7 @@ class RemoteConfig(SafeModelNonSerializable):
     assets: Assets = Assets()
     name: Optional[str] = None
     options: ChainletOptions = ChainletOptions()
+    runtime: Runtime = Runtime()
 
     def get_compute_spec(self) -> ComputeSpec:
         return self.compute.get_spec()

--- a/truss-chains/truss_chains/deployment/code_gen.py
+++ b/truss-chains/truss_chains/deployment/code_gen.py
@@ -668,7 +668,9 @@ def _make_truss_config(
     config.resources.memory = str(compute.memory)
     config.resources.accelerator = compute.accelerator
     config.resources.use_gpu = bool(compute.accelerator.count)
+    # Runtime
     config.runtime.predict_concurrency = compute.predict_concurrency
+    config.runtime.health_checks = chains_config.runtime.health_checks
     # Image.
     _inplace_fill_base_image(chains_config.docker_image, config)
     pip_requirements = _make_requirements(chains_config.docker_image)

--- a/truss-chains/truss_chains/deployment/code_gen.py
+++ b/truss-chains/truss_chains/deployment/code_gen.py
@@ -662,15 +662,14 @@ def _make_truss_config(
     config.model_class_name = _MODEL_CLS_NAME
     config.runtime.enable_tracing_data = chains_config.options.enable_b10_tracing
     config.environment_variables = dict(chains_config.options.env_variables)
+    config.runtime.health_checks = chains_config.options.health_checks
     # Compute.
     compute = chains_config.get_compute_spec()
     config.resources.cpu = str(compute.cpu_count)
     config.resources.memory = str(compute.memory)
     config.resources.accelerator = compute.accelerator
     config.resources.use_gpu = bool(compute.accelerator.count)
-    # Runtime
     config.runtime.predict_concurrency = compute.predict_concurrency
-    config.runtime.health_checks = chains_config.runtime.health_checks
     # Image.
     _inplace_fill_base_image(chains_config.docker_image, config)
     pip_requirements = _make_requirements(chains_config.docker_image)

--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -42,8 +42,6 @@ DEFAULT_SPEC_VERSION = "2.0"
 DEFAULT_PREDICT_CONCURRENCY = 1
 DEFAULT_STREAMING_RESPONSE_READ_TIMEOUT = 60
 DEFAULT_ENABLE_TRACING_DATA = False  # This should be in sync with tracing.py.
-MAX_FAILURE_THRESHOLD_SECONDS = 1800
-MIN_FAILURE_THRESHOLD_SECONDS = 30
 DEFAULT_CPU = "1"
 DEFAULT_MEMORY = "2Gi"
 DEFAULT_USE_GPU = False
@@ -850,7 +848,7 @@ def obj_to_dict(obj, verbose: bool = False):
                     field_curr_value, lambda data: data.to_dict()
                 )
             elif isinstance(field_curr_value, HealthChecks):
-                d[field_name] = transform_optional(
+                d["health_checks"] = transform_optional(
                     field_curr_value, lambda data: data.to_dict()
                 )
             else:

--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -159,26 +159,26 @@ class ModelCache:
 @dataclass
 class HealthChecks:
     restart_check_delay_seconds: int = 0
-    restart_failure_threshold_seconds: int = MAX_FAILURE_THRESHOLD_SECONDS
-    stop_traffic_failure_threshold_seconds: int = MAX_FAILURE_THRESHOLD_SECONDS
+    restart_threshold_seconds: int = MAX_FAILURE_THRESHOLD_SECONDS
+    stop_traffic_threshold_seconds: int = MAX_FAILURE_THRESHOLD_SECONDS
 
     @staticmethod
     def from_dict(d):
         return HealthChecks(
             restart_check_delay_seconds=d.get("restart_check_delay_seconds", 0),
-            restart_failure_threshold_seconds=d.get(
-                "restart_failure_threshold_seconds", MAX_FAILURE_THRESHOLD_SECONDS
+            restart_threshold_seconds=d.get(
+                "restart_threshold_seconds", MAX_FAILURE_THRESHOLD_SECONDS
             ),
-            stop_traffic_failure_threshold_seconds=d.get(
-                "stop_traffic_failure_threshold_seconds", MAX_FAILURE_THRESHOLD_SECONDS
+            stop_traffic_threshold_seconds=d.get(
+                "stop_traffic_threshold_seconds", MAX_FAILURE_THRESHOLD_SECONDS
             ),
         )
 
     def to_dict(self):
         return {
             "restart_check_delay_seconds": self.restart_check_delay_seconds,
-            "restart_failure_threshold_seconds": self.restart_failure_threshold_seconds,
-            "stop_traffic_failure_threshold_seconds": self.stop_traffic_failure_threshold_seconds,
+            "restart_threshold_seconds": self.restart_threshold_seconds,
+            "stop_traffic_threshold_seconds": self.stop_traffic_threshold_seconds,
         }
 
 

--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -157,45 +157,14 @@ class ModelCache:
 
 
 @dataclass
-class HealthCheck:
+class HealthChecks:
     restart_check_delay_seconds: int = 0
     restart_failure_threshold_seconds: int = MAX_FAILURE_THRESHOLD_SECONDS
     stop_traffic_failure_threshold_seconds: int = MAX_FAILURE_THRESHOLD_SECONDS
 
-    def __post_init__(self):
-        if not (0 <= self.restart_check_delay_seconds <= MAX_FAILURE_THRESHOLD_SECONDS):
-            raise ValidationError(
-                f"restart_check_delay_seconds must be between 0 and {MAX_FAILURE_THRESHOLD_SECONDS} seconds."
-            )
-        if not (
-            MIN_FAILURE_THRESHOLD_SECONDS
-            <= self.restart_failure_threshold_seconds
-            <= MAX_FAILURE_THRESHOLD_SECONDS
-        ):
-            raise ValidationError(
-                f"restart_failure_threshold_seconds must be between {MIN_FAILURE_THRESHOLD_SECONDS} and {MAX_FAILURE_THRESHOLD_SECONDS} seconds."
-            )
-        if not (
-            MIN_FAILURE_THRESHOLD_SECONDS
-            <= self.stop_traffic_failure_threshold_seconds
-            <= MAX_FAILURE_THRESHOLD_SECONDS
-        ):
-            raise ValidationError(
-                f"stop_traffic_failure_threshold_seconds must be between {MIN_FAILURE_THRESHOLD_SECONDS} and {MAX_FAILURE_THRESHOLD_SECONDS} seconds."
-            )
-
-        if (
-            self.restart_check_delay_seconds + self.restart_failure_threshold_seconds
-            > MAX_FAILURE_THRESHOLD_SECONDS
-        ):
-            raise ValidationError(
-                "The sum of restart_check_delay_seconds and max_failures_before_restart "
-                f"must not exceed {MAX_FAILURE_THRESHOLD_SECONDS} seconds."
-            )
-
     @staticmethod
     def from_dict(d):
-        return HealthCheck(
+        return HealthChecks(
             restart_check_delay_seconds=d.get("restart_check_delay_seconds", 0),
             restart_failure_threshold_seconds=d.get(
                 "restart_failure_threshold_seconds", MAX_FAILURE_THRESHOLD_SECONDS
@@ -219,7 +188,7 @@ class Runtime:
     streaming_read_timeout: int = DEFAULT_STREAMING_RESPONSE_READ_TIMEOUT
     enable_tracing_data: bool = DEFAULT_ENABLE_TRACING_DATA
     enable_debug_logs: bool = False
-    health_checks: HealthCheck = field(default_factory=HealthCheck)
+    health_checks: HealthChecks = field(default_factory=HealthChecks)
 
     @staticmethod
     def from_dict(d):
@@ -236,7 +205,7 @@ class Runtime:
             "streaming_read_timeout", DEFAULT_STREAMING_RESPONSE_READ_TIMEOUT
         )
         enable_tracing_data = d.get("enable_tracing_data", DEFAULT_ENABLE_TRACING_DATA)
-        health_checks = HealthCheck.from_dict(d.get("health_checks", {}))
+        health_checks = HealthChecks.from_dict(d.get("health_checks", {}))
 
         return Runtime(
             predict_concurrency=predict_concurrency,
@@ -884,7 +853,7 @@ def obj_to_dict(obj, verbose: bool = False):
                 d["docker_auth"] = transform_optional(
                     field_curr_value, lambda data: data.to_dict()
                 )
-            elif isinstance(field_curr_value, HealthCheck):
+            elif isinstance(field_curr_value, HealthChecks):
                 d[field_name] = transform_optional(
                     field_curr_value, lambda data: data.to_dict()
                 )

--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -158,20 +158,16 @@ class ModelCache:
 
 @dataclass
 class HealthChecks:
-    restart_check_delay_seconds: int = 0
-    restart_threshold_seconds: int = MAX_FAILURE_THRESHOLD_SECONDS
-    stop_traffic_threshold_seconds: int = MAX_FAILURE_THRESHOLD_SECONDS
+    restart_check_delay_seconds: Optional[int] = None
+    restart_threshold_seconds: Optional[int] = None
+    stop_traffic_threshold_seconds: Optional[int] = None
 
     @staticmethod
     def from_dict(d):
         return HealthChecks(
-            restart_check_delay_seconds=d.get("restart_check_delay_seconds", 0),
-            restart_threshold_seconds=d.get(
-                "restart_threshold_seconds", MAX_FAILURE_THRESHOLD_SECONDS
-            ),
-            stop_traffic_threshold_seconds=d.get(
-                "stop_traffic_threshold_seconds", MAX_FAILURE_THRESHOLD_SECONDS
-            ),
+            restart_check_delay_seconds=d.get("restart_check_delay_seconds"),
+            restart_threshold_seconds=d.get("restart_threshold_seconds"),
+            stop_traffic_threshold_seconds=d.get("stop_traffic_threshold_seconds"),
         )
 
     def to_dict(self):

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -494,16 +494,16 @@ class BasetenApi:
             logging.debug(f"Failed to sync patch: {result}")
         return result
 
-    def validate_truss_config(self, client_version: str, config: str):
+    def validate_truss(self, client_version: str, config: str):
         query_string = f"""{{
-            valid_truss_config(client_version: "{client_version}", config: "{config}") {{
+            truss_validation(client_version: "{client_version}", config: "{config}") {{
                 success
                 details
             }}
         }}
         """
         resp = self._post_graphql_query(query_string)
-        return resp["data"]["valid_truss_config"]
+        return resp["data"]["truss_validation"]
 
     def get_deployment(self, model_id: str, deployment_id: str) -> Any:
         headers = self._auth_token.header()

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -494,6 +494,17 @@ class BasetenApi:
             logging.debug(f"Failed to sync patch: {result}")
         return result
 
+    def validate_truss_config(self, client_version: str, config: str):
+        query_string = f"""{{
+            valid_truss_config(client_version: "{client_version}", config: "{config}") {{
+                success
+                details
+            }}
+        }}
+        """
+        resp = self._post_graphql_query(query_string)
+        return resp["data"]["valid_truss_config"]
+
     def get_deployment(self, model_id: str, deployment_id: str) -> Any:
         headers = self._auth_token.header()
         resp = requests.get(

--- a/truss/remote/baseten/core.py
+++ b/truss/remote/baseten/core.py
@@ -421,7 +421,7 @@ def validate_truss_config(api: BasetenApi, config: str):
     Returns:
         None if the config is valid, otherwise raises an error message
     """
-    valid_config = api.validate_truss_config(truss.version(), config)
+    valid_config = api.validate_truss(truss.version(), config)
     if not valid_config.get("success"):
         details = json.loads(valid_config.get("details"))
         errors = details.get("errors", [])

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -33,6 +33,7 @@ from truss.remote.baseten.core import (
     get_prod_version_from_versions,
     get_truss_watch_state,
     upload_truss,
+    validate_truss_config,
 )
 from truss.remote.baseten.error import ApiError, RemoteError
 from truss.remote.baseten.service import BasetenService, URLConfig
@@ -180,6 +181,8 @@ class BasetenRemote(TrussRemote):
         encoded_config_str = base64_encoded_json_str(
             gathered_truss._spec._config.to_dict()
         )
+
+        validate_truss_config(self._api, encoded_config_str)
 
         return FinalPushData(
             model_name=model_name,

--- a/truss/tests/remote/baseten/test_core.py
+++ b/truss/tests/remote/baseten/test_core.py
@@ -245,7 +245,7 @@ def test_create_truss_service_handles_allow_truss_download_for_new_models(
 
 
 def test_validate_truss_config():
-    def mock_validate_truss_config(client_version, config):
+    def mock_validate_truss(client_version, config):
         if config == {}:
             return {"success": True, "details": json.dumps({})}
         elif "hi" in config:
@@ -257,7 +257,7 @@ def test_validate_truss_config():
             }
 
     api = MagicMock()
-    api.validate_truss_config.side_effect = mock_validate_truss_config
+    api.validate_truss.side_effect = mock_validate_truss
 
     assert core.validate_truss_config(api, {}) is None
     with pytest.raises(

--- a/truss/tests/test_model_inference.py
+++ b/truss/tests/test_model_inference.py
@@ -980,52 +980,39 @@ def test_health_check_configuration():
     config = """runtime:
     health_checks:
         restart_check_delay_seconds: 100
-        restart_failure_threshold_seconds: 1700
+        restart_threshold_seconds: 1700
     """
 
     with ensure_kill_all(), _temp_truss(model, config) as tr:
         _ = tr.docker_run(local_port=8090, detach=True, wait_for_server_ready=True)
 
         assert tr.spec.config.runtime.health_checks.restart_check_delay_seconds == 100
+        assert tr.spec.config.runtime.health_checks.restart_threshold_seconds == 1700
         assert (
-            tr.spec.config.runtime.health_checks.restart_failure_threshold_seconds
-            == 1700
-        )
-        assert (
-            tr.spec.config.runtime.health_checks.stop_traffic_failure_threshold_seconds
-            == 1800
+            tr.spec.config.runtime.health_checks.stop_traffic_threshold_seconds == 1800
         )
 
     config = """runtime:
     health_checks:
         restart_check_delay_seconds: 1200
-        restart_failure_threshold_seconds: 90
-        stop_traffic_failure_threshold_seconds: 50
+        restart_threshold_seconds: 90
+        stop_traffic_threshold_seconds: 50
     """
 
     with ensure_kill_all(), _temp_truss(model, config) as tr:
         _ = tr.docker_run(local_port=8090, detach=True, wait_for_server_ready=True)
 
         assert tr.spec.config.runtime.health_checks.restart_check_delay_seconds == 1200
-        assert (
-            tr.spec.config.runtime.health_checks.restart_failure_threshold_seconds == 90
-        )
-        assert (
-            tr.spec.config.runtime.health_checks.stop_traffic_failure_threshold_seconds
-            == 50
-        )
+        assert tr.spec.config.runtime.health_checks.restart_threshold_seconds == 90
+        assert tr.spec.config.runtime.health_checks.stop_traffic_threshold_seconds == 50
 
     with ensure_kill_all(), _temp_truss(model, "") as tr:
         _ = tr.docker_run(local_port=8090, detach=True, wait_for_server_ready=True)
 
         assert tr.spec.config.runtime.health_checks.restart_check_delay_seconds == 0
+        assert tr.spec.config.runtime.health_checks.restart_threshold_seconds == 1800
         assert (
-            tr.spec.config.runtime.health_checks.restart_failure_threshold_seconds
-            == 1800
-        )
-        assert (
-            tr.spec.config.runtime.health_checks.stop_traffic_failure_threshold_seconds
-            == 1800
+            tr.spec.config.runtime.health_checks.stop_traffic_threshold_seconds == 1800
         )
 
 

--- a/truss/tests/test_model_inference.py
+++ b/truss/tests/test_model_inference.py
@@ -989,7 +989,7 @@ def test_health_check_configuration():
         assert tr.spec.config.runtime.health_checks.restart_check_delay_seconds == 100
         assert tr.spec.config.runtime.health_checks.restart_threshold_seconds == 1700
         assert (
-            tr.spec.config.runtime.health_checks.stop_traffic_threshold_seconds == 1800
+            tr.spec.config.runtime.health_checks.stop_traffic_threshold_seconds is None
         )
 
     config = """runtime:
@@ -1009,10 +1009,10 @@ def test_health_check_configuration():
     with ensure_kill_all(), _temp_truss(model, "") as tr:
         _ = tr.docker_run(local_port=8090, detach=True, wait_for_server_ready=True)
 
-        assert tr.spec.config.runtime.health_checks.restart_check_delay_seconds == 0
-        assert tr.spec.config.runtime.health_checks.restart_threshold_seconds == 1800
+        assert tr.spec.config.runtime.health_checks.restart_check_delay_seconds is None
+        assert tr.spec.config.runtime.health_checks.restart_threshold_seconds is None
         assert (
-            tr.spec.config.runtime.health_checks.stop_traffic_threshold_seconds == 1800
+            tr.spec.config.runtime.health_checks.stop_traffic_threshold_seconds is None
         )
 
 


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Adds new configuration fields to truss config for models and chains. Naming and defaults can be seen in examples below.

for models, we add a new `health_checks` section to `runtime`:
```
runtime:
  health_checks:
    restart_check_delay_seconds: 0
    restart_threshold_seconds: 1800 # 18 consecutive failures over 30 minutes
    stop_traffic_threshold_seconds: 1800 # 18 consecutive failures over 30 minutes
```
for chains, we add a new field to `ChainletConfig` that includes `health_checks`:
```
remote_config = chains.RemoteConfig(
  options=chains.ChainletConfig(
    health_checks=truss_config.HealthChecks(
      restart_check_delay_seconds=0,
      restart_threshold_seconds=1800,
      stop_traffic_threshold_seconds=1800
    )
  )
)		
```

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
Added a couple of integration test cases
Ensured that staging and production won't break with these changes, using `poetry run truss ...`
Testing using an RC on staging (`v0.9.59.rc001`)

Validation errors look like this for models:
```
poetry run truss push empty
? 🎮 Which remote do you want to connect to? baseten-dev-10-2
ERROR ValidationError: Validation failed with the following errors:
  `runtime.health_checks.restart_check_delay_seconds`: Input should be greater than or equal to 0.
  `runtime.health_checks.restart_threshold_seconds`: Input should be less than or equal to 1800.
  `runtime.health_checks.stop_traffic_threshold_seconds`: Input should be greater than or equal to 30.
```

And this for chains:
```
poetry run truss chains push truss-chains/truss_chains/hello.py 
? 🎮 Which remote do you want to connect to? baseten-staging-129
Using chain workspace dir: `/workspaces/truss/truss-chains/truss_chains` (files under this dir will be included as dependencies in the remote deployments and are importable).                                                 
Code generation for Chainlet `RandInt` in `/tmp/.chains_generated/CustomHealthChecks/chainlet_RandInt`.                                                                                                                        
Code generation for Chainlet `CustomHealthChecks` in `/tmp/.chains_generated/CustomHealthChecks/chainlet_CustomHealthChecks`.                                                                                                  
Pushing Chain 'CustomHealthChecks' to Baseten (publish=False, environment=None).                                                                                                                                               
ERROR ValidationError: Validation failed with the following errors:
  truss version `0.8.57` is deprecated. Please upgrade to the latest truss version.
  `runtime.health_checks.restart_check_delay_seconds`: Input should be less than or equal to 1800.
  `runtime.health_checks.stop_traffic_threshold_seconds`: Input should be a valid integer, got a number with a fractional part.
```