### PR TITLE
Make context builder / base images arm64 compatible

### DIFF
--- a/.github/workflows/build-context-builder-image.yml
+++ b/.github/workflows/build-context-builder-image.yml
@@ -2,6 +2,16 @@ name: Build Context Builder Image
 
 on:
   workflow_dispatch:
+    inputs:
+      target_platforms:
+        description: 'Select target platforms'
+        required: false
+        default: 'linux/amd64'
+        type: choice
+        options:
+          - linux/amd64
+          - linux/arm64
+          - linux/amd64,linux/arm64
 
 jobs:
   detect-version:
@@ -63,3 +73,4 @@ jobs:
         push: true
         tags: ${{ steps.generate_image_tag.outputs.tag }}
         labels: ${{ steps.meta.outputs.labels }}
+        platforms: ${{ github.event.inputs.target_platforms }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: baseten/truss-context-builder:v${{ needs.detect-version-changed.outputs.new_version }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
 
   publish-release-to-pypi:
     needs: [detect-version-changed]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 docker_build_context_builder:
 	VERSION=$(shell grep "^version " pyproject.toml | awk '{ print $$NF }' | sed 's/^"\(.*\)"$$/\1/') \
-	&& docker buildx build . -f context_builder.Dockerfile --platform=linux/amd64 -t baseten/truss-context-builder:v$$VERSION
+	&& docker buildx build . -f context_builder.Dockerfile --platform=linux/amd64,linux/arm64 -t baseten/truss-context-builder:v$$VERSION
 
 docker_build_push_context_builder: docker_build_context_builder
 	VERSION=$(shell grep "^version " pyproject.toml | awk '{ print $$NF }' | sed 's/^"\(.*\)"$$/\1/') \

--- a/context_builder.Dockerfile
+++ b/context_builder.Dockerfile
@@ -2,21 +2,32 @@
 # for creating docker build context out of a Truss.
 # Build that image as:
 # docker buildx build . -f context_builder.Dockerfile --platform=linux/amd64 -t baseten/truss-context-builder
-FROM python:3.9-slim
+FROM python:3.9-slim AS builder
 
 RUN apt-get update \
-    && apt-get install --yes --no-install-recommends curl tar \
+    && apt-get install --yes --no-install-recommends curl build-essential golang-go \
     && apt-get autoremove -y \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/* /tmp/library-scripts/
 
 RUN curl -sSL https://install.python-poetry.org | python -
-
 ENV PATH="/root/.local/bin:${PATH}"
-COPY ./truss ./truss
+
+# NB(nikhil): We need to explicitly install Rust and golang-go on arm64 architectures
+# for certain truss dependencies (blake3, dockerfile) that don't have prebuilt wheels.
+# This is a multi stage image, so the extra tools don't bloat the final image.
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+RUN rustup update stable && rustup default stable
+
+# Will only exist for arm64 builds, but is a no-op otherwise.
+ENV PATH="/root/.cargo/bin:${PATH}"
+
 # Chains/train source code is not actually needed (and deps from chains group won't be
 # installed when using `--only builder`). But nonetheless poetry fails the install
 # if this directory is not present/empty - so we copy it.
+WORKDIR /app
+COPY ./truss ./truss
 COPY ./truss-chains ./truss-chains
 COPY ./truss-train ./truss-train
 COPY ./pyproject.toml ./pyproject.toml
@@ -26,4 +37,16 @@ COPY ./README.md ./README.md
 # https://python-poetry.org/docs/configuration/#virtualenvsin-project
 # to write to project root .venv file to be used for context builder test
 RUN poetry config virtualenvs.in-project true && poetry install --extras=all
+
+FROM python:3.9-slim
+
+WORKDIR /app
+COPY --from=builder /app /app
+
+# Copy `poetry` and required files
+COPY --from=builder /root/.local /root/.local
+
+ENV PATH="/root/.local/bin:${PATH}"
 ENV ENGINE_BUILDER_TRUSS_RUNTIME_MIGRATION="True"
+
+RUN apt-get update && apt-get install --yes --no-install-recommends curl tar

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.71"
+version = "0.9.72rc001"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/base/constants.py
+++ b/truss/base/constants.py
@@ -10,6 +10,9 @@ CUSTOM = "custom"
 HUGGINGFACE_TRANSFORMER = "huggingface_transformer"
 LIGHTGBM = "lightgbm"
 
+ARM_PLATFORMS = ("aarch64", "arm64")
+
+
 _TRUSS_ROOT = pathlib.Path(__file__).parent.parent.resolve()
 
 TEMPLATES_DIR = _TRUSS_ROOT / "templates"

--- a/truss/contexts/image_builder/serving_image_builder.py
+++ b/truss/contexts/image_builder/serving_image_builder.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import platform
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
@@ -15,6 +16,7 @@ from huggingface_hub.utils import filter_repo_objects
 
 from truss.base import constants
 from truss.base.constants import (
+    ARM_PLATFORMS,
     BASE_SERVER_REQUIREMENTS_TXT_FILENAME,
     BASE_TRTLLM_REQUIREMENTS,
     BEI_MAX_CONCURRENCY_TARGET_REQUESTS,
@@ -666,6 +668,8 @@ class ServingImageBuilder(ImageBuilder):
             MIN_SUPPORTED_PYTHON_VERSION_IN_CUSTOM_BASE_IMAGE.split(".")[0]
         )
 
+        should_install_arm64_requirements = platform.machine() in ARM_PLATFORMS
+
         hf_access_token = config.secrets.get(constants.HF_ACCESS_TOKEN_KEY)
         dockerfile_contents = dockerfile_template.render(
             should_install_server_requirements=should_install_server_requirements,
@@ -697,7 +701,9 @@ class ServingImageBuilder(ImageBuilder):
             external_data_files=external_data_files,
             build_commands=build_commands,
             use_local_src=config.use_local_src,
+            should_install_arm64_requirements=should_install_arm64_requirements,
             **FILENAME_CONSTANTS_MAP,
         )
+
         docker_file_path = build_dir / MODEL_DOCKERFILE_NAME
         docker_file_path.write_text(dockerfile_contents)

--- a/truss/templates/base.Dockerfile.jinja
+++ b/truss/templates/base.Dockerfile.jinja
@@ -25,6 +25,20 @@ RUN pip install mkl
 {% block post_base %}
 {% endblock %}
 
+# NB(nikhil): We need to install additional toolchains to support installing
+# python dependencies (currently blake3 and dockerfile) on arm64 architecture.
+# Currently, we only support arm64 in local dev, but we need these for:
+#   1) Control server (depends on truss)
+#   2) Python DX / Chains (depends on truss)
+{% block install_arm64_requirements %}
+    {%- if should_install_arm64_requirements %}
+RUN apt-get update && apt-get install --yes --no-install-recommends golang-go
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+RUN rustup update stable && rustup default stable
+    {%- endif %}
+{% endblock %}
+
 {% block install_system_requirements %}
     {%- if should_install_system_requirements %}
 COPY ./{{system_packages_filename}} {{system_packages_filename}}

--- a/truss/tests/contexts/image_builder/test_serving_image_builder.py
+++ b/truss/tests/contexts/image_builder/test_serving_image_builder.py
@@ -26,8 +26,9 @@ from truss.truss_handle.truss_handle import TrussHandle
 BASE_DIR = Path(__file__).parent
 
 
+@patch("platform.machine", return_value="amd")
 def test_serving_image_dockerfile_from_user_base_image(
-    test_data_path, custom_model_truss_dir
+    mock_machine, test_data_path, custom_model_truss_dir
 ):
     th = TrussHandle(custom_model_truss_dir)
     # The test fixture python varies with host version, need to pin here.
@@ -43,11 +44,12 @@ def test_serving_image_dockerfile_from_user_base_image(
         with open(test_data_path / "server.Dockerfile", "r") as f:
             server_docker_lines = f.readlines()
 
-        def filter_empty_lines(lines):
-            return list(filter(lambda x: x and x != "\n" and x != "", lines))
+        # Remove both empty lines + comments
+        def filter_unneeded_lines(lines):
+            return [x for x in lines if x.strip() and not x.strip().startswith("#")]
 
-        gen_docker_lines = filter_empty_lines(gen_docker_lines)
-        server_docker_lines = filter_empty_lines(server_docker_lines)
+        gen_docker_lines = filter_unneeded_lines(gen_docker_lines)
+        server_docker_lines = filter_unneeded_lines(server_docker_lines)
         assert gen_docker_lines == server_docker_lines
 
 

--- a/truss/tests/test_data/test_requirements_file_truss/requirements.txt
+++ b/truss/tests/test_data/test_requirements_file_truss/requirements.txt
@@ -1,1 +1,3 @@
 torch>=2.0.1
+blake3>=0.3.3
+dockerfile>=3.2.0


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Changes our context builder + base images to be arm64 compatible. Modified a unit test that now runs locally on mac:
```
$ poetry run pytest truss/tests/test_model_inference.py::test_requirements_file_truss
```

And verified in local dev/staging via context builder `0.9.71rc008` that models can still build + run.

Before multi stage
<img width="935" alt="image" src="https://github.com/user-attachments/assets/a02b495e-374e-430a-8066-65dae0284e64" />


After multi stage
<img width="936" alt="image" src="https://github.com/user-attachments/assets/c4471454-497b-4121-a1a1-1df5ab63d588" />


<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
