### PR TITLE
Translate RPC timeout error message.

### DIFF
--- a/truss-chains/tests/timeout/timeout_chain.py
+++ b/truss-chains/tests/timeout/timeout_chain.py
@@ -1,0 +1,35 @@
+import asyncio
+import time
+
+import truss_chains as chains
+
+
+class Dependency(chains.ChainletBase):
+    async def run_remote(self) -> bool:
+        await asyncio.sleep(1)
+        return True
+
+
+class DependencySync(chains.ChainletBase):
+    def run_remote(self) -> bool:
+        time.sleep(1)
+        return True
+
+
+@chains.mark_entrypoint  # ("My Chain Name")
+class TimeoutChain(chains.ChainletBase):
+    def __init__(
+        self,
+        dep=chains.depends(Dependency, timeout_sec=0.5),
+        dep_sync=chains.depends(DependencySync, timeout_sec=0.5),
+    ):
+        self._dep = dep
+        self._dep_sync = dep_sync
+
+    async def run_remote(self, use_sync: bool) -> None:
+        if use_sync:
+            result = self._dep_sync.run_remote()
+            print(result)
+        else:
+            result = await self._dep.run_remote()
+            print(result)

--- a/truss-chains/truss_chains/definitions.py
+++ b/truss-chains/truss_chains/definitions.py
@@ -396,7 +396,7 @@ class RemoteConfig(SafeModelNonSerializable):
         return self.assets.get_spec()
 
 
-DEFAULT_TIMEOUT_SEC = 600
+DEFAULT_TIMEOUT_SEC = 600.0
 
 
 class RPCOptions(SafeModel):
@@ -415,7 +415,7 @@ class RPCOptions(SafeModel):
     """
 
     retries: int = 1
-    timeout_sec: int = DEFAULT_TIMEOUT_SEC
+    timeout_sec: float = DEFAULT_TIMEOUT_SEC
     use_binary: bool = False
 
 

--- a/truss-chains/truss_chains/public_api.py
+++ b/truss-chains/truss_chains/public_api.py
@@ -46,7 +46,7 @@ def depends_context() -> definitions.DeploymentContext:
 def depends(
     chainlet_cls: Type[framework.ChainletT],
     retries: int = 1,
-    timeout_sec: int = definitions.DEFAULT_TIMEOUT_SEC,
+    timeout_sec: float = definitions.DEFAULT_TIMEOUT_SEC,
     use_binary: bool = False,
 ) -> framework.ChainletT:
     """Sets a "symbolic marker" to indicate to the framework that a chainlet is a


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What

Catches timeouts around sync/async chainlet HTTP requests.
All "deeper" stack trace will be cut off (it can be confusing to read). A cleaner error is raised instead and in addition warning is logged:
```
{"asctime": "2025-01-14 23:54:13,304", "levelname": "WARNING", "message": "Timeout calling remote Chainlet `DependencySync` (0.5 seconds limit)."}
```

Also make `timeout_sec` `int` -> `float`.

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
