### PR TITLE
Bug bash improvements to Python DX, better error messages

### DIFF
--- a/truss-chains/tests/import/model_without_inheritance.py
+++ b/truss-chains/tests/import/model_without_inheritance.py
@@ -1,4 +1,4 @@
-class PassthroughModel:
+class ClassWithoutModelInheritance:
     def __init__(self):
         self._call_count = 0
 

--- a/truss-chains/tests/import/standalone_with_multiple_entrypoints.py
+++ b/truss-chains/tests/import/standalone_with_multiple_entrypoints.py
@@ -1,0 +1,19 @@
+import truss_chains as chains
+
+
+class FirstModel(chains.ModelBase):
+    def __init__(self):
+        self._call_count = 0
+
+    async def predict(self, call_count_increment: int) -> int:
+        self._call_count += call_count_increment
+        return self._call_count
+
+
+class SecondModel(chains.ModelBase):
+    def __init__(self):
+        self._call_count = 0
+
+    async def predict(self, call_count_increment: int) -> int:
+        self._call_count += call_count_increment
+        return self._call_count

--- a/truss-chains/tests/import/standalone_without_entrypoint.py
+++ b/truss-chains/tests/import/standalone_without_entrypoint.py
@@ -1,0 +1,7 @@
+class PassthroughModel:
+    def __init__(self):
+        self._call_count = 0
+
+    async def predict(self, call_count_increment: int) -> int:
+        self._call_count += call_count_increment
+        return self._call_count

--- a/truss-chains/tests/test_e2e.py
+++ b/truss-chains/tests/test_e2e.py
@@ -24,7 +24,9 @@ TEST_ROOT = Path(__file__).parent.resolve()
 def test_chain():
     with ensure_kill_all():
         chain_root = TEST_ROOT / "itest_chain" / "itest_chain.py"
-        with framework.import_target(chain_root, "ItestChain") as entrypoint:
+        with framework.ChainletImporter.import_target(
+            chain_root, "ItestChain"
+        ) as entrypoint:
             options = definitions.PushOptionsLocalDocker(
                 chain_name="integration-test", use_local_chains_src=True
             )
@@ -106,7 +108,9 @@ ValueError: \(showing chained remote errors, root error at the bottom\)
 @pytest.mark.asyncio
 async def test_chain_local():
     chain_root = TEST_ROOT / "itest_chain" / "itest_chain.py"
-    with framework.import_target(chain_root, "ItestChain") as entrypoint:
+    with framework.ChainletImporter.import_target(
+        chain_root, "ItestChain"
+    ) as entrypoint:
         with public_api.run_local():
             with pytest.raises(ValueError):
                 # First time `SplitTextFailOnce` raises an error and
@@ -140,7 +144,9 @@ def test_streaming_chain():
     with ensure_kill_all():
         examples_root = Path(__file__).parent.parent.resolve() / "examples"
         chain_root = examples_root / "streaming" / "streaming_chain.py"
-        with framework.import_target(chain_root, "Consumer") as entrypoint:
+        with framework.ChainletImporter.import_target(
+            chain_root, "Consumer"
+        ) as entrypoint:
             service = deployment_client.push(
                 entrypoint,
                 options=definitions.PushOptionsLocalDocker(
@@ -176,7 +182,7 @@ def test_streaming_chain():
 async def test_streaming_chain_local():
     examples_root = Path(__file__).parent.parent.resolve() / "examples"
     chain_root = examples_root / "streaming" / "streaming_chain.py"
-    with framework.import_target(chain_root, "Consumer") as entrypoint:
+    with framework.ChainletImporter.import_target(chain_root, "Consumer") as entrypoint:
         with public_api.run_local():
             result = await entrypoint().run_remote(cause_error=False)
             print(result)
@@ -198,7 +204,7 @@ def test_numpy_chain(mode):
         target = "HostBinary"
     with ensure_kill_all():
         chain_root = TEST_ROOT / "numpy_and_binary" / "chain.py"
-        with framework.import_target(chain_root, target) as entrypoint:
+        with framework.ChainletImporter.import_target(chain_root, target) as entrypoint:
             service = deployment_client.push(
                 entrypoint,
                 options=definitions.PushOptionsLocalDocker(
@@ -218,7 +224,9 @@ def test_numpy_chain(mode):
 async def test_timeout():
     with ensure_kill_all():
         chain_root = TEST_ROOT / "timeout" / "timeout_chain.py"
-        with framework.import_target(chain_root, "TimeoutChain") as entrypoint:
+        with framework.ChainletImporter.import_target(
+            chain_root, "TimeoutChain"
+        ) as entrypoint:
             options = definitions.PushOptionsLocalDocker(
                 chain_name="integration-test", use_local_chains_src=True
             )
@@ -285,7 +293,9 @@ def test_traditional_truss():
 def test_custom_health_checks_chain():
     with ensure_kill_all():
         chain_root = TEST_ROOT / "custom_health_checks" / "custom_health_checks.py"
-        with framework.import_target(chain_root, "CustomHealthChecks") as entrypoint:
+        with framework.ChainletImporter.import_target(
+            chain_root, "CustomHealthChecks"
+        ) as entrypoint:
             service = deployment_client.push(
                 entrypoint,
                 options=definitions.PushOptionsLocalDocker(

--- a/truss-chains/tests/test_framework.py
+++ b/truss-chains/tests/test_framework.py
@@ -2,6 +2,7 @@ import asyncio
 import contextlib
 import logging
 import re
+from pathlib import Path
 from typing import AsyncIterator, Iterator, List
 
 import pydantic
@@ -12,6 +13,7 @@ from truss_chains import definitions, framework, public_api, utils
 
 utils.setup_dev_logging(logging.DEBUG)
 
+TEST_ROOT = Path(__file__).parent.resolve()
 
 # Assert that naive chainlet initialization is detected and prevented. #################
 
@@ -668,3 +670,19 @@ def test_raises_is_healthy_not_boolean_typed():
 
             async def run_remote(self) -> str:
                 return ""
+
+
+def test_import_model_requires_entrypoint():
+    model_src = TEST_ROOT / "import" / "standalone_without_entrypoint.py"
+    match = r"No Model class in `.+` inherits from"
+    with pytest.raises(ValueError, match=match), _raise_errors():
+        with framework.ModelImporter.import_target(model_src):
+            pass
+
+
+def test_import_model_requires_single_entrypoint():
+    model_src = TEST_ROOT / "import" / "standalone_with_multiple_entrypoints.py"
+    match = r"Multiple Model classes in `.+` inherit from"
+    with pytest.raises(ValueError, match=match), _raise_errors():
+        with framework.ModelImporter.import_target(model_src):
+            pass

--- a/truss-chains/tests/test_framework.py
+++ b/truss-chains/tests/test_framework.py
@@ -1,8 +1,8 @@
 import asyncio
 import contextlib
 import logging
+import pathlib
 import re
-from pathlib import Path
 from typing import AsyncIterator, Iterator, List
 
 import pydantic
@@ -13,7 +13,7 @@ from truss_chains import definitions, framework, public_api, utils
 
 utils.setup_dev_logging(logging.DEBUG)
 
-TEST_ROOT = Path(__file__).parent.resolve()
+TEST_ROOT = pathlib.Path(__file__).parent.resolve()
 
 # Assert that naive chainlet initialization is detected and prevented. #################
 
@@ -673,7 +673,7 @@ def test_raises_is_healthy_not_boolean_typed():
 
 
 def test_import_model_requires_entrypoint():
-    model_src = TEST_ROOT / "import" / "standalone_without_entrypoint.py"
+    model_src = TEST_ROOT / "import" / "model_without_inheritance.py"
     match = r"No Model class in `.+` inherits from"
     with pytest.raises(ValueError, match=match), _raise_errors():
         with framework.ModelImporter.import_target(model_src):

--- a/truss-chains/truss_chains/__init__.py
+++ b/truss-chains/truss_chains/__init__.py
@@ -33,9 +33,8 @@ from truss_chains.definitions import (
     RemoteErrorDetail,
     RPCOptions,
 )
+from truss_chains.framework import ChainletBase, ModelBase
 from truss_chains.public_api import (
-    ChainletBase,
-    ModelBase,
     depends,
     depends_context,
     mark_entrypoint,

--- a/truss-chains/truss_chains/deployment/code_gen.py
+++ b/truss-chains/truss_chains/deployment/code_gen.py
@@ -733,7 +733,7 @@ def gen_truss_model_from_source(
     # TODO(nikhil): Improve detection of directory structure, since right now
     # we assume a flat structure
     root_dir = model_src.absolute().parent
-    with framework.import_target(model_src) as entrypoint_cls:
+    with framework.ModelImporter.import_target(model_src) as entrypoint_cls:
         descriptor = framework.get_descriptor(entrypoint_cls)
         return gen_truss_model(
             model_root=root_dir,
@@ -773,7 +773,7 @@ def gen_truss_chainlet(
     gen_root = pathlib.Path(tempfile.gettempdir())
     chainlet_dir = _make_chainlet_dir(chain_name, chainlet_descriptor, gen_root)
     logging.info(
-        f"Code generation for Chainlet `{chainlet_descriptor.name}` "
+        f"Code generation for {chainlet_descriptor.chainlet_cls.entity_type} `{chainlet_descriptor.name}` "
         f"in `{chainlet_dir}`."
     )
     _write_truss_config_yaml(

--- a/truss-chains/truss_chains/deployment/deployment_client.py
+++ b/truss-chains/truss_chains/deployment/deployment_client.py
@@ -635,7 +635,9 @@ class _Watcher:
         self._remote_provider = cast(
             b10_remote.BasetenRemote, remote_factory.RemoteFactory.create(remote=remote)
         )
-        with framework.import_target(source, entrypoint) as entrypoint_cls:
+        with framework.ChainletImporter.import_target(
+            source, entrypoint
+        ) as entrypoint_cls:
             self._deployed_chain_name = name or entrypoint_cls.__name__
             self._chain_root = _get_chain_root(entrypoint_cls)
             chainlet_names = set(
@@ -733,7 +735,7 @@ class _Watcher:
             # Handle import errors gracefully (e.g. if user saved file, but there
             # are syntax errors, undefined symbols etc.).
             try:
-                with framework.import_target(
+                with framework.ChainletImporter.import_target(
                     self._source, self._entrypoint
                 ) as entrypoint_cls:
                     chainlet_descriptors = _get_ordered_dependencies([entrypoint_cls])

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -626,7 +626,7 @@ def push_chain(
     if not remote:
         remote = inquire_remote_name(RemoteFactory.get_available_config_names())
 
-    with framework.import_target(source, entrypoint) as entrypoint_cls:
+    with framework.ChainletImporter.import_target(source, entrypoint) as entrypoint_cls:
         chain_name = (
             name or entrypoint_cls.meta_data.chain_name or entrypoint_cls.display_name
         )


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
This is a first pass at improving the new python DX after our bug bash:
- Validation that runs during `framework.import_target` will now be appropriately scoped to either a model or chainlet target
- In error message, we surface the classes that users interact with in `public_api` rather than our abstract `ABCChainlet`

Next steps:
- Improve error messages related to code examples

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
