### PR TITLE
Treat `truss` imports as first party, not third party

### DIFF
--- a/bin/generate_base_images.py
+++ b/bin/generate_base_images.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import List, Optional, Set
 
 from jinja2 import Environment, FileSystemLoader
+
 from truss.base.constants import SUPPORTED_PYTHON_VERSIONS
 from truss.contexts.image_builder.util import (
     truss_base_image_name,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,7 +190,7 @@ markers = [
 addopts = "--ignore=smoketests"
 
 [tool.ruff]
-src = ["truss", "truss-chains", "truss-train"]
+src = [".", "truss-chains", "truss-train"]
 # Parenthesized context managers are not supported in 3.8 but appear in the `templates` dir
 # which still supports 3.8. Therefore use 3.8 for formatting.
 target-version = "py38"

--- a/smoketests/test_chains.py
+++ b/smoketests/test_chains.py
@@ -9,10 +9,10 @@ import uuid
 
 import pytest
 import pytest_check
+
 from truss.remote.baseten import core
 from truss.remote.baseten import remote as b10_remote
 from truss.remote.baseten.utils import status as status_utils
-
 from truss_chains import definitions
 from truss_chains.remote_chainlet import stub, utils
 

--- a/truss-chains/examples/audio-transcription/whisper_chainlet.py
+++ b/truss-chains/examples/audio-transcription/whisper_chainlet.py
@@ -2,9 +2,9 @@ import base64
 import tempfile
 
 import data_types
-from truss.base import truss_config
 
 import truss_chains as chains
+from truss.base import truss_config
 
 
 def base64_to_wav(base64_string, output_file_path):

--- a/truss-chains/examples/mistral/mistral_chainlet.py
+++ b/truss-chains/examples/mistral/mistral_chainlet.py
@@ -1,9 +1,8 @@
 import asyncio
 from typing import Protocol
 
-from truss.base import truss_config
-
 import truss_chains as chains
+from truss.base import truss_config
 
 MISTRAL_HF_MODEL = "mistralai/Mistral-7B-Instruct-v0.2"
 

--- a/truss-chains/tests/test_e2e.py
+++ b/truss-chains/tests/test_e2e.py
@@ -6,12 +6,12 @@ from pathlib import Path
 import pytest
 import requests
 import websockets
+
 from truss.tests.test_testing_utilities_for_other_tests import (
     ensure_kill_all,
     get_container_logs_from_prefix,
 )
 from truss.truss_handle.build import load
-
 from truss_chains import definitions, framework, public_api, utils
 from truss_chains.deployment import deployment_client
 from truss_chains.deployment.code_gen import gen_truss_model_from_source

--- a/truss-chains/truss_chains/definitions.py
+++ b/truss-chains/truss_chains/definitions.py
@@ -26,6 +26,7 @@ from typing import (  # type: ignore[attr-defined]  # Chains uses Python >=3.9.
 )
 
 import pydantic
+
 from truss.base import truss_config
 from truss.base.constants import PRODUCTION_ENVIRONMENT_NAME
 

--- a/truss-chains/truss_chains/deployment/code_gen.py
+++ b/truss-chains/truss_chains/deployment/code_gen.py
@@ -36,11 +36,11 @@ import textwrap
 from typing import Any, Iterable, Mapping, Optional, get_args, get_origin
 
 import libcst
+
 import truss
 from truss.base import truss_config
 from truss.contexts.image_builder import serving_image_builder
 from truss.util import path as truss_path
-
 from truss_chains import definitions, framework, utils
 
 _INDENT = " " * 4

--- a/truss-chains/truss_chains/deployment/deployment_client.py
+++ b/truss-chains/truss_chains/deployment/deployment_client.py
@@ -23,6 +23,7 @@ from typing import (
 import requests
 import tenacity
 import watchfiles
+
 from truss.local import local_config_handler
 from truss.remote import remote_factory
 from truss.remote.baseten import core as b10_core
@@ -33,7 +34,6 @@ from truss.remote.baseten import service as b10_service
 from truss.truss_handle import truss_handle
 from truss.util import log_utils
 from truss.util import path as truss_path
-
 from truss_chains import definitions, framework, utils
 from truss_chains.deployment import code_gen
 

--- a/truss-chains/truss_chains/remote_chainlet/model_skeleton.py
+++ b/truss-chains/truss_chains/remote_chainlet/model_skeleton.py
@@ -2,7 +2,6 @@ import pathlib
 from typing import Optional
 
 from truss.templates.shared import secrets_resolver
-
 from truss_chains import definitions
 from truss_chains.remote_chainlet import utils
 

--- a/truss-chains/truss_chains/remote_chainlet/stub.py
+++ b/truss-chains/truss_chains/remote_chainlet/stub.py
@@ -24,8 +24,8 @@ import aiohttp
 import httpx
 import pydantic
 import tenacity
-from truss.templates.shared import serialization
 
+from truss.templates.shared import serialization
 from truss_chains import definitions
 from truss_chains.remote_chainlet import utils
 

--- a/truss-chains/truss_chains/remote_chainlet/utils.py
+++ b/truss-chains/truss_chains/remote_chainlet/utils.py
@@ -15,8 +15,8 @@ import aiohttp
 import fastapi
 import httpx
 import pydantic
-from truss.templates.shared import dynamic_config_resolver
 
+from truss.templates.shared import dynamic_config_resolver
 from truss_chains import definitions
 
 T = TypeVar("T")

--- a/truss-train/truss_train/definitions.py
+++ b/truss-train/truss_train/definitions.py
@@ -1,6 +1,7 @@
 from typing import Dict, List, Optional, Union
 
 import pydantic
+
 from truss.base import truss_config
 
 

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -16,10 +16,11 @@ import rich.spinner
 import rich.table
 import rich.traceback
 import rich_click as click
-import truss
 from InquirerPy import inquirer
 from rich import progress
 from rich.console import Console
+
+import truss
 from truss.base.constants import (
     PRODUCTION_ENVIRONMENT_NAME,
     TRTLLM_MIN_MEMORY_REQUEST_GI,

--- a/truss/cli/remote_cli.py
+++ b/truss/cli/remote_cli.py
@@ -3,6 +3,7 @@ from typing import List
 import rich
 from InquirerPy import inquirer
 from InquirerPy.validator import ValidationError, Validator
+
 from truss.remote.remote_factory import USER_TRUSSRC_PATH, RemoteFactory
 from truss.remote.truss_remote import RemoteConfig
 

--- a/truss/contexts/docker_build_setup.py
+++ b/truss/contexts/docker_build_setup.py
@@ -5,6 +5,7 @@ import pathlib
 import sys
 
 import click
+
 from truss.patch.hash import directory_content_hash
 from truss.patch.truss_dir_patch_applier import TrussDirPatchApplier
 from truss.templates.control.control.helpers.custom_types import Patch

--- a/truss/contexts/image_builder/serving_image_builder.py
+++ b/truss/contexts/image_builder/serving_image_builder.py
@@ -12,6 +12,7 @@ from botocore.client import Config
 from google.cloud import storage
 from huggingface_hub import get_hf_file_metadata, hf_hub_url, list_repo_files
 from huggingface_hub.utils import filter_repo_objects
+
 from truss.base import constants
 from truss.base.constants import (
     BASE_SERVER_REQUIREMENTS_TXT_FILENAME,

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -3,6 +3,7 @@ from enum import Enum
 from typing import Any, Dict, List, Optional
 
 import requests
+
 from truss.remote.baseten import custom_types as b10_types
 from truss.remote.baseten.auth import ApiKey, AuthService
 from truss.remote.baseten.error import ApiError

--- a/truss/remote/baseten/custom_types.py
+++ b/truss/remote/baseten/custom_types.py
@@ -4,6 +4,7 @@ from enum import Enum
 from typing import Optional
 
 import pydantic
+
 import truss
 
 

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -6,15 +6,10 @@ from typing import TYPE_CHECKING, List, NamedTuple, Optional, Tuple, Type
 
 import yaml
 from requests import ReadTimeout
-
-from truss.base.constants import PRODUCTION_ENVIRONMENT_NAME
-
-if TYPE_CHECKING:
-    from rich import console as rich_console
-    from rich import progress
 from watchfiles import watch
 
 from truss.base import validation
+from truss.base.constants import PRODUCTION_ENVIRONMENT_NAME
 from truss.base.truss_config import ModelServer
 from truss.local.local_config_handler import LocalConfigHandler
 from truss.remote.baseten import custom_types
@@ -46,6 +41,10 @@ from truss.remote.truss_remote import RemoteUser, TrussRemote
 from truss.truss_handle import build as truss_build
 from truss.truss_handle.truss_handle import TrussHandle
 from truss.util.path import is_ignored, load_trussignore_patterns_from_truss_dir
+
+if TYPE_CHECKING:
+    from rich import console as rich_console
+    from rich import progress
 
 
 class PatchStatus(enum.Enum):

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -6,11 +6,14 @@ from typing import TYPE_CHECKING, List, NamedTuple, Optional, Tuple, Type
 
 import yaml
 from requests import ReadTimeout
+
 from truss.base.constants import PRODUCTION_ENVIRONMENT_NAME
 
 if TYPE_CHECKING:
     from rich import console as rich_console
     from rich import progress
+from watchfiles import watch
+
 from truss.base import validation
 from truss.base.truss_config import ModelServer
 from truss.local.local_config_handler import LocalConfigHandler
@@ -43,7 +46,6 @@ from truss.remote.truss_remote import RemoteUser, TrussRemote
 from truss.truss_handle import build as truss_build
 from truss.truss_handle.truss_handle import TrussHandle
 from truss.util.path import is_ignored, load_trussignore_patterns_from_truss_dir
-from watchfiles import watch
 
 
 class PatchStatus(enum.Enum):

--- a/truss/remote/baseten/service.py
+++ b/truss/remote/baseten/service.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, Iterator, NamedTuple, Optional
 
 import requests
 from tenacity import retry, stop_after_delay, wait_fixed
+
 from truss.base.errors import RemoteNetworkError
 from truss.remote.baseten.api import BasetenApi
 from truss.remote.baseten.auth import AuthService

--- a/truss/remote/baseten/utils/transfer.py
+++ b/truss/remote/baseten/utils/transfer.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Optional, Type
 
 import boto3
 from boto3.s3.transfer import TransferConfig
+
 from truss.util.env_vars import override_env_vars
 
 if TYPE_CHECKING:

--- a/truss/tests/contexts/image_builder/test_serving_image_builder.py
+++ b/truss/tests/contexts/image_builder/test_serving_image_builder.py
@@ -6,6 +6,7 @@ from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
 import pytest
+
 from truss.base.constants import (
     BASE_TRTLLM_REQUIREMENTS,
     TRTLLM_BASE_IMAGE,

--- a/truss/tests/patch/test_calc_patch.py
+++ b/truss/tests/patch/test_calc_patch.py
@@ -4,6 +4,7 @@ from typing import Any, Callable, List, Optional
 
 import pytest
 import yaml
+
 from truss.base.truss_config import TrussConfig
 from truss.templates.control.control.helpers.custom_types import (
     Action,

--- a/truss/tests/patch/test_hash.py
+++ b/truss/tests/patch/test_hash.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Callable, List
 
 import pytest
+
 from truss.truss_handle.patch.hash import (
     directory_content_hash,
     file_content_hash,

--- a/truss/tests/patch/test_truss_dir_patch_applier.py
+++ b/truss/tests/patch/test_truss_dir_patch_applier.py
@@ -2,6 +2,7 @@ import logging
 from pathlib import Path
 
 import yaml
+
 from truss.base.truss_config import TrussConfig
 from truss.templates.control.control.helpers.custom_types import (
     Action,

--- a/truss/tests/remote/baseten/test_api.py
+++ b/truss/tests/remote/baseten/test_api.py
@@ -3,12 +3,12 @@ from unittest import mock
 import pytest
 import requests
 from requests import Response
+
+import truss_train.definitions as train_definitions
 from truss.remote.baseten import custom_types as b10_types
 from truss.remote.baseten.api import BasetenApi
 from truss.remote.baseten.custom_types import ChainletDataAtomic, OracleData
 from truss.remote.baseten.error import ApiError
-
-import truss_train.definitions as train_definitions
 
 
 @pytest.fixture

--- a/truss/tests/remote/baseten/test_auth.py
+++ b/truss/tests/remote/baseten/test_auth.py
@@ -1,4 +1,5 @@
 import pytest
+
 from truss.remote.baseten.auth import ApiKey, AuthService
 from truss.remote.baseten.error import AuthorizationError
 

--- a/truss/tests/remote/baseten/test_core.py
+++ b/truss/tests/remote/baseten/test_core.py
@@ -3,6 +3,7 @@ from tempfile import NamedTemporaryFile
 from unittest.mock import MagicMock
 
 import pytest
+
 from truss.base.constants import PRODUCTION_ENVIRONMENT_NAME
 from truss.base.errors import ValidationError
 from truss.remote.baseten import core

--- a/truss/tests/remote/baseten/test_remote.py
+++ b/truss/tests/remote/baseten/test_remote.py
@@ -1,5 +1,6 @@
 import pytest
 import requests_mock
+
 from truss.remote.baseten.core import (
     ModelId,
     ModelName,

--- a/truss/tests/remote/test_remote_factory.py
+++ b/truss/tests/remote/test_remote_factory.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 import pytest
+
 from truss.remote.remote_factory import RemoteFactory
 from truss.remote.truss_remote import RemoteConfig, RemoteUser, TrussRemote
 

--- a/truss/tests/remote/test_truss_remote.py
+++ b/truss/tests/remote/test_truss_remote.py
@@ -3,6 +3,7 @@ from unittest import mock
 
 import pytest
 from requests import Response
+
 from truss.remote.truss_remote import TrussService
 
 TEST_SERVICE_URL = "http://test.com"

--- a/truss/tests/templates/control/control/helpers/test_model_container_patch_applier.py
+++ b/truss/tests/templates/control/control/helpers/test_model_container_patch_applier.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
+
 from truss.base.truss_config import TrussConfig
 
 # Needed to simulate the set up on the model docker container

--- a/truss/tests/templates/control/control/helpers/test_requirement_name_identifier.py
+++ b/truss/tests/templates/control/control/helpers/test_requirement_name_identifier.py
@@ -1,4 +1,5 @@
 import pytest
+
 from truss.templates.control.control.helpers.truss_patch.requirement_name_identifier import (
     RequirementMeta,
     identify_requirement_name,

--- a/truss/tests/templates/control/control/test_server.py
+++ b/truss/tests/templates/control/control/test_server.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, patch
 import httpx
 import pytest
 from tenacity import RetryError
+
 from truss.truss_handle.patch.custom_types import PatchRequest
 
 # Needed to simulate the set up on the model docker container

--- a/truss/tests/templates/core/server/test_dynamic_config_resolver.py
+++ b/truss/tests/templates/core/server/test_dynamic_config_resolver.py
@@ -2,8 +2,8 @@ import json
 
 import aiofiles
 import pytest
-from truss.templates.shared import dynamic_config_resolver
 
+from truss.templates.shared import dynamic_config_resolver
 from truss_chains import definitions
 
 

--- a/truss/tests/templates/core/server/test_lazy_data_resolver.py
+++ b/truss/tests/templates/core/server/test_lazy_data_resolver.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 
 import pytest
 import requests_mock
+
 from truss.templates.shared.lazy_data_resolver import (
     BASETEN_FS_ENABLED_ENV_VAR,
     LAZY_DATA_RESOLVER_PATH,

--- a/truss/tests/templates/core/server/test_lazy_data_resolver_v2.py
+++ b/truss/tests/templates/core/server/test_lazy_data_resolver_v2.py
@@ -4,6 +4,7 @@ import time
 from pathlib import Path
 
 import pytest
+
 from truss.templates.shared.lazy_data_resolver import (
     TRUSS_TRANSFER_AVAILABLE,
     LazyDataResolverV2,

--- a/truss/tests/templates/server/common/test_retry.py
+++ b/truss/tests/templates/server/common/test_retry.py
@@ -2,6 +2,7 @@ from typing import Any
 from unittest.mock import Mock
 
 import pytest
+
 from truss.templates.server.common.retry import retry
 
 

--- a/truss/tests/templates/server/test_schema.py
+++ b/truss/tests/templates/server/test_schema.py
@@ -2,6 +2,7 @@ import inspect
 from typing import AsyncGenerator, Awaitable, Generator, Union
 
 from pydantic import BaseModel
+
 from truss.templates.server.common.schema import TrussSchema
 
 

--- a/truss/tests/trt_llm/test_trt_llm_config.py
+++ b/truss/tests/trt_llm/test_trt_llm_config.py
@@ -1,6 +1,7 @@
 import copy
 
 import pytest
+
 from truss.base.trt_llm_config import (
     TRTLLMConfiguration,
     TrussSpecDecMode,

--- a/truss/tests/trt_llm/test_validation.py
+++ b/truss/tests/trt_llm/test_validation.py
@@ -1,4 +1,5 @@
 import pytest
+
 from truss.base.errors import ValidationError
 from truss.base.truss_spec import TrussSpec
 from truss.trt_llm.validation import _verify_has_class_init_arg, validate

--- a/truss/tests/util/test_config_checks.py
+++ b/truss/tests/util/test_config_checks.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 import pytest
+
 from truss.base.constants import TRTLLM_MIN_MEMORY_REQUEST_GI
 from truss.trt_llm.config_checks import (
     is_missing_secrets_for_trt_llm_builder,

--- a/truss/trt_llm/config_checks.py
+++ b/truss/trt_llm/config_checks.py
@@ -1,4 +1,5 @@
 import requests
+
 from truss.base.constants import (
     HF_ACCESS_TOKEN_KEY,
     HF_MODELS_API_URL,

--- a/truss/util/download.py
+++ b/truss/util/download.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Optional
 
 import requests
+
 from truss.base.truss_config import ExternalData
 
 B10CP_EXECUTABLE_NAME = "b10cp"


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Fixes our categorization of imports from `truss` to be first party instead of third party as it is today. The `pyproject.toml` change is the main one to review.

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
