### PR TITLE
Fix python3.8 support

### DIFF
--- a/truss/templates/control/requirements.txt
+++ b/truss/templates/control/requirements.txt
@@ -5,7 +5,7 @@ uvicorn==0.24.0
 uvloop==0.19.0
 tenacity==8.1.0
 httpx==0.27.0
-httpx-ws>=0.7.0
+httpx-ws>=0.6.0
 python-json-logger==2.0.2
 loguru==0.7.2
 websockets<=14.0


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
https://github.com/basetenlabs/truss/pull/1441 accidentally broke support for py3.8, so we need to drop the [version requirement](https://github.com/frankie567/httpx-ws/releases/tag/v0.7.0) for httpx-ws. 

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
```
$ poetry run pytest truss/tests/test_control_truss_patching.py::test_control_truss_patch_ignored_changes
```

now passes
