### PR TITLE
Ruff configuration change for compact python code

### DIFF
--- a/bin/generate_base_images.py
+++ b/bin/generate_base_images.py
@@ -39,20 +39,14 @@ def _docker_login():
     subprocess.run(["docker", "login", "-u", "basetenservice", "-p", pw])
 
 
-def _render_dockerfile(
-    job_type: str,
-    python_version: str,
-    use_gpu: bool,
-) -> str:
+def _render_dockerfile(job_type: str, python_version: str, use_gpu: bool) -> str:
     # Render jinja
     jinja_env = Environment(
-        loader=FileSystemLoader(str(base_path / "docker" / "base_images")),
+        loader=FileSystemLoader(str(base_path / "docker" / "base_images"))
     )
     template = jinja_env.get_template("base_image.Dockerfile.jinja")
     return template.render(
-        use_gpu=use_gpu,
-        job_type=job_type,
-        python_version=python_version,
+        use_gpu=use_gpu, job_type=job_type, python_version=python_version
     )
 
 
@@ -66,9 +60,7 @@ def _build(
 ):
     image_name = truss_base_image_name(job_type=job_type)
     tag = truss_base_image_tag(
-        python_version=python_version,
-        use_gpu=use_gpu,
-        version_tag=version_tag,
+        python_version=python_version, use_gpu=use_gpu, version_tag=version_tag
     )
     image_with_tag = f"{image_name}:{tag}"
     print(f"Building image :: {image_with_tag}")
@@ -76,9 +68,7 @@ def _build(
         return
 
     dockerfile_content = _render_dockerfile(
-        job_type=job_type,
-        python_version=python_version,
-        use_gpu=use_gpu,
+        job_type=job_type, python_version=python_version, use_gpu=use_gpu
     )
     with tempfile.TemporaryDirectory() as temp_dir:
         build_ctx_path = Path(temp_dir)
@@ -90,13 +80,9 @@ def _build(
         else:
             raise ValueError(f"Unknown job type {job_type}")
 
-        shutil.copyfile(
-            str(reqs_copy_from),
-            str(build_ctx_path / "requirements.txt"),
-        )
+        shutil.copyfile(str(reqs_copy_from), str(build_ctx_path / "requirements.txt"))
         shutil.copytree(
-            str(templates_path / "control"),
-            str(build_ctx_path / "control"),
+            str(templates_path / "control"), str(build_ctx_path / "control")
         )
         cmd = [
             "docker",

--- a/docs/chains/doc_gen/generate_reference.py
+++ b/docs/chains/doc_gen/generate_reference.py
@@ -210,6 +210,4 @@ def generate_sphinx_docs(output_dir: pathlib.Path) -> None:
 
 
 if __name__ == "__main__":
-    generate_sphinx_docs(
-        output_dir=pathlib.Path("/tmp/doc_gen"),
-    )
+    generate_sphinx_docs(output_dir=pathlib.Path("/tmp/doc_gen"))

--- a/docs/chains/doc_gen/mdx_adapter.py
+++ b/docs/chains/doc_gen/mdx_adapter.py
@@ -136,8 +136,4 @@ class MDXAdapterBuilder(MarkdownBuilder):
 
 def setup(app: Any) -> Dict[str, Any]:
     app.add_builder(MDXAdapterBuilder)
-    return {
-        "version": "0.1",
-        "parallel_read_safe": True,
-        "parallel_write_safe": True,
-    }
+    return {"version": "0.1", "parallel_read_safe": True, "parallel_write_safe": True}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -197,6 +197,9 @@ lint.ignore = [
     "E402", # module-import-not-at-top
 ]
 
+[tool.ruff.format]
+skip-magic-trailing-comma = true
+
 [tool.ruff.lint.isort]
 # Matches the Google Python Style Guide.
 section-order = [
@@ -206,6 +209,7 @@ section-order = [
     "first-party",
     "local-folder",
 ]
+split-on-trailing-comma = false
 
 [tool.ruff.lint.extend-per-file-ignores]
 "**tests/samples.py" = [

--- a/truss-chains/examples/audio-transcription/helpers.py
+++ b/truss-chains/examples/audio-transcription/helpers.py
@@ -170,9 +170,7 @@ async def _extract_wav_info(
 
 
 def _find_silent_split_point(
-    wav_block: bytes,
-    smoothing_num_samples: int,
-    wav_info: data_types.WavInfo,
+    wav_block: bytes, smoothing_num_samples: int, wav_info: data_types.WavInfo
 ) -> int:
     # Note: this function uses both indices w.r.t to the bytes array and the numpy
     # array, with `bytes_per_sample` as a conversion factor. To avoid confusion
@@ -200,8 +198,7 @@ def _find_silent_split_point(
     if _DEBUG_PLOTS:
         dbg_data = np.frombuffer(wav_block, dtype=np.int16)
         _dbg_show_waveform(
-            abs(dbg_data),
-            split_index_np + half_index_bytes / wav_info.bytes_per_sample,
+            abs(dbg_data), split_index_np + half_index_bytes / wav_info.bytes_per_sample
         )
         # _dbg_show_waveform(data, split_index)
         # _dbg_show_waveform(smoothed_data, split_index)
@@ -317,8 +314,7 @@ class DownloadSubprocess:
 
 
 async def wav_chunker(
-    params: data_types.TranscribeParams,
-    download: DownloadSubprocess,
+    params: data_types.TranscribeParams, download: DownloadSubprocess
 ) -> AsyncIterator[tuple[data_types.ChunkInfo, str]]:
     """Consumes the download stream and yields small chunks of b64-encoded wav."""
     wav_info, initial_audio_data = await _extract_wav_info(download.wav_stream)

--- a/truss-chains/examples/audio-transcription/transcribe.py
+++ b/truss-chains/examples/audio-transcription/transcribe.py
@@ -49,13 +49,10 @@ class MacroChunkWorker(chains.ChainletBase):
     _whisper: DeployedWhisper
 
     def __init__(
-        self,
-        context: chains.DeploymentContext = chains.depends_context(),
+        self, context: chains.DeploymentContext = chains.depends_context()
     ) -> None:
         self._whisper = DeployedWhisper.from_url(
-            WHISPER_PREDICT_URL,
-            context,
-            options=chains.RPCOptions(retries=2),
+            WHISPER_PREDICT_URL, context, options=chains.RPCOptions(retries=2)
         )
         logging.getLogger("httpx").setLevel(logging.WARNING)
 
@@ -128,9 +125,7 @@ class Transcribe(chains.ChainletBase):
         logging.info(f"Transcribe request for `{duration_secs:.1f}` seconds.")
         # TODO: use silence-aware time chunking.
         macro_chunks = helpers.generate_time_chunks(
-            duration_secs,
-            params.macro_chunk_size_sec,
-            params.macro_chunk_overlap_sec,
+            duration_secs, params.macro_chunk_size_sec, params.macro_chunk_overlap_sec
         )
         tasks = []
         for i, macro_chunk in enumerate(macro_chunks):

--- a/truss-chains/examples/audio-transcription/whisper_chainlet.py
+++ b/truss-chains/examples/audio-transcription/whisper_chainlet.py
@@ -21,9 +21,7 @@ class WhisperModel(chains.ChainletBase):
             base_image=chains.CustomImage(
                 image="baseten/truss-server-base:3.10-gpu-v0.9.0"
             ),
-            apt_requirements=[
-                "ffmpeg",
-            ],
+            apt_requirements=["ffmpeg"],
             pip_requirements=["torch==2.0.1", "openai-whisper==20231106"],
         ),
         compute=chains.Compute(gpu="T4", cpu_count=2, memory="16Gi"),
@@ -38,8 +36,7 @@ class WhisperModel(chains.ChainletBase):
     )
 
     def __init__(
-        self,
-        context: chains.DeploymentContext = chains.depends_context(),
+        self, context: chains.DeploymentContext = chains.depends_context()
     ) -> None:
         import torch
         import whisper

--- a/truss-chains/examples/streaming/streaming_chain.py
+++ b/truss-chains/examples/streaming/streaming_chain.py
@@ -44,9 +44,7 @@ class Generator(chains.ChainletBase):
         header = Header(time=time.time(), msg="Start.")
         yield streamer.yield_header(header)
         for i in range(1, 5):
-            data = MyDataChunk(
-                words=[chr(x + 70) * x for x in range(1, i + 1)],
-            )
+            data = MyDataChunk(words=[chr(x + 70) * x for x in range(1, i + 1)])
             print("Yield")
             yield streamer.yield_item(data)
             if cause_error and i > 2:

--- a/truss-chains/tests/itest_chain/itest_chain.py
+++ b/truss-chains/tests/itest_chain/itest_chain.py
@@ -120,9 +120,7 @@ class ItestChain(chains.ChainletBase):
         data = self._data_generator.run_remote(length)
         text_parts, number, items = await self._data_splitter.run_remote(
             io_types.SplitTextInput(
-                data=data,
-                num_partitions=num_partitions,
-                mode=io_types.Modes.MODE_1,
+                data=data, num_partitions=num_partitions, mode=io_types.Modes.MODE_1
             ),
             extra_arg=123,
             list_arg=[io_types.Item(number=1), io_types.Item(number=2)],
@@ -130,13 +128,7 @@ class ItestChain(chains.ChainletBase):
         print(pydantic_default_arg, simple_default_arg)
         print(items)
         value = self._accumulate_parts(text_parts.parts)
-        return (
-            value,
-            data,
-            number,
-            pydantic_default_arg,
-            simple_default_arg,
-        )
+        return (value, data, number, pydantic_default_arg, simple_default_arg)
 
     def _accumulate_parts(self, parts) -> int:
         value = 0

--- a/truss-chains/tests/test_e2e.py
+++ b/truss-chains/tests/test_e2e.py
@@ -42,10 +42,7 @@ def test_chain():
             6280,
             "erodfderodfderodfderodfderodfd",
             123,
-            {
-                "parts": [],
-                "part_lens": [10],
-            },
+            {"parts": [], "part_lens": [10]},
             ["a", "b"],
         ]
         # Call with values for default arguments.
@@ -54,10 +51,7 @@ def test_chain():
             json={
                 "length": 30,
                 "num_partitions": 3,
-                "pydantic_default_arg": {
-                    "parts": ["marius"],
-                    "part_lens": [3],
-                },
+                "pydantic_default_arg": {"parts": ["marius"], "part_lens": [3]},
                 "simple_default_arg": ["bola"],
             },
         )
@@ -67,10 +61,7 @@ def test_chain():
             6280,
             "erodfderodfderodfderodfderodfd",
             123,
-            {
-                "parts": ["marius"],
-                "part_lens": [3],
-            },
+            {"parts": ["marius"], "part_lens": [3]},
             ["bola"],
         ]
 
@@ -125,21 +116,12 @@ async def test_chain_local():
                 4198,
                 "erodfderodfderodfder",
                 123,
-                {
-                    "parts": [],
-                    "part_lens": [10],
-                },
+                {"parts": [], "part_lens": [10]},
                 ["a", "b"],
             )
 
             # Convert the pydantic model to a dict for comparison
-            result_dict = (
-                result[0],
-                result[1],
-                result[2],
-                result[3].dict(),
-                result[4],
-            )
+            result_dict = (result[0], result[1], result[2], result[3].dict(), result[4])
 
             assert result_dict == expected
 
@@ -285,11 +267,7 @@ def test_traditional_truss():
         assert truss_handle.spec.config.model_name == "OverridePassthroughModelName"
 
         port = utils.get_free_port()
-        truss_handle.docker_run(
-            local_port=port,
-            detach=True,
-            network="host",
-        )
+        truss_handle.docker_run(local_port=port, detach=True, network="host")
 
         response = requests.post(
             f"http://localhost:{port}/v1/models/model:predict",

--- a/truss-chains/tests/test_streaming.py
+++ b/truss-chains/tests/test_streaming.py
@@ -119,9 +119,7 @@ async def test_reading_items_with_wrong_model():
 @pytest.mark.asyncio
 async def test_streaming_with_wrong_order():
     types = streaming.stream_types(
-        item_type=MyDataChunk,
-        header_type=Header,
-        footer_type=Footer,
+        item_type=MyDataChunk, header_type=Header, footer_type=Footer
     )
 
     writer = streaming.stream_writer(types)

--- a/truss-chains/tests/test_utils.py
+++ b/truss-chains/tests/test_utils.py
@@ -42,10 +42,7 @@ def test_populate_chainlet_service_predict_urls(tmp_path, dynamic_config_mount_d
     )
 
 
-@pytest.mark.parametrize(
-    "config",
-    [DYNAMIC_CHAINLET_CONFIG_VALUE, {}, ""],
-)
+@pytest.mark.parametrize("config", [DYNAMIC_CHAINLET_CONFIG_VALUE, {}, ""])
 def test_no_populate_chainlet_service_predict_urls(
     config, tmp_path, dynamic_config_mount_dir
 ):
@@ -54,9 +51,7 @@ def test_no_populate_chainlet_service_predict_urls(
 
     chainlet_to_service = {
         "RandInt": definitions.ServiceDescriptor(
-            name="RandInt",
-            display_name="RandInt",
-            options=definitions.RPCOptions(),
+            name="RandInt", display_name="RandInt", options=definitions.RPCOptions()
         )
     }
 

--- a/truss-chains/tests/traditional_truss/truss_model.py
+++ b/truss-chains/tests/traditional_truss/truss_model.py
@@ -3,8 +3,7 @@ import truss_chains as chains
 
 class PassthroughModel(chains.ModelBase):
     remote_config: chains.RemoteConfig = chains.RemoteConfig(  # type: ignore
-        compute=chains.Compute(4, "1Gi"),
-        name="OverridePassthroughModelName",
+        compute=chains.Compute(4, "1Gi"), name="OverridePassthroughModelName"
     )
 
     def __init__(self):

--- a/truss-chains/truss_chains/definitions.py
+++ b/truss-chains/truss_chains/definitions.py
@@ -73,9 +73,7 @@ class SafeModel(pydantic.BaseModel):
     """Pydantic base model with reasonable config."""
 
     model_config = pydantic.ConfigDict(
-        arbitrary_types_allowed=False,
-        strict=True,
-        validate_assignment=True,
+        arbitrary_types_allowed=False, strict=True, validate_assignment=True
     )
 
 

--- a/truss-chains/truss_chains/deployment/code_gen.py
+++ b/truss-chains/truss_chains/deployment/code_gen.py
@@ -264,8 +264,7 @@ def _stub_endpoint_signature_src(
 
     def_str = "async def" if endpoint.is_async else "def"
     return _Source(
-        src=f"{def_str} {endpoint.name}({','.join(args)}) -> {output}:",
-        imports=imports,
+        src=f"{def_str} {endpoint.name}({','.join(args)}) -> {output}:", imports=imports
     )
 
 
@@ -301,7 +300,7 @@ def _stub_endpoint_body_src(
     else:
         if endpoint.is_async:
             parts.append(
-                f"async for data in await self.predict_async_stream({inputs}):",
+                f"async for data in await self.predict_async_stream({inputs}):"
             )
             if endpoint.streaming_type.is_string:
                 parts.append(_indent("yield data.decode()"))
@@ -751,9 +750,7 @@ def gen_truss_chainlet(
     dep_services = {}
     for dep in chainlet_descriptor.dependencies.values():
         dep_services[dep.name] = definitions.ServiceDescriptor(
-            name=dep.name,
-            display_name=dep.display_name,
-            options=dep.options,
+            name=dep.name, display_name=dep.display_name, options=dep.options
         )
     gen_root = pathlib.Path(tempfile.gettempdir())
     chainlet_dir = _make_chainlet_dir(chain_name, chainlet_descriptor, gen_root)

--- a/truss-chains/truss_chains/deployment/deployment_client.py
+++ b/truss-chains/truss_chains/deployment/deployment_client.py
@@ -134,10 +134,7 @@ class ChainService(abc.ABC):
 
 
 class _ChainSourceGenerator:
-    def __init__(
-        self,
-        options: definitions.PushOptions,
-    ) -> None:
+    def __init__(self, options: definitions.PushOptions) -> None:
         self._options = options
 
     @property
@@ -147,8 +144,7 @@ class _ChainSourceGenerator:
         return False
 
     def generate_chainlet_artifacts(
-        self,
-        entrypoint: Type[definitions.ABCChainlet],
+        self, entrypoint: Type[definitions.ABCChainlet]
     ) -> tuple[b10_types.ChainletArtifact, list[b10_types.ChainletArtifact]]:
         chain_root = _get_chain_root(entrypoint)
         entrypoint_artifact: Optional[b10_types.ChainletArtifact] = None
@@ -205,17 +201,12 @@ def push(
 ) -> Optional[ChainService]:
     entrypoint_artifact, dependency_artifacts = _ChainSourceGenerator(
         options
-    ).generate_chainlet_artifacts(
-        entrypoint,
-    )
+    ).generate_chainlet_artifacts(entrypoint)
     if options.only_generate_trusses:
         return None
     if isinstance(options, definitions.PushOptionsBaseten):
         return _create_baseten_chain(
-            options,
-            entrypoint_artifact,
-            dependency_artifacts,
-            progress_bar,
+            options, entrypoint_artifact, dependency_artifacts, progress_bar
         )
     elif isinstance(options, definitions.PushOptionsLocalDocker):
         return _create_docker_chain(options, entrypoint_artifact, dependency_artifacts)
@@ -322,21 +313,17 @@ def _create_docker_chain(
     chainlet_to_service: Dict[str, DockerChainletService] = {}
     for chainlet_artifact in chainlet_artifacts:
         port = utils.get_free_port()
-        service = DockerChainletService(
-            is_draft=True,
-            port=port,
-        )
+        service = DockerChainletService(is_draft=True, port=port)
         docker_internal_url = service.predict_url.replace(
             "localhost", "host.docker.internal"
         )
         chainlet_to_predict_url[chainlet_artifact.display_name] = {
-            "predict_url": docker_internal_url,
+            "predict_url": docker_internal_url
         }
         chainlet_to_service[chainlet_artifact.name] = service
 
     local_config_handler.LocalConfigHandler.set_dynamic_config(
-        definitions.DYNAMIC_CHAINLET_CONFIG_KEY,
-        json.dumps(chainlet_to_predict_url),
+        definitions.DYNAMIC_CHAINLET_CONFIG_KEY, json.dumps(chainlet_to_predict_url)
     )
 
     # TODO(Tyron): We run the Docker containers in a
@@ -487,9 +474,7 @@ def _create_baseten_chain(
         progress_bar=progress_bar,
     )
     return BasetenChainService(
-        baseten_options.chain_name,
-        chain_deployment_handle,
-        remote_provider,
+        baseten_options.chain_name, chain_deployment_handle, remote_provider
     )
 
 
@@ -503,8 +488,7 @@ def _create_chains_secret_if_missing(remote_provider: b10_remote.BasetenRemote) 
             "Creating secret automatically."
         )
         remote_provider.api.upsert_secret(
-            definitions.BASETEN_API_SECRET_NAME,
-            remote_provider.api.auth_token.value,
+            definitions.BASETEN_API_SECRET_NAME, remote_provider.api.auth_token.value
         )
 
 
@@ -540,8 +524,7 @@ class _Watcher:
         self._error_console = error_console
         self._show_stack_trace = show_stack_trace
         self._remote_provider = cast(
-            b10_remote.BasetenRemote,
-            remote_factory.RemoteFactory.create(remote=remote),
+            b10_remote.BasetenRemote, remote_factory.RemoteFactory.create(remote=remote)
         )
         with framework.import_target(source, entrypoint) as entrypoint_cls:
             self._deployed_chain_name = name or entrypoint_cls.__name__
@@ -666,8 +649,7 @@ class _Watcher:
                             continue
 
                         future = executor.submit(
-                            self._code_gen_and_patch_thread,
-                            chainlet_descr,
+                            self._code_gen_and_patch_thread, chainlet_descr
                         )
                         future_to_display_name[future] = chainlet_descr.display_name
                     # Threads need to finish while inside the `import_target`-context.

--- a/truss-chains/truss_chains/framework.py
+++ b/truss-chains/truss_chains/framework.py
@@ -477,10 +477,7 @@ def _validate_and_describe_endpoint(
         is_streaming = inspect.isgeneratorfunction(endpoint_method)
 
     output_types = _validate_endpoint_output_types(
-        signature.return_annotation,
-        signature,
-        location,
-        is_streaming,
+        signature.return_annotation, signature, location, is_streaming
     )
 
     if is_streaming:
@@ -730,8 +727,7 @@ class _ChainletInitValidator:
 
 
 def _validate_remote_config(
-    cls: Type[definitions.ABCChainlet],
-    location: _ErrorLocation,
+    cls: Type[definitions.ABCChainlet], location: _ErrorLocation
 ):
     if not isinstance(
         remote_config := getattr(cls, definitions.REMOTE_CONFIG_NAME),
@@ -1220,9 +1216,7 @@ def import_target(
             _global_chainlet_registry.unregister_chainlet(chainlet_name)
 
 
-def _load_module(
-    module_path: pathlib.Path,
-) -> tuple[types.ModuleType, Loader]:
+def _load_module(module_path: pathlib.Path) -> tuple[types.ModuleType, Loader]:
     """The context manager ensures that modules imported by the Model/Chain
      are removed upon exit.
 

--- a/truss-chains/truss_chains/pydantic_numpy.py
+++ b/truss-chains/truss_chains/pydantic_numpy.py
@@ -81,7 +81,7 @@ class NumpyArrayField:
             except (ValueError, TypeError) as e:
                 raise TypeError(
                     "numpy_array_validation"
-                    f"Invalid data, shape, or dtype for NumPy array: {str(e)}",
+                    f"Invalid data, shape, or dtype for NumPy array: {str(e)}"
                 )
         if isinstance(value, np.ndarray):
             return cls(value)

--- a/truss-chains/truss_chains/remote_chainlet/stub.py
+++ b/truss-chains/truss_chains/remote_chainlet/stub.py
@@ -79,9 +79,7 @@ class BasetenSession:
     _cached_async_client: Optional[tuple[aiohttp.ClientSession, int]]
 
     def __init__(
-        self,
-        service_descriptor: definitions.DeployedServiceDescriptor,
-        api_key: str,
+        self, service_descriptor: definitions.DeployedServiceDescriptor, api_key: str
     ) -> None:
         logging.info(
             f"Creating BasetenSession (HTTP) for `{service_descriptor.name}`.\n"
@@ -158,9 +156,7 @@ class BasetenSession:
         if self._client_cycle_needed(self._cached_async_client):
             async with self._async_lock:
                 if self._client_cycle_needed(self._cached_async_client):
-                    connector = aiohttp.TCPConnector(
-                        limit=DEFAULT_MAX_CONNECTIONS,
-                    )
+                    connector = aiohttp.TCPConnector(limit=DEFAULT_MAX_CONNECTIONS)
                     self._cached_async_client = (
                         aiohttp.ClientSession(
                             headers=self._auth_header,
@@ -230,9 +226,7 @@ class StubBase(BasetenSession, abc.ABC):
 
     @final
     def __init__(
-        self,
-        service_descriptor: definitions.DeployedServiceDescriptor,
-        api_key: str,
+        self, service_descriptor: definitions.DeployedServiceDescriptor, api_key: str
     ) -> None:
         """
         Args:

--- a/truss-chains/truss_chains/remote_chainlet/utils.py
+++ b/truss-chains/truss_chains/remote_chainlet/utils.py
@@ -7,14 +7,7 @@ import sys
 import textwrap
 import threading
 import traceback
-from typing import (
-    Dict,
-    Iterator,
-    Mapping,
-    NoReturn,
-    Type,
-    TypeVar,
-)
+from typing import Dict, Iterator, Mapping, NoReturn, Type, TypeVar
 
 import aiohttp
 import fastapi
@@ -47,10 +40,7 @@ def populate_chainlet_service_predict_urls(
 
     dynamic_chainlet_config = json.loads(dynamic_chainlet_config_str)
 
-    for (
-        chainlet_name,
-        service_descriptor,
-    ) in chainlet_to_service.items():
+    for chainlet_name, service_descriptor in chainlet_to_service.items():
         display_name = service_descriptor.display_name
 
         # NOTE: The Chainlet `display_name` in the Truss CLI
@@ -185,9 +175,7 @@ def exception_to_http_error() -> Iterator[None]:
         _handle_exception(e)
 
 
-def _resolve_exception_class(
-    error: definitions.RemoteErrorDetail,
-) -> Type[Exception]:
+def _resolve_exception_class(error: definitions.RemoteErrorDetail) -> Type[Exception]:
     """Tries to find the exception class in builtins or imported libs,
     falls back to `definitions.GenericRemoteError` if not found."""
     exception_cls = None

--- a/truss-chains/truss_chains/streaming.py
+++ b/truss-chains/truss_chains/streaming.py
@@ -50,26 +50,19 @@ class StreamTypes(Generic[ItemT, HeaderTT, FooterTT]):
 
 @overload
 def stream_types(
-    item_type: Type[ItemT],
-    *,
-    header_type: Type[HeaderT],
-    footer_type: Type[FooterT],
+    item_type: Type[ItemT], *, header_type: Type[HeaderT], footer_type: Type[FooterT]
 ) -> StreamTypes[ItemT, HeaderT, FooterT]: ...
 
 
 @overload
 def stream_types(
-    item_type: Type[ItemT],
-    *,
-    header_type: Type[HeaderT],
+    item_type: Type[ItemT], *, header_type: Type[HeaderT]
 ) -> StreamTypes[ItemT, HeaderT, None]: ...
 
 
 @overload
 def stream_types(
-    item_type: Type[ItemT],
-    *,
-    footer_type: Type[FooterT],
+    item_type: Type[ItemT], *, footer_type: Type[FooterT]
 ) -> StreamTypes[ItemT, None, FooterT]: ...
 
 
@@ -244,35 +237,30 @@ class StreamReaderFull(
 
 @overload
 def stream_reader(
-    types: StreamTypes[ItemT, None, None],
-    stream: AsyncIterator[bytes],
+    types: StreamTypes[ItemT, None, None], stream: AsyncIterator[bytes]
 ) -> _StreamReader[ItemT, None, None]: ...
 
 
 @overload
 def stream_reader(
-    types: StreamTypes[ItemT, HeaderT, None],
-    stream: AsyncIterator[bytes],
+    types: StreamTypes[ItemT, HeaderT, None], stream: AsyncIterator[bytes]
 ) -> StreamReaderWithHeader[ItemT, HeaderT, None]: ...
 
 
 @overload
 def stream_reader(
-    types: StreamTypes[ItemT, None, FooterT],
-    stream: AsyncIterator[bytes],
+    types: StreamTypes[ItemT, None, FooterT], stream: AsyncIterator[bytes]
 ) -> StreamReaderWithFooter[ItemT, None, FooterT]: ...
 
 
 @overload
 def stream_reader(
-    types: StreamTypes[ItemT, HeaderT, FooterT],
-    stream: AsyncIterator[bytes],
+    types: StreamTypes[ItemT, HeaderT, FooterT], stream: AsyncIterator[bytes]
 ) -> StreamReaderFull[ItemT, HeaderT, FooterT]: ...
 
 
 def stream_reader(
-    types: StreamTypes[ItemT, HeaderTT, FooterTT],
-    stream: AsyncIterator[bytes],
+    types: StreamTypes[ItemT, HeaderTT, FooterTT], stream: AsyncIterator[bytes]
 ) -> _StreamReader:
     if types.header_type is None and types.footer_type is None:
         return _StreamReader(types, stream)
@@ -379,9 +367,7 @@ def stream_writer(
 ) -> StreamWriterFull[ItemT, HeaderT, FooterT]: ...
 
 
-def stream_writer(
-    types: StreamTypes[ItemT, HeaderTT, FooterTT],
-) -> _StreamWriter:
+def stream_writer(types: StreamTypes[ItemT, HeaderTT, FooterTT]) -> _StreamWriter:
     if types.header_type is None and types.footer_type is None:
         return _StreamWriter(types)
     if types.header_type is None:

--- a/truss-chains/truss_chains/utils.py
+++ b/truss-chains/truss_chains/utils.py
@@ -5,13 +5,7 @@ import logging
 import os
 import random
 import socket
-from typing import (
-    Any,
-    Iterable,
-    Iterator,
-    TypeVar,
-    Union,
-)
+from typing import Any, Iterable, Iterator, TypeVar, Union
 
 from truss_chains import definitions
 

--- a/truss/api/definitions.py
+++ b/truss/api/definitions.py
@@ -3,10 +3,7 @@ import time
 import pydantic
 
 from truss.remote.baseten import service
-from truss.remote.baseten.core import (
-    ACTIVE_STATUS,
-    DEPLOYING_STATUSES,
-)
+from truss.remote.baseten.core import ACTIVE_STATUS, DEPLOYING_STATUSES
 
 
 class ModelDeployment:

--- a/truss/base/constants.py
+++ b/truss/base/constants.py
@@ -84,20 +84,12 @@ XGBOOST_REQ_MODULE_NAMES: Set[str] = {"xgboost"}
 
 # list from https://www.tensorflow.org/install/pip
 # if problematic, lets look to https://www.tensorflow.org/install/source
-TENSORFLOW_REQ_MODULE_NAMES: Set[str] = {
-    "tensorflow",
-}
+TENSORFLOW_REQ_MODULE_NAMES: Set[str] = {"tensorflow"}
 
-LIGHTGBM_REQ_MODULE_NAMES: Set[str] = {
-    "lightgbm",
-}
+LIGHTGBM_REQ_MODULE_NAMES: Set[str] = {"lightgbm"}
 
 # list from https://pytorch.org/get-started/locally/
-PYTORCH_REQ_MODULE_NAMES: Set[str] = {
-    "torch",
-    "torchvision",
-    "torchaudio",
-}
+PYTORCH_REQ_MODULE_NAMES: Set[str] = {"torch", "torchvision", "torchaudio"}
 
 MLFLOW_REQ_MODULE_NAMES: Set[str] = {"mlflow"}
 

--- a/truss/base/custom_types.py
+++ b/truss/base/custom_types.py
@@ -23,13 +23,7 @@ class Example:
 
     @staticmethod
     def from_dict(example_dict):
-        return Example(
-            name=example_dict["name"],
-            input=example_dict["input"],
-        )
+        return Example(name=example_dict["name"], input=example_dict["input"])
 
     def to_dict(self) -> dict:
-        return {
-            "name": self.name,
-            "input": self.input,
-        }
+        return {"name": self.name, "input": self.input}

--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -8,9 +8,7 @@ from typing import Any, Callable, Dict, List, Optional, TypeVar
 
 import yaml
 
-from truss.base.constants import (
-    HTTP_PUBLIC_BLOB_BACKEND,
-)
+from truss.base.constants import HTTP_PUBLIC_BLOB_BACKEND
 from truss.base.custom_types import ModelFrameworkType
 from truss.base.errors import ValidationError
 from truss.base.trt_llm_config import (
@@ -274,10 +272,7 @@ class Resources:
             use_gpu = True
 
         return Resources(
-            cpu=cpu,
-            memory=memory,
-            use_gpu=use_gpu,
-            accelerator=accelerator,
+            cpu=cpu, memory=memory, use_gpu=use_gpu, accelerator=accelerator
         )
 
     def to_dict(self):
@@ -593,12 +588,9 @@ class TrussConfig:
 
     @property
     def canonical_python_version(self) -> str:
-        return {
-            "py311": "3.11",
-            "py310": "3.10",
-            "py39": "3.9",
-            "py38": "3.8",
-        }[self.python_version]
+        return {"py311": "3.11", "py310": "3.10", "py39": "3.9", "py38": "3.8"}[
+            self.python_version
+        ]
 
     @property
     def parsed_trt_llm_build_configs(self) -> List[TrussTRTLLMBuildConfiguration]:

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -66,21 +66,21 @@ click.rich_click.COMMAND_GROUPS = {
             "name": "Main usage",
             "commands": ["init", "push", "watch", "predict"],
             "table_styles": {  # type: ignore
-                "row_styles": ["green"],
+                "row_styles": ["green"]
             },
         },
         {
             "name": "Advanced Usage",
             "commands": ["image", "container", "cleanup"],
             "table_styles": {  # type: ignore
-                "row_styles": ["yellow"],
+                "row_styles": ["yellow"]
             },
         },
         {
             "name": "Chains",
             "commands": ["chains"],
             "table_styles": {  # type: ignore
-                "row_styles": ["red"],
+                "row_styles": ["red"]
             },
         },
     ]
@@ -372,10 +372,7 @@ def whoami(remote: Optional[str]):
 )
 @log_level_option
 @error_handling
-def watch(
-    target_directory: str,
-    remote: str,
-) -> None:
+def watch(target_directory: str, remote: str) -> None:
     """
     Seamless remote development with truss
 
@@ -779,9 +776,7 @@ def watch_chains(
 @click.argument("directory", type=Path, required=False)
 @log_level_option
 @error_handling
-def init_chain(
-    directory: Optional[Path],
-) -> None:
+def init_chain(directory: Optional[Path]) -> None:
     """
     Initializes a chains project directory.
 
@@ -914,12 +909,7 @@ def _extract_request_data(data: Optional[str], file: Optional[Path]):
     required=False,
     help="ID of model deployment to call",
 )
-@click.option(
-    "--model",
-    type=str,
-    required=False,
-    help="ID of model to call",
-)
+@click.option("--model", type=str, required=False, help="ID of model to call")
 @log_level_option
 def predict(
     target_directory: str,
@@ -1188,10 +1178,7 @@ def push(
                     "GPU memory required at build time may be significantly more than that required at inference time due to FP8 quantization, which can result in OOM failures during the engine build phase."
                     "`num_builder_gpus` can be used to specify the number of GPUs to use at build time."
                 )
-                console.print(
-                    fp8_and_num_builder_gpus_text,
-                    style="yellow",
-                )
+                console.print(fp8_and_num_builder_gpus_text, style="yellow")
 
     # TODO(Abu): This needs to be refactored to be more generic
     service = remote_provider.push(

--- a/truss/cli/remote_cli.py
+++ b/truss/cli/remote_cli.py
@@ -23,9 +23,7 @@ def inquire_remote_config() -> RemoteConfig:
     # can do so manually in the .trussrc file.
     remote_url = "https://app.baseten.co"
     api_key = inquirer.secret(
-        message="🤫 Quietly paste your API_KEY:",
-        qmark="",
-        validate=NonEmptyValidator(),
+        message="🤫 Quietly paste your API_KEY:", qmark="", validate=NonEmptyValidator()
     ).execute()
 
     return RemoteConfig(
@@ -56,7 +54,4 @@ def inquire_remote_name(available_remotes: List[str]) -> str:
 
 
 def inquire_model_name() -> str:
-    return inquirer.text(
-        "📦 Name this model:",
-        qmark="",
-    ).execute()
+    return inquirer.text("📦 Name this model:", qmark="").execute()

--- a/truss/contexts/image_builder/cache_warmer.py
+++ b/truss/contexts/image_builder/cache_warmer.py
@@ -25,11 +25,7 @@ def _b10cp_path() -> Optional[str]:
     return os.environ.get(B10CP_PATH_TRUSS_ENV_VAR_NAME)
 
 
-def _download_from_url_using_b10cp(
-    b10cp_path: str,
-    url: str,
-    download_to: Path,
-):
+def _download_from_url_using_b10cp(b10cp_path: str, url: str, download_to: Path):
     return subprocess.Popen(
         [
             b10cp_path,
@@ -157,9 +153,7 @@ class GCSFile(RepositoryFile):
 
         if is_private:
             url = blob.generate_signed_url(
-                version="v4",
-                expiration=datetime.timedelta(minutes=15),
-                method="GET",
+                version="v4", expiration=datetime.timedelta(minutes=15), method="GET"
             )
         else:
             base_url = "https://storage.googleapis.com"

--- a/truss/contexts/image_builder/serving_image_builder.py
+++ b/truss/contexts/image_builder/serving_image_builder.py
@@ -344,7 +344,7 @@ def generate_docker_server_supervisord_config(build_dir, config):
         "docker_server.start_command is required to use custom server"
     )
     supervisord_contents = supervisord_template.render(
-        start_command=config.docker_server.start_command,
+        start_command=config.docker_server.start_command
     )
     supervisord_filepath = build_dir / "supervisord.conf"
     supervisord_filepath.write_text(supervisord_contents)
@@ -449,8 +449,7 @@ class ServingImageBuilder(ImageBuilder):
         config.runtime.predict_concurrency = TRTLLM_PREDICT_CONCURRENCY
 
         config.base_image = BaseImage(
-            image=TRTLLM_BASE_IMAGE,
-            python_executable_path=TRTLLM_PYTHON_EXECUTABLE,
+            image=TRTLLM_BASE_IMAGE, python_executable_path=TRTLLM_PYTHON_EXECUTABLE
         )
         config.requirements.extend(BASE_TRTLLM_REQUIREMENTS)
 
@@ -508,10 +507,7 @@ class ServingImageBuilder(ImageBuilder):
         if self._spec.external_data is not None:
             for ext_file in self._spec.external_data.items:
                 external_data_files.append(
-                    (
-                        ext_file.url,
-                        (data_dir / ext_file.local_data_path).resolve(),
-                    )
+                    (ext_file.url, (data_dir / ext_file.local_data_path).resolve())
                 )
 
         # Download from HuggingFace

--- a/truss/contexts/image_builder/util.py
+++ b/truss/contexts/image_builder/util.py
@@ -36,9 +36,7 @@ def truss_base_image_name(job_type: str) -> str:
 
 
 def truss_base_image_tag(
-    python_version: str,
-    use_gpu: bool,
-    version_tag: Optional[str] = None,
+    python_version: str, use_gpu: bool, version_tag: Optional[str] = None
 ) -> str:
     if version_tag is None:
         version_tag = f"v{__version__}"

--- a/truss/contexts/local_loader/docker_build_emulator.py
+++ b/truss/contexts/local_loader/docker_build_emulator.py
@@ -22,11 +22,7 @@ class DockerBuildEmulator:
     Support COPY, ENV, ENTRYPOINT, WORKDIR commands. All other commands are ignored.
     """
 
-    def __init__(
-        self,
-        dockerfile_path: Path,
-        context_dir: Path,
-    ) -> None:
+    def __init__(self, dockerfile_path: Path, context_dir: Path) -> None:
         import dockerfile
 
         self._commands = dockerfile.parse_file(str(dockerfile_path))

--- a/truss/contexts/local_loader/truss_module_loader.py
+++ b/truss/contexts/local_loader/truss_module_loader.py
@@ -33,7 +33,7 @@ class TrussModuleFinder(PathFinder):
             truss_modules_path = [cls._truss_dir]
         else:
             truss_modules_path = [
-                str(Path(cls._truss_dir) / cls._bundled_packages_dir_name),
+                str(Path(cls._truss_dir) / cls._bundled_packages_dir_name)
             ]
             if cls._external_packages_dirs:
                 truss_modules_path += [

--- a/truss/local/local_config.py
+++ b/truss/local/local_config.py
@@ -13,8 +13,7 @@ class LocalConfig:
     @staticmethod
     def from_dict(d):
         return LocalConfig(
-            secrets=d.get("secrets", {}),
-            use_sudo=d.get("use_sudo", False),
+            secrets=d.get("secrets", {}), use_sudo=d.get("use_sudo", False)
         )
 
     @staticmethod
@@ -23,10 +22,7 @@ class LocalConfig:
             return LocalConfig.from_dict(yaml.safe_load(yaml_file))
 
     def to_dict(self):
-        return {
-            "secrets": self.secrets,
-            "use_sudo": self.use_sudo,
-        }
+        return {"secrets": self.secrets, "use_sudo": self.use_sudo}
 
     def write_to_yaml_file(self, path: Path):
         with path.open("w") as config_file:

--- a/truss/local/local_config_handler.py
+++ b/truss/local/local_config_handler.py
@@ -44,10 +44,7 @@ class LocalConfigHandler:
         LocalConfigHandler._ensure_config_dir()
         validate_secret_name(secret_name)
         local_config = LocalConfigHandler.get_config()
-        new_secrets = {
-            **local_config.secrets,
-            secret_name: secret_value,
-        }
+        new_secrets = {**local_config.secrets, secret_name: secret_value}
         new_local_config = replace(local_config, secrets=new_secrets)
         new_local_config.write_to_yaml_file(LocalConfigHandler._config_path())
 

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -50,10 +50,7 @@ def _chainlet_data_atomic_to_graphql_mutation(
 ) -> str:
     oracle_data_string = _oracle_data_to_graphql_mutation(chainlet.oracle)
 
-    args = [
-        f'name: "{chainlet.name}"',
-        f"oracle: {oracle_data_string}",
-    ]
+    args = [f'name: "{chainlet.name}"', f"oracle: {oracle_data_string}"]
 
     args_str = ",\n".join(args)
 
@@ -531,10 +528,7 @@ class BasetenApi:
 
     def get_all_secrets(self) -> Any:
         headers = self._auth_token.header()
-        resp = requests.get(
-            f"{self._rest_api_url}/v1/secrets",
-            headers=headers,
-        )
+        resp = requests.get(f"{self._rest_api_url}/v1/secrets", headers=headers)
         if not resp.ok:
             resp.raise_for_status()
 

--- a/truss/remote/baseten/core.py
+++ b/truss/remote/baseten/core.py
@@ -156,9 +156,7 @@ def create_chain_atomic(
         raise ValueError(NO_ENVIRONMENTS_EXIST_ERROR_MESSAGING)
     else:
         res = api.deploy_chain_atomic(
-            chain_name=chain_name,
-            entrypoint=entrypoint,
-            dependencies=dependencies,
+            chain_name=chain_name, entrypoint=entrypoint, dependencies=dependencies
         )
 
     return ChainDeploymentHandleAtomic(

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -115,10 +115,7 @@ class BasetenRemote(TrussRemote):
         )
         workspace_name = resp["data"]["organization"]["workspace_name"]
         user_email = resp["data"]["user"]["email"]
-        return RemoteUser(
-            workspace_name,
-            user_email,
-        )
+        return RemoteUser(workspace_name, user_email)
 
     # Validate and finalize options.
     # Upload Truss files to S3 and return S3 key.
@@ -298,8 +295,7 @@ class BasetenRemote(TrussRemote):
             )
             chainlet_data.append(
                 custom_types.ChainletDataAtomic(
-                    name=artifact.display_name,
-                    oracle=oracle_data,
+                    name=artifact.display_name, oracle=oracle_data
                 )
             )
 
@@ -380,12 +376,10 @@ class BasetenRemote(TrussRemote):
             raise ValueError("Baseten Service requires a model_identifier")
 
         published = kwargs.get("published", False)
-        (
-            service_url_path,
-            model_id,
-            model_version_id,
-        ) = self._get_service_url_path_and_model_ids(
-            self._api, model_identifier, published
+        (service_url_path, model_id, model_version_id) = (
+            self._get_service_url_path_and_model_ids(
+                self._api, model_identifier, published
+            )
         )
 
         return BasetenService(
@@ -415,10 +409,7 @@ class BasetenRemote(TrussRemote):
         truss_ignore_patterns = load_trussignore_patterns_from_truss_dir(watch_path)
 
         def watch_filter(_, path):
-            return not is_ignored(
-                Path(path),
-                truss_ignore_patterns,
-            )
+            return not is_ignored(Path(path), truss_ignore_patterns)
 
         # disable watchfiles logger
         logging.getLogger("watchfiles.main").disabled = True
@@ -547,8 +538,7 @@ class BasetenRemote(TrussRemote):
             return PatchResult(
                 PatchStatus.SUCCESS,
                 resp.get(
-                    "success_message",
-                    f"Model {model_name} patched successfully.",
+                    "success_message", f"Model {model_name} patched successfully."
                 ),
             )
 
@@ -566,8 +556,6 @@ class BasetenRemote(TrussRemote):
             error_console.print(result.message)
 
     def patch_for_chainlet(
-        self,
-        watch_path: Path,
-        truss_ignore_patterns: List[str],
+        self, watch_path: Path, truss_ignore_patterns: List[str]
     ) -> PatchResult:
         return self._patch(watch_path, truss_ignore_patterns, console=None)

--- a/truss/remote/baseten/service.py
+++ b/truss/remote/baseten/service.py
@@ -2,13 +2,7 @@ import enum
 import time
 import urllib.parse
 import warnings
-from typing import (
-    Any,
-    Dict,
-    Iterator,
-    NamedTuple,
-    Optional,
-)
+from typing import Any, Dict, Iterator, NamedTuple, Optional
 
 import requests
 from tenacity import retry, stop_after_delay, wait_fixed
@@ -128,10 +122,7 @@ class BasetenService(TrussService):
     def invocation_url(self) -> str:
         return f"{self._service_url}/predict"
 
-    def predict(
-        self,
-        model_request_body: Dict,
-    ) -> Any:
+    def predict(self, model_request_body: Dict) -> Any:
         response = self._send_request(
             self.predict_url, "POST", data=model_request_body, stream=True
         )

--- a/truss/remote/baseten/utils/transfer.py
+++ b/truss/remote/baseten/utils/transfer.py
@@ -45,9 +45,6 @@ def multipart_upload_boto3(
         with progress_context:
             s3_resource.Object(bucket_name, key).upload_file(
                 file_path,
-                Config=TransferConfig(
-                    max_concurrency=10,
-                    use_threads=True,
-                ),
+                Config=TransferConfig(max_concurrency=10, use_threads=True),
                 Callback=callback,
             )

--- a/truss/templates/control/control/application.py
+++ b/truss/templates/control/control/application.py
@@ -19,24 +19,12 @@ from starlette.datastructures import State
 
 async def handle_patch_error(_, exc):
     error_type = _camel_to_snake_case(type(exc).__name__)
-    return JSONResponse(
-        content={
-            "error": {
-                "type": error_type,
-                "msg": str(exc),
-            }
-        }
-    )
+    return JSONResponse(content={"error": {"type": error_type, "msg": str(exc)}})
 
 
 async def generic_error_handler(_, exc):
     return JSONResponse(
-        content={
-            "error": {
-                "type": "unknown",
-                "msg": f"{type(exc)}: {exc}",
-            }
-        }
+        content={"error": {"type": "unknown", "msg": f"{type(exc)}: {exc}"}}
     )
 
 
@@ -69,9 +57,7 @@ def create_app(base_config: Dict):
     pip_path = getattr(app_state, "pip_path", None)
 
     patch_applier = ModelContainerPatchApplier(
-        Path(app_state.inference_server_home),
-        app_logger,
-        pip_path,
+        Path(app_state.inference_server_home), app_logger, pip_path
     )
 
     oversee_inference_server = getattr(app_state, "oversee_inference_server", True)
@@ -86,8 +72,7 @@ def create_app(base_config: Dict):
     async def start_background_inference_startup():
         asyncio.create_task(
             async_inference_server_startup_flow(
-                app_state.inference_server_controller,
-                app_logger,
+                app_state.inference_server_controller, app_logger
             )
         )
 

--- a/truss/templates/control/control/helpers/custom_types.py
+++ b/truss/templates/control/control/helpers/custom_types.py
@@ -42,11 +42,7 @@ class ModelCodePatch(PatchBody):
     content: Optional[str] = None
 
     def to_dict(self):
-        return {
-            "action": self.action.value,
-            "path": self.path,
-            "content": self.content,
-        }
+        return {"action": self.action.value, "path": self.path, "content": self.content}
 
     @staticmethod
     def from_dict(patch_dict: Dict):
@@ -65,17 +61,13 @@ class PythonRequirementPatch(PatchBody):
     requirement: str
 
     def to_dict(self):
-        return {
-            "action": self.action.value,
-            "requirement": self.requirement,
-        }
+        return {"action": self.action.value, "requirement": self.requirement}
 
     @staticmethod
     def from_dict(patch_dict: Dict):
         action_str = patch_dict["action"]
         return PythonRequirementPatch(
-            action=Action[action_str],
-            requirement=patch_dict["requirement"],
+            action=Action[action_str], requirement=patch_dict["requirement"]
         )
 
 
@@ -86,17 +78,13 @@ class SystemPackagePatch(PatchBody):
     package: str
 
     def to_dict(self):
-        return {
-            "action": self.action.value,
-            "package": self.package,
-        }
+        return {"action": self.action.value, "package": self.package}
 
     @staticmethod
     def from_dict(patch_dict: Dict):
         action_str = patch_dict["action"]
         return SystemPackagePatch(
-            action=Action[action_str],
-            package=patch_dict["package"],
+            action=Action[action_str], package=patch_dict["package"]
         )
 
 
@@ -106,11 +94,7 @@ class ConfigPatch(PatchBody):
     path: str = "config.yaml"
 
     def to_dict(self):
-        return {
-            "action": self.action.value,
-            "config": self.config,
-            "path": self.path,
-        }
+        return {"action": self.action.value, "config": self.config, "path": self.path}
 
     @staticmethod
     def from_dict(patch_dict: Dict):
@@ -128,11 +112,7 @@ class DataPatch(PatchBody):
     content: Optional[str] = None
 
     def to_dict(self):
-        return {
-            "action": self.action.value,
-            "content": self.content,
-            "path": self.path,
-        }
+        return {"action": self.action.value, "content": self.content, "path": self.path}
 
     @staticmethod
     def from_dict(patch_dict: Dict):
@@ -150,11 +130,7 @@ class PackagePatch(PatchBody):
     content: Optional[str] = None
 
     def to_dict(self):
-        return {
-            "action": self.action.value,
-            "content": self.content,
-            "path": self.path,
-        }
+        return {"action": self.action.value, "content": self.content, "path": self.path}
 
     @staticmethod
     def from_dict(patch_dict: Dict):
@@ -171,18 +147,12 @@ class EnvVarPatch(PatchBody):
     item: dict
 
     def to_dict(self):
-        return {
-            "action": self.action.value,
-            "item": self.item,
-        }
+        return {"action": self.action.value, "item": self.item}
 
     @staticmethod
     def from_dict(patch_dict: Dict):
         action_str = patch_dict["action"]
-        return EnvVarPatch(
-            action=Action[action_str],
-            item=patch_dict["item"],
-        )
+        return EnvVarPatch(action=Action[action_str], item=patch_dict["item"])
 
 
 @dataclass
@@ -190,18 +160,12 @@ class ExternalDataPatch(PatchBody):
     item: Dict[str, str]
 
     def to_dict(self):
-        return {
-            "action": self.action.value,
-            "item": self.item,
-        }
+        return {"action": self.action.value, "item": self.item}
 
     @staticmethod
     def from_dict(patch_dict: Dict):
         action_str = patch_dict["action"]
-        return ExternalDataPatch(
-            action=Action[action_str],
-            item=patch_dict["item"],
-        )
+        return ExternalDataPatch(action=Action[action_str], item=patch_dict["item"])
 
 
 PATCH_BODY_BY_TYPE: Dict[
@@ -238,10 +202,7 @@ class Patch:
     body: PatchBody
 
     def to_dict(self):
-        return {
-            "type": self.type.value,
-            "body": self.body.to_dict(),
-        }
+        return {"type": self.type.value, "body": self.body.to_dict()}
 
     @staticmethod
     def from_dict(patch_dict: Dict):

--- a/truss/templates/control/control/helpers/inference_server_process_controller.py
+++ b/truss/templates/control/control/helpers/inference_server_process_controller.py
@@ -39,8 +39,7 @@ class InferenceServerProcessController:
         with current_directory(self._inference_server_home):
             inf_env["INFERENCE_SERVER_PORT"] = str(self._inference_server_port)
             self._inference_server_process = subprocess.Popen(
-                self._inference_server_process_args,
-                env=inf_env,
+                self._inference_server_process_args, env=inf_env
             )
 
             self._inference_server_started = True

--- a/truss/templates/control/control/helpers/inference_server_starter.py
+++ b/truss/templates/control/control/helpers/inference_server_starter.py
@@ -8,8 +8,7 @@ from tenacity import Retrying, stop_after_attempt, wait_exponential
 
 
 def inference_server_startup_flow(
-    inference_server_controller: InferenceServerController,
-    logger: Logger,
+    inference_server_controller: InferenceServerController, logger: Logger
 ) -> None:
     """
     Perform the inference server startup flow
@@ -39,8 +38,7 @@ def inference_server_startup_flow(
     payload = {"truss_hash": truss_hash}
 
     for attempt in Retrying(
-        stop=stop_after_attempt(15),
-        wait=wait_exponential(multiplier=2, min=1, max=4),
+        stop=stop_after_attempt(15), wait=wait_exponential(multiplier=2, min=1, max=4)
     ):
         with attempt:
             try:
@@ -62,8 +60,7 @@ def inference_server_startup_flow(
 
 
 async def async_inference_server_startup_flow(
-    inference_server_controller: InferenceServerController,
-    logger: Logger,
+    inference_server_controller: InferenceServerController, logger: Logger
 ) -> None:
     return await to_thread.run_sync(
         inference_server_startup_flow, inference_server_controller, logger

--- a/truss/templates/control/control/helpers/truss_patch/model_code_patch_applier.py
+++ b/truss/templates/control/control/helpers/truss_patch/model_code_patch_applier.py
@@ -11,11 +11,7 @@ except ModuleNotFoundError as exc:
     from truss.templates.control.control.helpers.custom_types import Action, Patch
 
 
-def apply_code_patch(
-    relative_dir: Path,
-    patch: Patch,
-    logger: logging.Logger,
-):
+def apply_code_patch(relative_dir: Path, patch: Patch, logger: logging.Logger):
     logger.debug(f"Applying code patch {patch.to_dict()}")
     filepath: Path = relative_dir / patch.path
     action = patch.action

--- a/truss/templates/control/control/helpers/truss_patch/model_container_patch_applier.py
+++ b/truss/templates/control/control/helpers/truss_patch/model_container_patch_applier.py
@@ -131,30 +131,12 @@ class ModelContainerPatchApplier:
 
         if action == Action.REMOVE:
             subprocess.run(
-                [
-                    "apt",
-                    "remove",
-                    "-y",
-                    system_package_patch.package,
-                ],
-                check=True,
+                ["apt", "remove", "-y", system_package_patch.package], check=True
             )
         elif action in [Action.ADD, Action.UPDATE]:
+            subprocess.run(["apt", "update"], check=True)
             subprocess.run(
-                [
-                    "apt",
-                    "update",
-                ],
-                check=True,
-            )
-            subprocess.run(
-                [
-                    "apt",
-                    "install",
-                    "-y",
-                    system_package_patch.package,
-                ],
-                check=True,
+                ["apt", "install", "-y", system_package_patch.package], check=True
             )
         else:
             raise ValueError(f"Unknown python requirement patch action {action}")

--- a/truss/templates/server/common/errors.py
+++ b/truss/templates/server/common/errors.py
@@ -4,14 +4,7 @@ import sys
 import textwrap
 from http import HTTPStatus
 from types import TracebackType
-from typing import (
-    Generator,
-    Mapping,
-    Optional,
-    Tuple,
-    Type,
-    Union,
-)
+from typing import Generator, Mapping, Optional, Tuple, Type, Union
 
 import fastapi
 import pydantic
@@ -68,9 +61,7 @@ def add_error_headers_to_user_response(response: starlette.responses.Response) -
 
 
 def _make_baseten_response(
-    http_status: int,
-    info: Union[str, Exception],
-    baseten_error_code: int,
+    http_status: int, info: Union[str, Exception], baseten_error_code: int
 ) -> fastapi.Response:
     msg = str(info) if isinstance(info, Exception) else info
     return JSONResponse(
@@ -91,9 +82,7 @@ async def exception_handler(_: fastapi.Request, exc: Exception) -> fastapi.Respo
         )
     if isinstance(exc, InputParsingError):
         return _make_baseten_response(
-            HTTPStatus.BAD_REQUEST.value,
-            exc,
-            _BASETEN_CLIENT_ERROR_CODE,
+            HTTPStatus.BAD_REQUEST.value, exc, _BASETEN_CLIENT_ERROR_CODE
         )
     if isinstance(exc, ModelDefinitionError):
         return _make_baseten_response(
@@ -134,8 +123,7 @@ HANDLED_EXCEPTIONS = {
 def filter_traceback(
     model_file_name: str,
 ) -> Union[
-    Tuple[Type[BaseException], BaseException, TracebackType],
-    Tuple[None, None, None],
+    Tuple[Type[BaseException], BaseException, TracebackType], Tuple[None, None, None]
 ]:
     exc_type, exc_value, tb = sys.exc_info()
     if tb is None:

--- a/truss/templates/server/truss_server.py
+++ b/truss/templates/server/truss_server.py
@@ -331,9 +331,7 @@ class TrussServer:
                 # Endpoint aliases for Sagemaker hosting
                 FastAPIRoute(r"/ping", self._endpoints.invocations_ready),
                 FastAPIRoute(
-                    r"/invocations",
-                    self._endpoints.invocations,
-                    methods=["POST"],
+                    r"/invocations", self._endpoints.invocations, methods=["POST"]
                 ),
             ],
             exception_handlers={

--- a/truss/templates/shared/lazy_data_resolver.py
+++ b/truss/templates/shared/lazy_data_resolver.py
@@ -82,10 +82,7 @@ class LazyDataResolver:
 
         # Streaming download to keep memory usage low
         resp = requests.get(
-            URL,
-            allow_redirects=True,
-            stream=True,
-            timeout=BLOB_DOWNLOAD_TIMEOUT_SECS,
+            URL, allow_redirects=True, stream=True, timeout=BLOB_DOWNLOAD_TIMEOUT_SECS
         )
         resp.raise_for_status()
 

--- a/truss/templates/trtllm-audio/model/model.py
+++ b/truss/templates/trtllm-audio/model/model.py
@@ -25,11 +25,11 @@ class Model:
 
         if audio_base64 and audio_url:
             return {
-                "error": "Only a base64 audio file OR a URL can be passed to the API, not both of them.",
+                "error": "Only a base64 audio file OR a URL can be passed to the API, not both of them."
             }
         if not audio_base64 and not audio_url:
             return {
-                "error": "Please provide either an audio file in base64 string format or a URL to an audio file.",
+                "error": "Please provide either an audio file in base64 string format or a URL to an audio file."
             }
 
         binary_data = None

--- a/truss/templates/trtllm-audio/packages/whisper_trt/__init__.py
+++ b/truss/templates/trtllm-audio/packages/whisper_trt/__init__.py
@@ -62,9 +62,7 @@ class WhisperModel(object):
         )[0]
 
         self.batch_processor = WhisperBatchProcessor(
-            self,
-            max_batch_size=self.batch_size,
-            max_queue_time=max_queue_time,
+            self, max_batch_size=self.batch_size, max_queue_time=max_queue_time
         )
 
     def preprocess_audio(self, binary_data) -> dict:
@@ -125,10 +123,7 @@ class WhisperModel(object):
         text.replace(text_prefix, "")
         return text
 
-    async def detect_audio_and_language(
-        self,
-        mel,
-    ) -> Optional[str]:
+    async def detect_audio_and_language(self, mel) -> Optional[str]:
         """
         Detects the audio and language from the given mel spectrogram.
 
@@ -141,16 +136,11 @@ class WhisperModel(object):
         text_prefix = "<|startoftranscript|>"
 
         prompt_ids = self.tokenizer.encode(
-            text_prefix,
-            allowed_special=self.tokenizer.special_tokens_set,
+            text_prefix, allowed_special=self.tokenizer.special_tokens_set
         )
 
         output_ids = await self.batch_processor.process(
-            item=BatchWhisperItem(
-                mel=mel,
-                prompt_ids=prompt_ids,
-                max_new_tokens=1,
-            )
+            item=BatchWhisperItem(mel=mel, prompt_ids=prompt_ids, max_new_tokens=1)
         )
         text = self.decode_output_ids(output_ids, text_prefix)
         if text == "<|nospeech|>":
@@ -189,15 +179,12 @@ class WhisperModel(object):
         )
 
         prompt_ids = self.tokenizer.encode(
-            text_prefix,
-            allowed_special=self.tokenizer.special_tokens_set,
+            text_prefix, allowed_special=self.tokenizer.special_tokens_set
         )
 
         output_ids: Tensor = await self.batch_processor.process(
             item=BatchWhisperItem(
-                mel=mel,
-                prompt_ids=prompt_ids,
-                max_new_tokens=max_new_tokens,
+                mel=mel, prompt_ids=prompt_ids, max_new_tokens=max_new_tokens
             )
         )
 

--- a/truss/templates/trtllm-briton/src/extension.py
+++ b/truss/templates/trtllm-briton/src/extension.py
@@ -1,7 +1,5 @@
 from briton.spec_dec_truss_model import Model as SpecDecModel
-from briton.trtllm_config import (
-    TRTLLMConfiguration,
-)
+from briton.trtllm_config import TRTLLMConfiguration
 from briton.truss_model import Model
 
 # TODO(pankaj) Define an ABC base class for this. That baseclass should live in

--- a/truss/tests/conftest.py
+++ b/truss/tests/conftest.py
@@ -14,10 +14,7 @@ import requests
 import yaml
 
 from truss.base.custom_types import Example
-from truss.base.trt_llm_config import (
-    TrussSpecDecMode,
-    TrussTRTLLMBatchSchedulerPolicy,
-)
+from truss.base.trt_llm_config import TrussSpecDecMode, TrussTRTLLMBatchSchedulerPolicy
 from truss.base.truss_config import DEFAULT_BUNDLED_PACKAGES_DIR, Accelerator
 from truss.contexts.image_builder.serving_image_builder import (
     ServingImageBuilderContext,
@@ -238,29 +235,19 @@ def pytorch_model_init_args():
 
 @pytest.fixture
 def custom_model_truss_dir(tmp_path) -> Path:
-    yield _custom_model_from_code(
-        tmp_path,
-        "custom_truss",
-        CUSTOM_MODEL_CODE,
-    )
+    yield _custom_model_from_code(tmp_path, "custom_truss", CUSTOM_MODEL_CODE)
 
 
 @pytest.fixture
 def no_preprocess_custom_model(tmp_path):
     yield _custom_model_from_code(
-        tmp_path,
-        "my_no_preprocess_model",
-        NO_PREPROCESS_CUSTOM_MODEL_CODE,
+        tmp_path, "my_no_preprocess_model", NO_PREPROCESS_CUSTOM_MODEL_CODE
     )
 
 
 @pytest.fixture
 def long_load_model(tmp_path):
-    yield _custom_model_from_code(
-        tmp_path,
-        "long_load_model",
-        LONG_LOAD_MODEL_CODE,
-    )
+    yield _custom_model_from_code(tmp_path, "long_load_model", LONG_LOAD_MODEL_CODE)
 
 
 @pytest.fixture
@@ -280,8 +267,7 @@ def custom_model_external_data_access_tuple_fixture(tmp_path: Path):
     (tmp_path / filename).write_text(content)
     port = 9089
     proc = subprocess.Popen(
-        ["python", "-m", "http.server", str(port), "--bind", "*"],
-        cwd=tmp_path,
+        ["python", "-m", "http.server", str(port), "--bind", "*"], cwd=tmp_path
     )
     try:
         url = f"http://localhost:{port}/{filename}"
@@ -311,8 +297,7 @@ def custom_model_external_data_access_tuple_fixture_gpu(tmp_path: Path):
     (tmp_path / filename).write_text(content)
     port = 9089
     proc = subprocess.Popen(
-        ["python", "-m", "http.server", str(port), "--bind", "*"],
-        cwd=tmp_path,
+        ["python", "-m", "http.server", str(port), "--bind", "*"], cwd=tmp_path
     )
     try:
         url = f"http://localhost:{port}/{filename}"
@@ -368,27 +353,21 @@ def custom_model_with_external_package(tmp_path: Path):
 @pytest.fixture
 def no_postprocess_custom_model(tmp_path):
     yield _custom_model_from_code(
-        tmp_path,
-        "my_no_postprocess_model",
-        NO_POSTPROCESS_CUSTOM_MODEL_CODE,
+        tmp_path, "my_no_postprocess_model", NO_POSTPROCESS_CUSTOM_MODEL_CODE
     )
 
 
 @pytest.fixture
 def no_load_custom_model(tmp_path):
     yield _custom_model_from_code(
-        tmp_path,
-        "my_no_load_model",
-        NO_LOAD_CUSTOM_MODEL_CODE,
+        tmp_path, "my_no_load_model", NO_LOAD_CUSTOM_MODEL_CODE
     )
 
 
 @pytest.fixture
 def no_params_init_custom_model(tmp_path):
     yield _custom_model_from_code(
-        tmp_path,
-        "my_no_params_init_load_model",
-        NO_PARAMS_INIT_CUSTOM_MODEL_CODE,
+        tmp_path, "my_no_params_init_load_model", NO_PARAMS_INIT_CUSTOM_MODEL_CODE
     )
 
 
@@ -534,8 +513,8 @@ def custom_model_truss_dir_with_pre_and_post_str_example(tmp_path):
                     "inputs": [
                         {
                             "image_url": "https://github.com/pytorch/hub/raw/master/images/dog.jpg"
-                        },
-                    ],
+                        }
+                    ]
                 },
             )
         ]
@@ -642,10 +621,7 @@ def _pytorch_model_from_content(
 
 
 def _custom_model_from_code(
-    where_dir: Path,
-    truss_name: str,
-    model_code: str,
-    handle_ops: callable = None,
+    where_dir: Path, truss_name: str, model_code: str, handle_ops: callable = None
 ) -> Path:
     dir_path = where_dir / truss_name
     handle = init(str(dir_path))
@@ -664,10 +640,7 @@ def custom_model_data_dir(tmp_path: Path):
         handle.add_data(str(data_file.resolve()))
 
     yield _custom_model_from_code(
-        tmp_path,
-        "data_dir_truss",
-        CUSTOM_MODEL_CODE,
-        handle_ops=add_data,
+        tmp_path, "data_dir_truss", CUSTOM_MODEL_CODE, handle_ops=add_data
     )
 
 
@@ -778,10 +751,7 @@ def trtllm_config(default_config) -> Dict[str, Any]:
             "base_model": "llama",
             "max_seq_len": 2048,
             "max_batch_size": 512,
-            "checkpoint_repository": {
-                "source": "HF",
-                "repo": "meta/llama4-500B",
-            },
+            "checkpoint_repository": {"source": "HF", "repo": "meta/llama4-500B"},
             "gather_all_token_logits": False,
         },
         "runtime": {},
@@ -810,12 +780,9 @@ def deprecated_trtllm_config(default_config) -> Dict[str, Any]:
             "request_default_max_tokens": 10,
             "total_token_limit": 50,
             # end deprecated fields
-            "checkpoint_repository": {
-                "source": "HF",
-                "repo": "meta/llama4-500B",
-            },
+            "checkpoint_repository": {"source": "HF", "repo": "meta/llama4-500B"},
             "gather_all_token_logits": False,
-        },
+        }
     }
     return trtllm_config
 
@@ -841,10 +808,7 @@ def deprecated_trtllm_config_with_runtime_existing(default_config) -> Dict[str, 
             "request_default_max_tokens": 10,
             "total_token_limit": 50,
             # end deprecated fields
-            "checkpoint_repository": {
-                "source": "HF",
-                "repo": "meta/llama4-500B",
-            },
+            "checkpoint_repository": {"source": "HF", "repo": "meta/llama4-500B"},
             "gather_all_token_logits": False,
         },
         "runtime": {"total_token_limit": 100},
@@ -860,10 +824,7 @@ def trtllm_spec_dec_config_full(trtllm_config) -> Dict[str, Any]:
             "base_model": "llama",
             "max_seq_len": 2048,
             "max_batch_size": 512,
-            "checkpoint_repository": {
-                "source": "HF",
-                "repo": "meta/llama4-500B",
-            },
+            "checkpoint_repository": {"source": "HF", "repo": "meta/llama4-500B"},
             "plugin_configuration": {
                 "paged_kv_cache": True,
                 "gemm_plugin": "auto",
@@ -882,7 +843,7 @@ def trtllm_spec_dec_config_full(trtllm_config) -> Dict[str, Any]:
                     },
                 },
             },
-        },
+        }
     }
     return spec_dec_config
 
@@ -895,10 +856,7 @@ def trtllm_spec_dec_config(trtllm_config) -> Dict[str, Any]:
             "base_model": "llama",
             "max_seq_len": 2048,
             "max_batch_size": 512,
-            "checkpoint_repository": {
-                "source": "HF",
-                "repo": "meta/llama4-500B",
-            },
+            "checkpoint_repository": {"source": "HF", "repo": "meta/llama4-500B"},
             "plugin_configuration": {
                 "paged_kv_cache": True,
                 "gemm_plugin": "auto",
@@ -907,11 +865,8 @@ def trtllm_spec_dec_config(trtllm_config) -> Dict[str, Any]:
             "speculator": {
                 "speculative_decoding_mode": TrussSpecDecMode.DRAFT_EXTERNAL.value,
                 "num_draft_tokens": 4,
-                "checkpoint_repository": {
-                    "source": "HF",
-                    "repo": "meta/llama4-500B",
-                },
+                "checkpoint_repository": {"source": "HF", "repo": "meta/llama4-500B"},
             },
-        },
+        }
     }
     return spec_dec_config

--- a/truss/tests/contexts/image_builder/test_serving_image_builder.py
+++ b/truss/tests/contexts/image_builder/test_serving_image_builder.py
@@ -39,10 +39,7 @@ def test_serving_image_dockerfile_from_user_base_image(
         image_builder.prepare_image_build_dir(tmp_path)
         with open(tmp_path / "Dockerfile", "r") as f:
             gen_docker_lines = f.readlines()
-        with open(
-            test_data_path / "server.Dockerfile",
-            "r",
-        ) as f:
+        with open(test_data_path / "server.Dockerfile", "r") as f:
             server_docker_lines = f.readlines()
 
         def filter_empty_lines(lines):
@@ -78,8 +75,7 @@ def flatten_cached_files(local_cache_files):
 def test_correct_hf_files_accessed_for_caching():
     model = "openai/whisper-small"
     config = TrussConfig(
-        python_version="py39",
-        model_cache=ModelCache(models=[ModelRepo(repo_id=model)]),
+        python_version="py39", model_cache=ModelCache(models=[ModelRepo(repo_id=model)])
     )
 
     with TemporaryDirectory() as tmp_dir:
@@ -114,8 +110,7 @@ def test_correct_gcs_files_accessed_for_caching(mock_list_bucket_files):
     model = "gs://crazy-good-new-model-7b"
 
     config = TrussConfig(
-        python_version="py39",
-        model_cache=ModelCache(models=[ModelRepo(repo_id=model)]),
+        python_version="py39", model_cache=ModelCache(models=[ModelRepo(repo_id=model)])
     )
 
     with TemporaryDirectory() as tmp_dir:
@@ -148,8 +143,7 @@ def test_correct_s3_files_accessed_for_caching(mock_list_bucket_files):
     model = "s3://crazy-good-new-model-7b"
 
     config = TrussConfig(
-        python_version="py39",
-        model_cache=ModelCache(models=[ModelRepo(repo_id=model)]),
+        python_version="py39", model_cache=ModelCache(models=[ModelRepo(repo_id=model)])
     )
 
     with TemporaryDirectory() as tmp_dir:
@@ -182,8 +176,7 @@ def test_correct_nested_gcs_files_accessed_for_caching(mock_list_bucket_files):
     model = "gs://crazy-good-new-model-7b/folder_a/folder_b"
 
     config = TrussConfig(
-        python_version="py39",
-        model_cache=ModelCache(models=[ModelRepo(repo_id=model)]),
+        python_version="py39", model_cache=ModelCache(models=[ModelRepo(repo_id=model)])
     )
 
     with TemporaryDirectory() as tmp_dir:
@@ -220,8 +213,7 @@ def test_correct_nested_s3_files_accessed_for_caching(mock_list_bucket_files):
     model = "s3://crazy-good-new-model-7b/folder_a/folder_b"
 
     config = TrussConfig(
-        python_version="py39",
-        model_cache=ModelCache(models=[ModelRepo(repo_id=model)]),
+        python_version="py39", model_cache=ModelCache(models=[ModelRepo(repo_id=model)])
     )
 
     with TemporaryDirectory() as tmp_dir:
@@ -310,13 +302,9 @@ def test_trt_llm_build_dir(custom_model_trt_llm):
 
         # Check that all files were copied
         _assert_copied(
-            TRTLLM_TRUSS_DIR / "src",
-            tmp_path / "server" / "extensions" / "trt_llm",
+            TRTLLM_TRUSS_DIR / "src", tmp_path / "server" / "extensions" / "trt_llm"
         )
-        _assert_copied(
-            TRTLLM_TRUSS_DIR / "packages",
-            tmp_path / "packages",
-        )
+        _assert_copied(TRTLLM_TRUSS_DIR / "packages", tmp_path / "packages")
 
         assert (
             build_th.spec.config.runtime.predict_concurrency

--- a/truss/tests/patch/test_calc_patch.py
+++ b/truss/tests/patch/test_calc_patch.py
@@ -51,11 +51,7 @@ def test_calc_truss_patch_add_file(custom_model_truss_dir: Path):
     patch = patches[0]
     assert patch == Patch(
         type=PatchType.MODEL_CODE,
-        body=ModelCodePatch(
-            action=Action.ADD,
-            path="dummy",
-            content="content",
-        ),
+        body=ModelCodePatch(action=Action.ADD, path="dummy", content="content"),
     )
 
 
@@ -70,11 +66,7 @@ def test_calc_truss_patch_add_under_new_directory(custom_model_truss_dir: Path):
     patch = patches[0]
     assert patch == Patch(
         type=PatchType.MODEL_CODE,
-        body=ModelCodePatch(
-            action=Action.ADD,
-            path="dir/dummy",
-            content="",
-        ),
+        body=ModelCodePatch(action=Action.ADD, path="dir/dummy", content=""),
     )
 
 
@@ -87,10 +79,7 @@ def test_calc_truss_patch_remove_file(custom_model_truss_dir: Path):
     patch = patches[0]
     assert patch == Patch(
         type=PatchType.MODEL_CODE,
-        body=ModelCodePatch(
-            action=Action.REMOVE,
-            path="model.py",
-        ),
+        body=ModelCodePatch(action=Action.REMOVE, path="model.py"),
     )
 
 
@@ -124,10 +113,7 @@ def test_calc_truss_ignore_pycache(custom_model_truss_dir: Path):
     model_pycache_path.mkdir()
     (model_pycache_path / "foo.pyo").touch()
 
-    patches = calc_truss_patch(
-        custom_model_truss_dir,
-        prev_sign,
-    )
+    patches = calc_truss_patch(custom_model_truss_dir, prev_sign)
     assert len(patches) == 0
 
 
@@ -141,10 +127,7 @@ def test_calc_truss_ignore_pycache_existing(custom_model_truss_dir: Path):
     model_pycache_path.mkdir()
     (model_pycache_path / "foo.pyo").touch()
     sign = calc_truss_signature(custom_model_truss_dir)
-    patches = calc_truss_patch(
-        custom_model_truss_dir,
-        sign,
-    )
+    patches = calc_truss_patch(custom_model_truss_dir, sign)
     assert len(patches) == 0
 
 
@@ -159,19 +142,13 @@ def test_calc_truss_ignore_changes_outside_patch_relevant_dirs(
     git_dir.mkdir()
     (git_dir / "dummy").touch()
 
-    patches = calc_truss_patch(
-        custom_model_truss_dir,
-        prev_sign,
-    )
+    patches = calc_truss_patch(custom_model_truss_dir, prev_sign)
     assert len(patches) == 0
 
     # Removing should also be ignored
     new_sign = calc_truss_signature(custom_model_truss_dir)
     (git_dir / "dummy").unlink()
-    patches = calc_truss_patch(
-        custom_model_truss_dir,
-        new_sign,
-    )
+    patches = calc_truss_patch(custom_model_truss_dir, new_sign)
     assert len(patches) == 0
 
 
@@ -192,8 +169,7 @@ def test_calc_config_patches_add_python_requirement(custom_model_truss_dir: Path
         Patch(
             type=PatchType.PYTHON_REQUIREMENT,
             body=PythonRequirementPatch(
-                action=Action.ADD,
-                requirement="requests==1.0.0",
+                action=Action.ADD, requirement="requests==1.0.0"
             ),
         ),
     ]
@@ -210,11 +186,7 @@ def test_calc_truss_patch_add_package(custom_model_truss_dir: Path):
     patch = patches[0]
     assert patch == Patch(
         type=PatchType.PACKAGE,
-        body=PackagePatch(
-            action=Action.ADD,
-            path="dir/dummy",
-            content="",
-        ),
+        body=PackagePatch(action=Action.ADD, path="dir/dummy", content=""),
     )
 
 
@@ -234,10 +206,7 @@ def test_calc_truss_patch_remove_package(
     patch = patches[0]
     assert patch == Patch(
         type=PatchType.PACKAGE,
-        body=PackagePatch(
-            action=Action.REMOVE,
-            path="test_package/test.py",
-        ),
+        body=PackagePatch(action=Action.REMOVE, path="test_package/test.py"),
     )
 
 
@@ -288,9 +257,7 @@ def test_calc_truss_patch_handles_requirements_file_name_change(
         config.requirements.clear()
 
     patches = _apply_config_change_and_calc_patches(
-        custom_model_truss_dir,
-        config_op=config_op,
-        config_pre_op=pre_config_op,
+        custom_model_truss_dir, config_op=config_op, config_pre_op=pre_config_op
     )
     assert len(patches) == 1
     assert patches == [
@@ -300,13 +267,11 @@ def test_calc_truss_patch_handles_requirements_file_name_change(
                 action=Action.UPDATE,
                 config=yaml.safe_load((custom_model_truss_dir / "config.yaml").open()),
             ),
-        ),
+        )
     ]
 
 
-def test_calc_truss_patch_handles_requirements_comments(
-    custom_model_truss_dir: Path,
-):
+def test_calc_truss_patch_handles_requirements_comments(custom_model_truss_dir: Path):
     def pre_config_op(config: TrussConfig):
         requirements_contents = """xformers\n#torch==2.0.1"""
         filename = "./requirements.txt"
@@ -321,25 +286,17 @@ def test_calc_truss_patch_handles_requirements_comments(
             req_file.write(requirements_contents)
 
     patches = _apply_config_change_and_calc_patches(
-        custom_model_truss_dir,
-        config_op=config_op,
-        config_pre_op=pre_config_op,
+        custom_model_truss_dir, config_op=config_op, config_pre_op=pre_config_op
     )
     assert len(patches) == 2
     assert patches == [
         Patch(
             type=PatchType.PYTHON_REQUIREMENT,
-            body=PythonRequirementPatch(
-                action=Action.REMOVE,
-                requirement="xformers",
-            ),
+            body=PythonRequirementPatch(action=Action.REMOVE, requirement="xformers"),
         ),
         Patch(
             type=PatchType.PYTHON_REQUIREMENT,
-            body=PythonRequirementPatch(
-                action=Action.ADD,
-                requirement="torch==2.3.1",
-            ),
+            body=PythonRequirementPatch(action=Action.ADD, requirement="torch==2.3.1"),
         ),
     ]
 
@@ -361,32 +318,23 @@ def test_calc_truss_patch_handles_requirements_file_changes(
             req_file.write(requirements_contents)
 
     patches = _apply_config_change_and_calc_patches(
-        custom_model_truss_dir,
-        config_op=config_op,
-        config_pre_op=pre_config_op,
+        custom_model_truss_dir, config_op=config_op, config_pre_op=pre_config_op
     )
     assert len(patches) == 3
     assert patches == [
         # In this case, a Config Update patch is not issued. This does not cause issues on the backend
         Patch(
             type=PatchType.PYTHON_REQUIREMENT,
-            body=PythonRequirementPatch(
-                action=Action.REMOVE,
-                requirement="xformers",
-            ),
+            body=PythonRequirementPatch(action=Action.REMOVE, requirement="xformers"),
+        ),
+        Patch(
+            type=PatchType.PYTHON_REQUIREMENT,
+            body=PythonRequirementPatch(action=Action.ADD, requirement="requests"),
         ),
         Patch(
             type=PatchType.PYTHON_REQUIREMENT,
             body=PythonRequirementPatch(
-                action=Action.ADD,
-                requirement="requests",
-            ),
-        ),
-        Patch(
-            type=PatchType.PYTHON_REQUIREMENT,
-            body=PythonRequirementPatch(
-                action=Action.UPDATE,
-                requirement="torch==2.3.1",
+                action=Action.UPDATE, requirement="torch==2.3.1"
             ),
         ),
     ]
@@ -410,9 +358,7 @@ def test_calc_truss_patch_handles_requirements_file_changes_and_config_changes(
         config.requirements_file = filename
 
     patches = _apply_config_change_and_calc_patches(
-        custom_model_truss_dir,
-        config_op=config_op,
-        config_pre_op=pre_config_op,
+        custom_model_truss_dir, config_op=config_op, config_pre_op=pre_config_op
     )
     assert len(patches) == 4
     assert patches == [
@@ -425,23 +371,16 @@ def test_calc_truss_patch_handles_requirements_file_changes_and_config_changes(
         ),
         Patch(
             type=PatchType.PYTHON_REQUIREMENT,
-            body=PythonRequirementPatch(
-                action=Action.REMOVE,
-                requirement="xformers",
-            ),
+            body=PythonRequirementPatch(action=Action.REMOVE, requirement="xformers"),
+        ),
+        Patch(
+            type=PatchType.PYTHON_REQUIREMENT,
+            body=PythonRequirementPatch(action=Action.ADD, requirement="requests"),
         ),
         Patch(
             type=PatchType.PYTHON_REQUIREMENT,
             body=PythonRequirementPatch(
-                action=Action.ADD,
-                requirement="requests",
-            ),
-        ),
-        Patch(
-            type=PatchType.PYTHON_REQUIREMENT,
-            body=PythonRequirementPatch(
-                action=Action.UPDATE,
-                requirement="torch==2.3.1",
+                action=Action.UPDATE, requirement="torch==2.3.1"
             ),
         ),
     ]
@@ -466,9 +405,7 @@ def test_calc_truss_patch_handles_requirements_file_removal(
         os.remove(custom_model_truss_dir / filename)
 
     patches = _apply_config_change_and_calc_patches(
-        custom_model_truss_dir,
-        config_op=config_op,
-        config_pre_op=pre_config_op,
+        custom_model_truss_dir, config_op=config_op, config_pre_op=pre_config_op
     )
     assert len(patches) == 2
     assert patches == [
@@ -481,10 +418,7 @@ def test_calc_truss_patch_handles_requirements_file_removal(
         ),
         Patch(
             type=PatchType.PYTHON_REQUIREMENT,
-            body=PythonRequirementPatch(
-                action=Action.ADD,
-                requirement="requests",
-            ),
+            body=PythonRequirementPatch(action=Action.ADD, requirement="requests"),
         ),
     ]
 
@@ -518,9 +452,7 @@ def test_calc_truss_patch_handles_requirements_file_added_no_change(
         config.requirements.clear()
 
     patches = _apply_config_change_and_calc_patches(
-        custom_model_truss_dir,
-        config_op=config_op,
-        config_pre_op=pre_config_op,
+        custom_model_truss_dir, config_op=config_op, config_pre_op=pre_config_op
     )
     assert len(patches) == 1
     assert patches == [
@@ -530,7 +462,7 @@ def test_calc_truss_patch_handles_requirements_file_added_no_change(
                 action=Action.UPDATE,
                 config=yaml.safe_load((custom_model_truss_dir / "config.yaml").open()),
             ),
-        ),
+        )
     ]
 
 
@@ -561,10 +493,7 @@ def test_calc_truss_patch_handles_requirements_file_added_with_changes(
         ),
         Patch(
             type=PatchType.PYTHON_REQUIREMENT,
-            body=PythonRequirementPatch(
-                action=Action.ADD,
-                requirement="xformers",
-            ),
+            body=PythonRequirementPatch(action=Action.ADD, requirement="xformers"),
         ),
     ]
 
@@ -586,10 +515,7 @@ def test_calc_config_patches_remove_python_requirement(custom_model_truss_dir: P
         ),
         Patch(
             type=PatchType.PYTHON_REQUIREMENT,
-            body=PythonRequirementPatch(
-                action=Action.REMOVE,
-                requirement="requests",
-            ),
+            body=PythonRequirementPatch(action=Action.REMOVE, requirement="requests"),
         ),
     ]
 
@@ -615,8 +541,7 @@ def test_calc_config_patches_update_python_requirement(custom_model_truss_dir: P
         Patch(
             type=PatchType.PYTHON_REQUIREMENT,
             body=PythonRequirementPatch(
-                action=Action.UPDATE,
-                requirement="requests==2.0.0",
+                action=Action.UPDATE, requirement="requests==2.0.0"
             ),
         ),
     ]
@@ -700,14 +625,10 @@ def test_calc_config_patches_ignores_removal_of_url_based_requirements_without_e
         ]
 
     def config_op(config: TrussConfig):
-        config.requirements = [
-            "requests==1.0.0",
-        ]
+        config.requirements = ["requests==1.0.0"]
 
     patches = _apply_config_change_and_calc_patches(
-        custom_model_truss_dir,
-        config_pre_op=config_pre_op,
-        config_op=config_op,
+        custom_model_truss_dir, config_pre_op=config_pre_op, config_op=config_op
     )
     assert len(patches) == 1
     assert patches[0] == Patch(
@@ -733,15 +654,10 @@ def test_calc_config_patches_add_remove_and_update_python_requirement(
         ]
 
     def config_op(config: TrussConfig):
-        config.requirements = [
-            "requests==2.0.0",
-            "numpy>=1.8",
-        ]
+        config.requirements = ["requests==2.0.0", "numpy>=1.8"]
 
     patches = _apply_config_change_and_calc_patches(
-        custom_model_truss_dir,
-        config_pre_op=config_pre_op,
-        config_op=config_op,
+        custom_model_truss_dir, config_pre_op=config_pre_op, config_op=config_op
     )
     assert len(patches) == 5
     assert patches[0] == Patch(
@@ -763,31 +679,22 @@ def test_calc_config_patches_add_remove_and_update_python_requirement(
         ),
         Patch(
             type=PatchType.PYTHON_REQUIREMENT,
-            body=PythonRequirementPatch(
-                action=Action.REMOVE,
-                requirement="jinja",
-            ),
+            body=PythonRequirementPatch(action=Action.REMOVE, requirement="jinja"),
+        ),
+        Patch(
+            type=PatchType.PYTHON_REQUIREMENT,
+            body=PythonRequirementPatch(action=Action.ADD, requirement="numpy>=1.8"),
         ),
         Patch(
             type=PatchType.PYTHON_REQUIREMENT,
             body=PythonRequirementPatch(
-                action=Action.ADD,
-                requirement="numpy>=1.8",
-            ),
-        ),
-        Patch(
-            type=PatchType.PYTHON_REQUIREMENT,
-            body=PythonRequirementPatch(
-                action=Action.UPDATE,
-                requirement="requests==2.0.0",
+                action=Action.UPDATE, requirement="requests==2.0.0"
             ),
         ),
     ]
 
 
-def test_calc_config_patches_add_env_var(
-    custom_model_truss_dir: Path,
-):
+def test_calc_config_patches_add_env_var(custom_model_truss_dir: Path):
     patches = _apply_config_change_and_calc_patches(
         custom_model_truss_dir,
         config_op=lambda config: config.environment_variables.update({"foo": "bar"}),
@@ -803,17 +710,12 @@ def test_calc_config_patches_add_env_var(
         ),
         Patch(
             type=PatchType.ENVIRONMENT_VARIABLE,
-            body=EnvVarPatch(
-                action=Action.ADD,
-                item={"foo": "bar"},
-            ),
+            body=EnvVarPatch(action=Action.ADD, item={"foo": "bar"}),
         ),
     ]
 
 
-def test_calc_config_patches_add_remove_env_var(
-    custom_model_truss_dir: Path,
-):
+def test_calc_config_patches_add_remove_env_var(custom_model_truss_dir: Path):
     patches = _apply_config_change_and_calc_patches(
         custom_model_truss_dir,
         config_pre_op=lambda config: config.environment_variables.update(
@@ -832,18 +734,14 @@ def test_calc_config_patches_add_remove_env_var(
         ),
         Patch(
             type=PatchType.ENVIRONMENT_VARIABLE,
-            body=EnvVarPatch(
-                action=Action.REMOVE,
-                item={"foo": "bar"},
-            ),
+            body=EnvVarPatch(action=Action.REMOVE, item={"foo": "bar"}),
         ),
     ]
 
 
 def test_calc_config_patches_add_system_package(custom_model_truss_dir: Path):
     patches = _apply_config_change_and_calc_patches(
-        custom_model_truss_dir,
-        lambda config: config.system_packages.append("curl"),
+        custom_model_truss_dir, lambda config: config.system_packages.append("curl")
     )
     assert len(patches) == 2
     assert patches == [
@@ -856,10 +754,7 @@ def test_calc_config_patches_add_system_package(custom_model_truss_dir: Path):
         ),
         Patch(
             type=PatchType.SYSTEM_PACKAGE,
-            body=SystemPackagePatch(
-                action=Action.ADD,
-                package="curl",
-            ),
+            body=SystemPackagePatch(action=Action.ADD, package="curl"),
         ),
     ]
 
@@ -881,10 +776,7 @@ def test_calc_config_patches_remove_system_package(custom_model_truss_dir: Path)
         ),
         Patch(
             type=PatchType.SYSTEM_PACKAGE,
-            body=SystemPackagePatch(
-                action=Action.REMOVE,
-                package="curl",
-            ),
+            body=SystemPackagePatch(action=Action.REMOVE, package="curl"),
         ),
     ]
 
@@ -893,21 +785,13 @@ def test_calc_config_patches_add_and_remove_system_package(
     custom_model_truss_dir: Path,
 ):
     def config_pre_op(config: TrussConfig):
-        config.system_packages = [
-            "curl",
-            "jq",
-        ]
+        config.system_packages = ["curl", "jq"]
 
     def config_op(config: TrussConfig):
-        config.system_packages = [
-            "curl",
-            "libsnd",
-        ]
+        config.system_packages = ["curl", "libsnd"]
 
     patches = _apply_config_change_and_calc_patches(
-        custom_model_truss_dir,
-        config_pre_op=config_pre_op,
-        config_op=config_op,
+        custom_model_truss_dir, config_pre_op=config_pre_op, config_op=config_op
     )
     assert len(patches) == 3
     assert patches[0] == Patch(
@@ -922,17 +806,11 @@ def test_calc_config_patches_add_and_remove_system_package(
     assert patches == [
         Patch(
             type=PatchType.SYSTEM_PACKAGE,
-            body=SystemPackagePatch(
-                action=Action.REMOVE,
-                package="jq",
-            ),
+            body=SystemPackagePatch(action=Action.REMOVE, package="jq"),
         ),
         Patch(
             type=PatchType.SYSTEM_PACKAGE,
-            body=SystemPackagePatch(
-                action=Action.ADD,
-                package="libsnd",
-            ),
+            body=SystemPackagePatch(action=Action.ADD, package="libsnd"),
         ),
     ]
 
@@ -967,9 +845,7 @@ def test_calc_config_patches_add_external_data(
         config.external_data = None
 
     patches = _apply_config_change_and_calc_patches(
-        path,
-        config_pre_op=config_pre_op,
-        config_op=config_op,
+        path, config_pre_op=config_pre_op, config_op=config_op
     )
     assert len(patches) == 2
 
@@ -998,10 +874,7 @@ def test_calc_config_patches_remove_external_data(
     def config_op(config: TrussConfig):
         config.external_data = None
 
-    patches = _apply_config_change_and_calc_patches(
-        path,
-        config_op=config_op,
-    )
+    patches = _apply_config_change_and_calc_patches(path, config_op=config_op)
     assert len(patches) == 2
     assert patches == [
         Patch(
@@ -1021,11 +894,7 @@ def test_calc_config_patches_remove_external_data(
 
 
 def test_calc_unignored_paths():
-    ignore_patterns = [
-        ".mypy_cache/",
-        "venv/",
-        "*.tmp",
-    ]
+    ignore_patterns = [".mypy_cache/", "venv/", "*.tmp"]
 
     root_relative_paths = {
         ".mypy_cache/should_ignore.json",
@@ -1036,10 +905,7 @@ def test_calc_unignored_paths():
     }
 
     unignored_paths = _calc_unignored_paths(root_relative_paths, ignore_patterns)
-    assert unignored_paths == {
-        "config.yaml",
-        "model/model.py",
-    }
+    assert unignored_paths == {"config.yaml", "model/model.py"}
 
 
 def _apply_config_change_and_calc_patches(
@@ -1072,8 +938,7 @@ def _apply_config_change_and_calc_patches(
                 Patch(
                     type=PatchType.PYTHON_REQUIREMENT,
                     body=PythonRequirementPatch(
-                        action=Action.UPDATE,
-                        requirement="requests==2.0.0",
+                        action=Action.UPDATE, requirement="requests==2.0.0"
                     ),
                 )
             ],

--- a/truss/tests/patch/test_dir_signature.py
+++ b/truss/tests/patch/test_dir_signature.py
@@ -12,12 +12,7 @@ def test_directory_content_signature(tmp_path):
 
     content_sign = directory_content_signature(root)
 
-    assert content_sign.keys() == {
-        "dir",
-        "dir/file3",
-        "file1",
-        "file2",
-    }
+    assert content_sign.keys() == {"dir", "dir/file3", "file1", "file2"}
 
 
 def test_directory_content_signature_ignore_patterns(tmp_path):
@@ -40,8 +35,4 @@ def test_directory_content_signature_ignore_patterns(tmp_path):
         root=root, ignore_patterns=["data/*", ".git"]
     )
 
-    assert content_sign.keys() == {
-        "data",
-        "file1",
-        "file2",
-    }
+    assert content_sign.keys() == {"data", "file1", "file2"}

--- a/truss/tests/patch/test_truss_dir_patch_applier.py
+++ b/truss/tests/patch/test_truss_dir_patch_applier.py
@@ -59,10 +59,7 @@ def test_python_requirement_patch(custom_model_truss_dir: Path):
         [
             Patch(
                 type=PatchType.PYTHON_REQUIREMENT,
-                body=PythonRequirementPatch(
-                    action=Action.ADD,
-                    requirement=req,
-                ),
+                body=PythonRequirementPatch(action=Action.ADD, requirement=req),
             ),
             Patch(
                 type=PatchType.CONFIG,
@@ -91,10 +88,7 @@ def test_system_requirement_patch(custom_model_truss_dir: Path):
             ),
             Patch(
                 type=PatchType.SYSTEM_PACKAGE,
-                body=SystemPackagePatch(
-                    action=Action.ADD,
-                    package="curl",
-                ),
+                body=SystemPackagePatch(action=Action.ADD, package="curl"),
             ),
         ]
     )

--- a/truss/tests/remote/baseten/test_core.py
+++ b/truss/tests/remote/baseten/test_core.py
@@ -44,27 +44,19 @@ def test_upload_truss():
 
 
 def test_get_dev_version_from_versions():
-    versions = [
-        {"id": "1", "is_draft": False},
-        {"id": "2", "is_draft": True},
-    ]
+    versions = [{"id": "1", "is_draft": False}, {"id": "2", "is_draft": True}]
     dev_version = core.get_dev_version_from_versions(versions)
     assert dev_version["id"] == "2"
 
 
 def test_get_dev_version_from_versions_error():
-    versions = [
-        {"id": "1", "is_draft": False},
-    ]
+    versions = [{"id": "1", "is_draft": False}]
     dev_version = core.get_dev_version_from_versions(versions)
     assert dev_version is None
 
 
 def test_get_dev_version():
-    versions = [
-        {"id": "1", "is_draft": False},
-        {"id": "2", "is_draft": True},
-    ]
+    versions = [{"id": "1", "is_draft": False}, {"id": "2", "is_draft": True}]
     api = MagicMock()
     api.get_model.return_value = {"model": {"versions": versions}}
 
@@ -91,19 +83,10 @@ def test_get_prod_version_from_versions_error():
     assert prod_version is None
 
 
-@pytest.mark.parametrize(
-    "environment",
-    [
-        None,
-        PRODUCTION_ENVIRONMENT_NAME,
-    ],
-)
+@pytest.mark.parametrize("environment", [None, PRODUCTION_ENVIRONMENT_NAME])
 def test_create_truss_service_handles_eligible_environment_values(environment):
     api = MagicMock()
-    return_value = {
-        "id": "id",
-        "version_id": "model_version_id",
-    }
+    return_value = {"id": "id", "version_id": "model_version_id"}
     api.create_model_from_truss.return_value = return_value
     model_id, model_version_id = create_truss_service(
         api,
@@ -122,19 +105,10 @@ def test_create_truss_service_handles_eligible_environment_values(environment):
     api.create_model_from_truss.assert_called_once()
 
 
-@pytest.mark.parametrize(
-    "model_id",
-    [
-        "some_model_id",
-        None,
-    ],
-)
+@pytest.mark.parametrize("model_id", ["some_model_id", None])
 def test_create_truss_services_handles_is_draft(model_id):
     api = MagicMock()
-    return_value = {
-        "id": "id",
-        "version_id": "model_version_id",
-    }
+    return_value = {"id": "id", "version_id": "model_version_id"}
     api.create_development_model_from_truss.return_value = return_value
     model_id, model_version_id = create_truss_service(
         api,
@@ -177,9 +151,7 @@ def test_create_truss_services_handles_is_draft(model_id):
 )
 def test_create_truss_service_handles_existing_model(inputs):
     api = MagicMock()
-    return_value = {
-        "id": "model_version_id",
-    }
+    return_value = {"id": "model_version_id"}
     api.create_model_version_from_truss.return_value = return_value
     model_id, model_version_id = create_truss_service(
         api,
@@ -199,22 +171,13 @@ def test_create_truss_service_handles_existing_model(inputs):
         assert kwargs[k] == v
 
 
-@pytest.mark.parametrize(
-    "allow_truss_download",
-    [True, False],
-)
-@pytest.mark.parametrize(
-    "is_draft",
-    [True, False],
-)
+@pytest.mark.parametrize("allow_truss_download", [True, False])
+@pytest.mark.parametrize("is_draft", [True, False])
 def test_create_truss_service_handles_allow_truss_download_for_new_models(
     is_draft, allow_truss_download
 ):
     api = MagicMock()
-    return_value = {
-        "id": "id",
-        "version_id": "model_version_id",
-    }
+    return_value = {"id": "id", "version_id": "model_version_id"}
     api.create_model_from_truss.return_value = return_value
     api.create_development_model_from_truss.return_value = return_value
 

--- a/truss/tests/remote/baseten/test_remote.py
+++ b/truss/tests/remote/baseten/test_remote.py
@@ -32,19 +32,11 @@ def request_matches_expected_query(request, expected_query):
 def test_get_service_by_version_id():
     remote = BasetenRemote(_TEST_REMOTE_URL, "api_key")
 
-    version = {
-        "id": "version_id",
-        "oracle": {
-            "id": "model_id",
-        },
-    }
+    version = {"id": "version_id", "oracle": {"id": "model_id"}}
     model_version_response = {"data": {"model_version": version}}
 
     with requests_mock.Mocker() as m:
-        m.post(
-            _TEST_REMOTE_GRAPHQL_PATH,
-            json=model_version_response,
-        )
+        m.post(_TEST_REMOTE_GRAPHQL_PATH, json=model_version_response)
         service = remote.get_service(model_identifier=ModelVersionId("version_id"))
 
     assert service.model_id == "model_id"
@@ -55,10 +47,7 @@ def test_get_service_by_version_id_no_version():
     remote = BasetenRemote(_TEST_REMOTE_URL, "api_key")
     model_version_response = {"errors": [{"message": "error"}]}
     with requests_mock.Mocker() as m:
-        m.post(
-            _TEST_REMOTE_GRAPHQL_PATH,
-            json=model_version_response,
-        )
+        m.post(_TEST_REMOTE_GRAPHQL_PATH, json=model_version_response)
         with pytest.raises(RemoteError):
             remote.get_service(model_identifier=ModelVersionId("version_id"))
 
@@ -73,19 +62,12 @@ def test_get_service_by_model_name():
     ]
     model_response = {
         "data": {
-            "model": {
-                "name": "model_name",
-                "id": "model_id",
-                "versions": versions,
-            }
+            "model": {"name": "model_name", "id": "model_id", "versions": versions}
         }
     }
 
     with requests_mock.Mocker() as m:
-        m.post(
-            _TEST_REMOTE_GRAPHQL_PATH,
-            json=model_response,
-        )
+        m.post(_TEST_REMOTE_GRAPHQL_PATH, json=model_response)
 
         # Check that the production version is returned when published is True.
         service = remote.get_service(
@@ -105,24 +87,15 @@ def test_get_service_by_model_name():
 def test_get_service_by_model_name_no_dev_version():
     remote = BasetenRemote(_TEST_REMOTE_URL, "api_key")
 
-    versions = [
-        {"id": "1", "is_draft": False, "is_primary": True},
-    ]
+    versions = [{"id": "1", "is_draft": False, "is_primary": True}]
     model_response = {
         "data": {
-            "model": {
-                "name": "model_name",
-                "id": "model_id",
-                "versions": versions,
-            }
+            "model": {"name": "model_name", "id": "model_id", "versions": versions}
         }
     }
 
     with requests_mock.Mocker() as m:
-        m.post(
-            _TEST_REMOTE_GRAPHQL_PATH,
-            json=model_response,
-        )
+        m.post(_TEST_REMOTE_GRAPHQL_PATH, json=model_response)
 
         # Check that the production version is returned when published is True.
         service = remote.get_service(
@@ -142,24 +115,15 @@ def test_get_service_by_model_name_no_dev_version():
 def test_get_service_by_model_name_no_prod_version():
     remote = BasetenRemote(_TEST_REMOTE_URL, "api_key")
 
-    versions = [
-        {"id": "1", "is_draft": True, "is_primary": False},
-    ]
+    versions = [{"id": "1", "is_draft": True, "is_primary": False}]
     model_response = {
         "data": {
-            "model": {
-                "name": "model_name",
-                "id": "model_id",
-                "versions": versions,
-            }
+            "model": {"name": "model_name", "id": "model_id", "versions": versions}
         }
     }
 
     with requests_mock.Mocker() as m:
-        m.post(
-            _TEST_REMOTE_GRAPHQL_PATH,
-            json=model_response,
-        )
+        m.post(_TEST_REMOTE_GRAPHQL_PATH, json=model_response)
 
         # Since no production version exists, calling get_service with
         # published=True should raise an error.
@@ -188,10 +152,7 @@ def test_get_service_by_model_id():
     }
 
     with requests_mock.Mocker() as m:
-        m.post(
-            _TEST_REMOTE_GRAPHQL_PATH,
-            json=model_response,
-        )
+        m.post(_TEST_REMOTE_GRAPHQL_PATH, json=model_response)
 
         service = remote.get_service(model_identifier=ModelId("model_id"))
         assert service.model_id == "model_id"
@@ -202,10 +163,7 @@ def test_get_service_by_model_id_no_model():
     remote = BasetenRemote(_TEST_REMOTE_URL, "api_key")
     model_response = {"errors": [{"message": "error"}]}
     with requests_mock.Mocker() as m:
-        m.post(
-            _TEST_REMOTE_GRAPHQL_PATH,
-            json=model_response,
-        )
+        m.post(_TEST_REMOTE_GRAPHQL_PATH, json=model_response)
         with pytest.raises(RemoteError):
             remote.get_service(model_identifier=ModelId("model_id"))
 
@@ -224,10 +182,7 @@ def test_push_raised_value_error_when_deployment_name_and_not_publish(
         }
     }
     with requests_mock.Mocker() as m:
-        m.post(
-            _TEST_REMOTE_GRAPHQL_PATH,
-            json=model_response,
-        )
+        m.post(_TEST_REMOTE_GRAPHQL_PATH, json=model_response)
         th = TrussHandle(custom_model_truss_dir_with_pre_and_post)
 
         with pytest.raises(
@@ -259,10 +214,7 @@ def test_push_raised_value_error_when_deployment_name_is_not_valid(
         }
     }
     with requests_mock.Mocker() as m:
-        m.post(
-            _TEST_REMOTE_GRAPHQL_PATH,
-            json=model_response,
-        )
+        m.post(_TEST_REMOTE_GRAPHQL_PATH, json=model_response)
         th = TrussHandle(custom_model_truss_dir_with_pre_and_post)
 
         with pytest.raises(
@@ -294,10 +246,7 @@ def test_push_raised_value_error_when_keep_previous_prod_settings_and_not_promot
         }
     }
     with requests_mock.Mocker() as m:
-        m.post(
-            _TEST_REMOTE_GRAPHQL_PATH,
-            json=model_response,
-        )
+        m.post(_TEST_REMOTE_GRAPHQL_PATH, json=model_response)
         th = TrussHandle(custom_model_truss_dir_with_pre_and_post)
 
         with pytest.raises(
@@ -707,13 +656,9 @@ def test_create_chain_existing_chain_publish_true_no_promotion():
         assert deployment_handle.chain_deployment_id == "new-chain-deployment-id"
 
 
-@pytest.mark.parametrize(
-    "publish",
-    [True, False],
-)
+@pytest.mark.parametrize("publish", [True, False])
 def test_push_raised_value_error_when_disable_truss_download_for_existing_model(
-    publish,
-    custom_model_truss_dir_with_pre_and_post,
+    publish, custom_model_truss_dir_with_pre_and_post
 ):
     remote = BasetenRemote(_TEST_REMOTE_URL, "api_key")
     model_response = {
@@ -726,14 +671,10 @@ def test_push_raised_value_error_when_disable_truss_download_for_existing_model(
         }
     }
     with requests_mock.Mocker() as m:
-        m.post(
-            _TEST_REMOTE_GRAPHQL_PATH,
-            json=model_response,
-        )
+        m.post(_TEST_REMOTE_GRAPHQL_PATH, json=model_response)
         th = TrussHandle(custom_model_truss_dir_with_pre_and_post)
 
         with pytest.raises(
-            ValueError,
-            match="disable-truss-download can only be used for new models",
+            ValueError, match="disable-truss-download can only be used for new models"
         ):
             remote.push(th, "model_name", publish=publish, disable_truss_download=True)

--- a/truss/tests/remote/baseten/test_service.py
+++ b/truss/tests/remote/baseten/test_service.py
@@ -31,18 +31,14 @@ def test_chain_invocation_url_draft():
 
 def test_model_status_page_url():
     url = service.URLConfig.status_page_url(
-        "https://app.baseten.co",
-        service.URLConfig.MODEL,
-        "123",
+        "https://app.baseten.co", service.URLConfig.MODEL, "123"
     )
     assert url == "https://app.baseten.co/models/123/overview"
 
 
 def test_chain_status_page_url():
     url = service.URLConfig.status_page_url(
-        "https://app.baseten.co",
-        service.URLConfig.CHAIN,
-        "abc",
+        "https://app.baseten.co", service.URLConfig.CHAIN, "abc"
     )
     assert url == "https://app.baseten.co/chains/abc/overview"
 

--- a/truss/tests/remote/test_remote_factory.py
+++ b/truss/tests/remote/test_remote_factory.py
@@ -47,8 +47,7 @@ class TrussTestRemote(TrussRemote):
 
 def mock_service_config():
     return RemoteConfig(
-        name="mock-service",
-        configs={"remote_provider": "test_remote", **SAMPLE_CONFIG},
+        name="mock-service", configs={"remote_provider": "test_remote", **SAMPLE_CONFIG}
     )
 
 

--- a/truss/tests/templates/control/control/helpers/test_model_container_patch_applier.py
+++ b/truss/tests/templates/control/control/helpers/test_model_container_patch_applier.py
@@ -42,11 +42,7 @@ def test_patch_applier_model_code_patch_add(
 ):
     patch = Patch(
         type=PatchType.MODEL_CODE,
-        body=ModelCodePatch(
-            action=Action.ADD,
-            path="dummy",
-            content="",
-        ),
+        body=ModelCodePatch(action=Action.ADD, path="dummy", content=""),
     )
     patch_applier(patch, os.environ.copy())
     assert (truss_container_fs / "app" / "model" / "dummy").exists()
@@ -57,10 +53,7 @@ def test_patch_applier_model_code_patch_remove(
 ):
     patch = Patch(
         type=PatchType.MODEL_CODE,
-        body=ModelCodePatch(
-            action=Action.REMOVE,
-            path="model.py",
-        ),
+        body=ModelCodePatch(action=Action.REMOVE, path="model.py"),
     )
     assert (truss_container_fs / "app" / "model" / "model.py").exists()
     patch_applier(patch, os.environ.copy())
@@ -77,9 +70,7 @@ def test_patch_applier_model_code_patch_update(
     patch = Patch(
         type=PatchType.MODEL_CODE,
         body=ModelCodePatch(
-            action=Action.UPDATE,
-            path="model.py",
-            content=new_model_file_content,
+            action=Action.UPDATE, path="model.py", content=new_model_file_content
         ),
     )
     patch_applier(patch, os.environ.copy())
@@ -94,9 +85,7 @@ def test_patch_applier_package_patch_add(
     patch = Patch(
         type=PatchType.PACKAGE,
         body=PackagePatch(
-            action=Action.ADD,
-            path="test_package/test.py",
-            content="foobar",
+            action=Action.ADD, path="test_package/test.py", content="foobar"
         ),
     )
     patch_applier(patch, os.environ.copy())
@@ -104,15 +93,11 @@ def test_patch_applier_package_patch_add(
 
 
 def test_patch_applier_package_patch_remove(
-    patch_applier: ModelContainerPatchApplier,
-    truss_container_fs,
+    patch_applier: ModelContainerPatchApplier, truss_container_fs
 ):
     patch = Patch(
         type=PatchType.PACKAGE,
-        body=PackagePatch(
-            action=Action.REMOVE,
-            path="test_package/test.py",
-        ),
+        body=PackagePatch(action=Action.REMOVE, path="test_package/test.py"),
     )
     assert (truss_container_fs / "packages" / "test_package" / "test.py").exists()
     patch_applier(patch, os.environ.copy())
@@ -120,8 +105,7 @@ def test_patch_applier_package_patch_remove(
 
 
 def test_patch_applier_package_patch_update(
-    patch_applier: ModelContainerPatchApplier,
-    truss_container_fs,
+    patch_applier: ModelContainerPatchApplier, truss_container_fs
 ):
     new_package_content = """X = 2"""
     patch = Patch(
@@ -144,57 +128,39 @@ def test_patch_applier_config_patch_update(
     new_config_dict = {"model_name": "foobar"}
     patch = Patch(
         type=PatchType.CONFIG,
-        body=ConfigPatch(
-            action=Action.UPDATE,
-            config=new_config_dict,
-        ),
+        body=ConfigPatch(action=Action.UPDATE, config=new_config_dict),
     )
     patch_applier(patch, os.environ.copy())
     new_config = TrussConfig.from_yaml(truss_container_fs / "app" / "config.yaml")
     assert new_config.model_name == "foobar"
 
 
-def test_patch_applier_env_var_patch_update(
-    patch_applier: ModelContainerPatchApplier,
-):
+def test_patch_applier_env_var_patch_update(patch_applier: ModelContainerPatchApplier):
     env_var_dict = {"FOO": "BAR"}
     patch = Patch(
         type=PatchType.ENVIRONMENT_VARIABLE,
-        body=EnvVarPatch(
-            action=Action.UPDATE,
-            item={"FOO": "BAR-PATCHED"},
-        ),
+        body=EnvVarPatch(action=Action.UPDATE, item={"FOO": "BAR-PATCHED"}),
     )
     patch_applier(patch, env_var_dict)
     assert env_var_dict["FOO"] == "BAR-PATCHED"
 
 
-def test_patch_applier_env_var_patch_add(
-    patch_applier: ModelContainerPatchApplier,
-):
+def test_patch_applier_env_var_patch_add(patch_applier: ModelContainerPatchApplier):
     env_var_dict = {"FOO": "BAR"}
     patch = Patch(
         type=PatchType.ENVIRONMENT_VARIABLE,
-        body=EnvVarPatch(
-            action=Action.ADD,
-            item={"BAR": "FOO"},
-        ),
+        body=EnvVarPatch(action=Action.ADD, item={"BAR": "FOO"}),
     )
     patch_applier(patch, env_var_dict)
     assert env_var_dict["FOO"] == "BAR"
     assert env_var_dict["BAR"] == "FOO"
 
 
-def test_patch_applier_env_var_patch_remove(
-    patch_applier: ModelContainerPatchApplier,
-):
+def test_patch_applier_env_var_patch_remove(patch_applier: ModelContainerPatchApplier):
     env_var_dict = {"FOO": "BAR"}
     patch = Patch(
         type=PatchType.ENVIRONMENT_VARIABLE,
-        body=EnvVarPatch(
-            action=Action.REMOVE,
-            item={"FOO": "BAR"},
-        ),
+        body=EnvVarPatch(action=Action.REMOVE, item={"FOO": "BAR"}),
     )
     patch_applier(patch, env_var_dict)
     with pytest.raises(KeyError):
@@ -202,8 +168,7 @@ def test_patch_applier_env_var_patch_remove(
 
 
 def test_patch_applier_external_data_patch_add(
-    patch_applier: ModelContainerPatchApplier,
-    truss_container_fs,
+    patch_applier: ModelContainerPatchApplier, truss_container_fs
 ):
     patch = Patch(
         type=PatchType.EXTERNAL_DATA,

--- a/truss/tests/templates/control/control/helpers/test_requirement_name_identifier.py
+++ b/truss/tests/templates/control/control/helpers/test_requirement_name_identifier.py
@@ -36,11 +36,7 @@ def test_identify_requirement_name(req, expected_name):
 
 
 def test_reqs_by_name():
-    reqs = [
-        "pytorch",
-        " ",
-        "jinja==1.0",
-    ]
+    reqs = ["pytorch", " ", "jinja==1.0"]
     assert reqs_by_name(reqs) == {"pytorch": "pytorch", "jinja": "jinja==1.0"}
 
 

--- a/truss/tests/templates/control/control/test_server.py
+++ b/truss/tests/templates/control/control/test_server.py
@@ -104,9 +104,7 @@ class Model:
     patch = Patch(
         type=PatchType.MODEL_CODE,
         body=ModelCodePatch(
-            action=Action.UPDATE,
-            path="model.py",
-            content=mock_model_file_content,
+            action=Action.UPDATE, path="model.py", content=mock_model_file_content
         ),
     )
     await _verify_apply_patch_success(client, patch)
@@ -129,9 +127,7 @@ class Model:
     patch = Patch(
         type=PatchType.MODEL_CODE,
         body=ModelCodePatch(
-            action=Action.UPDATE,
-            path="model.py",
-            content=mock_model_file_content,
+            action=Action.UPDATE, path="model.py", content=mock_model_file_content
         ),
     )
     await _verify_apply_patch_success(client, patch)
@@ -146,9 +142,7 @@ async def test_patch_model_code_create_new(app, client):
     patch = Patch(
         type=PatchType.MODEL_CODE,
         body=ModelCodePatch(
-            action=Action.UPDATE,
-            path="touched",
-            content=empty_content,
+            action=Action.UPDATE, path="touched", content=empty_content
         ),
     )
     await _verify_apply_patch_success(client, patch)
@@ -161,9 +155,7 @@ async def test_patch_model_code_create_in_new_dir(app, client):
     patch = Patch(
         type=PatchType.MODEL_CODE,
         body=ModelCodePatch(
-            action=Action.UPDATE,
-            path="new_directory/touched",
-            content=empty_content,
+            action=Action.UPDATE, path="new_directory/touched", content=empty_content
         ),
     )
     await _verify_apply_patch_success(client, patch)

--- a/truss/tests/templates/control/control/test_server_integration.py
+++ b/truss/tests/templates/control/control/test_server_integration.py
@@ -62,10 +62,7 @@ class Model:
 
     def predict(inp):
         time.sleep(random.uniform(0, 0.5))
-        resp = requests.post(
-            f"{ctrl_url}/v1/models/model:predict",
-            json=inp,
-        )
+        resp = requests.post(f"{ctrl_url}/v1/models/model:predict", json=inp)
         return resp.json()
 
     with ThreadPool(10) as p:
@@ -98,8 +95,7 @@ class Model:
 def test_truss_control_server_patch_ping_delays(truss_control_container_fs: Path):
     for _ in range(10):
         with _configured_control_server(
-            truss_control_container_fs,
-            with_patch_ping_flow=True,
+            truss_control_container_fs, with_patch_ping_flow=True
         ) as control_server:
             # Account for patch ping delays
             time.sleep(PATCH_PING_MAX_DELAY_SECS)
@@ -171,8 +167,7 @@ def _process_tree_is_dead(pid: int):
 
 @contextmanager
 def _configured_control_server(
-    truss_control_container_fs: Path,
-    with_patch_ping_flow: bool = False,
+    truss_control_container_fs: Path, with_patch_ping_flow: bool = False
 ):
     # Pick random ports to reduce reuse, port release may take time
     # which can interfere with tests

--- a/truss/tests/templates/core/server/test_dynamic_config_resolver.py
+++ b/truss/tests/templates/core/server/test_dynamic_config_resolver.py
@@ -31,16 +31,7 @@ def test_get_dynamic_chainlet_config_value_sync(
 
 
 @pytest.mark.parametrize(
-    "config",
-    [
-        {
-            "environment_name": "production",
-            "foo": "bar",
-        },
-        {},
-        "",
-        None,
-    ],
+    "config", [{"environment_name": "production", "foo": "bar"}, {}, "", None]
 )
 def test_get_dynamic_config_environment_value_sync(
     config, tmp_path, dynamic_config_mount_dir
@@ -92,16 +83,7 @@ async def test_get_dynamic_chainlet_config_value_async(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "config",
-    [
-        {
-            "environment_name": "production",
-            "foo": "bar",
-        },
-        {},
-        "",
-        None,
-    ],
+    "config", [{"environment_name": "production", "foo": "bar"}, {}, "", None]
 )
 async def test_get_dynamic_config_environment_value_async(
     config, tmp_path, dynamic_config_mount_dir

--- a/truss/tests/templates/core/server/test_lazy_data_resolver.py
+++ b/truss/tests/templates/core/server/test_lazy_data_resolver.py
@@ -165,8 +165,7 @@ def test_lazy_data_fetch_to_cache_non_200_status(
         "truss.templates.shared.lazy_data_resolver.LAZY_DATA_RESOLVER_PATH",
         manifest_path,
     ) as _, patch(
-        "truss.templates.shared.lazy_data_resolver.CACHE_DIR",
-        cache_dir,
+        "truss.templates.shared.lazy_data_resolver.CACHE_DIR", cache_dir
     ) as _:
         data_dir = Path(tmp_path)
         ldr = LazyDataResolver(data_dir)
@@ -209,8 +208,7 @@ def test_lazy_data_fetch_to_cache(
         "truss.templates.shared.lazy_data_resolver.LAZY_DATA_RESOLVER_PATH",
         manifest_path,
     ) as _, patch(
-        "truss.templates.shared.lazy_data_resolver.CACHE_DIR",
-        cache_dir,
+        "truss.templates.shared.lazy_data_resolver.CACHE_DIR", cache_dir
     ) as CACHE_DIR:
         data_dir = Path(tmp_path)
         ldr = LazyDataResolver(data_dir)
@@ -259,8 +257,7 @@ def test_lazy_data_fetch_to_cache_fallback_if_no_space(
         "truss.templates.shared.lazy_data_resolver.LAZY_DATA_RESOLVER_PATH",
         manifest_path,
     ) as _, patch(
-        "truss.templates.shared.lazy_data_resolver.CACHE_DIR",
-        cache_dir,
+        "truss.templates.shared.lazy_data_resolver.CACHE_DIR", cache_dir
     ) as _, patch(
         "truss.templates.shared.lazy_data_resolver.shutil.disk_usage"
     ) as mock_disk_usage:
@@ -312,8 +309,7 @@ def test_lazy_data_fetch_cached(
         "truss.templates.shared.lazy_data_resolver.LAZY_DATA_RESOLVER_PATH",
         manifest_path,
     ) as _, patch(
-        "truss.templates.shared.lazy_data_resolver.CACHE_DIR",
-        cache_dir,
+        "truss.templates.shared.lazy_data_resolver.CACHE_DIR", cache_dir
     ) as CACHE_DIR:
         data_dir = Path(tmp_path)
         ldr = LazyDataResolver(data_dir)

--- a/truss/tests/templates/server/test_model_wrapper.py
+++ b/truss/tests/templates/server/test_model_wrapper.py
@@ -35,8 +35,7 @@ class Model:
         return request
     """
     with helpers.file_content(
-        truss_container_app_path / "model" / "model.py",
-        model_file_content,
+        truss_container_app_path / "model" / "model.py", model_file_content
     ), helpers.sys_path(truss_container_app_path):
         yield truss_container_app_path
 

--- a/truss/tests/templates/server/test_schema.py
+++ b/truss/tests/templates/server/test_schema.py
@@ -181,8 +181,7 @@ def test_truss_schema_union_sync():
 def test_truss_schema_union_async():
     class Model:
         async def predict(
-            self,
-            request: ModelInput,
+            self, request: ModelInput
         ) -> Union[Awaitable[ModelOutput], AsyncGenerator[str, None]]:
             if request.stream:
 
@@ -208,8 +207,7 @@ def test_truss_schema_union_async():
 def test_truss_schema_union_async_non_pydantic():
     class Model:
         async def predict(
-            self,
-            request: ModelInput,
+            self, request: ModelInput
         ) -> Union[Awaitable[str], AsyncGenerator[str, None]]:
             return "hello"
 

--- a/truss/tests/test_build.py
+++ b/truss/tests/test_build.py
@@ -14,9 +14,7 @@ def test_truss_init(tmp_path):
     assert spec.config_path.exists()
 
 
-def test_truss_init_with_data_file_and_requirements_file_and_bundled_packages(
-    tmp_path,
-):
+def test_truss_init_with_data_file_and_requirements_file_and_bundled_packages(tmp_path):
     dir_path = tmp_path / "truss"
     dir_name = str(dir_path)
 
@@ -27,10 +25,7 @@ def test_truss_init_with_data_file_and_requirements_file_and_bundled_packages(
 
     # Init requirements file
     req_file_path = tmp_path / "requirements.txt"
-    requirements = [
-        "tensorflow==2.3.1",
-        "uvicorn==0.12.2",
-    ]
+    requirements = ["tensorflow==2.3.1", "uvicorn==0.12.2"]
     with req_file_path.open("w") as req_file:
         for req in requirements:
             req_file.write(f"{req}\n")

--- a/truss/tests/test_config.py
+++ b/truss/tests/test_config.py
@@ -7,9 +7,7 @@ import pytest
 import yaml
 
 from truss.base.custom_types import ModelFrameworkType
-from truss.base.trt_llm_config import (
-    TrussTRTLLMQuantizationType,
-)
+from truss.base.trt_llm_config import TrussTRTLLMQuantizationType
 from truss.base.truss_config import (
     DEFAULT_CPU,
     DEFAULT_MEMORY,
@@ -158,10 +156,7 @@ def test_parse_base_image(input_dict, expect_base_image, output_dict):
 
 
 def test_default_config_not_crowded_end_to_end():
-    config = TrussConfig(
-        python_version="py39",
-        requirements=[],
-    )
+    config = TrussConfig(python_version="py39", requirements=[])
 
     config_yaml = """build_commands: []
 environment_variables: {}
@@ -188,9 +183,7 @@ system_packages: []
 )
 def test_model_framework(model_framework, default_config):
     config = TrussConfig(
-        python_version="py39",
-        requirements=[],
-        model_framework=model_framework,
+        python_version="py39", requirements=[], model_framework=model_framework
     )
 
     new_config = default_config
@@ -225,11 +218,7 @@ def test_huggingface_cache_single_model_default_revision(default_config):
     )
 
     new_config = default_config
-    new_config["model_cache"] = [
-        {
-            "repo_id": "test/model",
-        }
-    ]
+    new_config["model_cache"] = [{"repo_id": "test/model"}]
 
     assert new_config == config.to_dict(verbose=False)
     assert config.to_dict(verbose=True)["model_cache"][0].get("revision") is None
@@ -250,19 +239,14 @@ def test_huggingface_cache_multiple_models_default_revision(default_config):
         python_version="py39",
         requirements=[],
         model_cache=ModelCache(
-            models=[
-                ModelRepo("test/model1", "main"),
-                ModelRepo("test/model2"),
-            ]
+            models=[ModelRepo("test/model1", "main"), ModelRepo("test/model2")]
         ),
     )
 
     new_config = default_config
     new_config["model_cache"] = [
         {"repo_id": "test/model1", "revision": "main"},
-        {
-            "repo_id": "test/model2",
-        },
+        {"repo_id": "test/model2"},
     ]
 
     assert new_config == config.to_dict(verbose=False)
@@ -275,18 +259,13 @@ def test_huggingface_cache_multiple_models_mixed_revision(default_config):
         python_version="py39",
         requirements=[],
         model_cache=ModelCache(
-            models=[
-                ModelRepo("test/model1"),
-                ModelRepo("test/model2", "not-main2"),
-            ]
+            models=[ModelRepo("test/model1"), ModelRepo("test/model2", "not-main2")]
         ),
     )
 
     new_config = default_config
     new_config["model_cache"] = [
-        {
-            "repo_id": "test/model1",
-        },
+        {"repo_id": "test/model1"},
         {"repo_id": "test/model2", "revision": "not-main2"},
     ]
 

--- a/truss/tests/test_context_builder_image.py
+++ b/truss/tests/test_context_builder_image.py
@@ -42,11 +42,5 @@ def test_build_docker_image(test_data_path):
 
     # This will throw if building docker build context fails
     subprocess.run(
-        [
-            "docker",
-            "run",
-            "baseten/truss-context-builder-test",
-        ],
-        check=True,
-        cwd=root,
+        ["docker", "run", "baseten/truss-context-builder-test"], check=True, cwd=root
     )

--- a/truss/tests/test_control_truss_patching.py
+++ b/truss/tests/test_control_truss_patching.py
@@ -410,12 +410,7 @@ class Model:
                 )
             ],
         )
-        th._update_config(
-            lambda conf: replace(
-                conf,
-                external_data=new_external_data,
-            )
-        )
+        th._update_config(lambda conf: replace(conf, external_data=new_external_data))
         result = th.docker_predict([], tag=tag, network="host")
         assert result == content and orig_num_truss_images == current_num_docker_images(
             th

--- a/truss/tests/test_data/patch_ping_test_server/app.py
+++ b/truss/tests/test_data/patch_ping_test_server/app.py
@@ -22,9 +22,7 @@ def _inc_fn_call_stat():
 @app.route("/hash_is_current", methods=["POST"])
 def hash_is_current():
     _inc_fn_call_stat()
-    return {
-        "is_current": True,
-    }
+    return {"is_current": True}
 
 
 @app.route("/hash_is_current_but_only_every_third_call_succeeds", methods=["POST"])
@@ -33,18 +31,14 @@ def hash_is_current_but_only_every_third_call_succeeds():
     global _stats
     fn_name = inspect.stack()[0][3]
     if _stats[f"{fn_name}_called_count"] % 3 == 0:
-        return {
-            "is_current": True,
-        }
+        return {"is_current": True}
     return "simulated failure", 503
 
 
 @app.route("/accepted", methods=["POST"])
 def accepted():
     _inc_fn_call_stat()
-    return {
-        "accepted": True,
-    }
+    return {"accepted": True}
 
 
 @app.route("/health")

--- a/truss/tests/test_model_inference.py
+++ b/truss/tests/test_model_inference.py
@@ -134,22 +134,10 @@ def test_model_load_logs(test_data_path):
             local_port=8090, detach=True, wait_for_server_ready=True
         )
         logs = container.logs()
-        _assert_logs_contain(
-            logs,
-            message="Executing model.load()",
-        )
-        _assert_logs_contain(
-            logs,
-            message="Loading truss model from file",
-        )
-        _assert_logs_contain(
-            logs,
-            message="Completed model.load()",
-        )
-        _assert_logs_contain(
-            logs,
-            message="User Load Message",
-        )
+        _assert_logs_contain(logs, message="Executing model.load()")
+        _assert_logs_contain(logs, message="Loading truss model from file")
+        _assert_logs_contain(logs, message="Completed model.load()")
+        _assert_logs_contain(logs, message="User Load Message")
 
 
 @pytest.mark.integration
@@ -294,10 +282,7 @@ def test_async_streaming(test_data_path):
         ] == ["0", "1", "2", "3", "4"]
 
         predict_non_stream_response = requests.post(
-            PREDICT_URL,
-            json={},
-            stream=True,
-            headers={"accept": "application/json"},
+            PREDICT_URL, json={}, stream=True, headers={"accept": "application/json"}
         )
         assert "transfer-encoding" not in predict_non_stream_response.headers
         assert predict_non_stream_response.json() == "01234"
@@ -357,13 +342,7 @@ def test_streaming_with_error_and_stacktrace(test_data_path):
         assert [
             byte_string.decode()
             for byte_string in predict_non_error_response.iter_content()
-        ] == [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-        ]
+        ] == ["0", "1", "2", "3", "4"]
         expected_stack_trace = (
             "Traceback (most recent call last):\n"
             '  File "/app/model/model.py", line 12, in inner\n'
@@ -828,29 +807,19 @@ def test_init_environment_parameter():
         staging_env_str = json.dumps(staging_env)
         LocalConfigHandler.set_dynamic_config("environment", staging_env_str)
         container = tr.docker_run(
-            local_port=8090,
-            detach=True,
-            wait_for_server_ready=True,
+            local_port=8090, detach=True, wait_for_server_ready=True
         )
         assert "Executing model.load with environment: staging" in container.logs()
         response = requests.post(PREDICT_URL, json={})
         assert response.json() == "staging"
         assert response.status_code == 200
-        container.execute(
-            [
-                "bash",
-                "-c",
-                "rm -f /etc/b10_dynamic_config/environment",
-            ]
-        )
+        container.execute(["bash", "-c", "rm -f /etc/b10_dynamic_config/environment"])
 
     # Test a truss deployment with no associated environment
     config = "model_name: init-no-environment-truss"
     with ensure_kill_all(), _temp_truss(model, config) as tr:
         container = tr.docker_run(
-            local_port=8090,
-            detach=True,
-            wait_for_server_ready=True,
+            local_port=8090, detach=True, wait_for_server_ready=True
         )
         assert "Executing model.load with environment: None" in container.logs()
         response = requests.post(PREDICT_URL, json={})
@@ -874,9 +843,7 @@ def test_setup_environment():
     """
     with ensure_kill_all(), _temp_truss(model, "") as tr:
         container = tr.docker_run(
-            local_port=8090,
-            detach=True,
-            wait_for_server_ready=True,
+            local_port=8090, detach=True, wait_for_server_ready=True
         )
         # Mimic environment changing to beta
         beta_env = {"name": "beta"}
@@ -899,13 +866,7 @@ def test_setup_environment():
             in container.logs()
         )
         assert "in beta environment" in container.logs()
-        container.execute(
-            [
-                "bash",
-                "-c",
-                "rm -f /etc/b10_dynamic_config/environment",
-            ]
-        )
+        container.execute(["bash", "-c", "rm -f /etc/b10_dynamic_config/environment"])
 
     # Test a truss that uses the environment in load()
     model = """
@@ -928,9 +889,7 @@ def test_setup_environment():
         staging_env_str = json.dumps(staging_env)
         LocalConfigHandler.set_dynamic_config("environment", staging_env_str)
         container = tr.docker_run(
-            local_port=8090,
-            detach=True,
-            wait_for_server_ready=True,
+            local_port=8090, detach=True, wait_for_server_ready=True
         )
         # Don't need to wait here because we explicitly grab the environment from dynamic_config_resolver before calling user's load()
         assert (
@@ -948,11 +907,7 @@ def test_setup_environment():
         no_env = None
         no_env_str = json.dumps(no_env)
         container.execute(
-            [
-                "bash",
-                "-c",
-                f"echo '{no_env_str}' > /etc/b10_dynamic_config/environment",
-            ]
+            ["bash", "-c", f"echo '{no_env_str}' > /etc/b10_dynamic_config/environment"]
         )
         time.sleep(30)
         assert (
@@ -960,13 +915,7 @@ def test_setup_environment():
             in container.logs()
         )
         assert "setup_environment called with None" in container.logs()
-        container.execute(
-            [
-                "bash",
-                "-c",
-                "rm -f /etc/b10_dynamic_config/environment",
-            ]
-        )
+        container.execute(["bash", "-c", "rm -f /etc/b10_dynamic_config/environment"])
 
 
 @pytest.mark.integration
@@ -1258,13 +1207,7 @@ class Model:
         )
 
         lines = predict_response.text.strip().split("\n")
-        assert lines == [
-            "data: 0",
-            "",
-            "data: 1",
-            "",
-            "data: 2",
-        ]
+        assert lines == ["data: 0", "", "data: 1", "", "data: 2"]
 
 
 # Using Request in Model ###############################################################

--- a/truss/tests/test_model_schema.py
+++ b/truss/tests/test_model_schema.py
@@ -26,9 +26,7 @@ def test_truss_with_no_annotations(test_data_path):
         _ = tr.docker_run(local_port=8090, detach=True, wait_for_server_ready=True)
 
         response = requests.post(INFERENCE_URL, json={"prompt": "value"})
-        assert response.json() == {
-            "prompt": "value",
-        }
+        assert response.json() == {"prompt": "value"}
 
         schema_response = requests.get(SCHEMA_URL)
         assert schema_response.status_code == 404
@@ -105,9 +103,7 @@ def test_truss_with_annotated_inputs_outputs(test_data_path):
         # Valid JSON input.
         json_input = {"prompt": "value"}
         response = requests.post(INFERENCE_URL, json=json_input)
-        assert response.json() == {
-            "generated_text": "value",
-        }
+        assert response.json() == {"generated_text": "value"}
 
         # Valid binary input.
         byte_input = serialization.truss_msgpack_serialize(json_input)
@@ -455,9 +451,7 @@ class Model:
         schema = schema_response.json()
 
         assert schema["input_schema"] == {
-            "properties": {
-                "prompt": {"title": "Prompt", "type": "string"},
-            },
+            "properties": {"prompt": {"title": "Prompt", "type": "string"}},
             "required": ["prompt"],
             "title": "ModelInput",
             "type": "object",

--- a/truss/tests/test_truss_gatherer.py
+++ b/truss/tests/test_truss_gatherer.py
@@ -21,9 +21,7 @@ def test_gather(custom_model_with_external_package):
     ext_pkg_top_module2.unlink()
 
     assert _same_dir_content(
-        custom_model_with_external_package,
-        gathered_truss_path,
-        ["config.yaml"],
+        custom_model_with_external_package, gathered_truss_path, ["config.yaml"]
     )
 
 

--- a/truss/tests/test_truss_handle.py
+++ b/truss/tests/test_truss_handle.py
@@ -70,8 +70,7 @@ def test_readme_generation_int_example(
 
 
 def test_readme_generation_no_example(
-    test_data_path,
-    custom_model_truss_dir_with_pre_and_post_no_example,
+    test_data_path, custom_model_truss_dir_with_pre_and_post_no_example
 ):
     th = TrussHandle(custom_model_truss_dir_with_pre_and_post_no_example)
     if os.path.exists(th._spec.examples_path):
@@ -84,8 +83,7 @@ def test_readme_generation_no_example(
 
 
 def test_readme_generation_str_example(
-    test_data_path,
-    custom_model_truss_dir_with_pre_and_post_str_example,
+    test_data_path, custom_model_truss_dir_with_pre_and_post_str_example
 ):
     th = TrussHandle(custom_model_truss_dir_with_pre_and_post_str_example)
     readme_contents = th.generate_readme()
@@ -402,17 +400,10 @@ def test_enable_gpu(custom_model_truss_dir_with_pre_and_post):
 
 @pytest.mark.parametrize(
     "python_version, expected_python_version",
-    [
-        ("3.8", "py38"),
-        ("py38", "py38"),
-        ("3.9", "py39"),
-        ("py39", "py39"),
-    ],
+    [("3.8", "py38"), ("py38", "py38"), ("3.9", "py39"), ("py39", "py39")],
 )
 def test_update_python_version(
-    python_version,
-    expected_python_version,
-    custom_model_truss_dir_with_pre_and_post,
+    python_version, expected_python_version, custom_model_truss_dir_with_pre_and_post
 ):
     th = TrussHandle(custom_model_truss_dir_with_pre_and_post)
     th.update_python_version(python_version)
@@ -421,10 +412,7 @@ def test_update_python_version(
 
 def test_update_requirements(custom_model_truss_dir_with_pre_and_post):
     th = TrussHandle(custom_model_truss_dir_with_pre_and_post)
-    requirements = [
-        "tensorflow==2.3.1",
-        "uvicorn==0.12.2",
-    ]
+    requirements = ["tensorflow==2.3.1", "uvicorn==0.12.2"]
     th.update_requirements(requirements)
     sc_requirements = th.spec.requirements
     assert sc_requirements == requirements
@@ -440,10 +428,7 @@ def test_update_requirements_from_file(
         "    # this is comment with a big space. Please don't add.",
         "uvicorn==0.12.2",
     ]
-    allowed_requirements = [
-        "tensorflow==2.3.1",
-        "uvicorn==0.12.2",
-    ]
+    allowed_requirements = ["tensorflow==2.3.1", "uvicorn==0.12.2"]
     req_file_path = tmp_path / "requirements.txt"
     with req_file_path.open("w") as req_file:
         for req in file_requirements:
@@ -547,18 +532,13 @@ def test_add_example_new(custom_model_truss_dir_with_pre_and_post):
     th = TrussHandle(custom_model_truss_dir_with_pre_and_post)
     orig_examples = th.examples()
     th.add_example("example2", [[1]])
-    assert th.examples() == [
-        *orig_examples,
-        Example("example2", [[1]]),
-    ]
+    assert th.examples() == [*orig_examples, Example("example2", [[1]])]
 
 
 def test_add_example_update(custom_model_truss_dir_with_pre_and_post):
     th = TrussHandle(custom_model_truss_dir_with_pre_and_post)
     th.add_example("example1", [[1]])
-    assert th.examples() == [
-        Example("example1", [[1]]),
-    ]
+    assert th.examples() == [Example("example1", [[1]])]
 
 
 def test_model_without_pre_post(custom_model_truss_dir):
@@ -596,11 +576,9 @@ class Model:
                 Patch(
                     type=PatchType.MODEL_CODE,
                     body=ModelCodePatch(
-                        action=Action.UPDATE,
-                        path="model.py",
-                        content=new_model_code,
+                        action=Action.UPDATE, path="model.py", content=new_model_code
                     ),
-                ),
+                )
             ],
         )
 
@@ -640,8 +618,7 @@ class Model:
 
 @patch("truss.truss_handle.truss_handle.directory_content_hash")
 def test_truss_hash_caching_based_on_max_mod_time(
-    directory_content_patcher,
-    custom_model_truss_dir,
+    directory_content_patcher, custom_model_truss_dir
 ):
     directory_content_patcher.return_value = "mock_hash"
     th = TrussHandle(custom_model_truss_dir)
@@ -708,10 +685,7 @@ class Model:
 @pytest.mark.integration
 @pytest.mark.parametrize(
     "patch_path, expected_call_count",
-    [
-        ("hash_is_current", 1),
-        ("hash_is_current_but_only_every_third_call_succeeds", 3),
-    ],
+    [("hash_is_current", 1), ("hash_is_current_but_only_every_third_call_succeeds", 3)],
 )
 def test_patch_ping_flow(
     patch_path, expected_call_count, custom_model_control, patch_ping_test_server
@@ -721,11 +695,7 @@ def test_patch_ping_flow(
     th = TrussHandle(custom_model_control)
     tag = "test-docker-custom-model-control-tag:0.0.1"
     with ensure_kill_all():
-        result = th.docker_predict(
-            [1],
-            tag=tag,
-            patch_ping_url=patch_ping_url,
-        )
+        result = th.docker_predict([1], tag=tag, patch_ping_url=patch_ping_url)
         assert result == [1]
 
         # Make sure the patch ping url was actually hit
@@ -809,9 +779,7 @@ def verify_python_requirement_not_installed_on_container(container, req: str):
 
 
 def verify_environment_variable_on_container(
-    container,
-    env_var_name: str,
-    env_var_value: str,
+    container, env_var_name: str, env_var_value: str
 ):
     resp = container.execute(["env"])
     needle = f"{env_var_name}={env_var_value}"

--- a/truss/tests/util/test_path.py
+++ b/truss/tests/util/test_path.py
@@ -116,9 +116,7 @@ def test_is_ignored_with_base_dir(custom_model_truss_dir_with_hidden_files):
     )
 
 
-def test_ignored_files_in_docker_context(
-    custom_model_truss_dir_with_hidden_files,
-):
+def test_ignored_files_in_docker_context(custom_model_truss_dir_with_hidden_files):
     tr = load(custom_model_truss_dir_with_hidden_files)
 
     with path.given_or_temporary_dir() as dir:
@@ -159,13 +157,7 @@ def test_copy_tree_path_with_truss_ignore(custom_model_truss_dir_with_truss_igno
 
 
 def test_get_ignored_relative_paths():
-    ignore_patterns = [
-        ".mypy_cache/",
-        "venv/",
-        "*.tmp",
-        ".git",
-        "data/*",
-    ]
+    ignore_patterns = [".mypy_cache/", "venv/", "*.tmp", ".git", "data/*"]
 
     root_relative_paths = {
         ".mypy_cache/should_ignore.json",
@@ -192,12 +184,7 @@ def test_get_ignored_relative_paths():
 
 
 def test_get_ignored_relative_paths_from_root(custom_model_truss_dir_with_hidden_files):
-    ignore_patterns = [
-        "__pycache__",
-        ".DS_Store",
-        ".git",
-        "data/*",
-    ]
+    ignore_patterns = ["__pycache__", ".DS_Store", ".git", "data/*"]
 
     unignored_relative_paths = path.get_unignored_relative_paths_from_root(
         custom_model_truss_dir_with_hidden_files, ignore_patterns

--- a/truss/truss_handle/build.py
+++ b/truss/truss_handle/build.py
@@ -75,17 +75,14 @@ def init(
                           Truss in. The directory is created if it doesn't exist.
     """
     config = TrussConfig(
-        model_name=model_name,
-        python_version=map_local_to_supported_python_version(),
+        model_name=model_name, python_version=map_local_to_supported_python_version()
     )
 
     if build_config:
         config.build = build_config
 
     target_directory_path = _populate_target_directory(
-        config=config,
-        target_directory_path=target_directory,
-        populate_dirs=True,
+        config=config, target_directory_path=target_directory, populate_dirs=True
     )
 
     scaf = TrussHandle(target_directory_path)

--- a/truss/truss_handle/patch/calc_patch.py
+++ b/truss/truss_handle/patch/calc_patch.py
@@ -31,15 +31,8 @@ from truss.truss_handle.patch.hash import file_content_hash_str
 from truss.util.path import get_ignored_relative_paths
 
 logger: logging.Logger = logging.getLogger(__name__)
-PYCACHE_IGNORE_PATTERNS = [
-    "**/__pycache__/**/*",
-    "**/__pycache__/**",
-]
-UNPATCHABLE_CONFIG_KEYS = [
-    "live_reload",
-    "python_version",
-    "resources",
-]
+PYCACHE_IGNORE_PATTERNS = ["**/__pycache__/**/*", "**/__pycache__/**"]
+UNPATCHABLE_CONFIG_KEYS = ["live_reload", "python_version", "resources"]
 
 
 def calc_truss_patch(
@@ -67,9 +60,7 @@ def calc_truss_patch(
         ignore_patterns = PYCACHE_IGNORE_PATTERNS
 
     changed_paths = _calc_changed_paths(
-        truss_dir,
-        previous_truss_signature.content_hashes_by_path,
-        ignore_patterns,
+        truss_dir, previous_truss_signature.content_hashes_by_path, ignore_patterns
     )
 
     new_config = TrussConfig.from_yaml(truss_dir / CONFIG_FILE)
@@ -98,8 +89,7 @@ def calc_truss_patch(
                 Patch(
                     type=PatchType.MODEL_CODE,
                     body=ModelCodePatch(
-                        action=Action.REMOVE,
-                        path=_relative_to(path, model_module_path),
+                        action=Action.REMOVE, path=_relative_to(path, model_module_path)
                     ),
                 )
             )
@@ -228,8 +218,7 @@ def _calc_changed_paths(
 
 
 def _calc_unignored_paths(
-    root_relative_paths: Set[str],
-    ignore_patterns: Optional[List[str]] = None,
+    root_relative_paths: Set[str], ignore_patterns: Optional[List[str]] = None
 ) -> Set[str]:
     ignored_paths = set(
         get_ignored_relative_paths(root_relative_paths, ignore_patterns)
@@ -302,10 +291,7 @@ def _calc_env_var_patches(
     removed_items = prev_item_names.difference(new_item_names)
     for removed_item in removed_items:
         patches.append(
-            _mk_env_var_patch(
-                Action.REMOVE,
-                {removed_item: prev_items[removed_item]},
-            )
+            _mk_env_var_patch(Action.REMOVE, {removed_item: prev_items[removed_item]})
         )
     added_items = new_item_names.difference(prev_item_names)
     for added_item in added_items:
@@ -331,12 +317,7 @@ def _calc_external_data_patches(
 
     removed_items = [x for x in prev_items if x not in new_items]
     for removed_item in removed_items:
-        patches.append(
-            _mk_external_data_patch(
-                Action.REMOVE,
-                removed_item,
-            )
-        )
+        patches.append(_mk_external_data_patch(Action.REMOVE, removed_item))
     added_items = [x for x in new_items if x not in prev_items]
     for added_item in added_items:
         patches.append(_mk_external_data_patch(Action.ADD, added_item))
@@ -457,60 +438,39 @@ def _calc_system_packages_patches(
 
 
 def _mk_config_patch(action: Action, config: dict) -> Patch:
-    return Patch(
-        type=PatchType.CONFIG,
-        body=ConfigPatch(
-            action=action,
-            config=config,
-        ),
-    )
+    return Patch(type=PatchType.CONFIG, body=ConfigPatch(action=action, config=config))
 
 
 # Support for patching data changes yet to be implemented
 def _mk_data_patch(action: Action, item: str, path: str) -> Patch:
     return Patch(
-        type=PatchType.DATA,
-        body=DataPatch(action=action, content=item, path=path),
+        type=PatchType.DATA, body=DataPatch(action=action, content=item, path=path)
     )
 
 
 def _mk_env_var_patch(action: Action, item: dict) -> Patch:
     return Patch(
-        type=PatchType.ENVIRONMENT_VARIABLE,
-        body=EnvVarPatch(
-            action=action,
-            item=item,
-        ),
+        type=PatchType.ENVIRONMENT_VARIABLE, body=EnvVarPatch(action=action, item=item)
     )
 
 
 def _mk_external_data_patch(action: Action, item: Dict[str, str]) -> Patch:
     return Patch(
-        type=PatchType.EXTERNAL_DATA,
-        body=ExternalDataPatch(
-            action=action,
-            item=item,
-        ),
+        type=PatchType.EXTERNAL_DATA, body=ExternalDataPatch(action=action, item=item)
     )
 
 
 def _mk_python_requirement_patch(action: Action, requirement: str) -> Patch:
     return Patch(
         type=PatchType.PYTHON_REQUIREMENT,
-        body=PythonRequirementPatch(
-            action=action,
-            requirement=requirement,
-        ),
+        body=PythonRequirementPatch(action=action, requirement=requirement),
     )
 
 
 def _mk_system_package_patch(action: Action, package: str) -> Patch:
     return Patch(
         type=PatchType.SYSTEM_PACKAGE,
-        body=SystemPackagePatch(
-            action=action,
-            package=package,
-        ),
+        body=SystemPackagePatch(action=action, package=package),
     )
 
 

--- a/truss/truss_handle/patch/hash.py
+++ b/truss/truss_handle/patch/hash.py
@@ -7,8 +7,7 @@ from truss.util.path import get_unignored_relative_paths_from_root
 
 
 def directory_content_hash(
-    root: Path,
-    ignore_patterns: Optional[List[str]] = None,
+    root: Path, ignore_patterns: Optional[List[str]] = None
 ) -> str:
     """Calculate content based hash of a filesystem directory.
 

--- a/truss/truss_handle/truss_handle.py
+++ b/truss/truss_handle/truss_handle.py
@@ -178,11 +178,7 @@ class TrussHandle:
         return _docker_image_from_labels(labels)
 
     @proxy_to_shadow_if_scattered
-    def run_python_script(
-        self,
-        script_path: Path,
-        build_dir: Optional[Path] = None,
-    ):
+    def run_python_script(self, script_path: Path, build_dir: Optional[Path] = None):
         from python_on_whales.exceptions import DockerException
 
         image = self.build_serving_docker_image(build_dir=build_dir)
@@ -495,11 +491,7 @@ class TrussHandle:
         validate_secret_name(secret_name)
         self._update_config(
             lambda conf: replace(
-                conf,
-                secrets={
-                    **conf.secrets,
-                    secret_name: default_secret_value,
-                },
+                conf, secrets={**conf.secrets, secret_name: default_secret_value}
             )
         )
 
@@ -521,23 +513,12 @@ class TrussHandle:
             self._spec.config.external_data or ExternalData([])
         )
         new_external_data = replace(
-            current_external_data,
-            items=current_external_data.items + [item],
+            current_external_data, items=current_external_data.items + [item]
         )
-        self._update_config(
-            lambda conf: replace(
-                conf,
-                external_data=new_external_data,
-            )
-        )
+        self._update_config(lambda conf: replace(conf, external_data=new_external_data))
 
     def remove_all_external_data(self):
-        self._update_config(
-            lambda conf: replace(
-                conf,
-                external_data=None,
-            )
-        )
+        self._update_config(lambda conf: replace(conf, external_data=None))
 
     def update_requirements(self, requirements: List[str]):
         """Update requirements in truss model's config.
@@ -665,9 +646,7 @@ class TrussHandle:
 
     @proxy_to_shadow_if_scattered
     def get_serving_docker_containers_from_labels(
-        self,
-        all: bool = False,
-        labels: Optional[dict] = None,
+        self, all: bool = False, labels: Optional[dict] = None
     ) -> list:
         """Get serving docker containers, with given labels.
 
@@ -679,10 +658,7 @@ class TrussHandle:
             labels = self._get_serving_lookup_labels()
         else:
             # Make sure we're looking for serving container for this truss.
-            labels = {
-                TRUSS: True,
-                **labels,
-            }
+            labels = {TRUSS: True, **labels}
 
         return sorted(get_containers(labels, all=all), key=lambda c: c.created)
 
@@ -741,10 +717,7 @@ class TrussHandle:
                     python_executable_path=python_executable_path,
                 )
                 return replace(conf, base_image=new_base_image)
-            new_base_image = BaseImage(
-                image,
-                python_executable_path,
-            )
+            new_base_image = BaseImage(image, python_executable_path)
             return replace(conf, base_image=new_base_image)
 
         self._update_config(define_base_image_fn)
@@ -802,10 +775,7 @@ class TrussHandle:
             inferred_python_version = f"py{version_parts[0]}{version_parts[1]}"
 
         self._update_config(
-            lambda conf: replace(
-                conf,
-                python_version=inferred_python_version,
-            )
+            lambda conf: replace(conf, python_version=inferred_python_version)
         )
 
     def _control_serving_container_has_partially_applied_patch(self) -> Optional[bool]:

--- a/truss/util/download.py
+++ b/truss/util/download.py
@@ -41,9 +41,7 @@ def _b10cp_path() -> Optional[str]:
 
 
 def _download_external_data_using_b10cp(
-    b10cp_path: str,
-    data_dir: Path,
-    external_data: ExternalData,
+    b10cp_path: str, data_dir: Path, external_data: ExternalData
 ):
     procs = []
     # TODO(pankaj) Limit concurrency here
@@ -56,11 +54,7 @@ def _download_external_data_using_b10cp(
         proc.wait()
 
 
-def _download_from_url_using_b10cp(
-    b10cp_path: str,
-    url: str,
-    download_to: Path,
-):
+def _download_from_url_using_b10cp(b10cp_path: str, url: str, download_to: Path):
     return subprocess.Popen(
         [
             b10cp_path,
@@ -82,10 +76,7 @@ def _download_external_data_using_requests(data_dir: Path, external_data: Extern
 def download_from_url_using_requests(URL: str, download_to: Path):
     # Streaming download to keep memory usage low
     resp = requests.get(
-        URL,
-        allow_redirects=True,
-        stream=True,
-        timeout=BLOB_DOWNLOAD_TIMEOUT_SECS,
+        URL, allow_redirects=True, stream=True, timeout=BLOB_DOWNLOAD_TIMEOUT_SECS
     )
     resp.raise_for_status()
     with download_to.open("wb") as file:

--- a/truss/util/path.py
+++ b/truss/util/path.py
@@ -162,8 +162,7 @@ def get_ignored_relative_paths(
 
 
 def get_unignored_relative_paths_from_root(
-    root: Path,
-    ignore_patterns: Optional[List[str]] = None,
+    root: Path, ignore_patterns: Optional[List[str]] = None
 ) -> Set[Path]:
     """Given a root directory, returns an iterator of the relative paths that do not match ignore_patterns."""
     root_relative_paths = set(path.relative_to(root) for path in root.glob("**/*"))


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What

This PR adds a new ruff [configuration](https://docs.astral.sh/ruff/settings/#format_skip-magic-trailing-comma) to allow for more compact python code (personal preference). High level it takes:
```
# The arguments remain on separate lines because of the trailing comma after `b`
def test(
    a,
    b,
): pass
```

to 
```
# The arguments remain on separate lines because of the trailing comma after `b`
def test(a, b):
    pass
```

If people feel strongly about the trailing comma having the explicit impact of _not_ collapsing onto a single line, we don't have to merge this.

The configuration setting is in the first commit, and the formatting changes are in the second.

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
