### PR TITLE
Add support for A100-40GB accelerator

### DIFF
--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -71,6 +71,7 @@ class Accelerator(Enum):
     A10G = "A10G"
     V100 = "V100"
     A100 = "A100"
+    A100_40GB = "A100_40GB"
     H100 = "H100"
     H200 = "H200"
     H100_40GB = "H100_40GB"
@@ -768,6 +769,7 @@ class TrussConfig:
             ] and self.resources.accelerator.accelerator in [
                 Accelerator.A10G,
                 Accelerator.A100,
+                Accelerator.A100_40GB,
             ]:
                 raise ValueError(
                     "FP8 quantization is only supported on L4, H100, H200 accelerators or newer (CUDA_COMPUTE>=89)"

--- a/truss/tests/test_config.py
+++ b/truss/tests/test_config.py
@@ -106,6 +106,7 @@ def test_parse_resources(input_dict, expect_resources, output_dict):
         ("T4", AcceleratorSpec(Accelerator.T4, 1)),
         ("A10G:4", AcceleratorSpec(Accelerator.A10G, 4)),
         ("A100:8", AcceleratorSpec(Accelerator.A100, 8)),
+        ("A100_40GB", AcceleratorSpec(Accelerator.A100_40GB, 1)),
         ("H100", AcceleratorSpec(Accelerator.H100, 1)),
         ("H200", AcceleratorSpec(Accelerator.H200, 1)),
         ("H100_40GB", AcceleratorSpec(Accelerator.H100_40GB, 1)),


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Add ability to use truss to deploy to A100-40GB GPU types (in addition to default 80 GB A100)

<!--
  How was the change described above implemented?
-->
## :computer: How
Add new GPU type to enum

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
- Update unit tests
- Deployed model locally to test