### PR TITLE
Revert back to 0.9.60rc006 after broken release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.60.0"
+version = "0.9.60rc006"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Realized I messed up the versioning [here](https://basetenlabs.slack.com/archives/C04NM3YA2DT/p1738962679345939), so we're reverting back to the `rc` version until we have an official release likely next week.

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
