### PR TITLE
Support 'internal URLs' for chainlet stubs, update docs

### DIFF
--- a/docs/chains/doc_gen/API-reference.mdx
+++ b/docs/chains/doc_gen/API-reference.mdx
@@ -16,7 +16,7 @@ Inheriting from this class adds validations to make sure subclasses adhere to th
 chainlet pattern and facilitates remote chainlet deployment.
 
 Refer to [the docs](https://docs.baseten.co/chains/getting-started) and this
-[example chainlet](https://github.com/basetenlabs/truss/blob/main/truss-chains/truss_chains/example_chainlet.py)
+[example chainlet](https://github.com/basetenlabs/truss/blob/main/truss-chains/truss_chains/reference_code/reference_chainlet.py)
 for more guidance on how to create subclasses.
 
 
@@ -50,7 +50,7 @@ When deploying a chain remotely, a corresponding stub to the remote is injected 
 its place. In [`run_local`](#truss-chains-run-local) mode an instance of a local chainlet is injected.
 
 Refer to [the docs](https://docs.baseten.co/chains/getting-started) and this
-[example chainlet](https://github.com/basetenlabs/truss/blob/main/truss-chains/truss_chains/example_chainlet.py)
+[example chainlet](https://github.com/basetenlabs/truss/blob/main/truss-chains/truss_chains/reference_code/reference_chainlet.py)
 for more guidance on how make one chainlet depend on another chainlet.
 
 <Warning>
@@ -78,7 +78,7 @@ chainlet instance is provided.
 Sets a “symbolic marker” for injecting a context object at runtime.
 
 Refer to [the docs](https://docs.baseten.co/chains/getting-started) and this
-[example chainlet](https://github.com/basetenlabs/truss/blob/main/truss-chains/truss_chains/example_chainlet.py)
+[example chainlet](https://github.com/basetenlabs/truss/blob/main/truss-chains/truss_chains/reference_code/reference_chainlet.py)
 for more guidance on the `__init__`-signature of chainlets.
 
 <Warning>

--- a/docs/chains/doc_gen/API-reference.mdx
+++ b/docs/chains/doc_gen/API-reference.mdx
@@ -606,18 +606,18 @@ class MyChainlet(chains.ChainletBase):
 | `api_key`            | *str*                                                                         | A baseten API key to authorize requests.  |
 
 
-#### *classmethod* from_url(predict_url, context, options=None)
+#### *classmethod* from_url(predict_url, context_or_api_key, options=None)
 
 Factory method, convenient to be used in chainlet’s `__init__`-method.
 
 
 **Parameters:**
 
-| Name          | Type                                                         | Description                                                       |
-|---------------|--------------------------------------------------------------|-------------------------------------------------------------------|
-| `predict_url` | *str*                                                        | URL to predict endpoint of another chain / truss model.           |
-| `context`     | *[DeploymentContext](#class-truss-chains-deploymentcontext)* | Deployment context object, obtained in the chainlet’s `__init__`. |
-| `options`     | *[RPCOptions](#class-truss-chains-rpcoptions)*               | RPC options, e.g. retries.                                        |
+| Name                 | Type                                                         | Description                                                                          |
+|----------------------|--------------------------------------------------------------|--------------------------------------------------------------------------------------|
+| `predict_url`        | *str*                                                        | URL to predict endpoint of another chain / truss model.                              |
+| `context_or_api_key` | *[DeploymentContext](#class-truss-chains-deploymentcontext)* | Deployment context object, obtained in the chainlet’s `__init__` or Baseten API key. |
+| `options`            | *[RPCOptions](#class-truss-chains-rpcoptions)*               | RPC options, e.g. retries.                                                           |
 
 #### Invocation Methods
 

--- a/docs/chains/doc_gen/generated-reference.mdx
+++ b/docs/chains/doc_gen/generated-reference.mdx
@@ -16,7 +16,7 @@ Inheriting from this class adds validations to make sure subclasses adhere to th
 chainlet pattern and facilitates remote chainlet deployment.
 
 Refer to [the docs](https://docs.baseten.co/chains/getting-started) and this
-[example chainlet](https://github.com/basetenlabs/truss/blob/main/truss-chains/truss_chains/example_chainlet.py)
+[example chainlet](https://github.com/basetenlabs/truss/blob/main/truss-chains/truss_chains/reference_code/reference_chainlet.py)
 for more guidance on how to create subclasses.
 
 
@@ -48,7 +48,7 @@ When deploying a chain remotely, a corresponding stub to the remote is injected 
 its place. In `run_local` mode an instance of a local chainlet is injected.
 
 Refer to [the docs](https://docs.baseten.co/chains/getting-started) and this
-[example chainlet](https://github.com/basetenlabs/truss/blob/main/truss-chains/truss_chains/example_chainlet.py)
+[example chainlet](https://github.com/basetenlabs/truss/blob/main/truss-chains/truss_chains/reference_code/reference_chainlet.py)
 for more guidance on how make one chainlet depend on another chainlet.
 
 #### WARNING
@@ -77,7 +77,7 @@ chainlet instance is provided.
 Sets a “symbolic marker” for injecting a context object at runtime.
 
 Refer to [the docs](https://docs.baseten.co/chains/getting-started) and this
-[example chainlet](https://github.com/basetenlabs/truss/blob/main/truss-chains/truss_chains/example_chainlet.py)
+[example chainlet](https://github.com/basetenlabs/truss/blob/main/truss-chains/truss_chains/reference_code/reference_chainlet.py)
 for more guidance on the `__init__`-signature of chainlets.
 
 #### WARNING

--- a/docs/chains/doc_gen/generated-reference.mdx
+++ b/docs/chains/doc_gen/generated-reference.mdx
@@ -564,7 +564,7 @@ foo("./somewhere")
 * **Parameters:**
   **file_path** (*str*)
 * **Return type:**
-  public_types.AbsPath
+  *AbsPath*
 
 ### `truss_chains.run_local`
 
@@ -632,16 +632,42 @@ specifically with `StubBase`.
 | `name` | *str* |  |
 | `display_name` | *str* |  |
 | `options` | *[RPCOptions](#truss_chains.RPCOptions* |  |
-| `predict_url` | *str* |  |
+| `predict_url` | *str\|None* |  |
+| `internal_url` | *[InternalURL](#truss_chains.DeployedServiceDescriptor.InternalURL* |  |
 
+
+#### *class* InternalURL(, gateway_run_remote_url, hostname)
+
+Bases: `pydantic.BaseModel`
+
+**Parameters:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `gateway_run_remote_url` | *str* |  |
+| `hostname` | *str* |  |
+
+
+#### gateway_run_remote_url *: str*
+
+#### hostname *: str*
+
+#### check_at_least_one_url()
+
+* **Parameters:**
+  **self** ([*DeployedServiceDescriptor*](#truss_chains.DeployedServiceDescriptor))
+* **Return type:**
+  [*DeployedServiceDescriptor*](#truss_chains.DeployedServiceDescriptor)
 
 #### display_name *: str*
+
+#### internal_url *: [InternalURL](#truss_chains.DeployedServiceDescriptor.InternalURL) | None*
 
 #### name *: str*
 
 #### options *: [RPCOptions](#truss_chains.RPCOptions)*
 
-#### predict_url *: str*
+#### predict_url *: str | None*
 
 
 ### *class* `truss_chains.StubBase`
@@ -706,7 +732,7 @@ class MyChainlet(chains.ChainletBase):
 | `api_key` | *str* | A baseten API key to authorize requests. |
 
 
-#### *classmethod* from_url(predict_url, context, options=None)
+#### *classmethod* from_url(predict_url, context_or_api_key, options=None)
 
 Factory method, convenient to be used in chainlet’s `__init__`-method.
 
@@ -716,7 +742,7 @@ Factory method, convenient to be used in chainlet’s `__init__`-method.
 | Name | Type | Description |
 |------|------|-------------|
 | `predict_url` | *str* | URL to predict endpoint of another chain / truss model. |
-| `context` | *[DeploymentContext](#truss_chains.DeploymentContext* | Deployment context object, obtained in the chainlet’s `__init__`. |
+| `context_or_api_key` | *[DeploymentContext](#truss_chains.DeploymentContext* | Deployment context object, obtained in the chainlet’s `__init__` or Baseten API key. |
 | `options` | *[RPCOptions](#truss_chains.RPCOptions* | RPC options, e.g. retries. |
 
 

--- a/docs/chains/doc_gen/reference.patch
+++ b/docs/chains/doc_gen/reference.patch
@@ -1,5 +1,5 @@
---- docs/chains/doc_gen/generated-reference.mdx	2025-03-07 14:07:59.058967543 -0800
-+++ docs/chains/doc_gen/API-reference.mdx	2025-03-07 14:06:58.765143669 -0800
+--- docs/chains/doc_gen/generated-reference.mdx	2025-03-11 11:50:41.420102369 -0700
++++ docs/chains/doc_gen/API-reference.mdx	2025-03-11 11:45:47.101215413 -0700
 @@ -30,13 +30,15 @@
 
  ### *class* `truss_chains.EngineBuilderLLMChainlet`
@@ -173,14 +173,14 @@
 -| `use_binary` | *bool* | Whether to send data in binary format. This can give a parsing speedup and message size reduction (~25%) for numpy arrays. Use `NumpyArrayField` as a field type on pydantic models for integration and set this option to `True`. For simple text data, there is no significant benefit. |
 -
 -#### retries *: int*
+-
+-#### timeout_sec *: float*
 +| Name          | Type    | Description                                                                                                                                                                                                                                                                               |
 +|---------------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 +| `retries`     | *int*   | The number of times to retry the remote chainlet in case of failures (e.g. due to transient network issues). For streaming, retries are only made if the request fails before streaming any results back. Failures mid-stream not retried.                                                |
 +| `timeout_sec` | *float* | Timeout for the HTTP request to this chainlet.                                                                                                                                                                                                                                            |
 +| `use_binary`  | *bool*  | Whether to send data in binary format. This can give a parsing speedup and message size reduction (~25%) for numpy arrays. Use `NumpyArrayField` as a field type on pydantic models for integration and set this option to `True`. For simple text data, there is no significant benefit. |
 
--#### timeout_sec *: float*
--
 -#### use_binary *: bool*
 
  ### `truss_chains.mark_entrypoint`
@@ -582,7 +582,6 @@
 -* **Parameters:**
 -  **file_path** (*str*)
 -* **Return type:**
--  public_types.AbsPath
 +</Warning>
 +
 +**Parameters:**
@@ -593,9 +592,9 @@
 +
 +
 +* **Returns:**
-+  *AbsPath*
-+
+   *AbsPath*
 
++
  ### `truss_chains.run_local`
 
  Context manager local debug execution of a chain.
@@ -628,7 +627,7 @@
  import os
  import truss_chains as chains
 
-@@ -627,21 +536,12 @@
+@@ -627,47 +536,12 @@
 
  **Parameters:**
 
@@ -637,16 +636,42 @@
 -| `name` | *str* |  |
 -| `display_name` | *str* |  |
 -| `options` | *[RPCOptions](#truss_chains.RPCOptions* |  |
--| `predict_url` | *str* |  |
+-| `predict_url` | *str\|None* |  |
+-| `internal_url` | *[InternalURL](#truss_chains.DeployedServiceDescriptor.InternalURL* |  |
 -
+-
+-#### *class* InternalURL(, gateway_run_remote_url, hostname)
+-
+-Bases: `pydantic.BaseModel`
+-
+-**Parameters:**
+-
+-| Name | Type | Description |
+-|------|------|-------------|
+-| `gateway_run_remote_url` | *str* |  |
+-| `hostname` | *str* |  |
+-
+-
+-#### gateway_run_remote_url *: str*
+-
+-#### hostname *: str*
+-
+-#### check_at_least_one_url()
+-
+-* **Parameters:**
+-  **self** ([*DeployedServiceDescriptor*](#truss_chains.DeployedServiceDescriptor))
+-* **Return type:**
+-  [*DeployedServiceDescriptor*](#truss_chains.DeployedServiceDescriptor)
 -
 -#### display_name *: str*
+-
+-#### internal_url *: [InternalURL](#truss_chains.DeployedServiceDescriptor.InternalURL) | None*
 -
 -#### name *: str*
 -
 -#### options *: [RPCOptions](#truss_chains.RPCOptions)*
 -
--#### predict_url *: str*
+-#### predict_url *: str | None*
 +| Name           | Type                                           | Description |
 +|----------------|------------------------------------------------|-------------|
 +| `name`         | *str*                                          |             |
@@ -656,7 +681,7 @@
 
 
  ### *class* `truss_chains.StubBase`
-@@ -657,7 +557,7 @@
+@@ -683,7 +557,7 @@
  in user-code for wrapping a deployed truss model into the Chains framework. It
  flexibly supports JSON and pydantic inputs and output. Example usage:
 
@@ -665,7 +690,7 @@
  import pydantic
  import truss_chains as chains
 
-@@ -668,18 +568,18 @@
+@@ -694,18 +568,18 @@
 
  class DeployedWhisper(chains.StubBase):
      # Input JSON, output JSON.
@@ -687,7 +712,7 @@
          return await self.predict_async(data, output_model=WhisperOutput)
 
 
-@@ -700,10 +600,10 @@
+@@ -726,10 +600,10 @@
 
  **Parameters:**
 
@@ -701,15 +726,15 @@
 +| `api_key`            | *str*                                                                         | A baseten API key to authorize requests.  |
 
 
- #### *classmethod* from_url(predict_url, context, options=None)
-@@ -713,27 +613,25 @@
+ #### *classmethod* from_url(predict_url, context_or_api_key, options=None)
+@@ -739,27 +613,25 @@
 
  **Parameters:**
 
 -| Name | Type | Description |
 -|------|------|-------------|
 -| `predict_url` | *str* | URL to predict endpoint of another chain / truss model. |
--| `context` | *[DeploymentContext](#truss_chains.DeploymentContext* | Deployment context object, obtained in the chainlet’s `__init__`. |
+-| `context_or_api_key` | *[DeploymentContext](#truss_chains.DeploymentContext* | Deployment context object, obtained in the chainlet’s `__init__` or Baseten API key. |
 -| `options` | *[RPCOptions](#truss_chains.RPCOptions* | RPC options, e.g. retries. |
 -
 -
@@ -727,11 +752,11 @@
 -#### predict_sync(inputs: InputT, output_model: Type[OutputModelT]) → OutputModelT
 -
 -#### predict_sync(inputs: InputT, output_model: None = None) → Any
-+| Name          | Type                                                         | Description                                                       |
-+|---------------|--------------------------------------------------------------|-------------------------------------------------------------------|
-+| `predict_url` | *str*                                                        | URL to predict endpoint of another chain / truss model.           |
-+| `context`     | *[DeploymentContext](#class-truss-chains-deploymentcontext)* | Deployment context object, obtained in the chainlet’s `__init__`. |
-+| `options`     | *[RPCOptions](#class-truss-chains-rpcoptions)*               | RPC options, e.g. retries.                                        |
++| Name                 | Type                                                         | Description                                                                          |
++|----------------------|--------------------------------------------------------------|--------------------------------------------------------------------------------------|
++| `predict_url`        | *str*                                                        | URL to predict endpoint of another chain / truss model.                              |
++| `context_or_api_key` | *[DeploymentContext](#class-truss-chains-deploymentcontext)* | Deployment context object, obtained in the chainlet’s `__init__` or Baseten API key. |
++| `options`            | *[RPCOptions](#class-truss-chains-rpcoptions)*               | RPC options, e.g. retries.                                                           |
 +
 +#### Invocation Methods
 +
@@ -749,7 +774,7 @@
 
 
  ### *class* `truss_chains.RemoteErrorDetail`
-@@ -746,62 +644,21 @@
+@@ -772,62 +644,21 @@
 
  **Parameters:**
 

--- a/docs/chains/doc_gen/reference.patch
+++ b/docs/chains/doc_gen/reference.patch
@@ -29,7 +29,7 @@
 +its place. In [`run_local`](#truss-chains-run-local) mode an instance of a local chainlet is injected.
 
  Refer to [the docs](https://docs.baseten.co/chains/getting-started) and this
- [example chainlet](https://github.com/basetenlabs/truss/blob/main/truss-chains/truss_chains/example_chainlet.py)
+ [example chainlet](https://github.com/basetenlabs/truss/blob/main/truss-chains/truss_chains/reference_code/reference_chainlet.py)
  for more guidance on how make one chainlet depend on another chainlet.
 
 -#### WARNING
@@ -65,7 +65,7 @@
  ### `truss_chains.depends_context`
 
 @@ -80,16 +81,15 @@
- [example chainlet](https://github.com/basetenlabs/truss/blob/main/truss-chains/truss_chains/example_chainlet.py)
+ [example chainlet](https://github.com/basetenlabs/truss/blob/main/truss-chains/truss_chains/reference_code/reference_chainlet.py)
  for more guidance on the `__init__`-signature of chainlets.
 
 -#### WARNING

--- a/truss-chains/tests/test_utils.py
+++ b/truss-chains/tests/test_utils.py
@@ -7,7 +7,26 @@ from truss_chains.remote_chainlet.utils import populate_chainlet_service_predict
 
 DYNAMIC_CHAINLET_CONFIG_VALUE = {
     "Hello World!": {
-        "predict_url": "https://model-diff_id.api.baseten.co/deployment/diff_deployment_id/predict"
+        "predict_url": "https://chain-232p81ql.api.baseten.co/environments/production/run_remote"
+    }
+}
+
+DYNAMIC_CHAINLET_CONFIG_WITH_INTERNAL_URL = {
+    "Hello World!": {
+        "predict_url": "https://chain-232p81ql.api.baseten.co/environments/production/run_remote",
+        "internal_url": {
+            "gateway_run_remote_url": "https://aws-us-west-2-ai7.api.baseten.co/environments/production/run_remote",
+            "hostname": "chain-232p81ql.api.baseten.co",
+        },
+    }
+}
+
+DYNAMIC_CHAINLET_CONFIG_INTERNAL_ONLY = {
+    "InternalOnly": {
+        "internal_url": {
+            "gateway_run_remote_url": "https://aws-us-west-2-ai7.api.baseten.co/environments/production/run_remote",
+            "hostname": "chain-232p81ql.api.baseten.co",
+        }
     }
 }
 
@@ -40,6 +59,7 @@ def test_populate_chainlet_service_predict_urls(tmp_path, dynamic_config_mount_d
         new_chainlet_to_service["HelloWorld"].predict_url
         == DYNAMIC_CHAINLET_CONFIG_VALUE["Hello World!"]["predict_url"]
     )
+    assert new_chainlet_to_service["HelloWorld"].internal_url is None
 
 
 @pytest.mark.parametrize("config", [DYNAMIC_CHAINLET_CONFIG_VALUE, {}, ""])
@@ -59,3 +79,61 @@ def test_no_populate_chainlet_service_predict_urls(
         public_types.MissingDependencyError, match="Chainlet 'RandInt' not found"
     ):
         populate_chainlet_service_predict_urls(chainlet_to_service)
+
+
+def test_populate_chainlet_service_with_internal_url(
+    tmp_path, dynamic_config_mount_dir
+):
+    """Test that internal_url is correctly parsed when present."""
+    with (tmp_path / private_types.DYNAMIC_CHAINLET_CONFIG_KEY).open("w") as f:
+        f.write(json.dumps(DYNAMIC_CHAINLET_CONFIG_WITH_INTERNAL_URL))
+
+    chainlet_to_service = {
+        "HelloWorld": private_types.ServiceDescriptor(
+            name="HelloWorld",
+            display_name="Hello World!",
+            options=public_types.RPCOptions(),
+        )
+    }
+
+    new_chainlet_to_service = populate_chainlet_service_predict_urls(
+        chainlet_to_service
+    )
+
+    assert new_chainlet_to_service["HelloWorld"].predict_url is None
+    assert (
+        new_chainlet_to_service["HelloWorld"].internal_url.gateway_run_remote_url
+        == "https://aws-us-west-2-ai7.api.baseten.co/environments/production/run_remote"
+    )
+    assert (
+        new_chainlet_to_service["HelloWorld"].internal_url.hostname
+        == "chain-232p81ql.api.baseten.co"
+    )
+
+
+def test_populate_chainlet_service_internal_only(tmp_path, dynamic_config_mount_dir):
+    """Test case where only internal_url is provided (no predict_url)."""
+    with (tmp_path / private_types.DYNAMIC_CHAINLET_CONFIG_KEY).open("w") as f:
+        f.write(json.dumps(DYNAMIC_CHAINLET_CONFIG_INTERNAL_ONLY))
+
+    chainlet_to_service = {
+        "InternalService": private_types.ServiceDescriptor(
+            name="InternalService",
+            display_name="InternalOnly",
+            options=public_types.RPCOptions(),
+        )
+    }
+
+    new_chainlet_to_service = populate_chainlet_service_predict_urls(
+        chainlet_to_service
+    )
+
+    assert new_chainlet_to_service["InternalService"].predict_url is None
+    assert (
+        new_chainlet_to_service["InternalService"].internal_url.gateway_run_remote_url
+        == "https://aws-us-west-2-ai7.api.baseten.co/environments/production/run_remote"
+    )
+    assert (
+        new_chainlet_to_service["InternalService"].internal_url.hostname
+        == "chain-232p81ql.api.baseten.co"
+    )

--- a/truss-chains/truss_chains/deployment/code_gen.py
+++ b/truss-chains/truss_chains/deployment/code_gen.py
@@ -765,6 +765,7 @@ def _gen_truss_config(
             chainlet_to_service=chainlet_to_service
         ).model_dump()
     )
+    truss_config.TrussConfig.validate(config)
     return config
 
 

--- a/truss-chains/truss_chains/framework.py
+++ b/truss-chains/truss_chains/framework.py
@@ -1567,7 +1567,7 @@ class ChainletBase(private_types.ABCChainlet, metaclass=abc.ABCMeta):
     chainlet pattern and facilitates remote chainlet deployment.
 
     Refer to `the docs <https://docs.baseten.co/chains/getting-started>`_ and this
-    `example chainlet <https://github.com/basetenlabs/truss/blob/main/truss-chains/truss_chains/example_chainlet.py>`_
+    `example chainlet <https://github.com/basetenlabs/truss/blob/main/truss-chains/truss_chains/reference_code/reference_chainlet.py>`_
     for more guidance on how to create subclasses.
     """
 

--- a/truss-chains/truss_chains/public_api.py
+++ b/truss-chains/truss_chains/public_api.py
@@ -21,7 +21,7 @@ def depends_context() -> public_types.DeploymentContext:
     """Sets a "symbolic marker" for injecting a context object at runtime.
 
     Refer to `the docs <https://docs.baseten.co/chains/getting-started>`_ and this
-    `example chainlet <https://github.com/basetenlabs/truss/blob/main/truss-chains/truss_chains/example_chainlet.py>`_
+    `example chainlet <https://github.com/basetenlabs/truss/blob/main/truss-chains/truss_chains/reference_code/reference_chainlet.py>`_
     for more guidance on the ``__init__``-signature of chainlets.
 
     Warning:
@@ -55,7 +55,7 @@ def depends(
     its place. In ``run_local`` mode an instance of a local chainlet is injected.
 
     Refer to `the docs <https://docs.baseten.co/chains/getting-started>`_ and this
-    `example chainlet <https://github.com/basetenlabs/truss/blob/main/truss-chains/truss_chains/example_chainlet.py>`_
+    `example chainlet <https://github.com/basetenlabs/truss/blob/main/truss-chains/truss_chains/reference_code/reference_chainlet.py>`_
     for more guidance on how make one chainlet depend on another chainlet.
 
     Warning:

--- a/truss-chains/truss_chains/public_types.py
+++ b/truss-chains/truss_chains/public_types.py
@@ -639,8 +639,10 @@ class DeployedServiceDescriptor(types.SafeModel):
     name: str
     display_name: str
     options: RPCOptions
-    predict_url: Optional[str] = pydantic.Field(None, deprecated=True)
-    internal_url: Optional[InternalURL] = None
+    predict_url: Optional[str] = None
+    internal_url: Optional[InternalURL] = pydantic.Field(
+        None, description="If provided, takes precedence over `predict_url`."
+    )
 
     @pydantic.model_validator(mode="after")
     def check_at_least_one_url(

--- a/truss-chains/truss_chains/remote_chainlet/stub.py
+++ b/truss-chains/truss_chains/remote_chainlet/stub.py
@@ -258,7 +258,10 @@ class StubBase(BasetenSession, abc.ABC):
         self, inputs: InputT, for_httpx: bool = False
     ) -> Mapping[str, Any]:
         kwargs: Dict[str, Any] = {}
-        headers = {private_types.OTEL_TRACE_PARENT_HEADER_KEY: utils.get_trace_parent()}
+        headers = {}
+        if trace_parent := utils.get_trace_parent():
+            headers[private_types.OTEL_TRACE_PARENT_HEADER_KEY] = trace_parent
+
         if isinstance(inputs, pydantic.BaseModel):
             if self._service_descriptor.options.use_binary:
                 data_dict = inputs.model_dump(mode="python")

--- a/truss-chains/truss_chains/remote_chainlet/stub.py
+++ b/truss-chains/truss_chains/remote_chainlet/stub.py
@@ -46,7 +46,8 @@ class BasetenSession:
         max_connections=DEFAULT_MAX_CONNECTIONS,
         max_keepalive_connections=DEFAULT_MAX_KEEPALIVE_CONNECTIONS,
     )
-    _auth_header: Mapping[str, str]
+    _target_url: str
+    _headers: Mapping[str, str]
     _service_descriptor: public_types.DeployedServiceDescriptor
     _cached_sync_client: Optional[tuple[httpx.Client, int]]
     _cached_async_client: Optional[tuple[aiohttp.ClientSession, int]]
@@ -54,12 +55,27 @@ class BasetenSession:
     def __init__(
         self, service_descriptor: public_types.DeployedServiceDescriptor, api_key: str
     ) -> None:
+        headers = {"Authorization": f"Api-Key {api_key}"}
+        # `internal_url`, if present, takes precedence!
+        if service_descriptor.internal_url:
+            target_msg = str(service_descriptor.internal_url)
+            headers["Host"] = service_descriptor.internal_url.hostname
+            target_url = service_descriptor.internal_url.gateway_run_remote_url
+        elif service_descriptor.predict_url:
+            target_msg = service_descriptor.predict_url
+            target_url = service_descriptor.predict_url
+        else:
+            assert False, (
+                "Per validation of `DeployedServiceDescriptor` either `predict_url` "
+                f"or `internal_url` must be present. Got {service_descriptor}"
+            )
+
         logging.info(
             f"Creating BasetenSession (HTTP) for `{service_descriptor.name}`.\n"
-            f"\tTarget: `{service_descriptor.predict_url}`\n"
-            f"\t`{service_descriptor.options}`."
+            f"\tTarget: `{target_msg}`\n\t`{service_descriptor.options}`."
         )
-        self._auth_header = {"Authorization": f"Api-Key {api_key}"}
+        self._target_url = target_url
+        self._headers = headers
         self._service_descriptor = service_descriptor
         self._cached_sync_client = None
         self._cached_async_client = None
@@ -109,7 +125,7 @@ class BasetenSession:
                 if self._client_cycle_needed(self._cached_sync_client):
                     self._cached_sync_client = (
                         httpx.Client(
-                            headers=self._auth_header,
+                            headers=self._headers,
                             timeout=self._service_descriptor.options.timeout_sec,
                             limits=self._client_limits,
                         ),
@@ -132,7 +148,7 @@ class BasetenSession:
                     connector = aiohttp.TCPConnector(limit=DEFAULT_MAX_CONNECTIONS)
                     self._cached_async_client = (
                         aiohttp.ClientSession(
-                            headers=self._auth_header,
+                            headers=self._headers,
                             connector=connector,
                             timeout=aiohttp.ClientTimeout(
                                 total=self._service_descriptor.options.timeout_sec
@@ -212,17 +228,22 @@ class StubBase(BasetenSession, abc.ABC):
     def from_url(
         cls,
         predict_url: str,
-        context: public_types.DeploymentContext,
+        context_or_api_key: Union[public_types.DeploymentContext, str],
         options: Optional[public_types.RPCOptions] = None,
     ):
         """Factory method, convenient to be used in chainlet's ``__init__``-method.
 
         Args:
             predict_url: URL to predict endpoint of another chain / truss model.
-            context: Deployment context object, obtained in the chainlet's ``__init__``.
+            context_or_api_key: Deployment context object, obtained in the
+               chainlet's ``__init__`` or Baseten API key.
             options: RPC options, e.g. retries.
         """
         options = options or public_types.RPCOptions()
+        if isinstance(context_or_api_key, str):
+            api_key = context_or_api_key
+        else:
+            api_key = context_or_api_key.get_baseten_api_key()
         return cls(
             service_descriptor=public_types.DeployedServiceDescriptor(
                 name=cls.__name__,
@@ -230,7 +251,7 @@ class StubBase(BasetenSession, abc.ABC):
                 predict_url=predict_url,
                 options=options,
             ),
-            api_key=context.get_baseten_api_key(),
+            api_key=api_key,
         )
 
     def _make_request_params(
@@ -290,7 +311,7 @@ class StubBase(BasetenSession, abc.ABC):
         def _rpc() -> bytes:
             client: httpx.Client
             with self._client_sync() as client:
-                response = client.post(self._service_descriptor.predict_url, **params)
+                response = client.post(self._target_url, **params)
             utils.response_raise_errors(response, self.name)
             return response.content
 
@@ -325,9 +346,7 @@ class StubBase(BasetenSession, abc.ABC):
         async def _rpc() -> bytes:
             client: aiohttp.ClientSession
             async with self._client_async() as client:
-                async with client.post(
-                    self._service_descriptor.predict_url, **params
-                ) as response:
+                async with client.post(self._target_url, **params) as response:
                     await utils.async_response_raise_errors(response, self.name)
                     return await response.read()
 
@@ -352,9 +371,7 @@ class StubBase(BasetenSession, abc.ABC):
         async def _rpc() -> AsyncIterator[bytes]:
             client: aiohttp.ClientSession
             async with self._client_async() as client:
-                response = await client.post(
-                    self._service_descriptor.predict_url, **params
-                )
+                response = await client.post(self._target_url, **params)
                 await utils.async_response_raise_errors(response, self.name)
                 return response.content.iter_any()
 

--- a/truss-chains/truss_chains/remote_chainlet/utils.py
+++ b/truss-chains/truss_chains/remote_chainlet/utils.py
@@ -117,8 +117,8 @@ class ThreadSafeCounter:
         self.decrement()
 
 
-_trace_parent_context: contextvars.ContextVar[str] = contextvars.ContextVar(
-    "trace_parent"
+_trace_parent_context: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+    "trace_parent", default=None
 )
 
 
@@ -143,7 +143,7 @@ def trace_parent_raw(trace_parent: str) -> Iterator[None]:
 
 
 def get_trace_parent() -> Optional[str]:
-    return " "  # _trace_parent_context.get()
+    return _trace_parent_context.get()
 
 
 def pydantic_set_field_dict(obj: pydantic.BaseModel) -> dict[str, pydantic.BaseModel]:


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What

Allows chainlet stubs to be instantiated like:
```
service_descriptor = chains.DeployedServiceDescriptor(
    name="test",
    display_name="test",
    internal_url={
        "gateway_predict_url": "https://gcp-us-central1-a9x.api.baseten.co/deployment/dq4g01q2/chainlet/dq44pdq2/run_remote",
        "hostname": "chain-4w5d6v32.api.baseten.co",
    },
    options=chains.RPCOptions(use_binary=False),
)

llm = Llama7BChainletStub(
    service_descriptor, api_key="???"
)
```

And uses `internal_url` with preference if provided in the config map.

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
