### PR TITLE
Introduce `truss train` subcommand, API stubs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ keywords = [
 packages = [
     { include = "truss", from = "." },
     { include = "truss_chains", from = "./truss-chains" },
+    { include = "truss_train", from = "./truss-train" },
 ]
 
 requires-poetry = ">=2.0"
@@ -189,7 +190,7 @@ markers = [
 addopts = "--ignore=smoketests"
 
 [tool.ruff]
-src = ["truss", "truss-chains"]
+src = ["truss", "truss-chains", "truss-train"]
 # Parenthesized context managers are not supported in 3.8 but appear in the `templates` dir
 # which still supports 3.8. Therefore use 3.8 for formatting.
 target-version = "py38"

--- a/truss-chains/truss_chains/definitions.py
+++ b/truss-chains/truss_chains/definitions.py
@@ -27,6 +27,7 @@ from typing import (  # type: ignore[attr-defined]  # Chains uses Python >=3.9.
 import pydantic
 from truss.base import truss_config
 from truss.base.constants import PRODUCTION_ENVIRONMENT_NAME
+from truss.base.custom_types import SafeModel, SafeModelNonSerializable
 
 BASETEN_API_SECRET_NAME = "baseten_chain_api_key"
 SECRET_DUMMY = "***"
@@ -68,25 +69,6 @@ class MappingNoIter(Protocol[K, V]):
     def __len__(self) -> int: ...
 
     def __contains__(self, key: K) -> bool: ...
-
-
-class SafeModel(pydantic.BaseModel):
-    """Pydantic base model with reasonable config."""
-
-    model_config = pydantic.ConfigDict(
-        arbitrary_types_allowed=False, strict=True, validate_assignment=True
-    )
-
-
-class SafeModelNonSerializable(pydantic.BaseModel):
-    """Pydantic base model with reasonable config - allowing arbitrary types."""
-
-    model_config = pydantic.ConfigDict(
-        arbitrary_types_allowed=True,
-        strict=True,
-        validate_assignment=True,
-        extra="forbid",
-    )
 
 
 class ChainsUsageError(TypeError):

--- a/truss-train/tests/import/config_with_multiple_training_projects.py
+++ b/truss-train/tests/import/config_with_multiple_training_projects.py
@@ -1,0 +1,18 @@
+from truss_train import definitions
+
+runtime_config = definitions.Runtime(
+    start_commands=["/bin/bash ./my-entrypoint.sh"],
+    environment_variables={
+        "FOO_VAR": "FOO_VAL",
+        "BAR_VAR": definitions.SecretReference(name="BAR_SECRET"),
+    },
+)
+
+training_job = definitions.TrainingJob(
+    image=definitions.Image(base_image="base-image"),
+    compute=definitions.Compute(node_count=1, cpu_count=1),
+    runtime_config=runtime_config,
+)
+
+first_project = definitions.TrainingProject(name="first-project", job=training_job)
+second_project = definitions.TrainingProject(name="second-project", job=training_job)

--- a/truss-train/tests/import/config_with_single_training_project.py
+++ b/truss-train/tests/import/config_with_single_training_project.py
@@ -1,0 +1,17 @@
+from truss_train import definitions
+
+runtime_config = definitions.Runtime(
+    start_commands=["/bin/bash ./my-entrypoint.sh"],
+    environment_variables={
+        "FOO_VAR": "FOO_VAL",
+        "BAR_VAR": definitions.SecretReference(name="BAR_SECRET"),
+    },
+)
+
+training_job = definitions.TrainingJob(
+    image=definitions.Image(base_image="base-image"),
+    compute=definitions.Compute(node_count=1, cpu_count=4),
+    runtime_config=runtime_config,
+)
+
+first_project = definitions.TrainingProject(name="first-project", job=training_job)

--- a/truss-train/tests/import/config_without_training_project.py
+++ b/truss-train/tests/import/config_without_training_project.py
@@ -1,0 +1,15 @@
+from truss_train import definitions
+
+runtime_config = definitions.Runtime(
+    start_commands=["/bin/bash ./my-entrypoint.sh"],
+    environment_variables={
+        "FOO_VAR": "FOO_VAL",
+        "BAR_VAR": definitions.SecretReference(name="BAR_SECRET"),
+    },
+)
+
+_ = definitions.TrainingJob(
+    image=definitions.Image(base_image="base-image"),
+    compute=definitions.Compute(node_count=1, cpu_count=1),
+    runtime_config=runtime_config,
+)

--- a/truss-train/tests/test_loader.py
+++ b/truss-train/tests/test_loader.py
@@ -1,0 +1,38 @@
+import pathlib
+
+import pytest
+
+from truss_train import loader
+
+TEST_ROOT = pathlib.Path(__file__).parent.resolve()
+
+
+def test_import_requires_training_project():
+    job_src = TEST_ROOT / "import" / "config_without_training_project.py"
+    match = r"No `.+` was found."
+    with pytest.raises(ValueError, match=match):
+        with loader.import_target(job_src):
+            pass
+
+
+def test_import_requires_single_training_project():
+    job_src = TEST_ROOT / "import" / "config_with_multiple_training_projects.py"
+    match = r"Multiple `.+`s were found."
+    with pytest.raises(ValueError, match=match):
+        with loader.import_target(job_src):
+            pass
+
+
+def test_import_with_single_training_project():
+    job_src = TEST_ROOT / "import" / "config_with_single_training_project.py"
+    with loader.import_target(job_src) as training_project:
+        assert training_project.name == "first-project"
+        assert training_project.job.compute.cpu_count == 4
+
+
+def test_import_directory_fails():
+    job_src = TEST_ROOT / "import"
+    match = r"You must point to a python file"
+    with pytest.raises(ImportError, match=match):
+        with loader.import_target(job_src):
+            pass

--- a/truss-train/truss_train/__init__.py
+++ b/truss-train/truss_train/__init__.py
@@ -1,0 +1,9 @@
+from truss_train.definitions import (
+    Compute,
+    Runtime,
+    SecretReference,
+    TrainingJob,
+    TrainingProject,
+)
+
+__all__ = ["Compute", "Runtime", "SecretReference", "TrainingJob", "TrainingProject"]

--- a/truss-train/truss_train/definitions.py
+++ b/truss-train/truss_train/definitions.py
@@ -1,0 +1,38 @@
+from typing import Dict, List, Optional, Union
+
+from pydantic import Field
+from truss.base import truss_config
+from truss.base.custom_types import SafeModel
+
+
+class SecretReference(SafeModel):
+    name: str
+
+
+class Compute(SafeModel):
+    node_count: int = 1
+    cpu_count: int = 1
+    memory: str = "2Gi"
+    accelerator: Optional[truss_config.AcceleratorSpec] = None
+
+
+class Runtime(SafeModel):
+    start_commands: List[str] = []
+    environment_variables: Dict[str, Union[str, SecretReference]] = {}
+
+
+class Image(SafeModel):
+    base_image: str
+
+
+class TrainingJob(SafeModel):
+    image: Image
+    compute: Compute = Compute()
+    runtime: Runtime = Runtime()
+
+
+class TrainingProject(SafeModel):
+    name: str
+    # TrainingProject is the wrapper around project config and job config. However, we exclude job
+    # in serialization so just TrainingProject metadata is included in API requests.
+    job: TrainingJob = Field(exclude=True)

--- a/truss-train/truss_train/loader.py
+++ b/truss-train/truss_train/loader.py
@@ -1,0 +1,36 @@
+import contextlib
+import importlib.util
+import os
+import pathlib
+from typing import Iterator
+
+from truss_train import definitions
+
+
+@contextlib.contextmanager
+def import_target(module_path: pathlib.Path) -> Iterator[definitions.TrainingProject]:
+    module_name = module_path.stem
+    if not os.path.isfile(module_path):
+        raise ImportError(
+            f"`{module_path}` is not a file. You must point to a python file where "
+            f"the training configuration is defined."
+        )
+
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    if not spec or not spec.loader:
+        raise ImportError(f"Could not import `{module_path}`. Check path.")
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    module_vars = (getattr(module, name) for name in dir(module))
+    training_projects = [
+        sym for sym in module_vars if isinstance(sym, definitions.TrainingProject)
+    ]
+
+    if len(training_projects) == 0:
+        raise ValueError(f"No `{definitions.TrainingProject}` was found.")
+    elif len(training_projects) > 1:
+        raise ValueError(f"Multiple `{definitions.TrainingProject}`s were found.")
+
+    yield training_projects[0]

--- a/truss/base/custom_types.py
+++ b/truss/base/custom_types.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any
 
+import pydantic
+
 
 # TODO(marius/TaT): kill this.
 class ModelFrameworkType(Enum):
@@ -27,3 +29,22 @@ class Example:
 
     def to_dict(self) -> dict:
         return {"name": self.name, "input": self.input}
+
+
+class SafeModel(pydantic.BaseModel):
+    """Pydantic base model with reasonable config."""
+
+    model_config = pydantic.ConfigDict(
+        arbitrary_types_allowed=False, strict=True, validate_assignment=True
+    )
+
+
+class SafeModelNonSerializable(pydantic.BaseModel):
+    """Pydantic base model with reasonable config - allowing arbitrary types."""
+
+    model_config = pydantic.ConfigDict(
+        arbitrary_types_allowed=True,
+        strict=True,
+        validate_assignment=True,
+        extra="forbid",
+    )

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -865,11 +865,11 @@ def train():
 
 
 @train.command(name="push")
-@click.argument("source", type=Path, required=True)
+@click.argument("config", type=Path, required=True)
 @click.option("--remote", type=str, required=False, help="Remote to use")
 @log_level_option
 @error_handling
-def push_training_job(source: Path, remote: Optional[str]):
+def push_training_job(config: Path, remote: Optional[str]):
     """Run a training job"""
     from truss_train import loader
 
@@ -879,7 +879,7 @@ def push_training_job(source: Path, remote: Optional[str]):
     remote_provider: BasetenRemote = cast(
         BasetenRemote, RemoteFactory.create(remote=remote)
     )
-    with loader.import_target(source) as training_project:
+    with loader.import_target(config) as training_project:
         training_resp = remote_provider.api.upsert_training_project(
             training_project=training_project
         )

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -7,7 +7,7 @@ import time
 import warnings
 from functools import wraps
 from pathlib import Path
-from typing import Callable, List, Optional, Tuple, Union
+from typing import Callable, List, Optional, Tuple, Union, cast
 
 import rich
 import rich.live
@@ -40,6 +40,7 @@ from truss.remote.baseten.core import (
     ModelName,
     ModelVersionId,
 )
+from truss.remote.baseten.remote import BasetenRemote
 from truss.remote.baseten.service import BasetenService
 from truss.remote.baseten.utils.status import get_displayable_status
 from truss.remote.remote_factory import USER_TRUSSRC_PATH, RemoteFactory
@@ -81,6 +82,13 @@ click.rich_click.COMMAND_GROUPS = {
             "commands": ["chains"],
             "table_styles": {  # type: ignore
                 "row_styles": ["red"]
+            },
+        },
+        {
+            "name": "Train",
+            "commands": ["train"],
+            "table_styles": {  # type: ignore
+                "row_styles": ["magenta"]
             },
         },
     ]
@@ -850,6 +858,40 @@ def _load_example_chainlet_code() -> str:
 # End Chains Stuff #####################################################################
 
 
+# Start Training Stuff ####################################################################
+@click.group()
+def train():
+    """Subcommands for truss train"""
+
+
+@train.command(name="push")
+@click.argument("source", type=Path, required=True)
+@click.option("--remote", type=str, required=False, help="Remote to use")
+@log_level_option
+@error_handling
+def push_training_job(source: Path, remote: Optional[str]):
+    """Run a training job"""
+    from truss_train import loader
+
+    if not remote:
+        remote = inquire_remote_name(RemoteFactory.get_available_config_names())
+
+    remote_provider: BasetenRemote = cast(
+        BasetenRemote, RemoteFactory.create(remote=remote)
+    )
+    with loader.import_target(source) as training_project:
+        training_resp = remote_provider.api.upsert_training_project(
+            training_project=training_project
+        )
+
+        remote_provider.api.create_training_job(
+            project_id=training_resp["id"], job=training_project.job
+        )
+
+
+# End Training Stuff #####################################################################
+
+
 def _extract_and_validate_model_identifier(
     target_directory: str,
     model_id: Optional[str],
@@ -1356,6 +1398,7 @@ def _get_truss_from_directory(target_directory: Optional[str] = None):
 truss_cli.add_command(container)
 truss_cli.add_command(image)
 truss_cli.add_command(chains)
+truss_cli.add_command(train)
 
 if __name__ == "__main__":
     truss_cli()

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -10,6 +10,7 @@ from truss.remote.baseten.utils.transfer import base64_encoded_json_str
 
 logger = logging.getLogger(__name__)
 
+
 API_URL_MAPPING = {
     "https://app.baseten.co": "https://api.baseten.co",
     "https://app.staging.baseten.co": "https://api.staging.baseten.co",
@@ -566,3 +567,27 @@ class BasetenApi:
 
         secrets_info = resp.json()
         return secrets_info
+
+    def upsert_training_project(self, training_project):
+        headers = self._auth_token.header()
+        resp = requests.post(
+            f"{self._rest_api_url}/v1/training-projects",
+            headers=headers,
+            json={"training_project": training_project.model_dump()},
+        )
+        if not resp.ok:
+            resp.raise_for_status()
+
+        return resp.json()
+
+    def create_training_job(self, project_id: str, job):
+        headers = self._auth_token.header()
+        resp = requests.post(
+            f"{self._rest_api_url}/v1/training-projects/{project_id}/jobs",
+            headers=headers,
+            json={"training_job": job.model_dump()},
+        )
+        if not resp.ok:
+            resp.raise_for_status()
+
+        return resp.json()

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -552,3 +552,6 @@ class BasetenRemote(TrussRemote):
         self, watch_path: Path, truss_ignore_patterns: List[str]
     ) -> PatchResult:
         return self._patch(watch_path, truss_ignore_patterns, console=None)
+
+    def upsert_training_project(self, training_project):
+        return self._api.upsert_training_project(training_project)


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
This PR adds the foundation for new `truss_train` functionality:
- `truss train push` CLI stub to create a training project + job
- framework code to import + validate training job definitions
- pydantic types (not finalized)

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
- New unit tests
- Sample `truss train push` with the following config:
```
from truss_train import definitions

runtime_config = definitions.RuntimeConfig(
    start_commands=["/bin/bash ./my-entrypoint.sh"],
    environment_variables={
        "FOO_VAR": "FOO_VAL",
        "BAR_VAR": definitions.SecretReference(name="BAR_SECRET"),
    },
)

training_job = definitions.TrainingJob(
    compute=definitions.Compute(node_count=1, cpu_count=4),
    runtime_config=runtime_config,
)

first_project = definitions.TrainingProject(name="first-project", job=training_job)
```
