### PR TITLE
Modify truss release workflow to be more automated

### DIFF
--- a/.github/workflows/create_release_pr.yml
+++ b/.github/workflows/create_release_pr.yml
@@ -3,9 +3,15 @@ name: Create Release PR
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: 'Version to bump to'
+      release_type:
+        description: 'Select release type (patch, minor, or major)'
         required: true
+        default: patch
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
 
 jobs:
   bump_version:
@@ -20,33 +26,31 @@ jobs:
         curl -sSL https://install.python-poetry.org | python3 -
 
     - name: Bump version in pyproject.toml
-      run: |
-        poetry version $INPUT_VERSION
-      env:
-        INPUT_VERSION: ${{ github.event.inputs.version }}
-
+      id: bump-version
+      run: ./bin/bump_truss_version.sh ${{ github.event.inputs.release_type }}
 
     - name: Commit changes
       run: |
         git config --local user.email "96544894+basetenbot@users.noreply.github.com"
         git config --local user.name "basetenbot"
         git add pyproject.toml
-        git commit -m "Bump version to $INPUT_VERSION"
+        git commit -m "Bump version to $TARGET_VERSION"
       env:
-        INPUT_VERSION: ${{ github.event.inputs.version }}
+        TARGET_VERSION: ${{ steps.bump-version.outputs.version }}
 
     # TODO: Also push changes to main
     - name: Push changes to new branch
       run: |
-        git push origin HEAD:refs/heads/bump-version-${{ github.event.inputs.version }}
+        git push origin HEAD:refs/heads/bump-version-$TARGET_VERSION
       env:
+        TARGET_VERSION: ${{ steps.bump-version.outputs.version }}
         GH_TOKEN: ${{ secrets.BASETENBOT_GITHUB_TOKEN }}
 
     - name: Make PR
       run: |
-        CURR_VERSION=$(curl https://pypi.org/pypi/truss/json | jq ".info.version")
-        PR_BODY="Updating Truss from [$CURR_VERSION](https://pypi.org/pypi/truss/json) to $INPUT_VERSION. **PLEASE ENSURE YOU MERGE, NOT SQUASH**"
-        PR_URL=$(gh pr create --base release --head refs/heads/bump-version-$INPUT_VERSION --title "Release $INPUT_VERSION" --body "$PR_BODY")
+        CURR_VERSION=$(curl -s https://pypi.org/pypi/truss/json | jq -r ".info.version")
+        PR_BODY="Updating Truss from [$CURR_VERSION](https://pypi.org/pypi/truss/json) to $TARGET_VERSION. **PLEASE ENSURE YOU MERGE, NOT SQUASH**"
+        gh pr create --base release --head bump-version-$TARGET_VERSION --title "Release $TARGET_VERSION" --body "$PR_BODY"
       env:
-        INPUT_VERSION: ${{ github.event.inputs.version }}
+        TARGET_VERSION: ${{ steps.bump-version.outputs.version }}
         GH_TOKEN: ${{ secrets.BASETENBOT_GITHUB_TOKEN }}

--- a/bin/bump_truss_version.sh
+++ b/bin/bump_truss_version.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# This script bumps the project version using Poetry.
+# It extracts the current version from `poetry version`, strips any non-semver suffix,
+# and then increments the major, minor, or patch version as specified.
+#
+# Usage:
+#   ./bump_version.sh         # bumps the patch (micro) version by default
+#   ./bump_version.sh major   # bumps the major version (resets minor and patch to 0)
+#   ./bump_version.sh minor   # bumps the minor version (resets patch to 0)
+
+set -euo pipefail
+
+# Default bump type is "patch" (micro)
+BUMP_TYPE="${1:-patch}"
+
+# Get the current version using Poetry.
+# Expected output format: "truss 0.9.60rc006"
+version_output=$(poetry version)
+
+# Extract the version (second field)
+current_version=$(echo "$version_output" | awk '{print $2}')
+
+# Strip any suffix beyond the semver (retain only X.Y.Z)
+semver=$(echo "$current_version" | sed -E 's/^([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+
+# Split the semver into major, minor, and patch
+IFS='.' read -r major minor patch <<< "$semver"
+
+# Bump the version based on the bump type argument
+case "$BUMP_TYPE" in
+  major)
+    major=$((major + 1))
+    minor=0
+    patch=0
+    ;;
+  minor)
+    minor=$((minor + 1))
+    patch=0
+    ;;
+  patch)
+    patch=$((patch + 1))
+    ;;
+  *)
+    echo "Invalid bump type: $BUMP_TYPE. Use 'major', 'minor', or 'patch'."
+    exit 1
+    ;;
+esac
+
+# Construct the new version string
+new_version="${major}.${minor}.${patch}"
+
+# Set the new version using Poetry
+poetry version "$new_version"
+
+# If GITHUB_OUTPUT is set (GitHub Actions context), write the output there.
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  echo "version=${new_version}" >> "${GITHUB_OUTPUT}"
+fi


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Adds more automation to semver changes, in light of a recent mistake which released a bad truss version. Instead of manually specifying a version, you can now specific patch/minor/major and it'll derive automatically. 

Current GH workflow:
<img width="365" alt="image" src="https://github.com/user-attachments/assets/cf16b32a-a0af-4845-a247-95ded520c91c" />


New GH workflow:
<img width="349" alt="image" src="https://github.com/user-attachments/assets/5a60819b-0678-447e-8687-a5f78a9b1113" />


<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing

- Ran this to create https://github.com/basetenlabs/truss/pull/1381
