### PR TITLE
Fix release script, derive current version from pypi

### DIFF
--- a/.github/workflows/create_release_pr.yml
+++ b/.github/workflows/create_release_pr.yml
@@ -25,9 +25,15 @@ jobs:
       run: |
         curl -sSL https://install.python-poetry.org | python3 -
 
+    - name: Get current Truss version
+      id: get-version
+      run: |
+        CURR_VERSION=$(curl -s https://pypi.org/pypi/truss/json | jq -r ".info.version")
+        echo "curr_version=$CURR_VERSION" >> "$GITHUB_OUTPUT"
+
     - name: Bump version in pyproject.toml
       id: bump-version
-      run: ./bin/bump_truss_version.sh ${{ github.event.inputs.release_type }}
+      run: ./bin/bump_truss_version.sh ${{ steps.get-version.outputs.curr_version }} ${{ github.event.inputs.release_type }}
 
     - name: Commit changes
       run: |
@@ -48,9 +54,9 @@ jobs:
 
     - name: Make PR
       run: |
-        CURR_VERSION=$(curl -s https://pypi.org/pypi/truss/json | jq -r ".info.version")
         PR_BODY="Updating Truss from [$CURR_VERSION](https://pypi.org/pypi/truss/json) to $TARGET_VERSION. **PLEASE ENSURE YOU MERGE, NOT SQUASH**"
         gh pr create --base release --head bump-version-$TARGET_VERSION --title "Release $TARGET_VERSION" --body "$PR_BODY"
       env:
+        CURR_VERSION: ${{ steps.get-version.outputs.curr_version }}
         TARGET_VERSION: ${{ steps.bump-version.outputs.version }}
         GH_TOKEN: ${{ secrets.BASETENBOT_GITHUB_TOKEN }}

--- a/bin/bump_truss_version.sh
+++ b/bin/bump_truss_version.sh
@@ -1,44 +1,42 @@
 #!/bin/bash
-# This script bumps the project version using Poetry.
-# It extracts the current version from `poetry version`, strips any non-semver suffix,
-# and then increments the major, minor, or patch version as specified.
+# This script bumps the project version based on an input version number.
+# It takes an existing version number as an argument instead of extracting it via Poetry
+# and increments the major, minor, or patch version as specified.
 #
 # Usage:
-#   ./bump_version.sh         # bumps the patch (micro) version by default
-#   ./bump_version.sh major   # bumps the major version (resets minor and patch to 0)
-#   ./bump_version.sh minor   # bumps the minor version (resets patch to 0)
+#   ./bump_version.sh 0.9.60         # bumps the patch (micro) version by default
+#   ./bump_version.sh 0.9.60 major   # bumps the major version (resets minor and patch to 0)
+#   ./bump_version.sh 0.9.60 minor   # bumps the minor version (resets patch to 0)
 
 set -euo pipefail
 
-# Default bump type is "patch" (micro)
-BUMP_TYPE="${1:-patch}"
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <current_version> [major|minor|patch]"
+  exit 1
+fi
 
-# Get the current version using Poetry.
-# Expected output format: "truss 0.9.60rc006"
-version_output=$(poetry version)
-
-# Extract the version (second field)
-current_version=$(echo "$version_output" | awk '{print $2}')
+CURRENT_VERSION="$1"
+BUMP_TYPE="${2:-patch}"  # Default bump type is "patch" (micro)
 
 # Strip any suffix beyond the semver (retain only X.Y.Z)
-semver=$(echo "$current_version" | sed -E 's/^([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+semver=$(echo "$CURRENT_VERSION" | sed -E 's/^([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
 
 # Split the semver into major, minor, and patch
-IFS='.' read -r major minor patch <<< "$semver"
+IFS='.' read -r major minor path <<< "$semver"
 
 # Bump the version based on the bump type argument
 case "$BUMP_TYPE" in
   major)
     major=$((major + 1))
     minor=0
-    patch=0
+    path=0
     ;;
   minor)
     minor=$((minor + 1))
-    patch=0
+    path=0
     ;;
   patch)
-    patch=$((patch + 1))
+    path=$((path + 1))
     ;;
   *)
     echo "Invalid bump type: $BUMP_TYPE. Use 'major', 'minor', or 'patch'."
@@ -47,7 +45,7 @@ case "$BUMP_TYPE" in
 esac
 
 # Construct the new version string
-new_version="${major}.${minor}.${patch}"
+new_version="${major}.${minor}.${path}"
 
 # Set the new version using Poetry
 poetry version "$new_version"

--- a/bin/bump_truss_version.sh
+++ b/bin/bump_truss_version.sh
@@ -4,9 +4,9 @@
 # and increments the major, minor, or patch version as specified.
 #
 # Usage:
-#   ./bump_version.sh 0.9.60         # bumps the patch (micro) version by default
-#   ./bump_version.sh 0.9.60 major   # bumps the major version (resets minor and patch to 0)
-#   ./bump_version.sh 0.9.60 minor   # bumps the minor version (resets patch to 0)
+#   ./bump_version.sh 0.9.60         # bumps the patch (micro) version by default -> 0.9.61
+#   ./bump_version.sh 0.9.60 major   # bumps the major version (resets minor and patch to 0) -> 1.0.0
+#   ./bump_version.sh 0.9.60 minor   # bumps the minor version (resets patch to 0) -> 0.10.0
 
 set -euo pipefail
 

--- a/bin/bump_truss_version.sh
+++ b/bin/bump_truss_version.sh
@@ -22,21 +22,21 @@ BUMP_TYPE="${2:-patch}"  # Default bump type is "patch" (micro)
 semver=$(echo "$CURRENT_VERSION" | sed -E 's/^([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
 
 # Split the semver into major, minor, and patch
-IFS='.' read -r major minor path <<< "$semver"
+IFS='.' read -r major minor patch <<< "$semver"
 
 # Bump the version based on the bump type argument
 case "$BUMP_TYPE" in
   major)
     major=$((major + 1))
     minor=0
-    path=0
+    patch=0
     ;;
   minor)
     minor=$((minor + 1))
-    path=0
+    patch=0
     ;;
   patch)
-    path=$((path + 1))
+    patch=$((patch + 1))
     ;;
   *)
     echo "Invalid bump type: $BUMP_TYPE. Use 'major', 'minor', or 'patch'."
@@ -45,7 +45,7 @@ case "$BUMP_TYPE" in
 esac
 
 # Construct the new version string
-new_version="${major}.${minor}.${path}"
+new_version="${major}.${minor}.${patch}"
 
 # Set the new version using Poetry
 poetry version "$new_version"


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
My recent attempt to improve the release flow had a slight [bug](https://github.com/basetenlabs/truss/pull/1390#issuecomment-2657017862) which caused us to skip a version number. The root cause is we create RCs off the _next intended_ version, which my script didn't account for. Instead of trying to bake that logic into the script, I actually think it's better to derive the current version from PyPI rather than try to parse it from `pyproject.toml`

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
Created https://github.com/basetenlabs/truss/pull/1394
