### PR TITLE
Fix integration test expectations

### DIFF
--- a/truss/tests/test_model_inference.py
+++ b/truss/tests/test_model_inference.py
@@ -1512,7 +1512,7 @@ def test_truss_with_requests_and_invalid_argument_combinations():
         time.sleep(1.0)  # Wait for logs.
         _assert_logs_contain_error(
             container.logs(),
-            "When using preprocessing, the predict method cannot only have the request argument",
+            "When using `preprocess`, the predict method cannot only have the request argument",
             "Exception while loading model",
         )
 
@@ -1532,7 +1532,7 @@ def test_truss_with_requests_and_invalid_argument_combinations():
         time.sleep(1.0)  # Wait for logs.
         _assert_logs_contain_error(
             container.logs(),
-            "The postprocessing method cannot only have the request argument",
+            "The `postprocess` method cannot only have the request argument",
             "Exception while loading model",
         )
 


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Noticed that I broke integration [tests](https://github.com/basetenlabs/truss/actions/runs/13186241988/job/36809615964), all the functionality works but the output log changed slightly.

Confirmed fix by manually running:
```
$ poetry run pytest truss/tests/test_model_inference.py::test_truss_with_requests_and_invalid_argument_combinations
```

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
