### PR TITLE
Refactor method overriding into shared settings configuration

### DIFF
--- a/truss-chains/truss_chains/definitions.py
+++ b/truss-chains/truss_chains/definitions.py
@@ -367,6 +367,12 @@ class ChainletMetadata(SafeModelNonSerializable):
     init_is_patched: bool = False
 
 
+class FrameworkConfig(SafeModelNonSerializable):
+    entity_type: Literal["Chainlet", "Model"]
+    supports_dependencies: bool
+    endpoint_method_name: str
+
+
 class RemoteConfig(SafeModelNonSerializable):
     """Bundles config values needed to deploy a chainlet remotely.
 
@@ -508,6 +514,7 @@ class ABCChainlet(abc.ABC):
     remote_config: ClassVar[RemoteConfig] = RemoteConfig()
     # `meta_data` is not shared between subclasses, each has an isolated copy.
     meta_data: ClassVar[ChainletMetadata] = ChainletMetadata()
+    _framework_config: ClassVar[FrameworkConfig]
 
     @classmethod
     def has_custom_init(cls) -> bool:
@@ -523,20 +530,20 @@ class ABCChainlet(abc.ABC):
     def display_name(cls) -> str:
         return cls.remote_config.name or cls.name
 
+    @classproperty
     @classmethod
-    @abc.abstractmethod
     def supports_dependencies(cls) -> bool:
-        pass
+        return cls._framework_config.supports_dependencies
 
+    @classproperty
     @classmethod
-    @abc.abstractmethod
     def entity_type(cls) -> Literal["Chainlet", "Model"]:
-        pass
+        return cls._framework_config.entity_type
 
+    @classproperty
     @classmethod
-    @abc.abstractmethod
     def endpoint_method_name(cls) -> str:
-        pass
+        return cls._framework_config.endpoint_method_name
 
     # Cannot add this abstract method to API, because we want to allow arbitrary
     # arg/kwarg names and specifying any function signature here would give type errors

--- a/truss-chains/truss_chains/framework.py
+++ b/truss-chains/truss_chains/framework.py
@@ -441,19 +441,19 @@ def _validate_and_describe_endpoint(
       `_validate_io_type` for valid types.
     * Generators are allowed, too (but not yet supported).
     """
-    if not hasattr(cls, cls.endpoint_method_name()):
+    if not hasattr(cls, cls.endpoint_method_name):
         _collect_error(
-            f"{cls.entity_type()}s must have a `{cls.endpoint_method_name()}` method.",
+            f"{cls.entity_type}s must have a `{cls.endpoint_method_name}` method.",
             _ErrorKind.MISSING_API_ERROR,
             location,
         )
         return _DUMMY_ENDPOINT_DESCRIPTOR
 
     # This is the unbound method.
-    endpoint_method = getattr(cls, cls.endpoint_method_name())
+    endpoint_method = getattr(cls, cls.endpoint_method_name)
     line = inspect.getsourcelines(endpoint_method)[1]
     location = location.model_copy(
-        update={"line": line, "method_name": cls.endpoint_method_name()}
+        update={"line": line, "method_name": cls.endpoint_method_name}
     )
 
     if not inspect.isfunction(endpoint_method):
@@ -494,7 +494,7 @@ def _validate_and_describe_endpoint(
 
     if not is_async:
         warnings.warn(
-            f"`{cls.endpoint_method_name()}` must be an async (coroutine) function in future releases. "
+            f"`{cls.endpoint_method_name}` must be an async (coroutine) function in future releases. "
             "Replace `def run_remote(...)` with `async def run_remote(...)`. "
             "Local testing and execution can be done with  "
             "`asyncio.run(my_chainlet.run_remote(...))`.\n"
@@ -512,7 +512,7 @@ def _validate_and_describe_endpoint(
         )
 
     return definitions.EndpointAPIDescriptor(
-        name=cls.endpoint_method_name(),
+        name=cls.endpoint_method_name,
         input_args=input_args,
         output_types=output_types,
         is_async=is_async,
@@ -597,7 +597,7 @@ class _ChainletInitValidator:
     def _validate_context_arg(self, params: list[inspect.Parameter]):
         def make_context_error_msg():
             return (
-                f"If `{self._cls.entity_type()}` uses context for initialization, it "
+                f"If `{self._cls.entity_type}` uses context for initialization, it "
                 f"must have `{definitions.CONTEXT_ARG_NAME}` argument of type "
                 f"`{definitions.DeploymentContext}` as the last argument.\n"
                 f"Got arguments: `{params}`.\n"
@@ -643,9 +643,9 @@ class _ChainletInitValidator:
         used = set()
         dependencies = {}
 
-        if params and not self._cls.supports_dependencies():
+        if params and not self._cls.supports_dependencies:
             _collect_error(
-                f"The only supported argument to `__init__` for {self._cls.entity_type()}s "
+                f"The only supported argument to `__init__` for {self._cls.entity_type}s "
                 f"is the optional context argument.",
                 _ErrorKind.TYPE_ERROR,
                 self._location,
@@ -738,7 +738,7 @@ def _validate_remote_config(
         definitions.RemoteConfig,
     ):
         _collect_error(
-            f"{cls.entity_type()}s must have a `{definitions.REMOTE_CONFIG_NAME}` class variable "
+            f"{cls.entity_type}s must have a `{definitions.REMOTE_CONFIG_NAME}` class variable "
             f"of type `{definitions.RemoteConfig}`. Got `{type(remote_config)}` "
             f"for `{cls}`.",
             _ErrorKind.TYPE_ERROR,

--- a/truss-chains/truss_chains/public_api.py
+++ b/truss-chains/truss_chains/public_api.py
@@ -4,7 +4,6 @@ from typing import (
     TYPE_CHECKING,
     Callable,
     ContextManager,
-    Literal,
     Mapping,
     Optional,
     Type,
@@ -103,20 +102,13 @@ class ChainletBase(definitions.ABCChainlet):
     for more guidance on how to create subclasses.
     """
 
-    @classmethod
-    def entity_type(cls) -> Literal["Chainlet", "Model"]:
-        return "Chainlet"
-
-    @classmethod
-    def supports_dependencies(cls) -> bool:
-        return True
-
-    @classmethod
-    def endpoint_method_name(cls) -> str:
-        return definitions.RUN_REMOTE_METHOD_NAME
-
     def __init_subclass__(cls, **kwargs) -> None:
         super().__init_subclass__(**kwargs)
+        cls._framework_config = definitions.FrameworkConfig(
+            entity_type="Chainlet",
+            supports_dependencies=True,
+            endpoint_method_name=definitions.RUN_REMOTE_METHOD_NAME,
+        )
         # Each sub-class has own, isolated metadata, e.g. we don't want
         # `mark_entrypoint` to propagate to subclasses.
         cls.meta_data = definitions.ChainletMetadata()
@@ -142,20 +134,13 @@ class ModelBase(definitions.ABCChainlet):
     truss model pattern.
     """
 
-    @classmethod
-    def entity_type(cls) -> Literal["Chainlet", "Model"]:
-        return "Model"
-
-    @classmethod
-    def supports_dependencies(cls) -> bool:
-        return False
-
-    @classmethod
-    def endpoint_method_name(cls) -> str:
-        return definitions.MODEL_ENDPOINT_METHOD_NAME
-
     def __init_subclass__(cls, **kwargs) -> None:
         super().__init_subclass__(**kwargs)
+        cls._framework_config = definitions.FrameworkConfig(
+            entity_type="Model",
+            supports_dependencies=False,
+            endpoint_method_name=definitions.MODEL_ENDPOINT_METHOD_NAME,
+        )
         cls.meta_data = definitions.ChainletMetadata(is_entrypoint=True)
         framework.validate_and_register_cls(cls)
 


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
A previous PR comment [suggested](https://github.com/basetenlabs/truss/pull/1329#discussion_r1925816317) a better approach to encode differences between Chainlets and Models in the framework. With this new approach, we can logically group all of the settings that affect validation / code gen / etc into this `FrameworkConfig` (name could use some work)

No behavior changes are expected.

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
