### PR TITLE
Add extra job status to logs watch

### DIFF
--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -578,4 +578,11 @@ class BasetenApi:
         resp_json = self._rest_api_client.post(
             f"v1/training_projects/{project_id}/jobs/{job_id}/logs", body=payload
         )
+
         return resp_json["logs"]
+
+    def get_training_job(self, project_id: str, job_id: str):
+        resp_json = self._rest_api_client.get(
+            f"v1/training_projects/{project_id}/jobs/{job_id}"
+        )
+        return resp_json["training_job"]


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Adds extra job state information to the log watcher, very barebones for now.

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing

https://github.com/user-attachments/assets/9e2e9b8d-a33a-4e51-8da8-0038fbaea2ff


Video is slightly uncleear, but transitions between created to deploying to tailing logs