### PR TITLE
More truss integration for training

### DIFF
--- a/truss-train/truss_train/deployment.py
+++ b/truss-train/truss_train/deployment.py
@@ -19,6 +19,13 @@ class S3Artifact(SafeModel):
 class PreparedTrainingJob(TrainingJob):
     runtime_artifacts: List[S3Artifact] = []
 
+    def model_dump(self, *args, **kwargs):
+        data = super().model_dump(*args, **kwargs)
+
+        # NB(nikhil): nest our processed artifacts back under runtime
+        data["runtime"]["artifacts"] = data.pop("runtime_artifacts")
+        return data
+
 
 def prepare_push(api: BasetenApi, config: pathlib.Path, training_job: TrainingJob):
     # Assume config is at the root of the directory.

--- a/truss-train/truss_train/log_utils.py
+++ b/truss-train/truss_train/log_utils.py
@@ -1,0 +1,35 @@
+from datetime import datetime
+from typing import Any, List, Optional
+
+import pydantic
+import rich
+from rich import text
+
+
+class RawTrainingJobLog(pydantic.BaseModel):
+    timestamp: str
+    message: str
+    replica: Optional[str]
+
+
+def _output_log(log: RawTrainingJobLog, console: "rich.Console"):
+    epoch_nanos = int(log.timestamp)
+    dt = datetime.fromtimestamp(epoch_nanos / 1e9)
+    formatted_time = dt.strftime("%Y-%m-%d %H:%M:%S")
+
+    time_text = text.Text(f"[{formatted_time}]", style="blue")
+
+    assert log.replica is not None
+    replica_text = text.Text(f" ({log.replica})", style="green")
+    message_text = text.Text(f": {log.message.strip()}", style="white")
+
+    # Output the combined log line to the console
+    console.print(time_text, replica_text, message_text, sep="")
+
+
+def format_and_output_logs(api_logs: List[Any], console: "rich.Console"):
+    logs = [RawTrainingJobLog(**log) for log in api_logs]
+    # The API returns the most recent results first, but users expect
+    # to see those at the bottom.
+    for log in logs[::-1]:
+        _output_log(log, console)

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -591,7 +591,7 @@ class BasetenApi:
         if not resp.ok:
             resp.raise_for_status()
 
-        return resp.json()
+        return resp.json()["training_job"]
 
     def get_blob_credentials(self, blob_type: b10_types.BlobType):
         headers = self._auth_token.header()
@@ -603,3 +603,14 @@ class BasetenApi:
             resp.raise_for_status()
 
         return resp.json()
+
+    def get_training_job_logs(self, project_id: str, job_id: str):
+        headers = self._auth_token.header()
+        resp = requests.post(
+            f"{self._rest_api_url}/v1/training_projects/{project_id}/jobs/{job_id}/logs",
+            headers=headers,
+        )
+        if not resp.ok:
+            resp.raise_for_status()
+
+        return resp.json()["logs"]


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Adds a couple more `truss` integrations for training functionality:
- Logs
- Fixes runtime artifact upload

Followups will solve:
- Better log API (not requiring the users to pass in project/job ID)
- Log streaming
- Log query param customization (limit, range, etc)

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
<img width="842" alt="image" src="https://github.com/user-attachments/assets/4d177043-55fd-4377-aea3-887a63651046" />

<img width="1099" alt="image" src="https://github.com/user-attachments/assets/a43eabdb-5433-4aec-8a60-48e4cb5ebdbc" />

