### PR TITLE
Default to multi platform build on context builder

### DIFF
--- a/.github/workflows/build-context-builder-image.yml
+++ b/.github/workflows/build-context-builder-image.yml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       target_platforms:
-        description: 'Select target platforms'
+        description: 'Select target platforms. NOTE: Only change default if performing local testing.'
         required: false
-        default: 'linux/amd64'
+        default: 'linux/amd64,linux/arm64'
         type: choice
         options:
           - linux/amd64


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
<img width="355" alt="image" src="https://github.com/user-attachments/assets/17a00dd8-a5bd-4085-8552-ad80a478fbe2" />

Let's change the default to build both [images](https://basetenlabs.slack.com/archives/C04NM3YA2DT/p1743086158237539), and for local testing people can just publish amd64. In the future, I think we should only publish 'real' candidates via releases, but for now this is ok.

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
