### PR TITLE
Fix streaming for OpenAI clients

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.60rc005"
+version = "0.9.60rc006"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/templates/server/model_wrapper.py
+++ b/truss/templates/server/model_wrapper.py
@@ -716,18 +716,35 @@ class ModelWrapper:
             result = await self._execute_async_model_fn(inputs, request, descriptor)
 
         if inspect.isgenerator(result) or inspect.isasyncgen(result):
-            if request.headers.get("accept") == "application/json":
-                return await _gather_generator(result)
-            else:
-                return await self._stream_with_background_task(
-                    result,
-                    fn_span,
-                    detached_ctx,
-                    # No semaphores needed for non-predict model functions.
-                    release_and_end=lambda: None,
-                )
+            return await self._handle_generator_response(
+                request, result, fn_span, detached_ctx, release_and_end=lambda: None
+            )
 
         return result
+
+    def _should_gather_generator(self, request: starlette.requests.Request) -> bool:
+        # The OpenAI SDK sends an accept header for JSON even in a streaming context,
+        # but we need to stream results back for client compatibility.
+        user_agent = request.headers.get("user-agent", "")
+        if "openai" in user_agent.lower():
+            return False
+        # TODO(nikhil): determine if we can safely deprecate this behavior.
+        return request.headers.get("accept") == "application/json"
+
+    async def _handle_generator_response(
+        self,
+        request: starlette.requests.Request,
+        generator: Union[Generator[bytes, None, None], AsyncGenerator[bytes, None]],
+        span: trace.Span,
+        trace_ctx: trace.Context,
+        release_and_end: Callable[[], None],
+    ):
+        if self._should_gather_generator(request):
+            return await _gather_generator(generator)
+        else:
+            return await self._stream_with_background_task(
+                generator, span, trace_ctx, release_and_end
+            )
 
     async def completions(
         self, inputs: InputType, request: starlette.requests.Request
@@ -801,17 +818,13 @@ class ModelWrapper:
                             "the predict method."
                         )
 
-                if request.headers.get("accept") == "application/json":
-                    # In the case of a streaming response, consume stream
-                    # if the http accept header is set, and json is requested.
-                    return await _gather_generator(predict_result)
-                else:
-                    return await self._stream_with_background_task(
-                        predict_result,
-                        span_predict,
-                        detached_ctx,
-                        release_and_end=get_defer_fn(),
-                    )
+                return await self._handle_generator_response(
+                    request,
+                    predict_result,
+                    span_predict,
+                    detached_ctx,
+                    release_and_end=get_defer_fn(),
+                )
 
             if isinstance(predict_result, starlette.responses.Response):
                 if self.model_descriptor.postprocess:

--- a/truss/templates/server/model_wrapper.py
+++ b/truss/templates/server/model_wrapper.py
@@ -724,7 +724,8 @@ class ModelWrapper:
 
     def _should_gather_generator(self, request: starlette.requests.Request) -> bool:
         # The OpenAI SDK sends an accept header for JSON even in a streaming context,
-        # but we need to stream results back for client compatibility.
+        # but we need to stream results back for client compatibility. Luckily,
+        # we can differentiate by looking at the user agent (e.g. OpenAI/Python 1.61.0)
         user_agent = request.headers.get("user-agent", "")
         if "openai" in user_agent.lower():
             return False


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
When testing new endpoints with the OpenAI SDK, I found that the client sends an `accept: application/json` header even in streaming context, which breaks an [assumption](https://github.com/basetenlabs/truss/blob/911dddfbb5aaf9235737d42f2d8e770765360c26/truss/templates/server/model_wrapper.py?plain=1#L719-L720) we make about how to handle those requests. It's hard to tell whether any existing truss relies on the functionality of converting a generator into a synchronous response based on the presence of this header, so to get around this temporarily we add a check to the user agent. 

This will specifically fix the case for the OpenAI SDK, but we'll have to test any other compatible clients to see what their behavior is for sending this header in streaming contexts. 

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing

I deployed a model via engine builder and confirmed both streaming / non streaming capabilities work with the newest context builder image. 

Also added a unit test, but that's more contrived. 
