### PR TITLE
Fix truss integration tests

### DIFF
--- a/context_builder.Dockerfile
+++ b/context_builder.Dockerfile
@@ -14,10 +14,11 @@ RUN curl -sSL https://install.python-poetry.org | python -
 
 ENV PATH="/root/.local/bin:${PATH}"
 COPY ./truss ./truss
-# Chains source code is not actually needed (and deps from chains group won't be
+# Chains/train source code is not actually needed (and deps from chains group won't be
 # installed when using `--only builder`). But nonetheless poetry fails the install
 # if this directory is not present/empty - so we copy it.
 COPY ./truss-chains ./truss-chains
+COPY ./truss-train ./truss-train
 COPY ./pyproject.toml ./pyproject.toml
 COPY ./poetry.lock ./poetry.lock
 COPY ./README.md ./README.md

--- a/truss-chains/truss_chains/definitions.py
+++ b/truss-chains/truss_chains/definitions.py
@@ -27,7 +27,6 @@ from typing import (  # type: ignore[attr-defined]  # Chains uses Python >=3.9.
 import pydantic
 from truss.base import truss_config
 from truss.base.constants import PRODUCTION_ENVIRONMENT_NAME
-from truss.base.custom_types import SafeModel, SafeModelNonSerializable
 
 BASETEN_API_SECRET_NAME = "baseten_chain_api_key"
 SECRET_DUMMY = "***"
@@ -69,6 +68,25 @@ class MappingNoIter(Protocol[K, V]):
     def __len__(self) -> int: ...
 
     def __contains__(self, key: K) -> bool: ...
+
+
+class SafeModel(pydantic.BaseModel):
+    """Pydantic base model with reasonable config."""
+
+    model_config = pydantic.ConfigDict(
+        arbitrary_types_allowed=False, strict=True, validate_assignment=True
+    )
+
+
+class SafeModelNonSerializable(pydantic.BaseModel):
+    """Pydantic base model with reasonable config - allowing arbitrary types."""
+
+    model_config = pydantic.ConfigDict(
+        arbitrary_types_allowed=True,
+        strict=True,
+        validate_assignment=True,
+        extra="forbid",
+    )
 
 
 class ChainsUsageError(TypeError):

--- a/truss-train/truss_train/definitions.py
+++ b/truss-train/truss_train/definitions.py
@@ -1,8 +1,15 @@
 from typing import Dict, List, Optional, Union
 
-from pydantic import Field
+import pydantic
 from truss.base import truss_config
-from truss.base.custom_types import SafeModel
+
+
+class SafeModel(pydantic.BaseModel):
+    """Pydantic base model with reasonable config."""
+
+    model_config = pydantic.ConfigDict(
+        arbitrary_types_allowed=False, strict=True, validate_assignment=True
+    )
 
 
 class SecretReference(SafeModel):
@@ -35,4 +42,4 @@ class TrainingProject(SafeModel):
     name: str
     # TrainingProject is the wrapper around project config and job config. However, we exclude job
     # in serialization so just TrainingProject metadata is included in API requests.
-    job: TrainingJob = Field(exclude=True)
+    job: TrainingJob = pydantic.Field(exclude=True)

--- a/truss/base/custom_types.py
+++ b/truss/base/custom_types.py
@@ -2,8 +2,6 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any
 
-import pydantic
-
 
 # TODO(marius/TaT): kill this.
 class ModelFrameworkType(Enum):
@@ -29,22 +27,3 @@ class Example:
 
     def to_dict(self) -> dict:
         return {"name": self.name, "input": self.input}
-
-
-class SafeModel(pydantic.BaseModel):
-    """Pydantic base model with reasonable config."""
-
-    model_config = pydantic.ConfigDict(
-        arbitrary_types_allowed=False, strict=True, validate_assignment=True
-    )
-
-
-class SafeModelNonSerializable(pydantic.BaseModel):
-    """Pydantic base model with reasonable config - allowing arbitrary types."""
-
-    model_config = pydantic.ConfigDict(
-        arbitrary_types_allowed=True,
-        strict=True,
-        validate_assignment=True,
-        extra="forbid",
-    )


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
`truss` integration tests were failing after https://github.com/basetenlabs/truss/pull/1422 for 2 reasons:
- Context builder image building was failing, because we need to copy `./truss-train` into the image (comment exists for chains)
- Chains depends pinned version of the base truss [package](https://github.com/basetenlabs/truss/blob/5d7faf97a7e31d758ad9b53113fa7c228b6327a0/truss-chains/truss_chains/deployment/code_gen.py?plain=1#L639), so moving code into `base` breaks integration tests. I'll figure out the intended way to move code outside of chains in a followup

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
