### PR TITLE
Add `DRAFT_EXTERNAL` as a default `speculator.speculative_decoding_mode`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.58rc1"
+version = "0.9.58rc2"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/base/trt_llm_config.py
+++ b/truss/base/trt_llm_config.py
@@ -172,7 +172,7 @@ class TrussTRTLLMBuildConfiguration(BaseModel):
 
 
 class TrussSpeculatorConfiguration(BaseModel):
-    speculative_decoding_mode: TrussSpecDecMode
+    speculative_decoding_mode: TrussSpecDecMode = TrussSpecDecMode.DRAFT_EXTERNAL
     num_draft_tokens: int
     checkpoint_repository: Optional[CheckpointRepository] = None
     runtime: TrussTRTLLMRuntimeConfiguration = TrussTRTLLMRuntimeConfiguration()


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
- We only support one speculative decoding mode for the launch, make this the default value
<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
