### PR TITLE
Expose `--tail` functionality to traditional truss pushes

### DIFF
--- a/truss-train/truss_train/log_utils.py
+++ b/truss-train/truss_train/log_utils.py
@@ -1,16 +1,10 @@
-import hashlib
 import time
-from datetime import datetime
 from typing import Any, List, Optional
 
-import pydantic
 import rich
-from rich import text
 
 from truss.remote.baseten.api import BasetenApi
-
-POLL_INTERVAL_SEC = 2
-CLOCK_SKEW_BUFFER_MS = 1000
+from truss.shared.log_watcher import POLL_INTERVAL_SEC, LogWatcher
 
 # NB(nikhil): When a job ends, we poll for this many seconds after to capture
 # any trailing logs that contain information about errors.
@@ -20,98 +14,49 @@ JOB_STARTING_STATES = ["TRAINING_JOB_CREATED", "TRAINING_JOB_DEPLOYING"]
 JOB_RUNNING_STATES = ["TRAINING_JOB_RUNNING"]
 
 
-class RawTrainingJobLog(pydantic.BaseModel):
-    timestamp: str
-    message: str
-    replica: Optional[str]
-
-
-def _output_log(log: RawTrainingJobLog, console: "rich.Console"):
-    epoch_nanos = int(log.timestamp)
-    dt = datetime.fromtimestamp(epoch_nanos / 1e9)
-    formatted_time = dt.strftime("%Y-%m-%d %H:%M:%S")
-
-    time_text = text.Text(f"[{formatted_time}]", style="blue")
-
-    assert log.replica is not None
-    replica_text = text.Text(f" ({log.replica})", style="green")
-    message_text = text.Text(f": {log.message.strip()}", style="white")
-
-    # Output the combined log line to the console
-    console.print(time_text, replica_text, message_text, sep="")
-
-
-def _parse_logs(api_logs: List[Any]) -> List[RawTrainingJobLog]:
-    return [RawTrainingJobLog(**log) for log in api_logs]
-
-
-def format_and_output_logs(api_logs: List[Any], console: "rich.Console"):
-    logs = _parse_logs(api_logs)
-    # The API returns the most recent results first, but users expect
-    # to see those at the bottom.
-    for log in logs[::-1]:
-        _output_log(log, console)
-
-
-class LogWatcher:
-    api: BasetenApi
+class TrainingLogWatcher(LogWatcher):
     project_id: str
     job_id: str
-    console: "rich.Console"
-    # NB(nikhil): we add buffer for clock skew, so this helps us detect duplicates.
-    # TODO(nikhil): clean up hashes so this doesn't grow indefinitely.
-    _log_hashes: set[str] = set()
-    _last_poll_time: Optional[int] = None
     _poll_stop_time: Optional[int] = None
+    _current_status: Optional[str] = None
 
     def __init__(
         self, api: BasetenApi, project_id: str, job_id: str, console: "rich.Console"
     ):
-        self.api = api
+        super().__init__(api, console)
         self.project_id = project_id
         self.job_id = job_id
-        self.console = console
-
-    def _hash_log(self, log: RawTrainingJobLog) -> str:
-        log_str = f"{log.timestamp}-{log.message}-{log.replica}"
-        return hashlib.sha256(log_str.encode("utf-8")).hexdigest()
-
-    def _poll(self) -> None:
-        start_epoch: Optional[int] = None
-        now = int(time.time() * 1000)
-        if self._last_poll_time is not None:
-            start_epoch = self._last_poll_time - CLOCK_SKEW_BUFFER_MS
-
-        api_logs = self.api.get_training_job_logs(
-            project_id=self.project_id,
-            job_id=self.job_id,
-            start_epoch_millis=start_epoch,
-            end_epoch_millis=now + CLOCK_SKEW_BUFFER_MS,
-        )
-
-        parsed_logs = _parse_logs(api_logs)
-        for log in parsed_logs[::-1]:
-            h = self._hash_log(log)
-            if h not in self._log_hashes:
-                self._log_hashes.add(h)
-                _output_log(log, self.console)
-
-        self._last_poll_time = now
 
     def _get_current_job_status(self) -> str:
         job = self.api.get_training_job(self.project_id, self.job_id)
         return job["current_status"]
 
-    def _wait_until_running(self) -> None:
-        current_status = self._get_current_job_status()
+    def before_polling(self) -> None:
+        self._current_status = self._get_current_job_status()
         status_str = "Waiting for job to run, currently {current_status}..."
         with self.console.status(
-            status_str.format(current_status=current_status), spinner="dots"
+            status_str.format(current_status=self._current_status), spinner="dots"
         ) as status_console:
-            while current_status in JOB_STARTING_STATES:
+            while self._current_status in JOB_STARTING_STATES:
                 time.sleep(POLL_INTERVAL_SEC)
-                current_status = self._get_current_job_status()
-                status_console.update(status_str.format(current_status=current_status))
+                self._current_status = self._get_current_job_status()
+                status_console.update(
+                    status_str.format(current_status=self._current_status)
+                )
+
+    def fetch_logs(
+        self, start_epoch_millis: Optional[int], end_epoch_millis: Optional[int]
+    ) -> List[Any]:
+        return self.api.get_training_job_logs(
+            self.project_id, self.job_id, start_epoch_millis, end_epoch_millis
+        )
+
+    def should_poll_again(self) -> bool:
+        return self._current_status in JOB_RUNNING_STATES or self._poll_final_logs()
+
+    def post_poll(self) -> None:
+        self._current_status = self._get_current_job_status()
+        self._maybe_update_poll_stop_time(self._current_status)
 
     def _poll_final_logs(self):
         if self._poll_stop_time is None:
@@ -122,20 +67,3 @@ class LogWatcher:
     def _maybe_update_poll_stop_time(self, current_status: str) -> None:
         if current_status not in JOB_RUNNING_STATES and self._poll_stop_time is None:
             self._poll_stop_time = int(time.time()) + JOB_TERMINATION_GRACE_PERIOD_SEC
-
-    def watch(self) -> None:
-        self._wait_until_running()
-        with self.console.status("Waiting for logs...", spinner="dots"):
-            while True:
-                self._poll()
-                if self._log_hashes:
-                    break
-                time.sleep(POLL_INTERVAL_SEC)
-
-        current_status = self._get_current_job_status()
-        while current_status in JOB_RUNNING_STATES or self._poll_final_logs():
-            self._poll()
-            time.sleep(POLL_INTERVAL_SEC)
-
-            current_status = self._get_current_job_status()
-            self._maybe_update_poll_stop_time(current_status)

--- a/truss/base/log_watcher.py
+++ b/truss/base/log_watcher.py
@@ -1,0 +1,52 @@
+from typing import Any, List, Optional
+
+import rich
+
+from truss.remote.baseten.api import BasetenApi
+from truss.shared.log_watcher import LogWatcher
+
+# NB(nikhil): These are slightly translated verisons of our internal model state machine.
+MODEL_RUNNING_STATES = [
+    "BUILDING",
+    "DEPLOYING",
+    "LOADING_MODEL",
+    "ACTIVE",
+    "UPDATING",
+    "WAKING_UP",
+]
+
+
+class ModelDeploymentLogWatcher(LogWatcher):
+    _model_id: str
+    _deployment_id: str
+    _current_status: Optional[str] = None
+
+    def __init__(
+        self,
+        api: BasetenApi,
+        model_id: str,
+        deployment_id: str,
+        console: "rich.Console",
+    ):
+        super().__init__(api, console)
+        self._model_id = model_id
+        self._deployment_id = deployment_id
+
+    def before_polling(self) -> None:
+        self._current_status = self._get_current_status()
+
+    def fetch_logs(
+        self, start_epoch_millis: Optional[int], end_epoch_millis: Optional[int]
+    ) -> List[Any]:
+        return self.api.get_model_deployment_logs(
+            self._model_id, self._deployment_id, start_epoch_millis, end_epoch_millis
+        )
+
+    def should_poll_again(self) -> bool:
+        return self._current_status in MODEL_RUNNING_STATES
+
+    def _get_current_status(self) -> str:
+        return self.api.get_deployment(self._model_id, self._deployment_id)["status"]
+
+    def post_poll(self) -> None:
+        self._current_status = self._get_current_status()

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -26,10 +26,10 @@ from truss.base.constants import (
     TRTLLM_MIN_MEMORY_REQUEST_GI,
 )
 from truss.base.errors import RemoteNetworkError
-from truss.base.log_watcher import ModelDeploymentLogWatcher
 from truss.base.trt_llm_config import TrussTRTLLMQuantizationType
 from truss.base.truss_config import Build, ModelServer
 from truss.cli import remote_cli
+from truss.cli.utils import logs as cli_log_utils
 from truss.remote.baseten.core import (
     ACTIVE_STATUS,
     DEPLOYING_STATUSES,
@@ -42,7 +42,7 @@ from truss.remote.baseten.remote import BasetenRemote
 from truss.remote.baseten.service import BasetenService
 from truss.remote.baseten.utils.status import get_displayable_status
 from truss.remote.remote_factory import USER_TRUSSRC_PATH, RemoteFactory
-from truss.shared.log_watcher import format_and_output_logs
+from truss.shared.log_watcher import parse_logs
 from truss.trt_llm.config_checks import (
     has_no_tags_trt_llm_builder,
     is_missing_secrets_for_trt_llm_builder,
@@ -95,6 +95,7 @@ click.rich_click.COMMAND_GROUPS = {
 }
 
 console = Console()
+spinner_factory = cli_log_utils.gen_spinner_factory(console)
 
 error_console = Console(stderr=True, style="bold red")
 
@@ -888,11 +889,11 @@ def train():
 @click.argument("config", type=Path, required=True)
 @click.option("--remote", type=str, required=False, help="Remote to use")
 @click.option(
-    "--watch", type=bool, is_flag=True, help="Watch for status + logs after push."
+    "--tail", type=bool, is_flag=True, help="Tail for status + logs after push."
 )
 @log_level_option
 @error_handling
-def push_training_job(config: Path, remote: Optional[str], watch: bool):
+def push_training_job(config: Path, remote: Optional[str], tail: bool):
     """Run a training job"""
     from truss_train import deployment, loader, log_utils
 
@@ -918,24 +919,26 @@ def push_training_job(config: Path, remote: Optional[str], watch: bool):
         console.print("✨ Training job successfully created!", style="green")
         console.print(
             f"🪵 View logs for your job via "
-            f"[cyan]`truss train logs --project-id {project_resp['id']} --job-id {job_resp['id']} [--watch]`[/cyan]"
+            f"[cyan]`truss train logs --project-id {project_resp['id']} --job-id {job_resp['id']} [--tail]`[/cyan]"
         )
 
-    if watch:
-        log_watcher = log_utils.TrainingLogWatcher(
-            remote_provider.api, project_resp["id"], job_resp["id"], console
+    if tail:
+        project_id, job_id = project_resp["id"], job_resp["id"]
+        watcher = log_utils.TrainingLogWatcher(
+            remote_provider.api, project_id, job_id, spinner_factory
         )
-        log_watcher.watch()
+        for log in watcher.watch():
+            cli_log_utils.output_log(log, console)
 
 
 @train.command(name="logs")
 @click.option("--remote", type=str, required=False, help="Remote to use")
 @click.option("--project-id", type=str, required=True, help="Project ID.")
 @click.option("--job-id", type=str, required=True, help="Job ID.")
-@click.option("--watch", type=bool, is_flag=True, help="Tail for ongoing logs.")
+@click.option("--tail", type=bool, is_flag=True, help="Tail for ongoing logs.")
 @log_level_option
 @error_handling
-def get_job_logs(remote: Optional[str], project_id: str, job_id: str, watch: bool):
+def get_job_logs(remote: Optional[str], project_id: str, job_id: str, tail: bool):
     """Fetch logs for a training job"""
     from truss_train import log_utils
 
@@ -946,14 +949,16 @@ def get_job_logs(remote: Optional[str], project_id: str, job_id: str, watch: boo
         BasetenRemote, RemoteFactory.create(remote=remote)
     )
 
-    if not watch:
+    if not tail:
         logs = remote_provider.api.get_training_job_logs(project_id, job_id)
-        format_and_output_logs(logs, console)
+        for log in parse_logs(logs):
+            cli_log_utils.output_log(log, console)
     else:
         log_watcher = log_utils.TrainingLogWatcher(
-            remote_provider.api, project_id, job_id, console
+            remote_provider.api, project_id, job_id, spinner_factory
         )
-        log_watcher.watch()
+        for log in log_watcher.watch():
+            cli_log_utils.output_log(log, console)
 
 
 # End Training Stuff #####################################################################
@@ -1406,10 +1411,11 @@ def push(
                 sys.exit(1)
     elif tail and isinstance(service, BasetenService):
         bt_remote = cast(BasetenRemote, remote_provider)
-        log_watcher = ModelDeploymentLogWatcher(
-            bt_remote.api, service.model_id, service.model_version_id, console
+        log_watcher = cli_log_utils.ModelDeploymentLogWatcher(
+            bt_remote.api, service.model_id, service.model_version_id, spinner_factory
         )
-        log_watcher.watch()
+        for log in log_watcher.watch():
+            cli_log_utils.output_log(log, console)
 
 
 @truss_cli.command()
@@ -1426,10 +1432,11 @@ def model_logs(remote: Optional[str], model_id: str, deployment_id: str) -> None
     if not remote:
         remote = remote_cli.inquire_remote_name()
     remote_provider = cast(BasetenRemote, RemoteFactory.create(remote=remote))
-    log_watcher = ModelDeploymentLogWatcher(
-        remote_provider.api, model_id, deployment_id, console
+    log_watcher = cli_log_utils.ModelDeploymentLogWatcher(
+        remote_provider.api, model_id, deployment_id, spinner_factory
     )
-    log_watcher.watch()
+    for log in log_watcher.watch():
+        cli_log_utils.output_log(log, console)
 
 
 @truss_cli.command()

--- a/truss/cli/utils/logs.py
+++ b/truss/cli/utils/logs.py
@@ -6,6 +6,7 @@ from rich import console as rich_console
 from rich import text
 
 from truss.remote.baseten.api import BasetenApi
+from truss.remote.baseten.utils.status import MODEL_RUNNING_STATES
 from truss.shared.log_watcher import LogWatcher
 from truss.shared.types import ParsedLog, Spinner, SpinnerFactory
 
@@ -33,17 +34,6 @@ def output_log(log: ParsedLog, console: rich_console.Console):
 
     # Output the combined log line to the console
     console.print(time_text, replica_text, message_text, sep="")
-
-
-# NB(nikhil): These are slightly translated verisons of our internal model state machine.
-MODEL_RUNNING_STATES = [
-    "BUILDING",
-    "DEPLOYING",
-    "LOADING_MODEL",
-    "ACTIVE",
-    "UPDATING",
-    "WAKING_UP",
-]
 
 
 class ModelDeploymentLogWatcher(LogWatcher):

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -562,6 +562,18 @@ class BasetenApi:
     def get_blob_credentials(self, blob_type: b10_types.BlobType):
         return self._rest_api_client.get(f"v1/blobs/credentials/{blob_type.value}")
 
+    def _prepare_logs_query(
+        self,
+        start_epoch_millis: Optional[int] = None,
+        end_epoch_millis: Optional[int] = None,
+    ) -> Dict[str, int]:
+        payload = {}
+        if start_epoch_millis:
+            payload["start_epoch_millis"] = start_epoch_millis
+        if end_epoch_millis:
+            payload["end_epoch_millis"] = end_epoch_millis
+        return payload
+
     def get_training_job_logs(
         self,
         project_id: str,
@@ -569,16 +581,24 @@ class BasetenApi:
         start_epoch_millis: Optional[int] = None,
         end_epoch_millis: Optional[int] = None,
     ):
-        payload = {}
-        if start_epoch_millis:
-            payload["start_epoch_millis"] = start_epoch_millis
-        if end_epoch_millis:
-            payload["end_epoch_millis"] = end_epoch_millis
-
         resp_json = self._rest_api_client.post(
-            f"v1/training_projects/{project_id}/jobs/{job_id}/logs", body=payload
+            f"v1/training_projects/{project_id}/jobs/{job_id}/logs",
+            body=self._prepare_logs_query(start_epoch_millis, end_epoch_millis),
         )
 
+        return resp_json["logs"]
+
+    def get_model_deployment_logs(
+        self,
+        model_id: str,
+        deployment_id: str,
+        start_epoch_millis: Optional[int] = None,
+        end_epoch_millis: Optional[int] = None,
+    ):
+        resp_json = self._rest_api_client.post(
+            f"v1/models/{model_id}/deployments/{deployment_id}/logs",
+            body=self._prepare_logs_query(start_epoch_millis, end_epoch_millis),
+        )
         return resp_json["logs"]
 
     def get_training_job(self, project_id: str, job_id: str):

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -1,6 +1,6 @@
 import logging
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Mapping, Optional
 
 import requests
 
@@ -566,7 +566,7 @@ class BasetenApi:
         self,
         start_epoch_millis: Optional[int] = None,
         end_epoch_millis: Optional[int] = None,
-    ) -> Dict[str, int]:
+    ) -> Mapping[str, int]:
         payload = {}
         if start_epoch_millis:
             payload["start_epoch_millis"] = start_epoch_millis

--- a/truss/remote/baseten/utils/status.py
+++ b/truss/remote/baseten/utils/status.py
@@ -16,6 +16,16 @@ STATUS_TO_DISPLAYABLE = {
     "SCALING_FROM_ZERO": "WAKING_UP",
 }
 
+# NB(nikhil): These are slightly translated verisons of our internal model state machine.
+MODEL_RUNNING_STATES = [
+    "BUILDING",
+    "DEPLOYING",
+    "LOADING_MODEL",
+    "ACTIVE",
+    "UPDATING",
+    "WAKING_UP",
+]
+
 
 def get_displayable_status(status: str) -> str:
     """

--- a/truss/shared/log_watcher.py
+++ b/truss/shared/log_watcher.py
@@ -1,0 +1,96 @@
+import hashlib
+import time
+from abc import ABC, abstractmethod
+from typing import Any, List, Optional
+
+import rich
+
+from truss.remote.baseten.api import BasetenApi
+from truss.shared.types import ParsedLog
+
+CLOCK_SKEW_BUFFER_MS = 1000
+POLL_INTERVAL_SEC = 2
+
+
+def _parse_logs(api_logs: List[Any]) -> List[ParsedLog]:
+    return [ParsedLog.from_raw(api_log) for api_log in api_logs]
+
+
+def format_and_output_logs(api_logs: List[Any], console: "rich.Console"):
+    logs = _parse_logs(api_logs)
+    # The API returns the most recent results first, but users expect
+    # to see those at the bottom.
+    for log in logs[::-1]:
+        log.to_console(console)
+
+
+class LogWatcher(ABC):
+    api: BasetenApi
+    console: "rich.Console"
+    # NB(nikhil): we add buffer for clock skew, so this helps us detect duplicates.
+    # TODO(nikhil): clean up hashes so this doesn't grow indefinitely.
+    _log_hashes: set[str] = set()
+    _last_poll_time: Optional[int] = None
+
+    def __init__(self, api: BasetenApi, console: "rich.Console"):
+        self.api = api
+        self.console = console
+
+    def _hash_log(self, log: ParsedLog) -> str:
+        log_str = f"{log.timestamp}-{log.message}-{log.replica}"
+        return hashlib.sha256(log_str.encode("utf-8")).hexdigest()
+
+    def _poll(self) -> None:
+        start_epoch: Optional[int] = None
+        now = int(time.time() * 1000)
+        if self._last_poll_time is not None:
+            start_epoch = self._last_poll_time - CLOCK_SKEW_BUFFER_MS
+
+        api_logs = self.fetch_logs(
+            start_epoch_millis=start_epoch, end_epoch_millis=now + CLOCK_SKEW_BUFFER_MS
+        )
+
+        parsed_logs = _parse_logs(api_logs)
+        for log in parsed_logs[::-1]:
+            h = self._hash_log(log)
+            if h not in self._log_hashes:
+                self._log_hashes.add(h)
+                log.to_console(self.console)
+
+        self._last_poll_time = now
+
+    def watch(self) -> None:
+        self.before_polling()
+        with self.console.status("Waiting for logs...", spinner="dots"):
+            while True:
+                self._poll()
+                if self._log_hashes:
+                    break
+                time.sleep(POLL_INTERVAL_SEC)
+
+        while self.should_poll_again():
+            self._poll()
+            time.sleep(POLL_INTERVAL_SEC)
+
+            self.post_poll()
+
+    @abstractmethod
+    def fetch_logs(
+        self, start_epoch_millis: Optional[int], end_epoch_millis: Optional[int]
+    ) -> List[Any]:
+        pass
+
+    @abstractmethod
+    def before_polling(self) -> None:
+        """Hook to run code before any polling begins."""
+        pass
+
+    @abstractmethod
+    def should_poll_again(self) -> bool:
+        """Hook that returns whether we should poll again."""
+        pass
+
+    @abstractmethod
+    def post_poll(self) -> None:
+        """Hook to run code after an individual poll."""
+        pass

--- a/truss/shared/log_watcher.py
+++ b/truss/shared/log_watcher.py
@@ -6,7 +6,8 @@ from typing import Any, Iterator, List, Optional
 from truss.remote.baseten.api import BasetenApi
 from truss.shared.types import ParsedLog, SpinnerFactory
 
-CLOCK_SKEW_BUFFER_MS = 1000
+# NB(nikhil): This helps account for (1) log processing delays (2) clock skews
+CLOCK_SKEW_BUFFER_MS = 10000
 POLL_INTERVAL_SEC = 2
 
 

--- a/truss/shared/types.py
+++ b/truss/shared/types.py
@@ -1,9 +1,15 @@
-from datetime import datetime
-from typing import Any, Optional
+from typing import Any, Callable, ContextManager, Optional, Protocol
 
 import pydantic
-import rich
-from rich import text
+
+
+# NB(nikhil): Helper function to output text with a spinner, intended
+# to remove dependency on `rich` outside the `cli` packages.
+class Spinner(Protocol):
+    def update(self, text: str) -> None: ...
+
+
+SpinnerFactory = Callable[[str], ContextManager[Spinner]]
 
 
 class SafeModel(pydantic.BaseModel):
@@ -29,21 +35,6 @@ class ParsedLog(pydantic.BaseModel):
     timestamp: str
     message: str
     replica: Optional[str]
-
-    def to_console(self, console: "rich.Console") -> None:
-        epoch_nanos = int(self.timestamp)
-        dt = datetime.fromtimestamp(epoch_nanos / 1e9)
-        formatted_time = dt.strftime("%Y-%m-%d %H:%M:%S")
-
-        time_text = text.Text(f"[{formatted_time}]: ", style="blue")
-        message_text = text.Text(f"{self.message.strip()}", style="white")
-        if self.replica:
-            replica_text = text.Text(f"({self.replica}) ", style="green")
-        else:
-            replica_text = text.Text()
-
-        # Output the combined log line to the console
-        console.print(time_text, replica_text, message_text, sep="")
 
     @classmethod
     def from_raw(self, raw_log: Any) -> "ParsedLog":

--- a/truss/shared/types.py
+++ b/truss/shared/types.py
@@ -1,4 +1,9 @@
+from datetime import datetime
+from typing import Any, Optional
+
 import pydantic
+import rich
+from rich import text
 
 
 class SafeModel(pydantic.BaseModel):
@@ -18,3 +23,28 @@ class SafeModelNonSerializable(pydantic.BaseModel):
         validate_assignment=True,
         extra="forbid",
     )
+
+
+class ParsedLog(pydantic.BaseModel):
+    timestamp: str
+    message: str
+    replica: Optional[str]
+
+    def to_console(self, console: "rich.Console") -> None:
+        epoch_nanos = int(self.timestamp)
+        dt = datetime.fromtimestamp(epoch_nanos / 1e9)
+        formatted_time = dt.strftime("%Y-%m-%d %H:%M:%S")
+
+        time_text = text.Text(f"[{formatted_time}]: ", style="blue")
+        message_text = text.Text(f"{self.message.strip()}", style="white")
+        if self.replica:
+            replica_text = text.Text(f"({self.replica}) ", style="green")
+        else:
+            replica_text = text.Text()
+
+        # Output the combined log line to the console
+        console.print(time_text, replica_text, message_text, sep="")
+
+    @classmethod
+    def from_raw(self, raw_log: Any) -> "ParsedLog":
+        return ParsedLog(**raw_log)


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Builds on top of https://github.com/basetenlabs/baseten/pull/10827, exposes a `--tail` argument to `truss push` to automatically tail incoming logs.

Next steps:
- Port train commands to use `--tail` so it's consistent

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
- Ensured that `truss train --watch` still works



https://github.com/user-attachments/assets/21fc7dfc-7829-423c-a9f8-cea74b6daf2b

