### PR TITLE
Update trusted publishing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -102,6 +102,9 @@ jobs:
           skipIfReleaseExists: true
           tag: "v${{ needs.detect-version-changed.outputs.new_version }}"
 
-      - name: Publish to PyPI
+      - name: Publish package to PyPI (Trusted Publishing)
         if: ${{ github.event_name != 'pull_request' }}
-        run: poetry publish -u "${{ secrets.PYPI_USERNAME }}" -p "${{ secrets.PYPI_PASSWORD }}"
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          verbose: true
+          print-hash: true

--- a/.github/workflows/release-truss-utils.yml
+++ b/.github/workflows/release-truss-utils.yml
@@ -46,7 +46,9 @@ jobs:
         working-directory: truss-utils
         run: poetry build
 
-      - name: Publish to PyPI
+      - name: Publish package to PyPI (Trusted Publishing)
         if: ${{ github.event_name != 'pull_request' }}
-        working-directory: truss-utils
-        run: poetry publish -u "${{ secrets.PYPI_USERNAME }}" -p "${{ secrets.PYPI_PASSWORD }}"
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          verbose: true
+          print-hash: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,6 +98,7 @@ jobs:
           tag: "v${{ needs.detect-version-changed.outputs.new_version }}"
 
       - name: Publish package to PyPI (Trusted Publishing)
+        if: ${{ github.event_name != 'pull_request' }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           verbose: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.59rc004"
+version = "0.9.59rc006"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
- I did setup trusted-publishing on PYPI
- accidentally enabled it with push to main (sorry about that! Affects only main releases, not RC) (https://github.com/basetenlabs/truss/commit/ba976f278653d3d761de47f8bf0fc730f1047e1b) 

After its
-> this PR fixes the rest, tests the workflow with RC version, which then should be good to go. 

-> after we can evict "secrets.PYPI_PASSWORD" from the gh secrets (important!)
<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
