### PR TITLE
Support local `truss` source code, refactor common pydantic types

### DIFF
--- a/truss-chains/tests/test_e2e.py
+++ b/truss-chains/tests/test_e2e.py
@@ -34,7 +34,7 @@ def test_chain():
             chain_root, "ItestChain"
         ) as entrypoint:
             options = definitions.PushOptionsLocalDocker(
-                chain_name="integration-test", use_local_chains_src=True
+                chain_name="integration-test", use_local_src=True
             )
             service = deployment_client.push(entrypoint, options)
 
@@ -161,7 +161,7 @@ def test_streaming_chain():
                 options=definitions.PushOptionsLocalDocker(
                     chain_name="integration-test-stream",
                     only_generate_trusses=False,
-                    use_local_chains_src=True,
+                    use_local_src=True,
                 ),
             )
             assert service is not None
@@ -219,7 +219,7 @@ def test_numpy_chain(mode):
                 options=definitions.PushOptionsLocalDocker(
                     chain_name=f"integration-test-numpy-{mode}",
                     only_generate_trusses=False,
-                    use_local_chains_src=True,
+                    use_local_src=True,
                 ),
             )
             assert service is not None
@@ -237,7 +237,7 @@ async def test_timeout():
             chain_root, "TimeoutChain"
         ) as entrypoint:
             options = definitions.PushOptionsLocalDocker(
-                chain_name="integration-test", use_local_chains_src=True
+                chain_name="integration-test", use_local_src=True
             )
             service = deployment_client.push(entrypoint, options)
 
@@ -281,7 +281,7 @@ TimeoutError: Timeout calling remote Chainlet `DependencySync` \(0.5 seconds lim
 def test_traditional_truss():
     with ensure_kill_all():
         chain_root = TEST_ROOT / "traditional_truss" / "truss_model.py"
-        truss_dir = gen_truss_model_from_source(chain_root, use_local_chains_src=True)
+        truss_dir = gen_truss_model_from_source(chain_root, use_local_src=True)
         truss_handle = load(truss_dir)
 
         assert truss_handle.spec.config.resources.cpu == "4"
@@ -310,7 +310,7 @@ def test_custom_health_checks_chain():
                 options=definitions.PushOptionsLocalDocker(
                     chain_name="integration-test-custom-health-checks",
                     only_generate_trusses=False,
-                    use_local_chains_src=True,
+                    use_local_src=True,
                 ),
             )
 
@@ -347,7 +347,7 @@ async def test_websocket_chain(anyio_backend):
                 options=definitions.PushOptionsLocalDocker(
                     chain_name=chain_name,
                     only_generate_trusses=False,
-                    use_local_chains_src=True,
+                    use_local_src=True,
                 ),
             )
             # Get something like `ws://localhost:38605/v1/websocket`.

--- a/truss-chains/truss_chains/definitions.py
+++ b/truss-chains/truss_chains/definitions.py
@@ -771,7 +771,7 @@ class PushOptionsLocalDocker(PushOptions):
     # If enabled, chains code is copied from the local package into `/app/truss_chains`
     # in the docker image (which takes precedence over potential pip/site-packages).
     # This should be used for integration tests or quick local dev loops.
-    use_local_chains_src: bool = False
+    use_local_src: bool = False
 
 
 class WebSocketProtocol(Protocol):

--- a/truss-chains/truss_chains/deployment/code_gen.py
+++ b/truss-chains/truss_chains/deployment/code_gen.py
@@ -40,6 +40,7 @@ import libcst
 import truss
 from truss.base import truss_config
 from truss.contexts.image_builder import serving_image_builder
+from truss.shared import types
 from truss.util import path as truss_path
 from truss_chains import definitions, framework, utils
 
@@ -90,7 +91,7 @@ def _format_python_file(file_path: pathlib.Path) -> None:
     _run_simple_subprocess(f"ruff format {file_path}")
 
 
-class _Source(definitions.SafeModelNonSerializable):
+class _Source(types.SafeModelNonSerializable):
     src: str
     imports: set[str] = set()
 

--- a/truss-chains/truss_chains/deployment/code_gen.py
+++ b/truss-chains/truss_chains/deployment/code_gen.py
@@ -685,7 +685,7 @@ def _write_truss_config_yaml(
     chains_config: definitions.RemoteConfig,
     chainlet_to_service: Mapping[str, definitions.ServiceDescriptor],
     model_name: str,
-    use_local_chains_src: bool,
+    use_local_src: bool,
     is_websocket_endpoint: bool,
 ):
     """Generate a truss config for a Chainlet."""
@@ -718,7 +718,7 @@ def _write_truss_config_yaml(
     if chains_config.docker_image.external_package_dirs:
         for ext_dir in chains_config.docker_image.external_package_dirs:
             config.external_package_dirs.append(ext_dir.abs_path)
-    config.use_local_chains_src = use_local_chains_src
+    config.use_local_src = use_local_src
     # Assets.
     assets = chains_config.get_asset_spec()
     config.secrets = assets.secrets
@@ -744,7 +744,7 @@ def _write_truss_config_yaml(
 
 
 def gen_truss_model_from_source(
-    model_src: pathlib.Path, use_local_chains_src: bool = False
+    model_src: pathlib.Path, use_local_src: bool = False
 ) -> pathlib.Path:
     # TODO(nikhil): Improve detection of directory structure, since right now
     # we assume a flat structure
@@ -755,7 +755,7 @@ def gen_truss_model_from_source(
             model_root=root_dir,
             model_name=entrypoint_cls.display_name,
             model_descriptor=descriptor,
-            use_local_chains_src=use_local_chains_src,
+            use_local_src=use_local_src,
         )
 
 
@@ -763,13 +763,13 @@ def gen_truss_model(
     model_root: pathlib.Path,
     model_name: str,
     model_descriptor: definitions.ChainletAPIDescriptor,
-    use_local_chains_src: bool = False,
+    use_local_src: bool = False,
 ) -> pathlib.Path:
     return gen_truss_chainlet(
         chain_root=model_root,
         chain_name=model_name,
         chainlet_descriptor=model_descriptor,
-        use_local_chains_src=use_local_chains_src,
+        use_local_src=use_local_src,
     )
 
 
@@ -778,7 +778,7 @@ def gen_truss_chainlet(
     chain_name: str,
     chainlet_descriptor: definitions.ChainletAPIDescriptor,
     model_name: Optional[str] = None,
-    use_local_chains_src: bool = False,
+    use_local_src: bool = False,
 ) -> pathlib.Path:
     # Filter needed services and customize options.
     dep_services = {}
@@ -797,7 +797,7 @@ def gen_truss_chainlet(
         chains_config=chainlet_descriptor.chainlet_cls.remote_config,
         model_name=model_name or chain_name,
         chainlet_to_service=dep_services,
-        use_local_chains_src=use_local_chains_src,
+        use_local_src=use_local_src,
         is_websocket_endpoint=chainlet_descriptor.endpoint.is_websocket,
     )
     # This assumes all imports are absolute w.r.t chain root (or site-packages).

--- a/truss-chains/truss_chains/deployment/deployment_client.py
+++ b/truss-chains/truss_chains/deployment/deployment_client.py
@@ -139,9 +139,9 @@ class _ChainSourceGenerator:
         self._options = options
 
     @property
-    def _use_local_chains_src(self) -> bool:
+    def _use_local_src(self) -> bool:
         if isinstance(self._options, definitions.PushOptionsLocalDocker):
-            return self._options.use_local_chains_src
+            return self._options.use_local_src
         return False
 
     def generate_chainlet_artifacts(
@@ -172,7 +172,7 @@ class _ChainSourceGenerator:
                 self._options.chain_name,
                 chainlet_descriptor,
                 model_name,
-                self._use_local_chains_src,
+                self._use_local_src,
             )
             artifact = b10_types.ChainletArtifact(
                 truss_dir=chainlet_dir,
@@ -707,7 +707,7 @@ class _Watcher:
                 self._deployed_chain_name,
                 descr,
                 self._chainlet_data[descr.display_name].oracle_name,
-                use_local_chains_src=False,
+                use_local_src=False,
             )
             patch_result = self._remote_provider.patch_for_chainlet(
                 chainlet_dir, self._ignore_patterns

--- a/truss-chains/truss_chains/framework.py
+++ b/truss-chains/truss_chains/framework.py
@@ -33,9 +33,9 @@ from typing import (
 )
 
 import pydantic
-from truss.shared import types as shared_types
 from typing_extensions import ParamSpec
 
+from truss.shared import types as shared_types
 from truss_chains import definitions, utils
 
 _SIMPLE_TYPES = {int, float, complex, bool, str, bytes, None, pydantic.BaseModel}

--- a/truss-chains/truss_chains/framework.py
+++ b/truss-chains/truss_chains/framework.py
@@ -33,6 +33,7 @@ from typing import (
 )
 
 import pydantic
+from truss.shared import types as shared_types
 from typing_extensions import ParamSpec
 
 from truss_chains import definitions, utils
@@ -68,7 +69,7 @@ class _ErrorKind(str, enum.Enum):
     MISSING_API_ERROR = enum.auto()
 
 
-class _ErrorLocation(definitions.SafeModel):
+class _ErrorLocation(shared_types.SafeModel):
     src_path: str
     line: Optional[int] = None
     chainlet_name: Optional[str] = None
@@ -85,7 +86,7 @@ class _ErrorLocation(definitions.SafeModel):
         return value
 
 
-class _ValidationError(definitions.SafeModel):
+class _ValidationError(shared_types.SafeModel):
     msg: str
     kind: _ErrorKind
     location: _ErrorLocation

--- a/truss-train/truss_train/definitions.py
+++ b/truss-train/truss_train/definitions.py
@@ -3,43 +3,36 @@ from typing import Dict, List, Optional, Union
 import pydantic
 
 from truss.base import truss_config
+from truss.shared import types
 
 
-class SafeModel(pydantic.BaseModel):
-    """Pydantic base model with reasonable config."""
-
-    model_config = pydantic.ConfigDict(
-        arbitrary_types_allowed=False, strict=True, validate_assignment=True
-    )
-
-
-class SecretReference(SafeModel):
+class SecretReference(types.SafeModel):
     name: str
 
 
-class Compute(SafeModel):
+class Compute(types.SafeModel):
     node_count: int = 1
     cpu_count: int = 1
     memory: str = "2Gi"
     accelerator: Optional[truss_config.AcceleratorSpec] = None
 
 
-class Runtime(SafeModel):
+class Runtime(types.SafeModel):
     start_commands: List[str] = []
     environment_variables: Dict[str, Union[str, SecretReference]] = {}
 
 
-class Image(SafeModel):
+class Image(types.SafeModel):
     base_image: str
 
 
-class TrainingJob(SafeModel):
+class TrainingJob(types.SafeModel):
     image: Image
     compute: Compute = Compute()
     runtime: Runtime = Runtime()
 
 
-class TrainingProject(SafeModel):
+class TrainingProject(types.SafeModel):
     name: str
     # TrainingProject is the wrapper around project config and job config. However, we exclude job
     # in serialization so just TrainingProject metadata is included in API requests.

--- a/truss/base/constants.py
+++ b/truss/base/constants.py
@@ -25,6 +25,7 @@ SHARED_SERVING_AND_TRAINING_CODE_DIR: pathlib.Path = (
 )
 CONTROL_SERVER_CODE_DIR: pathlib.Path = TEMPLATES_DIR / "control"
 CHAINS_CODE_DIR: pathlib.Path = _TRUSS_ROOT.parent / "truss-chains" / "truss_chains"
+TRUSS_CODE_DIR: pathlib.Path = _TRUSS_ROOT.parent / "truss"
 
 SUPPORTED_PYTHON_VERSIONS = {"3.8", "3.9", "3.10", "3.11"}
 MAX_SUPPORTED_PYTHON_VERSION_IN_CUSTOM_BASE_IMAGE = "3.12"

--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -621,7 +621,7 @@ class TrussConfig:
     model_cache: ModelCache = field(default_factory=ModelCache)
     trt_llm: Optional[TRTLLMConfiguration] = None
     build_commands: List[str] = field(default_factory=list)
-    use_local_chains_src: bool = False
+    use_local_src: bool = False
     # internal
     cache_internal: CacheInternal = field(default_factory=CacheInternal)
 
@@ -692,7 +692,7 @@ class TrussConfig:
                 d.get("trt_llm"), lambda x: (TRTLLMConfiguration(**x))
             ),
             build_commands=d.get("build_commands", []),
-            use_local_chains_src=d.get("use_local_chains_src", False),
+            use_local_src=d.get("use_local_src", False),
         )
         config.validate()
         return config

--- a/truss/contexts/image_builder/serving_image_builder.py
+++ b/truss/contexts/image_builder/serving_image_builder.py
@@ -41,6 +41,7 @@ from truss.base.constants import (
     TRTLLM_PREDICT_CONCURRENCY,
     TRTLLM_PYTHON_EXECUTABLE,
     TRTLLM_TRUSS_DIR,
+    TRUSS_CODE_DIR,
     TRUSSLESS_MAX_PAYLOAD_SIZE,
     USER_SUPPLIED_REQUIREMENTS_TXT_FILENAME,
 )
@@ -78,6 +79,7 @@ BUILD_SERVER_DIR_NAME = "server"
 BUILD_CONTROL_SERVER_DIR_NAME = "control"
 BUILD_SERVER_EXTENSIONS_PATH = "extensions"
 BUILD_CHAINS_DIR_NAME = "truss_chains"
+BUILD_TRUSS_DIR_NAME = "truss"
 
 CONFIG_FILE = "config.yaml"
 USER_TRUSS_IGNORE_FILE = ".truss_ignore"
@@ -543,8 +545,9 @@ class ServingImageBuilder(ImageBuilder):
                 + SHARED_SERVING_AND_TRAINING_CODE_DIR_NAME,
             )
 
-        if config.use_local_chains_src:
+        if config.use_local_src:
             self._copy_into_build_dir(CHAINS_CODE_DIR, build_dir, BUILD_CHAINS_DIR_NAME)
+            self._copy_into_build_dir(TRUSS_CODE_DIR, build_dir, BUILD_TRUSS_DIR_NAME)
 
         # Copy base TrussServer requirements if supplied custom base image
         base_truss_server_reqs_filepath = SERVER_CODE_DIR / REQUIREMENTS_TXT_FILENAME
@@ -691,7 +694,7 @@ class ServingImageBuilder(ImageBuilder):
             hf_access_token_file_name=HF_ACCESS_TOKEN_FILE_NAME,
             external_data_files=external_data_files,
             build_commands=build_commands,
-            use_local_chains_src=config.use_local_chains_src,
+            use_local_src=config.use_local_src,
             **FILENAME_CONSTANTS_MAP,
         )
         docker_file_path = build_dir / MODEL_DOCKERFILE_NAME

--- a/truss/shared/__init__.py
+++ b/truss/shared/__init__.py
@@ -1,0 +1,9 @@
+import pydantic
+
+pydantic_major_version = int(pydantic.VERSION.split(".")[0])
+if pydantic_major_version < 2:
+    raise RuntimeError(
+        f"Pydantic version {pydantic.VERSION} is not supported for shared code."
+    )
+
+del pydantic, pydantic_major_version

--- a/truss/shared/__init__.py
+++ b/truss/shared/__init__.py
@@ -3,7 +3,7 @@ import pydantic
 pydantic_major_version = int(pydantic.VERSION.split(".")[0])
 if pydantic_major_version < 2:
     raise RuntimeError(
-        f"Pydantic version {pydantic.VERSION} is not supported for shared code."
+        "Please upgrade to pydantic v2 to use shared chains / train features"
     )
 
 del pydantic, pydantic_major_version

--- a/truss/shared/types.py
+++ b/truss/shared/types.py
@@ -1,0 +1,20 @@
+import pydantic
+
+
+class SafeModel(pydantic.BaseModel):
+    """Pydantic base model with reasonable config."""
+
+    model_config = pydantic.ConfigDict(
+        arbitrary_types_allowed=False, strict=True, validate_assignment=True
+    )
+
+
+class SafeModelNonSerializable(pydantic.BaseModel):
+    """Pydantic base model with reasonable config - allowing arbitrary types."""
+
+    model_config = pydantic.ConfigDict(
+        arbitrary_types_allowed=True,
+        strict=True,
+        validate_assignment=True,
+        extra="forbid",
+    )

--- a/truss/templates/server.Dockerfile.jinja
+++ b/truss/templates/server.Dockerfile.jinja
@@ -80,9 +80,10 @@ COPY ./{{config.data_dir}} /app/data
 COPY ./server /app
 {%- endif %}
 
-{%- if use_local_chains_src %}
+{%- if use_local_src %}
 {# This path takes precedence over site-packages. #}
 COPY ./truss_chains /app/truss_chains
+COPY ./truss /app/truss
 {%- endif %}
 
 COPY ./config.yaml /app/config.yaml


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
This PR does two things:
- Allows both `truss` and `truss_chains` src to be injected into the container if `use_local_src` is set
- Refactors common `SafeModel` and `SafeModelNonSerializable`, now that the integration test failures initially caused by https://github.com/basetenlabs/truss/pull/1422 are fixed by above

Recommended to review by commit to see the isolated changes

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
```
$ poetry run pytest truss-chains/tests/test_e2e.py::test_traditional_truss
```

now works
