### PR TITLE
[truss-transfer] ci + bump truss-transfer version

### DIFF
--- a/.github/workflows/truss-transfer-build-maturin.yaml
+++ b/.github/workflows/truss-transfer-build-maturin.yaml
@@ -232,7 +232,7 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
         uses: PyO3/maturin-action@v1
         env:
-          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+          MATURIN_PYPI_TOKEN: ${{ secrets.TRUSS_TRANSFER_PYPI_API_TOKEN }}
         with:
           command: upload
           args: --non-interactive --skip-existing wheels-*/*

--- a/.github/workflows/truss-transfer-cli-release.yaml
+++ b/.github/workflows/truss-transfer-cli-release.yaml
@@ -1,0 +1,51 @@
+name: Build and Release truss-transfer CLI
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  build-and-upload-cli:
+    name: Build and Upload CLI Binary
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          components: rust-src
+
+      - name: Build CLI Binary
+        run: |
+          cargo build --release --features cli
+          mkdir -p dist/cli
+          cp target/release/truss_transfer_cli dist/cli/
+
+      - name: Test CLI Binary
+        run: |
+          sudo mkdir -p /bptr
+          sudo chown $(whoami):$(whoami) /bptr
+          cp ./exampe-bptr-manifest.json /bptr/bptr-manifest
+          dist/cli/truss_transfer_cli ./example_bptr_resolved
+          # test files are created in example_bptr_resolved
+          if [ ! -d "./example_bptr_resolved" ]; then
+            echo "❌ Test failed: output directory not created."
+            exit 1
+          fi
+
+      - name: Upload CLI to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/cli/truss_transfer_cli
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/truss-transfer-cli-release.yaml
+++ b/.github/workflows/truss-transfer-cli-release.yaml
@@ -1,4 +1,5 @@
 name: Build and Release truss-transfer CLI
+# relases a new version of the CLI binary on each Github release
 
 on:
   release:

--- a/.github/workflows/truss-transfer-test.yml
+++ b/.github/workflows/truss-transfer-test.yml
@@ -38,9 +38,20 @@ jobs:
         run: |
           sudo mkdir -p /bptr
           sudo chown $(whoami):$(whoami) /bptr
-          cp ./exampe-bptr-manifest.json /bptr/exampe-bptr-manifest
+          cp ./exampe-bptr-manifest.json /bptr/bptr-manifest
 
           source .venv/bin/activate
           python -c "import truss_transfer; truss_transfer.lazy_data_resolve('./tmp_no_cache/test', 4)"
+          if [ ! -d "./tmp_no_cache/test" ]; then
+            echo "❌ Test failed: output directory not created."
+            exit 1
+          fi
+
           export BASETEN_FS_ENABLED=True
           python -c "import truss_transfer; truss_transfer.lazy_data_resolve('./tmp_fs_enabled/test', 32)"
+          # test files are created in example_bptr_resolved
+
+          if [ ! -d "./tmp_fs_enabled/test" ]; then
+            echo "❌ Test failed: output directory not created."
+            exit 1
+          fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.59.rc0-013"
+version = "0.9.59.rc1"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.59.rc1"
+version = "0.9.59.rc0-013"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss-transfer/Cargo.lock
+++ b/truss-transfer/Cargo.lock
@@ -1358,7 +1358,7 @@ dependencies = [
 
 [[package]]
 name = "truss_transfer"
-version = "0.0.1-rc0"
+version = "0.0.1-rc1"
 dependencies = [
  "anyhow",
  "bytes",

--- a/truss-transfer/Cargo.toml
+++ b/truss-transfer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "truss_transfer"
-version = "0.0.1-rc0"
+version = "0.0.1-rc1"
 edition = "2021"
 
 [lib]

--- a/truss-transfer/README.md
+++ b/truss-transfer/README.md
@@ -4,17 +4,17 @@ Python-optional download utility
 
 
 ```base
-pip install truss_transfer
+pip install truss-transfer
 # pip install /workspace/model-performance/michaelfeil/truss/truss-transfer/target/wheels/truss_transfer-0.1.0-cp39-cp39-manylinux_2_34_x86_64.whl
 ```
 
 ```python
 import truss_transfer
 
-def lazy_data_loader(download_dir: str, num_workers: int = 64):
+def lazy_data_loader(download_dir: str):
     print(f"download using {truss_transfer.__version__}")
     try:
-        truss_transfer.lazy_data_resolve(str(download_dir), int(num_workers))
+        truss_transfer.lazy_data_resolve(str(download_dir))
     except Exception as e:
         print(f"Lazy data resolution failed: {e}")
         raise


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What

- Bumps the `truss-transfer` package, just released 0.0.1.rc0 manually
- adds a CI that would trigger the placement of a manual wheel on each Github Release
- added a new secret as correct pypi token
<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
