### PR TITLE
truss trt - config update refactor [max_seq_len]

### DIFF
--- a/truss/base/constants.py
+++ b/truss/base/constants.py
@@ -112,7 +112,9 @@ BEI_TRTLLM_BASE_IMAGE = "baseten/bei:0.0.18"
 
 BEI_TRTLLM_PYTHON_EXECUTABLE = "/usr/bin/python3"
 
-OPENAI_COMPATIBLE_TAG = "openai-compatible"
+OPENAI_COMPATIBLE_TAG = (
+    "openai-compatible"  # deprecated - openai-compatible is now the default
+)
 OPENAI_NON_COMPATIBLE_TAG = "non-openai-compatible"
 
 

--- a/truss/base/constants.py
+++ b/truss/base/constants.py
@@ -113,5 +113,7 @@ BEI_TRTLLM_BASE_IMAGE = "baseten/bei:0.0.18"
 BEI_TRTLLM_PYTHON_EXECUTABLE = "/usr/bin/python3"
 
 OPENAI_COMPATIBLE_TAG = "openai-compatible"
+OPENAI_NON_COMPATIBLE_TAG = "non-openai-compatible"
+
 
 PRODUCTION_ENVIRONMENT_NAME = "production"

--- a/truss/base/trt_llm_config.py
+++ b/truss/base/trt_llm_config.py
@@ -128,7 +128,7 @@ class TrussTRTLLMRuntimeConfiguration(BaseModel):
 
 class TrussTRTLLMBuildConfiguration(BaseModel):
     base_model: TrussTRTLLMModel = TrussTRTLLMModel.DECODER
-    max_seq_len: int
+    max_seq_len: Optional[int] = None
     max_batch_size: int = 256
     max_num_tokens: int = 8192
     max_beam_width: int = 1
@@ -188,10 +188,12 @@ class TrussTRTLLMBuildConfiguration(BaseModel):
         """performs embedding specfic optimizations (no kv-cache, high batch size)"""
         if self.base_model == TrussTRTLLMModel.ENCODER:
             # Encoder specific settings
-            logger.info(
-                f"Your setting of `build.max_seq_len={self.max_seq_len}` is not used and "
-                "automatically inferred from the model repo config.json -> `max_position_embeddings`"
-            )
+            if self.max_seq_len:
+                logger.info(
+                    f"Your setting of `build.max_seq_len={self.max_seq_len}` is not used and "
+                    "automatically inferred from the model repo config.json -> `max_position_embeddings`"
+                )
+            # delayed import, as it is not available in all environments [Briton]
             from truss.base.constants import BEI_REQUIRED_MAX_NUM_TOKENS
 
             if self.max_num_tokens < BEI_REQUIRED_MAX_NUM_TOKENS:

--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -751,19 +751,26 @@ class TrussConfig:
                 is TrussTRTLLMQuantizationType.WEIGHTS_ONLY_INT8
                 and self.resources.accelerator.accelerator is Accelerator.A100
             ):
+                logger.warning(
+                    "Weight only int8 quantization on A100 accelerators is not recommended."
+                )
+            if self.resources.accelerator.accelerator in [
+                Accelerator.T4,
+                Accelerator.V100,
+            ]:
                 raise ValueError(
-                    "Weight only int8 quantization on A100 accelerators is not currently supported"
+                    "TRT-LLM is not supported on CUDA_COMPUTE_75 (T4) and CUDA_COMPUTE_70 (V100) GPUs"
+                    "the lowest supported CUDA compute capability is CUDA_COMPUTE_80 (A100) or A10G (CUDA_COMPUTE_86)"
                 )
             elif self.trt_llm.build.quantization_type in [
                 TrussTRTLLMQuantizationType.FP8,
                 TrussTRTLLMQuantizationType.FP8_KV,
-            ] and self.resources.accelerator.accelerator not in [
-                Accelerator.H100,
-                Accelerator.H100_40GB,
-                Accelerator.L4,
+            ] and self.resources.accelerator.accelerator in [
+                Accelerator.A10G,
+                Accelerator.A100,
             ]:
                 raise ValueError(
-                    "FP8 quantization is only supported on L4 and H100 accelerators"
+                    "FP8 quantization is only supported on L4, H100, H200 accelerators or newer (CUDA_COMPUTE>=89)"
                 )
             tensor_parallel_count = self.trt_llm.build.tensor_parallel_count
 

--- a/truss/tests/test_config.py
+++ b/truss/tests/test_config.py
@@ -576,8 +576,13 @@ def test_from_yaml_invalid_requirements_configuration():
         (TrussTRTLLMQuantizationType.FP8, Accelerator.H100, does_not_raise()),
         (TrussTRTLLMQuantizationType.FP8_KV, Accelerator.H100_40GB, does_not_raise()),
         (
-            TrussTRTLLMQuantizationType.WEIGHTS_ONLY_INT8,
-            Accelerator.A100,
+            TrussTRTLLMQuantizationType.NO_QUANT,
+            Accelerator.T4,
+            pytest.raises(ValueError),
+        ),
+        (
+            TrussTRTLLMQuantizationType.NO_QUANT,
+            Accelerator.V100,
             pytest.raises(ValueError),
         ),
         (TrussTRTLLMQuantizationType.FP8, Accelerator.A100, pytest.raises(ValueError)),


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
- weight int 8 is actually supported. If its not supported with a particular combo or model, we should raise in engine-builder. 
- max_seq_len will be automatically inferred (default to max_seq len from hf_repo or 32768, whatever is smaller)

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
