### PR TITLE
Missed return in websocket code path

### DIFF
--- a/truss/templates/server/model_wrapper.py
+++ b/truss/templates/server/model_wrapper.py
@@ -799,7 +799,8 @@ class ModelWrapper:
 
         if descriptor.is_async:
             await self._model.websocket(ws)
-        await to_thread.run_sync(self._model.websocket, ws)
+        else:
+            await to_thread.run_sync(self._model.websocket, ws)
 
     async def predict(
         self, inputs: Optional[InputType], request: starlette.requests.Request


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Small fix, old behavior was that for async websocket definitions, we would attempt to await it _and then_ run it synchronously in a thread. The websocket would have already been closed the second time around, but it occasionally was throwing errors like:
```
/usr/local/lib/python3.9/site-packages/anyio/_backends/_asyncio.py:847: RuntimeWarning: coroutine 'Model.websocket' was never awaited
  result = None
```

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
