### PR TITLE
Pin briton server version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.73rc0.dev100"
+version = "0.9.74rc0"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.73rc0.dev1"
+version = "0.9.73rc0.dev100"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.73"
+version = "0.9.73rc0.dev1"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/base/constants.py
+++ b/truss/base/constants.py
@@ -108,9 +108,9 @@ REGISTRY_BUILD_SECRET_PREFIX = "DOCKER_REGISTRY_"
 
 TRTLLM_SPEC_DEC_TARGET_MODEL_NAME = "target"
 TRTLLM_SPEC_DEC_DRAFT_MODEL_NAME = "draft"
-TRTLLM_BASE_IMAGE = "baseten/briton-server:v0.17.0_v0.0.25"
+TRTLLM_BASE_IMAGE = "baseten/briton-server:v0.17.0-f3fc323"
 TRTLLM_PYTHON_EXECUTABLE = "/usr/local/briton/venv/bin/python"
-BASE_TRTLLM_REQUIREMENTS = ["briton==0.4.10.post3"]
+BASE_TRTLLM_REQUIREMENTS = ["briton==0.4.10.post4"]
 BEI_TRTLLM_BASE_IMAGE = "baseten/bei:0.0.18"
 
 BEI_TRTLLM_PYTHON_EXECUTABLE = "/usr/bin/python3"

--- a/truss/base/constants.py
+++ b/truss/base/constants.py
@@ -110,7 +110,7 @@ TRTLLM_SPEC_DEC_TARGET_MODEL_NAME = "target"
 TRTLLM_SPEC_DEC_DRAFT_MODEL_NAME = "draft"
 TRTLLM_BASE_IMAGE = "baseten/briton-server:v0.17.0-f3fc323"
 TRTLLM_PYTHON_EXECUTABLE = "/usr/local/briton/venv/bin/python"
-BASE_TRTLLM_REQUIREMENTS = ["briton==0.4.10.post4"]
+BASE_TRTLLM_REQUIREMENTS = ["briton==0.4.10.post3"]
 BEI_TRTLLM_BASE_IMAGE = "baseten/bei:0.0.18"
 
 BEI_TRTLLM_PYTHON_EXECUTABLE = "/usr/bin/python3"


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What

Our build pipeline currently overwrites the briton server tag each time we merge to main in briton. This is a temporary fix to pin the Briton version to a sha-based tag before we fix the pipeline

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
