### PR TITLE
Various refactors to model wrapper + truss server

### DIFF
--- a/truss/templates/server/common/errors.py
+++ b/truss/templates/server/common/errors.py
@@ -45,6 +45,10 @@ class UserCodeError(Exception):
     pass
 
 
+class ModelMethodNotImplemented(Exception):
+    pass
+
+
 class ModelDefinitionError(TypeError):
     """When the user-defined truss model does not meet the contract."""
 
@@ -96,6 +100,10 @@ async def exception_handler(_: fastapi.Request, exc: Exception) -> fastapi.Respo
             "Internal Server Error",
             _BASETEN_DOWNSTREAM_ERROR_CODE,
         )
+    if isinstance(exc, ModelMethodNotImplemented):
+        return _make_baseten_response(
+            HTTPStatus.NOT_FOUND.value, exc, _BASETEN_CLIENT_ERROR_CODE
+        )
     if isinstance(exc, fastapi.HTTPException):
         # This is a pass through, but additionally adds our custom error headers.
         return _make_baseten_response(
@@ -117,6 +125,7 @@ HANDLED_EXCEPTIONS = {
     UserCodeError,
     ModelDefinitionError,
     fastapi.HTTPException,
+    ModelMethodNotImplemented,
 }
 
 


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Various refactors to cleanup interfaces across ModelWrapper/TrussServer. Will leave comments throughout, but high level:
- Raising a 404 when the method wasn't implemented was initially explicitly done in TrussServer. Now it's more generically thrown in ModelWrapper, and then our error handler converts that to a 404.
- Consolidate method args across both classes
- Remove some `@static` methods to clean up invocations
- Previously we would dynamically check that the `model_name` passed in certain routes matched. It seems like this is hardcoded at both the routing layer and truss layer, so we can likely get rid of it. We need to confirm this behavior is ok before merging.

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing

All existing unit tests pass, and
```
$ poetry run pytest truss/tests/test_model_inference.py
```
