### PR TITLE
Guard websocket implementations more

### DIFF
--- a/truss/tests/test_model_inference.py
+++ b/truss/tests/test_model_inference.py
@@ -1844,11 +1844,34 @@ async def test_raise_predict_and_websocket_endpoint():
         container = tr.docker_run(
             local_port=8090, detach=True, wait_for_server_ready=False
         )
-        time.sleep(1)
+        time.sleep(3)
         _assert_logs_contain_error(
             container.logs(),
             message="Exception while loading model",
-            error="cannot have both `predict` and `websocket` method",
+            error="cannot have both",
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_raise_preprocess_and_websocket_endpoint():
+    model = """
+    class Model:
+        async def websocket(self, websocket):
+            pass
+
+        async def preprocess(self, inputs):
+            pass
+    """
+    with ensure_kill_all(), _temp_truss(model, "") as tr:
+        container = tr.docker_run(
+            local_port=8090, detach=True, wait_for_server_ready=False
+        )
+        time.sleep(3)
+        _assert_logs_contain_error(
+            container.logs(),
+            message="Exception while loading model",
+            error="cannot have both",
         )
 
 


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Small runtime improvement to ensure that users don't provide any of the traditional hooks (predict, preprocess, postprocess) alongside websocket.

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
```
$ poetry run pytest truss/tests/test_model_inference.py::test_raise_preprocess_and_websocket_endpoint
$ poetry run pytest truss/tests/test_model_inference.py::test_raise_predict_and_websocket_endpoint
```