### PR TITLE
Better typing to avoid fmt directive

### DIFF
--- a/truss-chains/truss_chains/framework.py
+++ b/truss-chains/truss_chains/framework.py
@@ -1016,14 +1016,13 @@ def _create_modified_init_for_local(
             if up_func_name == _INIT_NAME and self_value == up_self_value:
                 continue  # OK, call to `super().__init__()`.
 
-            # Everything else is invalid. We must turn formatting off because ruff
-            # attempts to move the ignore to an invalid line, causing mypy issues.
-            # fmt: off
+            # Everything else is invalid.
+            code_context = up_frame.code_context
+            assert code_context is not None
             location = (
                 f"{up_frame.filename}:{up_frame.lineno} ({up_frame.function})\n"
-                f"    {up_frame.code_context[0].strip()}" # type: ignore[index]
+                f"    {code_context[0].strip()}"
             )
-            # fmt: on
             raise definitions.ChainsRuntimeError(
                 _instantiation_error_msg(chainlet_descriptor.name, location)
             )


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Super small followup to this [PR](https://github.com/basetenlabs/truss/pull/1305) with no intended behavior changes, but uses an `assert` to pass mypy type checks instead of an `#ignore` pragma.

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
