### PR TITLE
Bump truss version to 0.9.60rc001

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.59"
+version = "0.9.60rc001"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss-chains/tests/test_e2e.py
+++ b/truss-chains/tests/test_e2e.py
@@ -213,6 +213,7 @@ def test_numpy_chain(mode):
             print(response.json())
 
 
+@pytest.mark.integration
 @pytest.mark.asyncio
 async def test_timeout():
     with ensure_kill_all():


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Releases a new `truss` version `0.9.60rc001` for the new `patch` changes introduces by https://github.com/basetenlabs/truss/pull/1337

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
