### PR TITLE
add build resources in trt-llm config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.65"
+version = "0.9.66rc001"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/base/trt_llm_config.py
+++ b/truss/base/trt_llm_config.py
@@ -19,14 +19,6 @@ ENGINE_BUILDER_TRUSS_RUNTIME_MIGRATION = (
     os.environ.get("ENGINE_BUILDER_TRUSS_RUNTIME_MIGRATION", "False") == "True"
 )
 
-# Workaround for briton import without truss installed.
-try:
-    from truss.base.truss_config import Resources
-except ImportError:
-
-    class Resources(BaseModel):  # type: ignore
-        pass
-
 
 class TrussTRTLLMModel(str, Enum):
     ENCODER = "encoder"
@@ -156,18 +148,32 @@ class TrussTRTLLMBuildConfiguration(BaseModel):
         TrussTRTLLMPluginConfiguration()
     )
     num_builder_gpus: Optional[int] = None
-    build_resources: Optional[Resources] = None
+    build_resources: Optional[Any] = None
     speculator: Optional[TrussSpeculatorConfiguration] = None
 
     class Config:
         extra = "forbid"
 
     def __init__(self, **data):
+        data = self.parse_build_resources(data)
         super().__init__(**data)
         self._validate_kv_cache_flags()
         self._validate_speculator_config()
         self._bei_specfic_migration()
         self._depreacate_num_builder_gpus()
+
+    @staticmethod
+    def parse_build_resources(data):
+        build_resources = data.get("build_resources")
+        if build_resources:
+            try:
+                from truss.base.truss_config import Resources
+
+                print("build_resources", build_resources)
+                data["build_resources"] = Resources.from_dict(build_resources)
+            except ImportError:
+                pass
+        return data
 
     def _depreacate_num_builder_gpus(self):
         if self.num_builder_gpus:

--- a/truss/base/trt_llm_config.py
+++ b/truss/base/trt_llm_config.py
@@ -171,7 +171,7 @@ class TrussTRTLLMBuildConfiguration(BaseModel):
 
                 print("build_resources", build_resources)
                 data["build_resources"] = Resources.from_dict(build_resources)
-            except ImportError:
+            except (ImportError, Exception):
                 pass
         return data
 

--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -4,7 +4,7 @@ import sys
 from dataclasses import _MISSING_TYPE, dataclass, field, fields
 from enum import Enum
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, TypeVar
+from typing import Any, Callable, Dict, List, Optional, TypeVar, Union
 
 import yaml
 
@@ -89,10 +89,18 @@ class AcceleratorSpec:
         return self.accelerator.value
 
     @staticmethod
-    def from_str(acc_spec: Optional[str]):
+    def from_str(acc_spec: Optional[Union[str, dict]]):
         if acc_spec is None:
             return AcceleratorSpec()
-        parts = acc_spec.split(":")
+        # if pre-initialized
+        if isinstance(acc_spec, dict):
+            accelerator, count = acc_spec.get("accelerator"), acc_spec.get("count", 1)
+            assert isinstance(accelerator, Accelerator), (
+                f"accelerator must be an Accelerator Enum, got {accelerator}"
+            )
+            parts = [accelerator.value, str(count)]
+        else:
+            parts = acc_spec.split(":")
         count = 1
         if len(parts) not in [1, 2]:
             raise ValidationError("`accelerator` does not match parsing requirements.")

--- a/truss/tests/trt_llm/test_trt_llm_config.py
+++ b/truss/tests/trt_llm/test_trt_llm_config.py
@@ -74,11 +74,13 @@ def test_trt_llm_chunked_prefill_fix(trtllm_config):
 
 
 def test_trt_llm_builder_gpus(trtllm_config):
+    db_dict = {"cpu": "1", "accelerator": "A10G:2", "memory": "1G", "node_count": None}
+    trtllm_config["trt_llm"]["build"]["build_resources"] = db_dict
+
     trt_llm_config = TRTLLMConfiguration(**trtllm_config["trt_llm"])
-    trt_llm_config.build.build_resources = Resources(
-        cpu=1, accelerator="A10G:2", memory="1G"
-    )
-    assert trt_llm_config.build.build_resources.accelerator == "A10G:2"
+    build_resources = Resources.from_dict(db_dict)
+    trt_llm_config.build.build_resources = build_resources
+    assert trt_llm_config.build.build_resources == build_resources
 
 
 def test_trt_llm_lookahead_decoding(trtllm_config):

--- a/truss/tests/trt_llm/test_trt_llm_config.py
+++ b/truss/tests/trt_llm/test_trt_llm_config.py
@@ -9,6 +9,7 @@ from truss.base.trt_llm_config import (
     TrussTRTLLMBuildConfiguration,
     TrussTRTLLMRuntimeConfiguration,
 )
+from truss.base.truss_config import Resources
 
 
 def test_trt_llm_config_init_from_pydantic_models(trtllm_config):
@@ -70,6 +71,14 @@ def test_trt_llm_chunked_prefill_fix(trtllm_config):
     trt_llm2.runtime.enable_chunked_context = False
     trt_llm2.build.plugin_configuration.use_paged_context_fmha = False
     TRTLLMConfiguration(**trt_llm2.model_dump())
+
+
+def test_trt_llm_builder_gpus(trtllm_config):
+    trt_llm_config = TRTLLMConfiguration(**trtllm_config["trt_llm"])
+    trt_llm_config.build.build_resources = Resources(
+        cpu=1, accelerator="A10G:2", memory="1G"
+    )
+    assert trt_llm_config.build.build_resources.accelerator == "A10G:2"
 
 
 def test_trt_llm_lookahead_decoding(trtllm_config):


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: Background
- current engine builder jobs need more GPU memory CPU memory and CPUs in the build job than in the deployment. 
- Generally speaking, the number deployment typically needs only half of the gpus that are needed to set during build time. `number_builder_gpus: int = 2*deployment_gpus`

For some models, we also need more CPU memory for the build stage, especially in cases where CPU memory * 2 < VRAM. 

Examples:
For e.g. a 70B model from fp16 to fp8 we need around:
- 140GB Vram 
- 140GB (loading the model) (potentally + 70GB cpu memory for export.)
-> H100:1 has currently 234GB - works

L4:1 and A10G:1 have issues, as they have issues with memory. 

This PR is just a draft, there could potentially be a much better way to implement this, e.g. by finding the actual replica and get the request limits from it, instead of "blindly" doubeling. 
<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing

<!--
  For each of the categories of requirements, please specify what is required or write "none".

  Pre-release requirements - Are there any changes need to be made or or rolled out before release of this PR?
  - In most cases, before feature flags, Django fields, or internal APIs are deleted, all usages of them should be removed.
  - Link to any PRs that need to be merged and fully deployed before this PR can be merged.

  Post-release requirements - Does anything need to be changed or configured after this PR is merged for it to be fully rolled out?
  - E.g. does a feature flag need to be enabled, a constance value updated, or a management command run?
  - Please include *when* this should happen (e.g. immediately after a deploy, or are there other dependencies or tests that need to take place).
  - Does this change require an image tag update?

  External communication - Does this PR require a docs update, a changelog post, or reaching out to impacted customers?
-->
## :ship: Release requirements

- **Pre-release:** Specify here
- **Post-release:** Specify here
- **External communication:** Specify here
