### PR TITLE
Small log improvements

### DIFF
--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -586,7 +586,8 @@ class BasetenApi:
             body=self._prepare_logs_query(start_epoch_millis, end_epoch_millis),
         )
 
-        return resp_json["logs"]
+        # NB(nikhil): reverse order so latest logs are at the end
+        return resp_json["logs"][::-1]
 
     def get_model_deployment_logs(
         self,
@@ -599,7 +600,9 @@ class BasetenApi:
             f"v1/models/{model_id}/deployments/{deployment_id}/logs",
             body=self._prepare_logs_query(start_epoch_millis, end_epoch_millis),
         )
-        return resp_json["logs"]
+
+        # NB(nikhil): reverse order so latest logs are at the end
+        return resp_json["logs"][::-1]
 
     def get_training_job(self, project_id: str, job_id: str):
         resp_json = self._rest_api_client.get(

--- a/truss/shared/log_watcher.py
+++ b/truss/shared/log_watcher.py
@@ -42,7 +42,7 @@ class LogWatcher(ABC):
         )
 
         parsed_logs = parse_logs(api_logs)
-        for log in parsed_logs[::-1]:
+        for log in parsed_logs:
             h = self._hash_log(log)
             if h not in self._log_hashes:
                 self._log_hashes.add(h)


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Some small improvements I noticed before I want to share more broadly:
- `--model_id` flag becomes `--model-id` (deployment_id similar)
- Add `--tail` option to model-logs command
- API will reverse order, so consumers don't have to

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
