### PR TITLE
custom metrics: remove default collectors and _created metrics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.72rc002"
+version = "0.9.72rc003"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.72rc001"
+version = "0.9.72rc002"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/templates/control/requirements.txt
+++ b/truss/templates/control/requirements.txt
@@ -4,7 +4,6 @@ httpx-ws>=0.6.0
 httpx>=0.27.0
 loguru>=0.7.2
 python-json-logger>=2.0.2
-prometheus-client>=0.21.1
 tenacity>=8.1.0
 truss==0.9.50  # TODO(marius/TaT): remove after TaT.
 uvicorn>=0.24.0

--- a/truss/templates/control/requirements.txt
+++ b/truss/templates/control/requirements.txt
@@ -4,6 +4,7 @@ httpx-ws>=0.6.0
 httpx>=0.27.0
 loguru>=0.7.2
 python-json-logger>=2.0.2
+prometheus-client>=0.21.1
 tenacity>=8.1.0
 truss==0.9.50  # TODO(marius/TaT): remove after TaT.
 uvicorn>=0.24.0

--- a/truss/templates/server/truss_server.py
+++ b/truss/templates/server/truss_server.py
@@ -29,7 +29,14 @@ from model_wrapper import ModelWrapper
 from opentelemetry import propagate as otel_propagate
 from opentelemetry import trace
 from opentelemetry.sdk import trace as sdk_trace
-from prometheus_client import make_asgi_app
+from prometheus_client import (
+    REGISTRY,
+    gc_collector,
+    make_asgi_app,
+    metrics,
+    platform_collector,
+    process_collector,
+)
 from pydantic import BaseModel
 from shared import log_config, serialization
 from shared.secrets_resolver import SecretsResolver
@@ -437,6 +444,12 @@ class TrussServer:
         # This here is a fallback to add our custom headers in all other cases.
         app.add_exception_handler(Exception, errors.exception_handler)
 
+        # Unregister default prometheus metrics collectors
+        REGISTRY.unregister(process_collector.PROCESS_COLLECTOR)
+        REGISTRY.unregister(platform_collector.PLATFORM_COLLECTOR)
+        REGISTRY.unregister(gc_collector.GC_COLLECTOR)
+        # Disable exporting _created metrics
+        metrics.disable_created_metrics()
         # Add prometheus asgi middleware to route /metrics requests
         metrics_app = make_asgi_app()
         app.mount("/metrics", metrics_app)

--- a/truss/tests/templates/control/control/test_server_integration.py
+++ b/truss/tests/templates/control/control/test_server_integration.py
@@ -16,6 +16,7 @@ import psutil
 import pytest
 import requests
 import websockets
+from prometheus_client.parser import text_string_to_metric_families
 
 PATCH_PING_MAX_DELAY_SECS = 3
 
@@ -180,8 +181,9 @@ class Model:
     requests.post(f"{ctrl_url}/v1/models/model:predict", json={})
     resp = requests.get(f"{ctrl_url}/metrics")
     assert resp.status_code == 200
+    metric_names = [family.name for family in text_string_to_metric_families(resp.text)]
+    assert metric_names == ["my_really_cool_metric"]
     assert "my_really_cool_metric_total 20.0" in resp.text
-    assert "my_really_cool_metric_created" in resp.text
 
 
 @pytest.mark.integration

--- a/truss/tests/test_model_inference.py
+++ b/truss/tests/test_model_inference.py
@@ -1213,11 +1213,11 @@ def test_instrument_metrics():
         requests.post(PREDICT_URL, json={})
         resp = requests.get(metrics_url)
         assert resp.status_code == 200
-        metric_names = [
+        metric_names = {
             family.name for family in text_string_to_metric_families(resp.text)
-        ]
-        assert len(metric_names) == 2
-        assert "my_really_cool_metric" in metric_names
+        }
+        expected_metric_names = {"target_info", "my_really_cool_metric"}
+        assert metric_names == expected_metric_names
         assert "my_really_cool_metric_total 10.0" in resp.text
         assert "/metrics" not in container.logs()
 


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Realized we export default metrics from the prometheus default registry and those are also scraped by VM (and end up in grafana). In order to restrict the number of metrics scraped to just those instrumented by the user in the truss itself, we should unregister any default metrics.

<!--
  How was the change described above implemented?
-->
## :computer: How
* Unregister process collector, platform collector, and gc collector metrics
* Disable `_created` metrics (will remove an extra time series for all counters, histograms, gauges instrumented) 

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
### Previous output of `/metrics` (default registry)
```
# HELP python_gc_objects_collected_total Objects collected during gc
# TYPE python_gc_objects_collected_total counter
python_gc_objects_collected_total{generation="0"} 3996.0
python_gc_objects_collected_total{generation="1"} 9983.0
python_gc_objects_collected_total{generation="2"} 130.0
# HELP python_gc_objects_uncollectable_total Uncollectable objects found during GC
# TYPE python_gc_objects_uncollectable_total counter
python_gc_objects_uncollectable_total{generation="0"} 0.0
python_gc_objects_uncollectable_total{generation="1"} 0.0
python_gc_objects_uncollectable_total{generation="2"} 0.0
# HELP python_gc_collections_total Number of times this generation was collected
# TYPE python_gc_collections_total counter
python_gc_collections_total{generation="0"} 205.0
python_gc_collections_total{generation="1"} 18.0
python_gc_collections_total{generation="2"} 1.0
# HELP python_info Python platform information
# TYPE python_info gauge
python_info{implementation="CPython",major="3",minor="9",patchlevel="18",version="3.9.18"} 1.0
# HELP process_virtual_memory_bytes Virtual memory size in bytes.
# TYPE process_virtual_memory_bytes gauge
process_virtual_memory_bytes 2.60317184e+08
# HELP process_resident_memory_bytes Resident memory size in bytes.
# TYPE process_resident_memory_bytes gauge
process_resident_memory_bytes 6.76864e+07
# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds 1.74291634354e+09
# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
# TYPE process_cpu_seconds_total counter
process_cpu_seconds_total 1.24
# HELP process_open_fds Number of open file descriptors.
# TYPE process_open_fds gauge
process_open_fds 15.0
# HELP process_max_fds Maximum number of open file descriptors.
# TYPE process_max_fds gauge
process_max_fds 1.048576e+06
# HELP my_really_cool_metric_total my really cool metric description
# TYPE my_really_cool_metric_total counter
my_really_cool_metric_total 10.0
# HELP my_really_cool_metric_created my really cool metric description
# TYPE my_really_cool_metric_created gauge
my_really_cool_metric_created 1.7429163454029047e+09
```

### New output of `/metrics` (default registry with unregistered + disabled metrics)
```
# HELP my_really_cool_metric_total my really cool metric description
# TYPE my_really_cool_metric_total counter
my_really_cool_metric_total 10.0
```