### PR TITLE
Add training bundles to truss train

### DIFF
--- a/truss-train/tests/test_deployment.py
+++ b/truss-train/tests/test_deployment.py
@@ -1,0 +1,25 @@
+import pathlib
+from unittest import mock
+
+from truss_train import deployment
+from truss_train.definitions import Image, TrainingJob
+
+
+@mock.patch("truss.remote.baseten.utils.transfer.multipart_upload_boto3")
+@mock.patch("truss.remote.baseten.api.BasetenApi.get_blob_credentials")
+def test_prepare_push(get_blob_credentials_mock, multipart_upload_boto3_mock):
+    mock_api = mock.Mock()
+    mock_api.get_blob_credentials.return_value = {
+        "s3_bucket": "test-s3-bucket",
+        "s3_key": "test-s3-key",
+        "creds": {},
+    }
+
+    prepared_job = deployment.prepare_push(
+        mock_api,
+        pathlib.Path(__file__),
+        TrainingJob(image=Image(base_image="hello-world")),
+    )
+    assert len(prepared_job.runtime_artifacts) == 1
+    assert prepared_job.runtime_artifacts[0].s3_key == "test-s3-key"
+    assert prepared_job.runtime_artifacts[0].s3_bucket == "test-s3-bucket"

--- a/truss-train/truss_train/deployment.py
+++ b/truss-train/truss_train/deployment.py
@@ -4,7 +4,7 @@ from typing import List
 from truss.remote.baseten import custom_types as b10_types
 from truss.remote.baseten.api import BasetenApi
 from truss.remote.baseten.core import archive_dir
-from truss.remote.baseten.utils.transfer import multipart_upload_boto3
+from truss.remote.baseten.utils import transfer
 from truss.shared.types import SafeModel
 from truss_train.definitions import TrainingJob
 
@@ -24,7 +24,7 @@ def prepare_push(api: BasetenApi, config: pathlib.Path, training_job: TrainingJo
     # Assume config is at the root of the directory.
     archive = archive_dir(config.absolute().parent)
     credentials = api.get_blob_credentials(b10_types.BlobType.TRAIN)
-    multipart_upload_boto3(
+    transfer.multipart_upload_boto3(
         archive.name,
         credentials["s3_bucket"],
         credentials["s3_key"],

--- a/truss-train/truss_train/deployment.py
+++ b/truss-train/truss_train/deployment.py
@@ -1,0 +1,39 @@
+import pathlib
+from typing import List
+
+from truss.remote.baseten import custom_types as b10_types
+from truss.remote.baseten.api import BasetenApi
+from truss.remote.baseten.core import archive_dir
+from truss.remote.baseten.utils.transfer import multipart_upload_boto3
+from truss.shared.types import SafeModel
+from truss_train.definitions import TrainingJob
+
+
+class S3Artifact(SafeModel):
+    s3_bucket: str
+    s3_key: str
+
+
+# Performs validation/transformation of fields that we don't want to expose
+# to the end user via the TrainingJob SDK.
+class PreparedTrainingJob(TrainingJob):
+    runtime_artifacts: List[S3Artifact] = []
+
+
+def prepare_push(api: BasetenApi, config: pathlib.Path, training_job: TrainingJob):
+    # Assume config is at the root of the directory.
+    archive = archive_dir(config.absolute().parent)
+    credentials = api.get_blob_credentials(b10_types.BlobType.TRAIN)
+    multipart_upload_boto3(
+        archive.name,
+        credentials["s3_bucket"],
+        credentials["s3_key"],
+        credentials["creds"],
+    )
+
+    return PreparedTrainingJob(
+        **training_job.model_dump(),
+        runtime_artifacts=[
+            S3Artifact(s3_key=credentials["s3_key"], s3_bucket=credentials["s3_bucket"])
+        ],
+    )

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -872,7 +872,7 @@ def train():
 @error_handling
 def push_training_job(config: Path, remote: Optional[str]):
     """Run a training job"""
-    from truss_train import loader
+    from truss_train import deployment, loader
 
     if not remote:
         remote = inquire_remote_name(RemoteFactory.get_available_config_names())
@@ -885,8 +885,11 @@ def push_training_job(config: Path, remote: Optional[str]):
             training_project=training_project
         )
 
+        prepared_job = deployment.prepare_push(
+            remote_provider.api, config, training_project.job
+        )
         remote_provider.api.create_training_job(
-            project_id=training_resp["id"], job=training_project.job
+            project_id=training_resp["id"], job=prepared_job
         )
 
 

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -572,21 +572,32 @@ class BasetenApi:
     def upsert_training_project(self, training_project):
         headers = self._auth_token.header()
         resp = requests.post(
-            f"{self._rest_api_url}/v1/training-projects",
+            f"{self._rest_api_url}/v1/training_projects",
             headers=headers,
             json={"training_project": training_project.model_dump()},
         )
         if not resp.ok:
             resp.raise_for_status()
 
-        return resp.json()
+        return resp.json()["training_project"]
 
     def create_training_job(self, project_id: str, job):
         headers = self._auth_token.header()
         resp = requests.post(
-            f"{self._rest_api_url}/v1/training-projects/{project_id}/jobs",
+            f"{self._rest_api_url}/v1/training_projects/{project_id}/jobs",
             headers=headers,
             json={"training_job": job.model_dump()},
+        )
+        if not resp.ok:
+            resp.raise_for_status()
+
+        return resp.json()
+
+    def get_blob_credentials(self, blob_type: b10_types.BlobType):
+        headers = self._auth_token.header()
+        resp = requests.get(
+            f"{self._rest_api_url}/v1/blobs/credentials/{blob_type.value}",
+            headers=headers,
         )
         if not resp.ok:
             resp.raise_for_status()

--- a/truss/remote/baseten/custom_types.py
+++ b/truss/remote/baseten/custom_types.py
@@ -67,3 +67,8 @@ class TrussUserEnv(pydantic.BaseModel):
             pydantic_version=pydantic.version.version_short(),
             mypy_version=mypy_version,
         )
+
+
+class BlobType(Enum):
+    MODEL = "model"
+    TRAIN = "train"

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -22,7 +22,7 @@ from truss.remote.baseten.core import (
     ModelName,
     ModelVersionHandle,
     ModelVersionId,
-    archive_truss,
+    archive_dir,
     create_chain_atomic,
     create_truss_service,
     exists_model,
@@ -168,7 +168,7 @@ class BasetenRemote(TrussRemote):
         if model_id is not None and disable_truss_download:
             raise ValueError("disable-truss-download can only be used for new models")
 
-        temp_file = archive_truss(truss_handle, progress_bar)
+        temp_file = archive_dir(truss_handle._truss_dir, progress_bar)
         s3_key = upload_truss(self._api, temp_file, progress_bar)
         encoded_config_str = base64_encoded_json_str(
             truss_handle._spec._config.to_dict()

--- a/truss/remote/baseten/utils/transfer.py
+++ b/truss/remote/baseten/utils/transfer.py
@@ -22,7 +22,7 @@ def multipart_upload_boto3(
     bucket_name: str,
     key: str,
     credentials: dict,
-    progress_bar: Optional[Type["progress.Progress"]],
+    progress_bar: Optional[Type["progress.Progress"]] = None,
 ) -> None:
     # In the CLI flow, ignore any local ~/.aws/config files,
     # which can interfere with uploading the Truss to S3.


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Builds on top of https://github.com/basetenlabs/baseten/pull/10665 and adds the ability for `truss train push` to upload the current directory to S3 using credentials pulled from the rest API. Has a couple small unrelated fixes as I tested things end to end. 

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
