### PR TITLE
[Trt-llm] always perform verbose dump of defaults for forward compatibility

### DIFF
--- a/truss/base/trt_llm_config.py
+++ b/truss/base/trt_llm_config.py
@@ -276,5 +276,5 @@ class TRTLLMConfiguration(BaseModel):
 
     # TODO(Abu): Replace this with model_dump(json=True)
     # when pydantic v2 is used here
-    def to_json_dict(self, verbose=True):
-        return json.loads(self.json(exclude_unset=not verbose))
+    def to_json_dict(self):
+        return json.loads(self.json())

--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -825,7 +825,7 @@ def obj_to_dict(obj, verbose: bool = False):
                 )
             elif isinstance(field_curr_value, TRTLLMConfiguration):
                 d["trt_llm"] = transform_optional(
-                    field_curr_value, lambda data: data.to_json_dict(verbose=verbose)
+                    field_curr_value, lambda data: data.to_json_dict()
                 )
             elif isinstance(field_curr_value, BaseImage):
                 d["base_image"] = transform_optional(

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -65,23 +65,17 @@ click.rich_click.COMMAND_GROUPS = {
         {
             "name": "Main usage",
             "commands": ["init", "push", "watch", "predict"],
-            "table_styles": {  # type: ignore
-                "row_styles": ["green"]
-            },
+            "table_styles": {"row_styles": ["green"]},  # type: ignore
         },
         {
             "name": "Advanced Usage",
             "commands": ["image", "container", "cleanup"],
-            "table_styles": {  # type: ignore
-                "row_styles": ["yellow"]
-            },
+            "table_styles": {"row_styles": ["yellow"]},  # type: ignore
         },
         {
             "name": "Chains",
             "commands": ["chains"],
-            "table_styles": {  # type: ignore
-                "row_styles": ["red"]
-            },
+            "table_styles": {"row_styles": ["red"]},  # type: ignore
         },
     ]
 }
@@ -1179,6 +1173,8 @@ def push(
                     "`num_builder_gpus` can be used to specify the number of GPUs to use at build time."
                 )
                 console.print(fp8_and_num_builder_gpus_text, style="yellow")
+        # dump full config to yaml to ensure forward compatibility of current defaults
+        tr.spec.config.write_to_yaml_file(tr.spec.config_path, verbose=False)
 
     # TODO(Abu): This needs to be refactored to be more generic
     service = remote_provider.push(


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What

Background:
1. a config of (paged_kv_cache=False, enable_chunked_context=True) will lead to errors in briton. 
2. if a user on 0.9.57 sets TrtLLMConfig(paged_kv_cache=False), this means only paged_kv_cache=False is written in the yaml. The default of the 0.9.57  was enable_chunked_context=False.
3. The interpretation of the value `enable_chunked_context` is not clear from the user uploaded yaml. It depends on the truss version upstream. 
4. Now: The new default is changed to enable_chunked_context=True, on request of FDE

Issue:
- Changing default will lead to an upload of invalid configs. 
- Not knowing what the original config of the user was, makes it dependent on the truss version currently used upstream.

Solutions:
- To retain full compatibilit, model.yaml needs to be written out, and also migrated.
- on upload, the yaml needs to be completed with the current backend version, and fully dumped. 

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
