### PR TITLE
Add `--python-dx` flag to `truss init`

### DIFF
--- a/truss/base/constants.py
+++ b/truss/base/constants.py
@@ -13,6 +13,8 @@ LIGHTGBM = "lightgbm"
 _TRUSS_ROOT = pathlib.Path(__file__).parent.parent.resolve()
 
 TEMPLATES_DIR = _TRUSS_ROOT / "templates"
+TRADITIONAL_CUSTOM_TEMPLATE_DIR = TEMPLATES_DIR / "custom"
+PYTHON_DX_CUSTOM_TEMPLATE_DIR = TEMPLATES_DIR / "custom_python_dx"
 DOCKER_SERVER_TEMPLATES_DIR = TEMPLATES_DIR / "docker_server"
 SERVER_CODE_DIR: pathlib.Path = TEMPLATES_DIR / "server"
 TRITON_SERVER_CODE_DIR: pathlib.Path = TEMPLATES_DIR / "triton"

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -49,7 +49,7 @@ from truss.trt_llm.config_checks import (
     uses_trt_llm_builder,
 )
 from truss.truss_handle.build import cleanup as _cleanup
-from truss.truss_handle.build import init as _init
+from truss.truss_handle.build import init_directory as _init
 from truss.truss_handle.build import load
 from truss.util import docker
 from truss.util.log_utils import LogInterceptor
@@ -204,9 +204,15 @@ def image():
     type=click.Choice([server.value for server in ModelServer]),
 )
 @click.option("-n", "--name", type=click.STRING)
+@click.option(
+    "--python-dx/--no-python-dx",
+    type=bool,
+    default=False,
+    help="Uses the code first tooling to build models.",
+)
 @log_level_option
 @error_handling
-def init(target_directory, backend, name) -> None:
+def init(target_directory, backend, name, python_dx) -> None:
     """Create a new truss.
 
     TARGET_DIRECTORY: A Truss is created in this directory
@@ -226,6 +232,7 @@ def init(target_directory, backend, name) -> None:
         target_directory=target_directory,
         build_config=build_config,
         model_name=model_name,
+        python_dx=python_dx,
     )
     click.echo(f"Truss {model_name} was created in {tr_path.absolute()}")
 

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -205,14 +205,14 @@ def image():
 )
 @click.option("-n", "--name", type=click.STRING)
 @click.option(
-    "--python-dx/--no-python-dx",
+    "--python-configuration/--no-python-configuration",
     type=bool,
     default=False,
     help="Uses the code first tooling to build models.",
 )
 @log_level_option
 @error_handling
-def init(target_directory, backend, name, python_dx) -> None:
+def init(target_directory, backend, name, python_configuration) -> None:
     """Create a new truss.
 
     TARGET_DIRECTORY: A Truss is created in this directory
@@ -232,7 +232,7 @@ def init(target_directory, backend, name, python_dx) -> None:
         target_directory=target_directory,
         build_config=build_config,
         model_name=model_name,
-        python_dx=python_dx,
+        python_configuration=python_configuration,
     )
     click.echo(f"Truss {model_name} was created in {tr_path.absolute()}")
 

--- a/truss/templates/custom_python_dx/my_model.py
+++ b/truss/templates/custom_python_dx/my_model.py
@@ -1,0 +1,28 @@
+"""
+The `Model` class is an interface between the ML model that you're packaging and the model
+server that you're running it on.
+
+The main method to implement here is:
+* `predict`: runs every time the model server is called. Include any logic for model
+  inference and return the model output.
+
+See https://truss.baseten.co/quickstart for more.
+"""
+
+import truss_chains as baseten
+
+
+class Model(baseten.ModelBase):
+    # Configure resources for your model here.
+    remote_config: baseten.RemoteConfig = baseten.RemoteConfig(name="{{ MODEL_NAME }}")
+
+    def __init__(
+        self, context: baseten.DeploymentContext = baseten.depends_context()
+    ) -> None:
+        # Access secrets via optional `context` variable.
+        # Load model here and assign to self._model.
+        self._model = None
+
+    def predict(self, input_field: int) -> int:
+        # Run model inference here
+        return input_field

--- a/truss/tests/test_build.py
+++ b/truss/tests/test_build.py
@@ -1,7 +1,8 @@
 from pathlib import Path
 
 from truss.base.truss_spec import TrussSpec
-from truss.truss_handle.build import init
+from truss.truss_handle.build import init, init_directory, load
+from truss_chains.deployment import code_gen
 
 
 def test_truss_init(tmp_path):
@@ -56,3 +57,13 @@ def test_truss_init_with_data_file_and_requirements_file_and_bundled_packages(tm
     assert spec.requirements == requirements
     assert (spec.bundled_packages_dir / "dep_pkg" / "__init__.py").exists()
     assert (spec.bundled_packages_dir / "dep_pkg" / "file.py").exists()
+
+
+def test_truss_init_with_python_dx(tmp_path):
+    dir_name = str(tmp_path)
+    init_directory(dir_name, model_name="Test Model Name", python_dx=True)
+
+    generated_truss_dir = code_gen.gen_truss_model_from_source(tmp_path / "my_model.py")
+    truss_handle = load(generated_truss_dir)
+
+    assert truss_handle.spec.config.model_name == "Test Model Name"

--- a/truss/tests/test_build.py
+++ b/truss/tests/test_build.py
@@ -61,7 +61,7 @@ def test_truss_init_with_data_file_and_requirements_file_and_bundled_packages(tm
 
 def test_truss_init_with_python_dx(tmp_path):
     dir_name = str(tmp_path)
-    init_directory(dir_name, model_name="Test Model Name", python_dx=True)
+    init_directory(dir_name, model_name="Test Model Name", python_configuration=True)
 
     generated_truss_dir = code_gen.gen_truss_model_from_source(tmp_path / "my_model.py")
     truss_handle = load(generated_truss_dir)


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
This PR introduces an optional `--python-dx` flag to `truss init` which we believe will help streamline potential adoption of the new functionality. 

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
- New unit tests
- Explicitly running `truss init --no-python-dx` and `truss init --python dx`
