### PR TITLE
Use hostname for Chains

### DIFF
--- a/truss-chains/truss_chains/deployment/deployment_client.py
+++ b/truss-chains/truss_chains/deployment/deployment_client.py
@@ -680,9 +680,9 @@ class _Watcher:
         non_draft_chainlets = [
             chainlet.name for chainlet in deployed_chainlets if not chainlet.is_draft
         ]
-        assert not (
-            non_draft_chainlets
-        ), "If the chain is draft, the oracles must be draft."
+        assert not (non_draft_chainlets), (
+            "If the chain is draft, the oracles must be draft."
+        )
 
         self._chainlet_data = {c.name: c for c in deployed_chainlets}
         self._assert_chainlet_names_same(chainlet_names)

--- a/truss-chains/truss_chains/deployment/deployment_client.py
+++ b/truss-chains/truss_chains/deployment/deployment_client.py
@@ -380,12 +380,13 @@ class BasetenChainService(ChainService):
         """URL to invoke the entrypoint."""
 
         handle = self._chain_deployment_handle
-        config = b10_service.URLConfig.CHAIN
 
-        if handle.is_draft:
-            return f"{handle.hostname}/development/{config.value.invoke_endpoint}"
-        else:
-            return f"{handle.hostname}/deployment/{handle.chain_deployment_id}/{config.value.invoke_endpoint}"
+        return b10_service.URLConfig.invoke_url(
+            hostname=handle.hostname,
+            config=b10_service.URLConfig.CHAIN,
+            entity_version_id=handle.chain_deployment_id,
+            is_draft=handle.is_draft,
+        )
 
     def run_remote(self, json_data: Dict) -> Any:
         """Invokes the entrypoint with JSON data.

--- a/truss/api/definitions.py
+++ b/truss/api/definitions.py
@@ -14,8 +14,8 @@ class ModelDeployment:
     _baseten_service: service.BasetenService
 
     def __init__(self, service: service.BasetenService):
-        self.model_id = service._model_id
-        self.model_deployment_id = service._model_version_id
+        self.model_id = service.model_id
+        self.model_deployment_id = service.model_version_id
         self._baseten_service = service
 
     def wait_for_active(self, timeout_seconds: int = 600) -> bool:

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -138,27 +138,32 @@ class BasetenApi:
         origin: Optional[b10_types.ModelOrigin] = None,
     ):
         query_string = f"""
-        mutation {{
-            create_model_from_truss(
-                name: "{model_name}",
-                s3_key: "{s3_key}",
-                config: "{config}",
-                semver_bump: "{semver_bump}",
-                client_version: "{client_version}",
-                is_trusted: {"true" if is_trusted else "false"},
-                allow_truss_download: {"true" if allow_truss_download else "false"},
-                {f'version_name: "{deployment_name}"' if deployment_name else ""}
-                {f"model_origin: {origin.value}" if origin else ""}
-            ) {{
-                id,
-                name,
-                version_id
+            mutation {{
+                create_model_from_truss(
+                    name: "{model_name}"
+                    s3_key: "{s3_key}"
+                    config: "{config}"
+                    semver_bump: "{semver_bump}"
+                    client_version: "{client_version}"
+                    is_trusted: {"true" if is_trusted else "false"}
+                    allow_truss_download: {"true" if allow_truss_download else "false"}
+                    {f'version_name: "{deployment_name}"' if deployment_name else ""}
+                    {f"model_origin: {origin.value}" if origin else ""}
+                ) {{
+                    model_version {{
+                        id
+                        invoke_base_url
+                        oracle {{
+                            id
+                            name
+                        }}
+                    }}
+                }}
             }}
-        }}
         """
 
         resp = self._post_graphql_query(query_string)
-        return resp["data"]["create_model_from_truss"]
+        return resp["data"]["create_model_from_truss"]["model_version"]
 
     def create_model_version_from_truss(
         self,
@@ -173,21 +178,22 @@ class BasetenApi:
         environment: Optional[str] = None,
     ):
         query_string = f"""
-        mutation {{
-            create_model_version_from_truss(
-                model_id: "{model_id}"
-                s3_key: "{s3_key}",
-                config: "{config}",
-                semver_bump: "{semver_bump}",
-                client_version: "{client_version}",
-                is_trusted: {"true" if is_trusted else "false"},
-                scale_down_old_production: {"false" if preserve_previous_prod_deployment else "true"},
-                {f'name: "{deployment_name}"' if deployment_name else ""}
-                {f'environment_name: "{environment}"' if environment else ""}
-            ) {{
-                id
+            mutation {{
+                create_model_version_from_truss(
+                    model_id: "{model_id}"
+                    s3_key: "{s3_key}"
+                    config: "{config}"
+                    semver_bump: "{semver_bump}"
+                    client_version: "{client_version}"
+                    is_trusted: {"true" if is_trusted else "false"}
+                    scale_down_old_production: {"false" if preserve_previous_prod_deployment else "true"}
+                    {f'name: "{deployment_name}"' if deployment_name else ""}
+                    {f'environment_name: "{environment}"' if environment else ""}
+                ) {{
+                    id
+                    invoke_base_url
+                }}
             }}
-        }}
         """
 
         resp = self._post_graphql_query(query_string)
@@ -204,23 +210,29 @@ class BasetenApi:
         origin: Optional[b10_types.ModelOrigin] = None,
     ):
         query_string = f"""
-        mutation {{
-        deploy_draft_truss(name: "{model_name}",
-                    s3_key: "{s3_key}",
-                    config: "{config}",
-                    client_version: "{client_version}",
-                    is_trusted: {"true" if is_trusted else "false"},
-                    allow_truss_download: {"true" if allow_truss_download else "false"},
+            mutation {{
+                deploy_draft_truss(name: "{model_name}"
+                    s3_key: "{s3_key}"
+                    config: "{config}"
+                    client_version: "{client_version}"
+                    is_trusted: {"true" if is_trusted else "false"}
+                    allow_truss_download: {"true" if allow_truss_download else "false"}
                     {f"model_origin: {origin.value}" if origin else ""}
-    ) {{
-            id,
-            name,
-            version_id
-        }}
-        }}
+                ) {{
+                    model_version {{
+                        id
+                        invoke_base_url
+                        oracle {{
+                            id
+                            name
+                        }}
+                    }}
+                }}
+            }}
         """
+
         resp = self._post_graphql_query(query_string)
-        return resp["data"]["deploy_draft_truss"]
+        return resp["data"]["deploy_draft_truss"]["model_version"]
 
     def deploy_chain_atomic(
         self,
@@ -251,10 +263,13 @@ class BasetenApi:
                     dependencies: [{dependencies_str}]
                     client_version: "truss=={truss.version()}"
                 ) {{
-                    chain_id
-                    chain_deployment_id
-                    entrypoint_model_id
-                    entrypoint_model_version_id
+                    chain_deployment {{
+                        id
+                        chain {{
+                            id
+                            hostname
+                        }}
+                    }}
                 }}
             }}
         """
@@ -394,6 +409,7 @@ class BasetenApi:
                     truss_signature
                     is_draft
                     is_primary
+                    invoke_base_url
                     current_model_deployment_status {{
                         status
                     }}
@@ -416,6 +432,7 @@ class BasetenApi:
                     truss_hash
                     truss_signature
                     is_draft
+                    invoke_base_url
                     current_model_deployment_status {{
                         status
                     }}
@@ -434,6 +451,7 @@ class BasetenApi:
                 is_draft
                 truss_hash
                 truss_signature
+                invoke_base_url
                 oracle{{
                     id
                     name

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -152,10 +152,10 @@ class BasetenApi:
                 ) {{
                     model_version {{
                         id
-                        invoke_base_url
                         oracle {{
                             id
                             name
+                            hostname
                         }}
                     }}
                 }}
@@ -191,7 +191,7 @@ class BasetenApi:
                     {f'environment_name: "{environment}"' if environment else ""}
                 ) {{
                     id
-                    invoke_base_url
+                    hostname
                 }}
             }}
         """
@@ -221,10 +221,10 @@ class BasetenApi:
                 ) {{
                     model_version {{
                         id
-                        invoke_base_url
                         oracle {{
                             id
                             name
+                            hostname
                         }}
                     }}
                 }}
@@ -400,8 +400,9 @@ class BasetenApi:
         query_string = f"""
         {{
             model(name: "{model_name}") {{
-                name
                 id
+                name
+                hostname
                 versions{{
                     id
                     semver
@@ -409,7 +410,6 @@ class BasetenApi:
                     truss_signature
                     is_draft
                     is_primary
-                    invoke_base_url
                     current_model_deployment_status {{
                         status
                     }}
@@ -424,15 +424,15 @@ class BasetenApi:
         query_string = f"""
         {{
             model(id: "{model_id}") {{
-                name
                 id
+                name
+                hostname
                 primary_version{{
                     id
                     semver
                     truss_hash
                     truss_signature
                     is_draft
-                    invoke_base_url
                     current_model_deployment_status {{
                         status
                     }}
@@ -451,10 +451,10 @@ class BasetenApi:
                 is_draft
                 truss_hash
                 truss_signature
-                invoke_base_url
                 oracle{{
                     id
                     name
+                    hostname
                 }}
             }}
           }}

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -407,7 +407,7 @@ class BasetenApi:
                 id
                 name
                 hostname
-                versions{{
+                versions {{
                     id
                     semver
                     truss_hash

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -190,14 +190,18 @@ class BasetenApi:
                     {f'name: "{deployment_name}"' if deployment_name else ""}
                     {f'environment_name: "{environment}"' if environment else ""}
                 ) {{
-                    id
-                    hostname
+                    model_version {{
+                        id
+                        oracle {{
+                            hostname
+                        }}
+                    }}
                 }}
             }}
         """
 
         resp = self._post_graphql_query(query_string)
-        return resp["data"]["create_model_version_from_truss"]
+        return resp["data"]["create_model_version_from_truss"]["model_version"]
 
     def create_development_model_from_truss(
         self,

--- a/truss/remote/baseten/core.py
+++ b/truss/remote/baseten/core.py
@@ -197,9 +197,9 @@ def exists_model(api: BasetenApi, model_name: str) -> Optional[str]:
     return model["model"]["id"]
 
 
-def get_model_versions(api: BasetenApi, model_name: ModelName) -> Tuple[str, List]:
+def get_model_and_versions(api: BasetenApi, model_name: ModelName) -> Tuple[dict, List]:
     query_result = api.get_model(model_name.value)["model"]
-    return query_result["id"], query_result["versions"]
+    return query_result, query_result["versions"]
 
 
 def get_dev_version_from_versions(versions: List[dict]) -> Optional[dict]:

--- a/truss/remote/baseten/core.py
+++ b/truss/remote/baseten/core.py
@@ -71,7 +71,7 @@ class ChainDeploymentHandleAtomic(NamedTuple):
 
 
 class ModelVersionHandle(NamedTuple):
-    id: str
+    version_id: str
     model_id: str
     hostname: str
 
@@ -371,7 +371,7 @@ def create_truss_service(
         )
 
         return ModelVersionHandle(
-            id=model_version_json["id"],
+            version_id=model_version_json["id"],
             model_id=model_version_json["oracle"]["id"],
             hostname=model_version_json["oracle"]["hostname"],
         )
@@ -393,7 +393,7 @@ def create_truss_service(
         )
 
         return ModelVersionHandle(
-            id=model_version_json["id"],
+            version_id=model_version_json["id"],
             model_id=model_version_json["oracle"]["id"],
             hostname=model_version_json["oracle"]["hostname"],
         )
@@ -421,7 +421,7 @@ def create_truss_service(
         raise e
 
     return ModelVersionHandle(
-        id=model_version_json["id"],
+        version_id=model_version_json["id"],
         model_id=model_id,
         hostname=model_version_json["oracle"]["hostname"],
     )

--- a/truss/remote/baseten/core.py
+++ b/truss/remote/baseten/core.py
@@ -64,11 +64,16 @@ class TrussWatchState(NamedTuple):
 
 
 class ChainDeploymentHandleAtomic(NamedTuple):
+    hostname: str
     chain_id: str
     chain_deployment_id: str
     is_draft: bool
-    entrypoint_model_id: str
-    entrypoint_model_version_id: str
+
+
+class ModelVersionHandle(NamedTuple):
+    id: str
+    model_id: str
+    invoke_base_url: str
 
 
 def get_chain_id_by_name(api: BasetenApi, chain_name: str) -> Optional[str]:
@@ -160,10 +165,9 @@ def create_chain_atomic(
         )
 
     return ChainDeploymentHandleAtomic(
-        chain_id=res["chain_id"],
-        chain_deployment_id=res["chain_deployment_id"],
-        entrypoint_model_id=res["entrypoint_model_id"],
-        entrypoint_model_version_id=res["entrypoint_model_version_id"],
+        chain_deployment_id=res["chain_deployment"]["id"],
+        chain_id=res["chain_deployment"]["chain"]["id"],
+        hostname=res["chain_deployment"]["chain"]["hostname"],
         is_draft=is_draft,
     )
 
@@ -334,7 +338,7 @@ def create_truss_service(
     deployment_name: Optional[str] = None,
     origin: Optional[b10_types.ModelOrigin] = None,
     environment: Optional[str] = None,
-) -> Tuple[str, str]:
+) -> ModelVersionHandle:
     """
     Create a model in the Baseten remote.
 
@@ -352,8 +356,9 @@ def create_truss_service(
             development model.
 
     Returns:
-        A tuple of the model ID and version ID
+        A Model Version handle.
     """
+
     if is_draft:
         model_version_json = api.create_development_model_from_truss(
             model_name,
@@ -365,11 +370,16 @@ def create_truss_service(
             origin=origin,
         )
 
-        return model_version_json["id"], model_version_json["version_id"]
+        return ModelVersionHandle(
+            id=model_version_json["id"],
+            invoke_base_url=model_version_json["invoke_base_url"],
+            model_id=model_version_json["oracle"]["id"],
+        )
 
     if model_id is None:
         if environment and environment != PRODUCTION_ENVIRONMENT_NAME:
             raise ValueError(NO_ENVIRONMENTS_EXIST_ERROR_MESSAGING)
+
         model_version_json = api.create_model_from_truss(
             model_name=model_name,
             s3_key=s3_key,
@@ -381,7 +391,12 @@ def create_truss_service(
             deployment_name=deployment_name,
             origin=origin,
         )
-        return model_version_json["id"], model_version_json["version_id"]
+
+        return ModelVersionHandle(
+            id=model_version_json["id"],
+            invoke_base_url=model_version_json["invoke_base_url"],
+            model_id=model_version_json["oracle"]["id"],
+        )
 
     try:
         model_version_json = api.create_model_version_from_truss(
@@ -404,8 +419,12 @@ def create_truss_service(
                 f'Environment "{environment}" does not exist. You can create environments in the Baseten UI.'
             ) from e
         raise e
-    model_version_id = model_version_json["id"]
-    return model_id, model_version_id
+
+    return ModelVersionHandle(
+        id=model_version_json["id"],
+        model_id=model_id,
+        invoke_base_url=model_version_json["invoke_base_url"],
+    )
 
 
 def validate_truss_config(api: BasetenApi, config: str):

--- a/truss/remote/baseten/core.py
+++ b/truss/remote/baseten/core.py
@@ -73,7 +73,7 @@ class ChainDeploymentHandleAtomic(NamedTuple):
 class ModelVersionHandle(NamedTuple):
     id: str
     model_id: str
-    invoke_base_url: str
+    hostname: str
 
 
 def get_chain_id_by_name(api: BasetenApi, chain_name: str) -> Optional[str]:
@@ -372,8 +372,8 @@ def create_truss_service(
 
         return ModelVersionHandle(
             id=model_version_json["id"],
-            invoke_base_url=model_version_json["invoke_base_url"],
             model_id=model_version_json["oracle"]["id"],
+            hostname=model_version_json["oracle"]["hostname"],
         )
 
     if model_id is None:
@@ -394,8 +394,8 @@ def create_truss_service(
 
         return ModelVersionHandle(
             id=model_version_json["id"],
-            invoke_base_url=model_version_json["invoke_base_url"],
             model_id=model_version_json["oracle"]["id"],
+            hostname=model_version_json["oracle"]["hostname"],
         )
 
     try:
@@ -423,7 +423,7 @@ def create_truss_service(
     return ModelVersionHandle(
         id=model_version_json["id"],
         model_id=model_id,
-        invoke_base_url=model_version_json["invoke_base_url"],
+        hostname=model_version_json["oracle"]["hostname"],
     )
 
 

--- a/truss/remote/baseten/custom_types.py
+++ b/truss/remote/baseten/custom_types.py
@@ -11,7 +11,6 @@ class DeployedChainlet(pydantic.BaseModel):
     is_draft: bool
     status: str
     logs_url: str
-    oracle_predict_url: str
     oracle_name: str
 
 

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -241,7 +241,7 @@ class BasetenRemote(TrussRemote):
             model_version_handle=model_version_handle,
             is_draft=push_data.is_draft,
             api_key=self._auth_service.authenticate().value,
-            service_url=f"{self._remote_url}/model_versions/{model_version_handle.id}",
+            service_url=f"{self._remote_url}/model_versions/{model_version_handle.version_id}",
             truss_handle=truss_handle,
             api=self._api,
         )
@@ -337,7 +337,7 @@ class BasetenRemote(TrussRemote):
             service_url_path = f"/model_versions/{model_version_id}"
 
             return service_url_path, ModelVersionHandle(
-                id=model_version_id, model_id=model_id, hostname=hostname
+                version_id=model_version_id, model_id=model_id, hostname=hostname
             )
 
         if isinstance(model_identifier, ModelName):
@@ -367,7 +367,7 @@ class BasetenRemote(TrussRemote):
             )
 
         return service_url_path, ModelVersionHandle(
-            id=model_version_id, model_id=model_id, hostname=hostname
+            version_id=model_version_id, model_id=model_id, hostname=hostname
         )
 
     def get_service(self, **kwargs) -> BasetenService:

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -22,6 +22,7 @@ from truss.remote.baseten.core import (
     ModelId,
     ModelIdentifier,
     ModelName,
+    ModelVersionHandle,
     ModelVersionId,
     archive_truss,
     create_chain_atomic,
@@ -94,13 +95,6 @@ class BasetenRemote(TrussRemote):
                     chainlet["chain"]["id"],
                     chain_deployment_id,
                     chainlet["id"],
-                ),
-                oracle_predict_url=URLConfig.invocation_url(
-                    self._api.rest_api_url,
-                    URLConfig.MODEL,
-                    chainlet["oracle"]["id"],
-                    chainlet["oracle_version"]["id"],
-                    chainlet["oracle_version"]["is_draft"],
                 ),
                 oracle_name=chainlet["oracle"]["name"],
             )
@@ -228,7 +222,7 @@ class BasetenRemote(TrussRemote):
         # many functions. We should consolidate them into a
         # data class with standardized default values so
         # we're not drilling these arguments everywhere.
-        model_id, model_version_id = create_truss_service(
+        model_version_handle = create_truss_service(
             api=self._api,
             model_name=push_data.model_name,
             s3_key=push_data.s3_key,
@@ -244,11 +238,10 @@ class BasetenRemote(TrussRemote):
         )
 
         return BasetenService(
-            model_id=model_id,
-            model_version_id=model_version_id,
+            model_version_handle=model_version_handle,
             is_draft=push_data.is_draft,
             api_key=self._auth_service.authenticate().value,
-            service_url=f"{self._remote_url}/model_versions/{model_version_id}",
+            service_url=f"{self._remote_url}/model_versions/{model_version_handle.id}",
             truss_handle=truss_handle,
             api=self._api,
         )
@@ -332,16 +325,20 @@ class BasetenRemote(TrussRemote):
     @staticmethod
     def _get_service_url_path_and_model_ids(
         api: BasetenApi, model_identifier: ModelIdentifier, published: bool
-    ) -> Tuple[str, str, str]:
+    ) -> Tuple[str, ModelVersionHandle]:
         if isinstance(model_identifier, ModelVersionId):
             try:
                 model_version = api.get_model_version_by_id(model_identifier.value)
             except ApiError:
                 raise RemoteError(f"Model version {model_identifier.value} not found.")
             model_version_id = model_version["model_version"]["id"]
+            invoke_base_url = model_version["model_version"]["invoke_base_url"]
             model_id = model_version["model_version"]["oracle"]["id"]
             service_url_path = f"/model_versions/{model_version_id}"
-            return service_url_path, model_id, model_version_id
+
+            return service_url_path, ModelVersionHandle(
+                id=model_version_id, model_id=model_id, invoke_base_url=invoke_base_url
+            )
 
         if isinstance(model_identifier, ModelName):
             model_id, model_versions = get_model_versions(api, model_identifier)
@@ -349,6 +346,7 @@ class BasetenRemote(TrussRemote):
                 model_versions, published
             )
             model_version_id = model_version["id"]
+            invoke_base_url = model_version["invoke_base_url"]
             service_url_path = f"/model_versions/{model_version_id}"
         elif isinstance(model_identifier, ModelId):
             # TODO(helen): consider making this consistent with getting the
@@ -359,6 +357,7 @@ class BasetenRemote(TrussRemote):
                 raise RemoteError(f"Model {model_identifier.value} not found.")
             model_id = model["model"]["id"]
             model_version_id = model["model"]["primary_version"]["id"]
+            invoke_base_url = model["model"]["primary_version"]["invoke_base_url"]
             service_url_path = f"/models/{model_id}"
         else:
             # Model identifier is of invalid type.
@@ -367,7 +366,9 @@ class BasetenRemote(TrussRemote):
                 "--model-deployment or --model options."
             )
 
-        return service_url_path, model_id, model_version_id
+        return service_url_path, ModelVersionHandle(
+            id=model_version_id, model_id=model_id, invoke_base_url=invoke_base_url
+        )
 
     def get_service(self, **kwargs) -> BasetenService:
         try:
@@ -376,15 +377,14 @@ class BasetenRemote(TrussRemote):
             raise ValueError("Baseten Service requires a model_identifier")
 
         published = kwargs.get("published", False)
-        (service_url_path, model_id, model_version_id) = (
+        (service_url_path, model_version_handle) = (
             self._get_service_url_path_and_model_ids(
                 self._api, model_identifier, published
             )
         )
 
         return BasetenService(
-            model_id=model_id,
-            model_version_id=model_version_id,
+            model_version_handle=model_version_handle,
             is_draft=not published,
             api_key=self._auth_service.authenticate().value,
             service_url=f"{self._remote_url}{service_url_path}",

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -332,12 +332,12 @@ class BasetenRemote(TrussRemote):
             except ApiError:
                 raise RemoteError(f"Model version {model_identifier.value} not found.")
             model_version_id = model_version["model_version"]["id"]
-            invoke_base_url = model_version["model_version"]["invoke_base_url"]
+            hostname = model_version["model_version"]["oracle"]["hostname"]
             model_id = model_version["model_version"]["oracle"]["id"]
             service_url_path = f"/model_versions/{model_version_id}"
 
             return service_url_path, ModelVersionHandle(
-                id=model_version_id, model_id=model_id, invoke_base_url=invoke_base_url
+                id=model_version_id, model_id=model_id, hostname=hostname
             )
 
         if isinstance(model_identifier, ModelName):
@@ -346,7 +346,7 @@ class BasetenRemote(TrussRemote):
                 model_versions, published
             )
             model_version_id = model_version["id"]
-            invoke_base_url = model_version["invoke_base_url"]
+            hostname = model_version["oracle"]["hostname"]
             service_url_path = f"/model_versions/{model_version_id}"
         elif isinstance(model_identifier, ModelId):
             # TODO(helen): consider making this consistent with getting the
@@ -357,7 +357,7 @@ class BasetenRemote(TrussRemote):
                 raise RemoteError(f"Model {model_identifier.value} not found.")
             model_id = model["model"]["id"]
             model_version_id = model["model"]["primary_version"]["id"]
-            invoke_base_url = model["model"]["primary_version"]["invoke_base_url"]
+            hostname = model["model"]["hostname"]
             service_url_path = f"/models/{model_id}"
         else:
             # Model identifier is of invalid type.
@@ -367,7 +367,7 @@ class BasetenRemote(TrussRemote):
             )
 
         return service_url_path, ModelVersionHandle(
-            id=model_version_id, model_id=model_id, invoke_base_url=invoke_base_url
+            id=model_version_id, model_id=model_id, hostname=hostname
         )
 
     def get_service(self, **kwargs) -> BasetenService:

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -30,7 +30,7 @@ from truss.remote.baseten.core import (
     exists_model,
     get_dev_version,
     get_dev_version_from_versions,
-    get_model_versions,
+    get_model_and_versions,
     get_prod_version_from_versions,
     get_truss_watch_state,
     upload_truss,
@@ -341,12 +341,13 @@ class BasetenRemote(TrussRemote):
             )
 
         if isinstance(model_identifier, ModelName):
-            model_id, model_versions = get_model_versions(api, model_identifier)
+            model, model_versions = get_model_and_versions(api, model_identifier)
             model_version = BasetenRemote._get_matching_version(
                 model_versions, published
             )
+            model_id = model["id"]
             model_version_id = model_version["id"]
-            hostname = model_version["oracle"]["hostname"]
+            hostname = model["hostname"]
             service_url_path = f"/model_versions/{model_version_id}"
         elif isinstance(model_identifier, ModelId):
             # TODO(helen): consider making this consistent with getting the

--- a/truss/remote/baseten/service.py
+++ b/truss/remote/baseten/service.py
@@ -110,7 +110,7 @@ class BasetenService(TrussService):
 
     @property
     def model_version_id(self) -> str:
-        return self._model_version_handle.id
+        return self._model_version_handle.version_id
 
     def predict(self, model_request_body: Dict) -> Any:
         response = self._send_request(
@@ -159,7 +159,7 @@ class BasetenService(TrussService):
         return URLConfig.invoke_url(
             hostname=handle.hostname,
             config=URLConfig.MODEL,
-            entity_version_id=handle.id,
+            entity_version_id=handle.version_id,
             is_draft=self.is_draft,
         )
 

--- a/truss/tests/remote/baseten/test_api.py
+++ b/truss/tests/remote/baseten/test_api.py
@@ -40,7 +40,11 @@ def mock_create_model_version_response():
     response = Response()
     response.status_code = 200
     response.json = mock.Mock(
-        return_value={"data": {"create_model_version_from_truss": {"id": "12345"}}}
+        return_value={
+            "data": {
+                "create_model_version_from_truss": {"model_version": {"id": "12345"}}
+            }
+        }
     )
     return response
 
@@ -49,7 +53,9 @@ def mock_create_model_response():
     response = Response()
     response.status_code = 200
     response.json = mock.Mock(
-        return_value={"data": {"create_model_from_truss": {"id": "12345"}}}
+        return_value={
+            "data": {"create_model_from_truss": {"model_version": {"id": "12345"}}}
+        }
     )
     return response
 
@@ -58,7 +64,9 @@ def mock_create_development_model_response():
     response = Response()
     response.status_code = 200
     response.json = mock.Mock(
-        return_value={"data": {"deploy_draft_truss": {"id": "12345"}}}
+        return_value={
+            "data": {"deploy_draft_truss": {"model_version": {"id": "12345"}}}
+        }
     )
     return response
 

--- a/truss/tests/remote/baseten/test_api.py
+++ b/truss/tests/remote/baseten/test_api.py
@@ -70,10 +70,7 @@ def mock_deploy_chain_deployment_response():
         return_value={
             "data": {
                 "deploy_chain_atomic": {
-                    "chain_id": "12345",
-                    "chain_deployment_id": "54321",
-                    "entrypoint_model_id": "67890",
-                    "entrypoint_model_version_id": "09876",
+                    "chain_deployment": {"id": "54321", "chain": {"id": "12345"}}
                 }
             }
         }

--- a/truss/tests/remote/baseten/test_core.py
+++ b/truss/tests/remote/baseten/test_core.py
@@ -103,7 +103,7 @@ def test_create_truss_service_handles_eligible_environment_values(environment):
         deployment_name="deployment_name",
         environment=environment,
     )
-    assert version_handle.id == "model_version_id"
+    assert version_handle.version_id == "model_version_id"
     assert version_handle.model_id == "model_id"
     api.create_model_from_truss.assert_called_once()
 
@@ -127,7 +127,7 @@ def test_create_truss_services_handles_is_draft(model_id):
         model_id=model_id,
         deployment_name="deployment_name",
     )
-    assert version_handle.id == "model_version_id"
+    assert version_handle.version_id == "model_version_id"
     assert version_handle.model_id == "model_id"
     api.create_development_model_from_truss.assert_called_once()
 
@@ -172,7 +172,7 @@ def test_create_truss_service_handles_existing_model(inputs):
         **inputs,
     )
 
-    assert version_handle.id == "model_version_id"
+    assert version_handle.version_id == "model_version_id"
     assert version_handle.model_id == "model_id"
     api.create_model_version_from_truss.assert_called_once()
     _, kwargs = api.create_model_version_from_truss.call_args
@@ -205,7 +205,7 @@ def test_create_truss_service_handles_allow_truss_download_for_new_models(
         deployment_name="deployment_name",
         allow_truss_download=allow_truss_download,
     )
-    assert version_handle.id == "model_version_id"
+    assert version_handle.version_id == "model_version_id"
     assert version_handle.model_id == "model_id"
 
     create_model_mock = (

--- a/truss/tests/remote/baseten/test_core.py
+++ b/truss/tests/remote/baseten/test_core.py
@@ -86,9 +86,12 @@ def test_get_prod_version_from_versions_error():
 @pytest.mark.parametrize("environment", [None, PRODUCTION_ENVIRONMENT_NAME])
 def test_create_truss_service_handles_eligible_environment_values(environment):
     api = MagicMock()
-    return_value = {"id": "id", "version_id": "model_version_id"}
+    return_value = {
+        "id": "model_version_id",
+        "oracle": {"id": "model_id", "hostname": "hostname"},
+    }
     api.create_model_from_truss.return_value = return_value
-    model_id, model_version_id = create_truss_service(
+    version_handle = create_truss_service(
         api,
         "model_name",
         "s3_key",
@@ -100,17 +103,20 @@ def test_create_truss_service_handles_eligible_environment_values(environment):
         deployment_name="deployment_name",
         environment=environment,
     )
-    assert model_id == return_value["id"]
-    assert model_version_id == return_value["version_id"]
+    assert version_handle.id == "model_version_id"
+    assert version_handle.model_id == "model_id"
     api.create_model_from_truss.assert_called_once()
 
 
 @pytest.mark.parametrize("model_id", ["some_model_id", None])
 def test_create_truss_services_handles_is_draft(model_id):
     api = MagicMock()
-    return_value = {"id": "id", "version_id": "model_version_id"}
+    return_value = {
+        "id": "model_version_id",
+        "oracle": {"id": "model_id", "hostname": "hostname"},
+    }
     api.create_development_model_from_truss.return_value = return_value
-    model_id, model_version_id = create_truss_service(
+    version_handle = create_truss_service(
         api,
         "model_name",
         "s3_key",
@@ -121,8 +127,8 @@ def test_create_truss_services_handles_is_draft(model_id):
         model_id=model_id,
         deployment_name="deployment_name",
     )
-    assert model_id == return_value["id"]
-    assert model_version_id == return_value["version_id"]
+    assert version_handle.id == "model_version_id"
+    assert version_handle.model_id == "model_id"
     api.create_development_model_from_truss.assert_called_once()
 
 
@@ -151,9 +157,12 @@ def test_create_truss_services_handles_is_draft(model_id):
 )
 def test_create_truss_service_handles_existing_model(inputs):
     api = MagicMock()
-    return_value = {"id": "model_version_id"}
+    return_value = {
+        "id": "model_version_id",
+        "oracle": {"id": "model_id", "hostname": "hostname"},
+    }
     api.create_model_version_from_truss.return_value = return_value
-    model_id, model_version_id = create_truss_service(
+    version_handle = create_truss_service(
         api,
         "model_name",
         "s3_key",
@@ -163,8 +172,8 @@ def test_create_truss_service_handles_existing_model(inputs):
         **inputs,
     )
 
-    assert model_id == "model_id"
-    assert model_version_id == return_value["id"]
+    assert version_handle.id == "model_version_id"
+    assert version_handle.model_id == "model_id"
     api.create_model_version_from_truss.assert_called_once()
     _, kwargs = api.create_model_version_from_truss.call_args
     for k, v in inputs.items():
@@ -177,12 +186,14 @@ def test_create_truss_service_handles_allow_truss_download_for_new_models(
     is_draft, allow_truss_download
 ):
     api = MagicMock()
-    return_value = {"id": "id", "version_id": "model_version_id"}
+    return_value = {
+        "id": "model_version_id",
+        "oracle": {"id": "model_id", "hostname": "hostname"},
+    }
     api.create_model_from_truss.return_value = return_value
     api.create_development_model_from_truss.return_value = return_value
 
-    model_id = None
-    model_id, model_version_id = create_truss_service(
+    version_handle = create_truss_service(
         api,
         "model_name",
         "s3_key",
@@ -190,12 +201,12 @@ def test_create_truss_service_handles_allow_truss_download_for_new_models(
         is_trusted=False,
         preserve_previous_prod_deployment=False,
         is_draft=is_draft,
-        model_id=model_id,
+        model_id=None,
         deployment_name="deployment_name",
         allow_truss_download=allow_truss_download,
     )
-    assert model_id == return_value["id"]
-    assert model_version_id == return_value["version_id"]
+    assert version_handle.id == "model_version_id"
+    assert version_handle.model_id == "model_id"
 
     create_model_mock = (
         api.create_development_model_from_truss

--- a/truss/tests/remote/baseten/test_remote.py
+++ b/truss/tests/remote/baseten/test_remote.py
@@ -275,10 +275,10 @@ def test_create_chain_with_no_publish():
                     "json": {
                         "data": {
                             "deploy_chain_atomic": {
-                                "chain_id": "new-chain-id",
-                                "chain_deployment_id": "new-chain-deployment-id",
-                                "entrypoint_model_id": "new-entrypoint-model-id",
-                                "entrypoint_model_version_id": "new-entrypoint-model-version-id",
+                                "chain_deployment": {
+                                    "id": "new-chain-deployment-id",
+                                    "chain": {"id": "new-chain-id"},
+                                }
                             }
                         }
                     }
@@ -343,10 +343,12 @@ def test_create_chain_with_no_publish():
                     dependencies: []
                     client_version: "truss=={truss.version()}"
                 ) {{
-                    chain_id
-                    chain_deployment_id
-                    entrypoint_model_id
-                    entrypoint_model_version_id
+                    chain_deployment {{
+                        id
+                        chain {{
+                            id
+                        }}
+                    }}
                 }}
             }}
         """.strip()
@@ -371,10 +373,10 @@ def test_create_chain_no_existing_chain():
                     "json": {
                         "data": {
                             "deploy_chain_atomic": {
-                                "chain_id": "new-chain-id",
-                                "chain_deployment_id": "new-chain-deployment-id",
-                                "entrypoint_model_id": "new-entrypoint-model-id",
-                                "entrypoint_model_version_id": "new-entrypoint-model-version-id",
+                                "chain_deployment": {
+                                    "id": "new-chain-deployment-id",
+                                    "chain": {"id": "new-chain-id"},
+                                }
                             }
                         }
                     }
@@ -437,10 +439,12 @@ def test_create_chain_no_existing_chain():
                     dependencies: []
                     client_version: "truss=={truss.version()}"
                 ) {{
-                    chain_id
-                    chain_deployment_id
-                    entrypoint_model_id
-                    entrypoint_model_version_id
+                    chain_deployment {{
+                        id
+                        chain {{
+                            id
+                        }}
+                    }}
                 }}
             }}
         """.strip()
@@ -471,10 +475,10 @@ def test_create_chain_with_existing_chain_promote_to_environment_publish_false()
                     "json": {
                         "data": {
                             "deploy_chain_atomic": {
-                                "chain_id": "new-chain-id",
-                                "chain_deployment_id": "new-chain-deployment-id",
-                                "entrypoint_model_id": "new-entrypoint-model-id",
-                                "entrypoint_model_version_id": "new-entrypoint-model-version-id",
+                                "chain_deployment": {
+                                    "id": "new-chain-deployment-id",
+                                    "chain": {"id": "new-chain-id"},
+                                }
                             }
                         }
                     }
@@ -540,10 +544,12 @@ def test_create_chain_with_existing_chain_promote_to_environment_publish_false()
                     dependencies: []
                     client_version: "truss=={truss.version()}"
                 ) {{
-                    chain_id
-                    chain_deployment_id
-                    entrypoint_model_id
-                    entrypoint_model_version_id
+                    chain_deployment {{
+                        id
+                        chain {{
+                            id
+                        }}
+                    }}
                 }}
             }}
         """.strip()
@@ -574,10 +580,10 @@ def test_create_chain_existing_chain_publish_true_no_promotion():
                     "json": {
                         "data": {
                             "deploy_chain_atomic": {
-                                "chain_id": "new-chain-id",
-                                "chain_deployment_id": "new-chain-deployment-id",
-                                "entrypoint_model_id": "new-entrypoint-model-id",
-                                "entrypoint_model_version_id": "new-entrypoint-model-version-id",
+                                "chain_deployment": {
+                                    "id": "new-chain-deployment-id",
+                                    "chain": {"id": "new-chain-id"},
+                                }
                             }
                         }
                     }
@@ -640,10 +646,12 @@ def test_create_chain_existing_chain_publish_true_no_promotion():
                     dependencies: []
                     client_version: "truss=={truss.version()}"
                 ) {{
-                    chain_id
-                    chain_deployment_id
-                    entrypoint_model_id
-                    entrypoint_model_version_id
+                    chain_deployment {{
+                        id
+                        chain {{
+                            id
+                        }}
+                    }}
                 }}
             }}
         """.strip()

--- a/truss/tests/remote/baseten/test_remote.py
+++ b/truss/tests/remote/baseten/test_remote.py
@@ -32,7 +32,7 @@ def request_matches_expected_query(request, expected_query):
 def test_get_service_by_version_id():
     remote = BasetenRemote(_TEST_REMOTE_URL, "api_key")
 
-    version = {"id": "version_id", "oracle": {"id": "model_id"}}
+    version = {"id": "version_id", "oracle": {"id": "model_id", "hostname": "hostname"}}
     model_version_response = {"data": {"model_version": version}}
 
     with requests_mock.Mocker() as m:
@@ -56,9 +56,24 @@ def test_get_service_by_model_name():
     remote = BasetenRemote(_TEST_REMOTE_URL, "api_key")
 
     versions = [
-        {"id": "1", "is_draft": False, "is_primary": False},
-        {"id": "2", "is_draft": False, "is_primary": True},
-        {"id": "3", "is_draft": True, "is_primary": False},
+        {
+            "id": "1",
+            "is_draft": False,
+            "is_primary": False,
+            "oracle": {"hostname": "hostname"},
+        },
+        {
+            "id": "2",
+            "is_draft": False,
+            "is_primary": True,
+            "oracle": {"hostname": "hostname"},
+        },
+        {
+            "id": "3",
+            "is_draft": True,
+            "is_primary": False,
+            "oracle": {"hostname": "hostname"},
+        },
     ]
     model_response = {
         "data": {
@@ -87,7 +102,14 @@ def test_get_service_by_model_name():
 def test_get_service_by_model_name_no_dev_version():
     remote = BasetenRemote(_TEST_REMOTE_URL, "api_key")
 
-    versions = [{"id": "1", "is_draft": False, "is_primary": True}]
+    versions = [
+        {
+            "id": "1",
+            "is_draft": False,
+            "is_primary": True,
+            "oracle": {"hostname": "hostname"},
+        }
+    ]
     model_response = {
         "data": {
             "model": {"name": "model_name", "id": "model_id", "versions": versions}
@@ -115,7 +137,14 @@ def test_get_service_by_model_name_no_dev_version():
 def test_get_service_by_model_name_no_prod_version():
     remote = BasetenRemote(_TEST_REMOTE_URL, "api_key")
 
-    versions = [{"id": "1", "is_draft": True, "is_primary": False}]
+    versions = [
+        {
+            "id": "1",
+            "is_draft": True,
+            "is_primary": False,
+            "oracle": {"hostname": "hostname"},
+        }
+    ]
     model_response = {
         "data": {
             "model": {"name": "model_name", "id": "model_id", "versions": versions}
@@ -147,6 +176,7 @@ def test_get_service_by_model_id():
                 "name": "model_name",
                 "id": "model_id",
                 "primary_version": {"id": "version_id"},
+                "hostname": "hostname",
             }
         }
     }
@@ -277,7 +307,10 @@ def test_create_chain_with_no_publish():
                             "deploy_chain_atomic": {
                                 "chain_deployment": {
                                     "id": "new-chain-deployment-id",
-                                    "chain": {"id": "new-chain-id"},
+                                    "chain": {
+                                        "id": "new-chain-id",
+                                        "hostname": "hostname",
+                                    },
                                 }
                             }
                         }
@@ -347,6 +380,7 @@ def test_create_chain_with_no_publish():
                         id
                         chain {{
                             id
+                            hostname
                         }}
                     }}
                 }}
@@ -375,7 +409,10 @@ def test_create_chain_no_existing_chain():
                             "deploy_chain_atomic": {
                                 "chain_deployment": {
                                     "id": "new-chain-deployment-id",
-                                    "chain": {"id": "new-chain-id"},
+                                    "chain": {
+                                        "id": "new-chain-id",
+                                        "hostname": "hostname",
+                                    },
                                 }
                             }
                         }
@@ -443,6 +480,7 @@ def test_create_chain_no_existing_chain():
                         id
                         chain {{
                             id
+                            hostname
                         }}
                     }}
                 }}
@@ -477,7 +515,10 @@ def test_create_chain_with_existing_chain_promote_to_environment_publish_false()
                             "deploy_chain_atomic": {
                                 "chain_deployment": {
                                     "id": "new-chain-deployment-id",
-                                    "chain": {"id": "new-chain-id"},
+                                    "chain": {
+                                        "id": "new-chain-id",
+                                        "hostname": "hostname",
+                                    },
                                 }
                             }
                         }
@@ -548,6 +589,7 @@ def test_create_chain_with_existing_chain_promote_to_environment_publish_false()
                         id
                         chain {{
                             id
+                            hostname
                         }}
                     }}
                 }}
@@ -582,7 +624,10 @@ def test_create_chain_existing_chain_publish_true_no_promotion():
                             "deploy_chain_atomic": {
                                 "chain_deployment": {
                                     "id": "new-chain-deployment-id",
-                                    "chain": {"id": "new-chain-id"},
+                                    "chain": {
+                                        "id": "new-chain-id",
+                                        "hostname": "hostname",
+                                    },
                                 }
                             }
                         }
@@ -650,6 +695,7 @@ def test_create_chain_existing_chain_publish_true_no_promotion():
                         id
                         chain {{
                             id
+                            hostname
                         }}
                     }}
                 }}

--- a/truss/tests/remote/baseten/test_remote.py
+++ b/truss/tests/remote/baseten/test_remote.py
@@ -56,28 +56,18 @@ def test_get_service_by_model_name():
     remote = BasetenRemote(_TEST_REMOTE_URL, "api_key")
 
     versions = [
-        {
-            "id": "1",
-            "is_draft": False,
-            "is_primary": False,
-            "oracle": {"hostname": "hostname"},
-        },
-        {
-            "id": "2",
-            "is_draft": False,
-            "is_primary": True,
-            "oracle": {"hostname": "hostname"},
-        },
-        {
-            "id": "3",
-            "is_draft": True,
-            "is_primary": False,
-            "oracle": {"hostname": "hostname"},
-        },
+        {"id": "1", "is_draft": False, "is_primary": False},
+        {"id": "2", "is_draft": False, "is_primary": True},
+        {"id": "3", "is_draft": True, "is_primary": False},
     ]
     model_response = {
         "data": {
-            "model": {"name": "model_name", "id": "model_id", "versions": versions}
+            "model": {
+                "name": "model_name",
+                "id": "model_id",
+                "hostname": "hostname",
+                "versions": versions,
+            }
         }
     }
 
@@ -102,17 +92,15 @@ def test_get_service_by_model_name():
 def test_get_service_by_model_name_no_dev_version():
     remote = BasetenRemote(_TEST_REMOTE_URL, "api_key")
 
-    versions = [
-        {
-            "id": "1",
-            "is_draft": False,
-            "is_primary": True,
-            "oracle": {"hostname": "hostname"},
-        }
-    ]
+    versions = [{"id": "1", "is_draft": False, "is_primary": True}]
     model_response = {
         "data": {
-            "model": {"name": "model_name", "id": "model_id", "versions": versions}
+            "model": {
+                "name": "model_name",
+                "id": "model_id",
+                "hostname": "hostname",
+                "versions": versions,
+            }
         }
     }
 
@@ -137,17 +125,15 @@ def test_get_service_by_model_name_no_dev_version():
 def test_get_service_by_model_name_no_prod_version():
     remote = BasetenRemote(_TEST_REMOTE_URL, "api_key")
 
-    versions = [
-        {
-            "id": "1",
-            "is_draft": True,
-            "is_primary": False,
-            "oracle": {"hostname": "hostname"},
-        }
-    ]
+    versions = [{"id": "1", "is_draft": True, "is_primary": False}]
     model_response = {
         "data": {
-            "model": {"name": "model_name", "id": "model_id", "versions": versions}
+            "model": {
+                "name": "model_name",
+                "id": "model_id",
+                "hostname": "hostname",
+                "versions": versions,
+            }
         }
     }
 

--- a/truss/tests/remote/baseten/test_service.py
+++ b/truss/tests/remote/baseten/test_service.py
@@ -1,34 +1,6 @@
 from truss.remote.baseten import service
 
 
-def test_model_invocation_url_prod():
-    url = service.URLConfig.invocation_url(
-        "https://api.baseten.co", service.URLConfig.MODEL, "123", "789", is_draft=False
-    )
-    assert url == "https://model-123.api.baseten.co/deployment/789/predict"
-
-
-def test_model_invocation_url_draft():
-    url = service.URLConfig.invocation_url(
-        "https://api.baseten.co", service.URLConfig.MODEL, "123", "789", is_draft=True
-    )
-    assert url == "https://model-123.api.baseten.co/development/predict"
-
-
-def test_chain_invocation_url_prod():
-    url = service.URLConfig.invocation_url(
-        "https://api.baseten.co", service.URLConfig.CHAIN, "abc", "666", is_draft=False
-    )
-    assert url == "https://chain-abc.api.baseten.co/deployment/666/run_remote"
-
-
-def test_chain_invocation_url_draft():
-    url = service.URLConfig.invocation_url(
-        "https://api.baseten.co", service.URLConfig.CHAIN, "abc", "666", is_draft=True
-    )
-    assert url == "https://chain-abc.api.baseten.co/development/run_remote"
-
-
 def test_model_status_page_url():
     url = service.URLConfig.status_page_url(
         "https://app.baseten.co", service.URLConfig.MODEL, "123"

--- a/truss/tests/remote/baseten/test_service.py
+++ b/truss/tests/remote/baseten/test_service.py
@@ -3,28 +3,40 @@ from truss.remote.baseten import service
 
 def test_model_invoke_url_prod():
     url = service.URLConfig.invoke_url(
-        "https://model-123.api.baseten.co", service.URLConfig.MODEL, "789", is_draft=False
+        "https://model-123.api.baseten.co",
+        service.URLConfig.MODEL,
+        "789",
+        is_draft=False,
     )
     assert url == "https://model-123.api.baseten.co/deployment/789/predict"
 
 
 def test_model_invoke_url_draft():
     url = service.URLConfig.invoke_url(
-        "https://model-123.api.baseten.co", service.URLConfig.MODEL, "789", is_draft=True
+        "https://model-123.api.baseten.co",
+        service.URLConfig.MODEL,
+        "789",
+        is_draft=True,
     )
     assert url == "https://model-123.api.baseten.co/development/predict"
 
 
 def test_chain_invoke_url_prod():
     url = service.URLConfig.invoke_url(
-        "https://chain-abc.api.baseten.co", service.URLConfig.CHAIN, "666", is_draft=False
+        "https://chain-abc.api.baseten.co",
+        service.URLConfig.CHAIN,
+        "666",
+        is_draft=False,
     )
     assert url == "https://chain-abc.api.baseten.co/deployment/666/run_remote"
 
 
 def test_chain_invoke_url_draft():
     url = service.URLConfig.invoke_url(
-        "https://chain-abc.api.baseten.co", service.URLConfig.CHAIN, "666", is_draft=True
+        "https://chain-abc.api.baseten.co",
+        service.URLConfig.CHAIN,
+        "666",
+        is_draft=True,
     )
     assert url == "https://chain-abc.api.baseten.co/development/run_remote"
 

--- a/truss/tests/remote/baseten/test_service.py
+++ b/truss/tests/remote/baseten/test_service.py
@@ -1,6 +1,34 @@
 from truss.remote.baseten import service
 
 
+def test_model_invoke_url_prod():
+    url = service.URLConfig.invoke_url(
+        "https://model-123.api.baseten.co", service.URLConfig.MODEL, "789", is_draft=False
+    )
+    assert url == "https://model-123.api.baseten.co/deployment/789/predict"
+
+
+def test_model_invoke_url_draft():
+    url = service.URLConfig.invoke_url(
+        "https://model-123.api.baseten.co", service.URLConfig.MODEL, "789", is_draft=True
+    )
+    assert url == "https://model-123.api.baseten.co/development/predict"
+
+
+def test_chain_invoke_url_prod():
+    url = service.URLConfig.invoke_url(
+        "https://chain-abc.api.baseten.co", service.URLConfig.CHAIN, "666", is_draft=False
+    )
+    assert url == "https://chain-abc.api.baseten.co/deployment/666/run_remote"
+
+
+def test_chain_invoke_url_draft():
+    url = service.URLConfig.invoke_url(
+        "https://chain-abc.api.baseten.co", service.URLConfig.CHAIN, "666", is_draft=True
+    )
+    assert url == "https://chain-abc.api.baseten.co/development/run_remote"
+
+
 def test_model_status_page_url():
     url = service.URLConfig.status_page_url(
         "https://app.baseten.co", service.URLConfig.MODEL, "123"


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
- Use Model invoke base URL and Chain hostname from backend so that self-hosted customers can call their deployments through Truss CLI.
- Depends on https://github.com/basetenlabs/baseten/pull/10369 being merged.

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
- [x] Manually test 3 Model deployment flows.
- [x] Manually test Chain deployment flow.
