### PR TITLE
Include better error when configuration file doesn't exist

### DIFF
--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import sys
 from dataclasses import _MISSING_TYPE, dataclass, field, fields
 from enum import Enum
@@ -661,6 +662,8 @@ class TrussConfig:
 
     @staticmethod
     def from_yaml(yaml_path: Path):
+        if not os.path.isfile(yaml_path):
+            raise ValueError(f"Expected a truss configuration file at {yaml_path}")
         with yaml_path.open() as yaml_file:
             raw_data = yaml.safe_load(yaml_file) or {}
             if "hf_cache" in raw_data:


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Very small UX improvement to show a better error when the truss configuration file cannot be found

Before
```
$ truss push --remote baseten-localhost
ERROR FileNotFoundError: [Errno 2] No such file or directory: '/Users/nnarayen/Desktop/repos/baseten-local-deploy/config.yaml'
```

After
```
$ truss push --remote baseten-localhost
ERROR ValueError: Expected a truss configuration file at /Users/nnarayen/Desktop/repos/baseten-local-deploy/config.yaml
```

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
