### PR TITLE
Prevent context builder image clobbers

### DIFF
--- a/.github/workflows/build-context-builder-image.yml
+++ b/.github/workflows/build-context-builder-image.yml
@@ -43,6 +43,10 @@ jobs:
       with:
         images: baseten/truss-context-builder
 
+    - name: Calculate short sha
+      id: git_sha
+      run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
     - name: Docker Build
       id: docker_build
       uses: docker/build-push-action@v5
@@ -50,5 +54,5 @@ jobs:
         context: ./
         file: ./context_builder.Dockerfile
         push: true
-        tags: baseten/truss-context-builder:v${{ needs.detect-version.outputs.version }}
+        tags: baseten/truss-context-builder:v${{ needs.detect-version.outputs.version }}-${{ steps.git_sha.outputs.sha_short }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-context-builder-image.yml
+++ b/.github/workflows/build-context-builder-image.yml
@@ -37,15 +37,22 @@ jobs:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+    - name: Generate image name
+      id: generate_image_tag
+      run: echo "tag=baseten/truss-context-builder:v${{ needs.detect-version.outputs.version }}" >> $GITHUB_OUTPUT
+
+    - name: Check if image already exists
+      run: |
+        if docker manifest inspect ${{ steps.generate_image_tag.outputs.tag }} > /dev/null 2>&1; then
+          echo "Context builder image with tag ${{ needs.detect-version.outputs.version }} already exists, please update pyproject.toml"
+          exit 1
+        fi
+
     - name: Docker meta
       id: meta
       uses: docker/metadata-action@v4
       with:
         images: baseten/truss-context-builder
-
-    - name: Calculate short sha
-      id: git_sha
-      run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
     - name: Docker Build
       id: docker_build
@@ -54,5 +61,5 @@ jobs:
         context: ./
         file: ./context_builder.Dockerfile
         push: true
-        tags: baseten/truss-context-builder:v${{ needs.detect-version.outputs.version }}-${{ steps.git_sha.outputs.sha_short }}
+        tags: ${{ steps.generate_image_tag.outputs.tag }}
         labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
It's pretty easy to accidentally clobber existing context builder images:
- Forget to update `version` [here](https://github.com/basetenlabs/truss/blob/d2aebd8cdcc622fef2b7275d6862bd80aa1fc3de/pyproject.toml?plain=1#L3)
- Two people are iterating in parallel, and happen to use the same `rcX` identifier

This PR adds a small check for the image tag before pushing. We don't protect against two simultaneous jobs running at the exact same time, but this seems like an edge case not worth solving.

Example build that will shows the new [error](https://github.com/basetenlabs/truss/actions/runs/12890152451/job/35939096261), and a job with these changes that shows a successful image [build](https://github.com/basetenlabs/truss/actions/runs/12890226016/job/35939337845). 

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
