### PR TITLE
implement `internal_cache` to enable node-level caching

### DIFF
--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -157,6 +157,21 @@ class ModelCache:
 
 
 @dataclass
+class CacheInternal:
+    models: List[ModelRepo] = field(default_factory=list)
+
+    @staticmethod
+    def from_list(items: List[Dict[str, str]]) -> "CacheInternal":
+        return CacheInternal([ModelRepo.from_dict(item) for item in items])
+
+    def to_list(self) -> List[Dict[str, str]]:
+        models = []
+        for model in self.models:
+            models.append({"repo_id": model.to_dict()["repo_id"]})
+        return models
+
+
+@dataclass
 class HealthChecks:
     restart_check_delay_seconds: Optional[int] = None
     restart_threshold_seconds: Optional[int] = None
@@ -607,6 +622,8 @@ class TrussConfig:
     trt_llm: Optional[TRTLLMConfiguration] = None
     build_commands: List[str] = field(default_factory=list)
     use_local_chains_src: bool = False
+    # internal
+    cache_internal: CacheInternal = field(default_factory=CacheInternal)
 
     @property
     def canonical_python_version(self) -> str:
@@ -666,6 +683,10 @@ class TrussConfig:
             model_cache=transform_optional(
                 d.get("model_cache") or d.get("hf_cache") or [],  # type: ignore
                 ModelCache.from_list,
+            ),
+            cache_internal=transform_optional(
+                d.get("cache_internal") or [],  # type: ignore
+                CacheInternal.from_list,
             ),
             trt_llm=transform_optional(
                 d.get("trt_llm"), lambda x: (TRTLLMConfiguration(**x))
@@ -844,6 +865,10 @@ def obj_to_dict(obj, verbose: bool = False):
             elif isinstance(field_curr_value, ModelCache):
                 d["model_cache"] = transform_optional(
                     field_curr_value, lambda data: data.to_list(verbose=verbose)
+                )
+            elif isinstance(field_curr_value, CacheInternal):
+                d["cache_internal"] = transform_optional(
+                    field_curr_value, lambda data: data.to_list()
                 )
             elif isinstance(field_curr_value, TRTLLMConfiguration):
                 d["trt_llm"] = transform_optional(

--- a/truss/tests/test_config.py
+++ b/truss/tests/test_config.py
@@ -15,6 +15,7 @@ from truss.base.truss_config import (
     Accelerator,
     AcceleratorSpec,
     BaseImage,
+    CacheInternal,
     DockerAuthSettings,
     DockerAuthType,
     ModelCache,
@@ -207,6 +208,14 @@ def test_model_framework(model_framework, default_config):
         assert new_config == config.to_dict(verbose=False)
 
 
+def test_null_cache_internal_key():
+    config_yaml_dict = {"cache_internal": None}
+    with tempfile.NamedTemporaryFile(mode="w", delete=False) as tmp_file:
+        yaml.safe_dump(config_yaml_dict, tmp_file)
+    config = TrussConfig.from_yaml(Path(tmp_file.name))
+    assert config.cache_internal == CacheInternal.from_list([])
+
+
 def test_null_model_cache_key():
     config_yaml_dict = {"model_cache": None}
     with tempfile.NamedTemporaryFile(mode="w", delete=False) as tmp_file:
@@ -221,6 +230,22 @@ def test_null_hf_cache_key():
         yaml.safe_dump(config_yaml_dict, tmp_file)
     config = TrussConfig.from_yaml(Path(tmp_file.name))
     assert config.model_cache == ModelCache.from_list([])
+
+
+def test_cache_internal_with_models(default_config):
+    config = TrussConfig(
+        python_version="py39",
+        requirements=[],
+        cache_internal=CacheInternal(
+            models=[ModelRepo("test/model"), ModelRepo("test/model2")]
+        ),
+    )
+    new_config = default_config
+    new_config["cache_internal"] = [
+        {"repo_id": "test/model"},
+        {"repo_id": "test/model2"},
+    ]
+    assert new_config == config.to_dict(verbose=False)
 
 
 def test_huggingface_cache_single_model_default_revision(default_config):


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
* adds new field to truss `internal_cache` to enable specifying repos that should be used for node cache
<!--
  How was the change described above implemented?
-->
## :computer: How
* Re-use existing types, and strip unnecessary fields before sending across the wire
<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
* Tested locally with https://github.com/basetenlabs/baseten/pull/10633