### PR TITLE
Add overrides for models using chains framework

### DIFF
--- a/truss-chains/tests/test_framework.py
+++ b/truss-chains/tests/test_framework.py
@@ -111,7 +111,7 @@ def test_raises_model_dependencies_not_allowed():
         def run_remote(self) -> str:
             return self.__class__.name
 
-    match = "Chainlet dependencies are not supported for Models"
+    match = "The only supported argument to `__init__` for Models"
     with pytest.raises(definitions.ChainsUsageError, match=re.escape(match)):
         with chains.run_local():
             ModelWithDependencies()
@@ -503,7 +503,7 @@ def test_raises_chainlet_reuse():
 
 
 def test_collects_multiple_errors():
-    match = r"The definitions contain 5 errors:"
+    match = r"The user defined code does not comply with the required spec"
 
     with pytest.raises(definitions.ChainsUsageError, match=match), _raise_errors():
 
@@ -523,7 +523,7 @@ def test_collects_multiple_errors_run_local():
 
         def run_remote(argument: object): ...
 
-    match = r"The definitions contain 5 errors:"
+    match = r"The user defined code does not comply with the required spec"
     with pytest.raises(definitions.ChainsUsageError, match=match), _raise_errors():
         with public_api.run_local():
             MultiIssue()

--- a/truss-chains/tests/test_framework.py
+++ b/truss-chains/tests/test_framework.py
@@ -92,6 +92,31 @@ def test_raises_depends_usage():
             chain.run_remote()
 
 
+def test_raises_model_requires_predict_method():
+    class ModelWithRunRemote(chains.ModelBase):
+        def run_remote(self) -> str:
+            return self.__class__.name
+
+    match = "Models must have a `predict` method."
+    with pytest.raises(definitions.ChainsUsageError, match=re.escape(match)):
+        with chains.run_local():
+            ModelWithRunRemote()
+
+
+def test_raises_model_dependencies_not_allowed():
+    class ModelWithDependencies(chains.ModelBase):
+        def __init__(self, c1=chains.depends(Chainlet1)):
+            self.c1 = c1
+
+        def run_remote(self) -> str:
+            return self.__class__.name
+
+    match = "Chainlet dependencies are not supported for Models"
+    with pytest.raises(definitions.ChainsUsageError, match=re.escape(match)):
+        with chains.run_local():
+            ModelWithDependencies()
+
+
 # The problem with supporting helper functions in `run_local` is that the stack trace
 # looks similar to the forbidden one in `InitInRun`.
 @pytest.mark.skip(reason="Helper functions not supported yet.")
@@ -433,9 +458,8 @@ def test_raises_dep_not_chainlet_annot():
 def test_raises_context_missing_default():
     match = (
         rf"{TEST_FILE}:\d+ \(ContextMissingDefault\.__init__\) \[kind: TYPE_ERROR\].*"
-        r"f `<class \'truss_chains.definitions.ABCChainlet\'>` uses context for "
-        r"initialization, it must have `context` argument of type `<class "
-        f"'truss_chains.definitions.DeploymentContext'>`"
+        r"If `Chainlet` uses context for initialization, it must have "
+        r"`context` argument of type `<class 'truss_chains.definitions.DeploymentContext'>`"
     )
 
     with pytest.raises(definitions.ChainsUsageError, match=match), _raise_errors():
@@ -447,9 +471,8 @@ def test_raises_context_missing_default():
 def test_raises_context_wrong_annot():
     match = (
         rf"{TEST_FILE}:\d+ \(ConextWrongAnnot\.__init__\) \[kind: TYPE_ERROR\].*"
-        r"f `<class \'truss_chains.definitions.ABCChainlet\'>` uses context for "
-        r"initialization, it must have `context` argument of type `<class "
-        f"'truss_chains.definitions.DeploymentContext'>`"
+        r"If `Chainlet` uses context for initialization, it must have "
+        r"`context` argument of type `<class 'truss_chains.definitions.DeploymentContext'>`"
     )
 
     with pytest.raises(definitions.ChainsUsageError, match=match), _raise_errors():
@@ -480,7 +503,7 @@ def test_raises_chainlet_reuse():
 
 
 def test_collects_multiple_errors():
-    match = r"The Chainlet definitions contain 5 errors:"
+    match = r"The definitions contain 5 errors:"
 
     with pytest.raises(definitions.ChainsUsageError, match=match), _raise_errors():
 
@@ -500,7 +523,7 @@ def test_collects_multiple_errors_run_local():
 
         def run_remote(argument: object): ...
 
-    match = r"The Chainlet definitions contain 5 errors:"
+    match = r"The definitions contain 5 errors:"
     with pytest.raises(definitions.ChainsUsageError, match=match), _raise_errors():
         with public_api.run_local():
             MultiIssue()

--- a/truss-chains/tests/traditional_truss/truss_model.py
+++ b/truss-chains/tests/traditional_truss/truss_model.py
@@ -10,6 +10,6 @@ class PassthroughModel(chains.ModelBase):
     def __init__(self):
         self._call_count = 0
 
-    async def run_remote(self, call_count_increment: int) -> int:
+    async def predict(self, call_count_increment: int) -> int:
         self._call_count += call_count_increment
         return self._call_count

--- a/truss-chains/truss_chains/definitions.py
+++ b/truss-chains/truss_chains/definitions.py
@@ -36,6 +36,7 @@ DYNAMIC_CHAINLET_CONFIG_KEY = "dynamic_chainlet_config"
 OTEL_TRACE_PARENT_HEADER_KEY = "traceparent"
 # Below arg names must correspond to `definitions.ABCChainlet`.
 ENDPOINT_METHOD_NAME = "run_remote"  # Chainlet method name exposed as endpoint.
+MODEL_ENDPOINT_METHOD_NAME = "predict"  # Model method name exposed as endpoint.
 CONTEXT_ARG_NAME = "context"  # Referring to Chainlets `__init__` signature.
 SELF_ARG_NAME = "self"
 REMOTE_CONFIG_NAME = "remote_config"
@@ -521,6 +522,21 @@ class ABCChainlet(abc.ABC):
     @classmethod
     def display_name(cls) -> str:
         return cls.remote_config.name or cls.name
+
+    @classmethod
+    @abc.abstractmethod
+    def supports_dependencies(cls) -> bool:
+        pass
+
+    @classmethod
+    @abc.abstractmethod
+    def entity_type(cls) -> Literal["Chainlet", "Model"]:
+        pass
+
+    @classmethod
+    @abc.abstractmethod
+    def rpc_method(cls) -> str:
+        pass
 
     # Cannot add this abstract method to API, because we want to allow arbitrary
     # arg/kwarg names and specifying any function signature here would give type errors

--- a/truss-chains/truss_chains/definitions.py
+++ b/truss-chains/truss_chains/definitions.py
@@ -35,7 +35,7 @@ GENERATED_CODE_DIR = ".chains_generated"
 DYNAMIC_CHAINLET_CONFIG_KEY = "dynamic_chainlet_config"
 OTEL_TRACE_PARENT_HEADER_KEY = "traceparent"
 # Below arg names must correspond to `definitions.ABCChainlet`.
-ENDPOINT_METHOD_NAME = "run_remote"  # Chainlet method name exposed as endpoint.
+RUN_REMOTE_METHOD_NAME = "run_remote"  # Chainlet method name exposed as endpoint.
 MODEL_ENDPOINT_METHOD_NAME = "predict"  # Model method name exposed as endpoint.
 CONTEXT_ARG_NAME = "context"  # Referring to Chainlets `__init__` signature.
 SELF_ARG_NAME = "self"
@@ -535,7 +535,7 @@ class ABCChainlet(abc.ABC):
 
     @classmethod
     @abc.abstractmethod
-    def rpc_method(cls) -> str:
+    def endpoint_method_name(cls) -> str:
         pass
 
     # Cannot add this abstract method to API, because we want to allow arbitrary
@@ -590,7 +590,7 @@ class InputArg(SafeModelNonSerializable):
 
 
 class EndpointAPIDescriptor(SafeModelNonSerializable):
-    name: str = ENDPOINT_METHOD_NAME
+    name: str = RUN_REMOTE_METHOD_NAME
     input_args: list[InputArg]
     output_types: list[TypeDescriptor]
     is_async: bool

--- a/truss-chains/truss_chains/public_api.py
+++ b/truss-chains/truss_chains/public_api.py
@@ -112,8 +112,8 @@ class ChainletBase(definitions.ABCChainlet):
         return True
 
     @classmethod
-    def rpc_method(cls) -> str:
-        return definitions.ENDPOINT_METHOD_NAME
+    def endpoint_method_name(cls) -> str:
+        return definitions.RUN_REMOTE_METHOD_NAME
 
     def __init_subclass__(cls, **kwargs) -> None:
         super().__init_subclass__(**kwargs)
@@ -151,7 +151,7 @@ class ModelBase(definitions.ABCChainlet):
         return False
 
     @classmethod
-    def rpc_method(cls) -> str:
+    def endpoint_method_name(cls) -> str:
         return definitions.MODEL_ENDPOINT_METHOD_NAME
 
     def __init_subclass__(cls, **kwargs) -> None:

--- a/truss-chains/truss_chains/public_api.py
+++ b/truss-chains/truss_chains/public_api.py
@@ -4,6 +4,7 @@ from typing import (
     TYPE_CHECKING,
     Callable,
     ContextManager,
+    Literal,
     Mapping,
     Optional,
     Type,
@@ -102,6 +103,18 @@ class ChainletBase(definitions.ABCChainlet):
     for more guidance on how to create subclasses.
     """
 
+    @classmethod
+    def entity_type(cls) -> Literal["Chainlet", "Model"]:
+        return "Chainlet"
+
+    @classmethod
+    def supports_dependencies(cls) -> bool:
+        return True
+
+    @classmethod
+    def rpc_method(cls) -> str:
+        return definitions.ENDPOINT_METHOD_NAME
+
     def __init_subclass__(cls, **kwargs) -> None:
         super().__init_subclass__(**kwargs)
         # Each sub-class has own, isolated metadata, e.g. we don't want
@@ -128,6 +141,18 @@ class ModelBase(definitions.ABCChainlet):
     Inheriting from this class adds validations to make sure subclasses adhere to the
     truss model pattern.
     """
+
+    @classmethod
+    def entity_type(cls) -> Literal["Chainlet", "Model"]:
+        return "Model"
+
+    @classmethod
+    def supports_dependencies(cls) -> bool:
+        return False
+
+    @classmethod
+    def rpc_method(cls) -> str:
+        return definitions.MODEL_ENDPOINT_METHOD_NAME
 
     def __init_subclass__(cls, **kwargs) -> None:
         super().__init_subclass__(**kwargs)


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
This PR introduces more diverging behavior between traditional models / chains using the chains code generation framework:
- Traditional models are _not_ allowed to have any other chainlet dependencies
- Traditional models are defined with a `predict` method instead of `run_remote`
- Error messages are tailored to say Models vs Chainlets, depending on the type

<!--
  How was the change described above implemented?
-->
## :computer: How


<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
Existing e2e unit test + new targeted framework unit tests
