### PR TITLE
Collect git info into TrussUserEnv.

### DIFF
--- a/truss-chains/examples/streaming/streaming_chain.py
+++ b/truss-chains/examples/streaming/streaming_chain.py
@@ -68,6 +68,7 @@ class StringGenerator(chains.ChainletBase):
         yield "last."
 
 
+@chains.mark_entrypoint
 class Consumer(chains.ChainletBase):
     """Consume that reads the raw streams and parses them."""
 

--- a/truss-chains/truss_chains/deployment/deployment_client.py
+++ b/truss-chains/truss_chains/deployment/deployment_client.py
@@ -473,12 +473,21 @@ def _create_baseten_chain(
         b10_remote.BasetenRemote,
         remote_factory.RemoteFactory.create(remote=baseten_options.remote),
     )
+
+    if remote_provider.include_git_info or baseten_options.include_git_info:
+        truss_user_env = b10_types.TrussUserEnv.collect_with_git_info(
+            baseten_options.working_dir
+        )
+    else:
+        truss_user_env = b10_types.TrussUserEnv.collect()
+
     _create_chains_secret_if_missing(remote_provider)
 
     chain_deployment_handle = remote_provider.push_chain_atomic(
-        chain_name=baseten_options.chain_name,
-        entrypoint_artifact=entrypoint_artifact,
-        dependency_artifacts=dependency_artifacts,
+        baseten_options.chain_name,
+        entrypoint_artifact,
+        dependency_artifacts,
+        truss_user_env,
         publish=baseten_options.publish,
         environment=baseten_options.environment,
         progress_bar=progress_bar,

--- a/truss-chains/truss_chains/framework.py
+++ b/truss-chains/truss_chains/framework.py
@@ -933,7 +933,7 @@ def validate_and_register_cls(cls: Type[private_types.ABCChainlet]) -> None:
         "EngineBuilderLLMChainlet",
     ]
     if cls.__name__ in _skip_class_name:
-        print(f"Skipping {cls}")
+        logging.debug(f"Skipping chainlet class validation for `{cls}`.")
         return
 
     src_path = os.path.abspath(inspect.getfile(cls))

--- a/truss-chains/truss_chains/private_types.py
+++ b/truss-chains/truss_chains/private_types.py
@@ -1,6 +1,7 @@
 # TODO: this file contains too much implementation -> restructure.
 import abc
 import enum
+import pathlib
 from typing import (  # type: ignore[attr-defined]  # Chains uses Python >=3.9.
     Any,
     Callable,
@@ -262,6 +263,8 @@ class PushOptionsBaseten(PushOptions):
     remote: str
     publish: bool
     environment: Optional[str]
+    include_git_info: bool
+    working_dir: pathlib.Path
 
     @classmethod
     def create(
@@ -271,6 +274,8 @@ class PushOptionsBaseten(PushOptions):
         promote: Optional[bool],
         only_generate_trusses: bool,
         remote: str,
+        include_git_info: bool,
+        working_dir: pathlib.Path,
         environment: Optional[str] = None,
     ) -> "PushOptionsBaseten":
         if promote and not environment:
@@ -283,6 +288,8 @@ class PushOptionsBaseten(PushOptions):
             publish=publish,
             only_generate_trusses=only_generate_trusses,
             environment=environment,
+            include_git_info=include_git_info,
+            working_dir=working_dir,
         )
 
 

--- a/truss-chains/truss_chains/public_api.py
+++ b/truss-chains/truss_chains/public_api.py
@@ -1,3 +1,4 @@
+import inspect
 import pathlib
 from typing import (
     TYPE_CHECKING,
@@ -141,6 +142,7 @@ def push(
     remote: str = "baseten",
     environment: Optional[str] = None,
     progress_bar: Optional[Type["progress.Progress"]] = None,
+    include_git_info: bool = False,
 ) -> deployment_client.BasetenChainService:
     """
     Deploys a chain remotely (with all dependent chainlets).
@@ -159,6 +161,9 @@ def push(
           inquired.
         environment: The name of an environment to promote deployment into.
         progress_bar: Optional `rich.progress.Progress` if output is desired.
+        include_git_info: Whether to attach git versioning info (sha, branch, tag) to
+          deployments made from within a git repo. If set to True in `.trussrc`, it
+          will always be attached.
 
     Returns:
         A chain service handle to the deployed chain.
@@ -171,6 +176,8 @@ def push(
         only_generate_trusses=only_generate_trusses,
         remote=remote,
         environment=environment,
+        include_git_info=include_git_info,
+        working_dir=pathlib.Path(inspect.getfile(entrypoint)).parent,
     )
     service = deployment_client.push(entrypoint, options, progress_bar=progress_bar)
     assert isinstance(

--- a/truss/api/__init__.py
+++ b/truss/api/__init__.py
@@ -1,3 +1,4 @@
+import pathlib
 import warnings
 from typing import TYPE_CHECKING, Optional, Type, cast
 
@@ -62,6 +63,7 @@ def push(
     deployment_name: Optional[str] = None,
     environment: Optional[str] = None,
     progress_bar: Optional[Type["progress.Progress"]] = None,
+    include_git_info: bool = False,
 ) -> definitions.ModelDeployment:
     """
     Pushes a Truss to Baseten.
@@ -83,6 +85,9 @@ def push(
             only contain alphanumeric, ’.’, ’-’ or ’_’ characters.
         environment: Name of stable environment on baseten.
         progress_bar: Optional `rich.progress.Progress` if output is desired.
+        include_git_info: Whether to attach git versioning info (sha, branch, tag) to
+          deployments made from within a git repo. If set to True in `.trussrc`, it
+          will always be attached.
 
     Returns:
         The newly created ModelDeployment.
@@ -114,16 +119,17 @@ def push(
         raise ValueError(
             "No model name provided. Please specify a model name in config.yaml."
         )
-
     service = remote_provider.push(
         tr,
         model_name=model_name,
+        working_dir=pathlib.Path(target_directory),
         publish=publish,
         promote=promote,
         preserve_previous_prod_deployment=preserve_previous_production_deployment,
         deployment_name=deployment_name,
         environment=environment,
         progress_bar=progress_bar,
+        include_git_info=include_git_info,
     )  # type: ignore
 
     return definitions.ModelDeployment(cast(BasetenService, service))

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -24,8 +24,6 @@ API_URL_MAPPING = {
 # using the production api routes
 DEFAULT_API_DOMAIN = "https://api.baseten.co"
 
-TRUSS_USER_ENV = b10_types.TrussUserEnv.collect().json()
-
 
 def _oracle_data_to_graphql_mutation(oracle: b10_types.OracleData) -> str:
     args = [
@@ -51,11 +49,8 @@ def _chainlet_data_atomic_to_graphql_mutation(
     chainlet: b10_types.ChainletDataAtomic,
 ) -> str:
     oracle_data_string = _oracle_data_to_graphql_mutation(chainlet.oracle)
-
     args = [f'name: "{chainlet.name}"', f"oracle: {oracle_data_string}"]
-
     args_str = ",\n".join(args)
-
     return f"""{{
         {args_str}
     }}"""
@@ -133,6 +128,7 @@ class BasetenApi:
         s3_key: str,
         config: str,
         semver_bump: str,
+        truss_user_env: b10_types.TrussUserEnv,
         allow_truss_download: bool = True,
         deployment_name: Optional[str] = None,
         origin: Optional[b10_types.ModelOrigin] = None,
@@ -161,7 +157,7 @@ class BasetenApi:
             }}
         """
         resp = self._post_graphql_query(
-            query_string, variables={"trussUserEnv": TRUSS_USER_ENV}
+            query_string, variables={"trussUserEnv": truss_user_env.json()}
         )
         return resp["data"]["create_model_from_truss"]["model_version"]
 
@@ -171,6 +167,7 @@ class BasetenApi:
         s3_key: str,
         config: str,
         semver_bump: str,
+        truss_user_env: b10_types.TrussUserEnv,
         preserve_previous_prod_deployment: bool = False,
         deployment_name: Optional[str] = None,
         environment: Optional[str] = None,
@@ -198,7 +195,7 @@ class BasetenApi:
         """
 
         resp = self._post_graphql_query(
-            query_string, variables={"trussUserEnv": TRUSS_USER_ENV}
+            query_string, variables={"trussUserEnv": truss_user_env.json()}
         )
         return resp["data"]["create_model_version_from_truss"]["model_version"]
 
@@ -207,6 +204,7 @@ class BasetenApi:
         model_name,
         s3_key,
         config,
+        truss_user_env: b10_types.TrussUserEnv,
         allow_truss_download=True,
         origin: Optional[b10_types.ModelOrigin] = None,
     ):
@@ -232,7 +230,7 @@ class BasetenApi:
         """
 
         resp = self._post_graphql_query(
-            query_string, variables={"trussUserEnv": TRUSS_USER_ENV}
+            query_string, variables={"trussUserEnv": truss_user_env.json()}
         )
         return resp["data"]["deploy_draft_truss"]["model_version"]
 
@@ -240,6 +238,7 @@ class BasetenApi:
         self,
         entrypoint: b10_types.ChainletDataAtomic,
         dependencies: List[b10_types.ChainletDataAtomic],
+        truss_user_env: b10_types.TrussUserEnv,
         chain_id: Optional[str] = None,
         chain_name: Optional[str] = None,
         environment: Optional[str] = None,
@@ -277,7 +276,7 @@ class BasetenApi:
         """
 
         resp = self._post_graphql_query(
-            query_string, variables={"trussUserEnv": TRUSS_USER_ENV}
+            query_string, variables={"trussUserEnv": truss_user_env.json()}
         )
 
         return resp["data"]["deploy_chain_atomic"]
@@ -484,8 +483,9 @@ class BasetenApi:
             }}
         }}
         """
+        truss_user_env = b10_types.TrussUserEnv.collect().json()
         resp = self._post_graphql_query(
-            query_string, variables={"trussUserEnv": TRUSS_USER_ENV}
+            query_string, variables={"trussUserEnv": truss_user_env}
         )
         result = resp["data"]["stage_patch_for_draft_truss"]
         if not result["succeeded"]:
@@ -511,8 +511,9 @@ class BasetenApi:
             }}
         }}
         """
+        truss_user_env = b10_types.TrussUserEnv.collect().json()
         resp = self._post_graphql_query(
-            query_string, variables={"trussUserEnv": TRUSS_USER_ENV}
+            query_string, variables={"trussUserEnv": truss_user_env}
         )
         result = resp["data"]["sync_draft_truss"]
         if not result["succeeded"]:
@@ -531,8 +532,9 @@ class BasetenApi:
             }}
         }}
         """
+        truss_user_env = b10_types.TrussUserEnv.collect().json()
         resp = self._post_graphql_query(
-            query_string, variables={"trussUserEnv": TRUSS_USER_ENV}
+            query_string, variables={"trussUserEnv": truss_user_env}
         )
         return resp["data"]["truss_validation"]
 

--- a/truss/remote/baseten/custom_types.py
+++ b/truss/remote/baseten/custom_types.py
@@ -1,4 +1,5 @@
 import pathlib
+import subprocess
 import sys
 from enum import Enum
 from typing import Optional
@@ -45,14 +46,54 @@ class ChainletDataAtomic(pydantic.BaseModel):
     oracle: OracleData
 
 
+class GitInfo(pydantic.BaseModel):
+    latest_commit_sha: str
+    latest_tag: Optional[str]
+    commits_since_tag: Optional[int]
+    has_uncommitted_changes: bool
+
+    @classmethod
+    def collect(cls, git_working_dir: pathlib.Path) -> Optional["GitInfo"]:
+        def run_git_command(*args):
+            try:
+                return subprocess.check_output(
+                    ["git", *args],
+                    text=True,
+                    stderr=subprocess.DEVNULL,
+                    cwd=git_working_dir,
+                ).strip()
+            except subprocess.CalledProcessError:
+                return None
+
+        latest_commit_sha = run_git_command("rev-parse", "HEAD")
+        if not latest_commit_sha:
+            return None  # Not inside a git repo
+
+        latest_tag = run_git_command("describe", "--tags", "--abbrev=0") or None
+        commits_since_tag = (
+            run_git_command("rev-list", f"{latest_tag}..HEAD", "--count")
+            if latest_tag
+            else None
+        )
+        has_uncommitted_changes = bool(run_git_command("status", "--porcelain"))
+
+        return cls(
+            latest_commit_sha=latest_commit_sha,
+            latest_tag=latest_tag,
+            commits_since_tag=int(commits_since_tag) if commits_since_tag else None,
+            has_uncommitted_changes=has_uncommitted_changes,
+        )
+
+
 class TrussUserEnv(pydantic.BaseModel):
     truss_client_version: str
     python_version: str
     pydantic_version: str
     mypy_version: Optional[str]
+    git_info: Optional[GitInfo]
 
     @classmethod
-    def collect(cls):
+    def collect(cls) -> "TrussUserEnv":
         py_version = sys.version_info
         try:
             import mypy.version
@@ -66,7 +107,14 @@ class TrussUserEnv(pydantic.BaseModel):
             python_version=f"{py_version.major}.{py_version.minor}.{py_version.micro}",
             pydantic_version=pydantic.version.version_short(),
             mypy_version=mypy_version,
+            git_info=None,
         )
+
+    @classmethod
+    def collect_with_git_info(cls, git_working_dir: pathlib.Path) -> "TrussUserEnv":
+        instance = cls.collect()
+        instance.git_info = GitInfo.collect(git_working_dir)
+        return instance
 
 
 class BlobType(Enum):

--- a/truss/tests/remote/baseten/test_core.py
+++ b/truss/tests/remote/baseten/test_core.py
@@ -7,6 +7,7 @@ import pytest
 from truss.base.constants import PRODUCTION_ENVIRONMENT_NAME
 from truss.base.errors import ValidationError
 from truss.remote.baseten import core
+from truss.remote.baseten import custom_types as b10_types
 from truss.remote.baseten.api import BasetenApi
 from truss.remote.baseten.core import create_truss_service
 from truss.remote.baseten.error import ApiError
@@ -97,6 +98,7 @@ def test_create_truss_service_handles_eligible_environment_values(environment):
         "model_name",
         "s3_key",
         "config",
+        b10_types.TrussUserEnv.collect(),
         preserve_previous_prod_deployment=False,
         is_draft=False,
         model_id=None,
@@ -121,6 +123,7 @@ def test_create_truss_services_handles_is_draft(model_id):
         "model_name",
         "s3_key",
         "config",
+        b10_types.TrussUserEnv.collect(),
         preserve_previous_prod_deployment=False,
         is_draft=True,
         model_id=model_id,
@@ -163,6 +166,7 @@ def test_create_truss_service_handles_existing_model(inputs):
         "model_name",
         "s3_key",
         "config",
+        b10_types.TrussUserEnv.collect(),
         is_draft=False,
         model_id="model_id",
         **inputs,
@@ -194,6 +198,7 @@ def test_create_truss_service_handles_allow_truss_download_for_new_models(
         "model_name",
         "s3_key",
         "config",
+        b10_types.TrussUserEnv.collect(),
         preserve_previous_prod_deployment=False,
         is_draft=is_draft,
         model_id=None,

--- a/truss/truss_handle/truss_handle.py
+++ b/truss/truss_handle/truss_handle.py
@@ -111,6 +111,10 @@ class TrussHandle:
         if validate:
             self.validate()
 
+    @property
+    def truss_dir(self) -> Path:
+        return self._truss_dir
+
     def validate(self):
         self._validate_external_packages()
         self._validate_extensions()


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What

Context: https://basetenlabs.slack.com/archives/C06CZ3RSXRU/p1741812989685269

When pushing chains/trusses and their respective source directory is in a git repo, include versioning info in the `truss_user_env` payload (to be stored on the deployment in the backend DB).

This behavior is opt in:
* Can be turned on push-by-push with a new flag.
* Can be globally turned on in `trussrc`.
* If not specified in `trussrc` and the command is run interactively, user will be prompted to make a choice that will be stored.


![image](https://github.com/user-attachments/assets/1176d166-fc75-4c8a-83c1-84121b9b5c0f)


Additionally clean up spurious print.

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
