### PR TITLE
[bt-14163] Usability improvements for training jobs

### DIFF
--- a/truss/cli/logs/training_log_watcher.py
+++ b/truss/cli/logs/training_log_watcher.py
@@ -1,3 +1,4 @@
+import signal
 import time
 from typing import Any, List, Optional
 
@@ -35,6 +36,13 @@ class TrainingLogWatcher(LogWatcher):
         super().__init__(api, console)
         self.project_id = project_id
         self.job_id = job_id
+        # register siging handler that instructs user on how to stop the job
+        signal.signal(signal.SIGINT, self._handle_sigint)
+
+    def _handle_sigint(self, signum: int, frame: Any) -> None:
+        msg = f"\n\nExiting training job logs. To stop the job, run `truss train stop --project-id {self.project_id} --job-id {self.job_id}`"
+        self.console.print(msg, style="yellow")
+        raise KeyboardInterrupt()
 
     def _get_current_job_status(self) -> str:
         job = self.api.get_training_job(self.project_id, self.job_id)

--- a/truss/cli/train.py
+++ b/truss/cli/train.py
@@ -1,0 +1,91 @@
+from typing import Optional, Tuple, cast
+import rich_click as click
+import rich
+
+from truss.remote.baseten.remote import BasetenRemote
+from InquirerPy import inquirer
+from rich.console import Console
+
+
+def get_args_for_stop(console: Console, remote_provider: BasetenRemote, project_id: Optional[str], job_id: Optional[str]) -> Tuple[str, str]:
+
+    if not project_id or not job_id:
+        # get all running jobs
+        job = _get_running_job(console, remote_provider, project_id, job_id)
+        if not job:
+            raise click.UsageError("Unable to stop training job. No running jobs found.")
+        project_id_for_job = cast(str, job["training_project_id"])
+        job_id_to_stop = cast(str, job["id"])
+        # check if the user wants to stop the inferred running job
+        if not job_id:
+            confirm = inquirer.confirm(
+                message=f"Are you sure you want to stop training job {job_id_to_stop}?",
+                default=False,
+            ).execute()
+            if not confirm:
+                raise click.UsageError("Training job not stopped.")
+        project_id = project_id_for_job
+        job_id = job_id_to_stop
+
+    return project_id, job_id
+
+def get_args_for_logs(console: Console, remote_provider: BasetenRemote, project_id: Optional[str], job_id: Optional[str]) -> Tuple[str, str]:
+    if not project_id or not job_id:
+        jobs = remote_provider.api.search_training_jobs(
+            project_id=project_id, job_id=job_id
+        )
+        if not jobs:
+            raise click.UsageError("Unable to get logs. No jobs found.")
+        if len(jobs) > 1:
+            console.print("Multiple jobs found. Showing logs for the most recently created job.", style="yellow")
+            sorted_jobs = sorted(jobs, key=lambda x: x["created_at"], reverse=True)
+            job = sorted_jobs[0]
+        else:
+            job = jobs[0]
+        project_id = cast(str, job["training_project_id"])
+        job_id = cast(str, job["id"])
+    return project_id, job_id
+
+def _get_running_job(
+    console: Console, remote_provider: BasetenRemote, project_id: Optional[str], job_id: Optional[str]
+):
+    jobs = remote_provider.api.search_training_jobs(
+        statuses=["TRAINING_JOB_RUNNING"], project_id=project_id, job_id=job_id
+    )
+    if not jobs:
+        console.print("No running jobs found.", style="yellow")
+        return
+    if len(jobs) > 1:
+        display_training_jobs(console, jobs, title="Running Training Jobs")
+        console.print(
+            "Multiple running jobs found. Please specify a project and job id.",
+            style="yellow",
+        )
+        return
+    return jobs[0]
+
+
+def display_training_jobs(console: Console, jobs, title="Training Job Details"):
+    table = rich.table.Table(
+        show_header=True,
+        header_style="bold magenta",
+        title=title,
+        box=rich.table.box.ROUNDED,
+        border_style="blue",
+    )
+    table.add_column("Project ID", style="cyan")
+    table.add_column("Job ID", style="cyan")
+    table.add_column("Status", style="white")
+    table.add_column("Instance Type", style="white")
+    table.add_column("Created At", style="white")
+    table.add_column("Updated At", style="white")
+    for job in jobs:
+        table.add_row(
+            job["training_project_id"],
+            job["id"],
+            job["current_status"],
+            job["instance_type"]["name"],
+            job["created_at"],
+            job["updated_at"],
+        )
+    console.print(table)

--- a/truss/cli/train.py
+++ b/truss/cli/train.py
@@ -1,19 +1,22 @@
 from typing import Optional, Tuple, cast
-import rich_click as click
-import rich
 
-from truss.remote.baseten.remote import BasetenRemote
+import rich
+import rich_click as click
 from InquirerPy import inquirer
 from rich.console import Console
 
+from truss.remote.baseten.remote import BasetenRemote
 
-def get_args_for_stop(console: Console, remote_provider: BasetenRemote, project_id: Optional[str], job_id: Optional[str]) -> Tuple[str, str]:
 
+def get_args_for_stop(
+    console: Console,
+    remote_provider: BasetenRemote,
+    project_id: Optional[str],
+    job_id: Optional[str],
+) -> Tuple[str, str]:
     if not project_id or not job_id:
         # get all running jobs
         job = _get_running_job(console, remote_provider, project_id, job_id)
-        if not job:
-            raise click.UsageError("Unable to stop training job. No running jobs found.")
         project_id_for_job = cast(str, job["training_project_id"])
         job_id_to_stop = cast(str, job["id"])
         # check if the user wants to stop the inferred running job
@@ -29,7 +32,13 @@ def get_args_for_stop(console: Console, remote_provider: BasetenRemote, project_
 
     return project_id, job_id
 
-def get_args_for_logs(console: Console, remote_provider: BasetenRemote, project_id: Optional[str], job_id: Optional[str]) -> Tuple[str, str]:
+
+def get_args_for_logs(
+    console: Console,
+    remote_provider: BasetenRemote,
+    project_id: Optional[str],
+    job_id: Optional[str],
+) -> Tuple[str, str]:
     if not project_id or not job_id:
         jobs = remote_provider.api.search_training_jobs(
             project_id=project_id, job_id=job_id
@@ -37,31 +46,33 @@ def get_args_for_logs(console: Console, remote_provider: BasetenRemote, project_
         if not jobs:
             raise click.UsageError("Unable to get logs. No jobs found.")
         if len(jobs) > 1:
-            console.print("Multiple jobs found. Showing logs for the most recently created job.", style="yellow")
             sorted_jobs = sorted(jobs, key=lambda x: x["created_at"], reverse=True)
             job = sorted_jobs[0]
+            console.print(
+                f"Multiple jobs found. Showing logs for the most recently created job: {job['id']}",
+                style="yellow",
+            )
         else:
             job = jobs[0]
         project_id = cast(str, job["training_project_id"])
         job_id = cast(str, job["id"])
     return project_id, job_id
 
+
 def _get_running_job(
-    console: Console, remote_provider: BasetenRemote, project_id: Optional[str], job_id: Optional[str]
-):
+    console: Console,
+    remote_provider: BasetenRemote,
+    project_id: Optional[str],
+    job_id: Optional[str],
+) -> dict:
     jobs = remote_provider.api.search_training_jobs(
         statuses=["TRAINING_JOB_RUNNING"], project_id=project_id, job_id=job_id
     )
     if not jobs:
-        console.print("No running jobs found.", style="yellow")
-        return
+        raise click.UsageError("No running jobs found.")
     if len(jobs) > 1:
         display_training_jobs(console, jobs, title="Running Training Jobs")
-        console.print(
-            "Multiple running jobs found. Please specify a project and job id.",
-            style="yellow",
-        )
-        return
+        raise click.UsageError("Multiple running jobs found. Please specify a job id.")
     return jobs[0]
 
 

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -575,10 +575,16 @@ class BasetenApi:
         statuses: Optional[List[str]] = None,
         project_id: Optional[str] = None,
         job_id: Optional[str] = None,
+        order_by: List[str] = ["-created_at"],
     ):
         resp_json = self._rest_api_client.post(
             "v1/training_jobs/search",
-            body={"statuses": statuses, "project_id": project_id, "job_id": job_id},
+            body={
+                "statuses": statuses,
+                "project_id": project_id,
+                "job_id": job_id,
+                "order_by": order_by,
+            },
         )
         return resp_json["training_jobs"]
 

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -570,19 +570,15 @@ class BasetenApi:
         resp_json = self._rest_api_client.get(f"v1/training_projects/{project_id}/jobs")
         return resp_json
 
-    def list_all_training_jobs(
+    def search_training_jobs(
         self,
-        status_filter: Optional[List[str]] = None,
+        statuses: Optional[List[str]] = None,
         project_id: Optional[str] = None,
         job_id: Optional[str] = None,
     ):
         resp_json = self._rest_api_client.post(
-            "v1/training_projects/all_jobs",
-            body={
-                "status_filter": status_filter,
-                "project_id": project_id,
-                "job_id": job_id,
-            },
+            "v1/training_jobs/search",
+            body={"statuses": statuses, "project_id": project_id, "job_id": job_id},
         )
         return resp_json["training_jobs"]
 

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -575,7 +575,7 @@ class BasetenApi:
         statuses: Optional[List[str]] = None,
         project_id: Optional[str] = None,
         job_id: Optional[str] = None,
-        order_by: List[str] = ["-created_at"],
+        order_by: List[dict[str, str]] = [{"field": "created_at", "order": "desc"}],
     ):
         resp_json = self._rest_api_client.post(
             "v1/training_jobs/search",

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -570,6 +570,22 @@ class BasetenApi:
         resp_json = self._rest_api_client.get(f"v1/training_projects/{project_id}/jobs")
         return resp_json
 
+    def list_all_training_jobs(
+        self,
+        status_filter: Optional[List[str]] = None,
+        project_id: Optional[str] = None,
+        job_id: Optional[str] = None,
+    ):
+        resp_json = self._rest_api_client.post(
+            "v1/training_projects/all_jobs",
+            body={
+                "status_filter": status_filter,
+                "project_id": project_id,
+                "job_id": job_id,
+            },
+        )
+        return resp_json["training_jobs"]
+
     def get_training_job(self, project_id: str, job_id: str):
         # training_job, training_project
         resp_json = self._rest_api_client.get(


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
* control+c during logs will output the stop command 
* allow users to only specify job id 
* print out running jobs when stop is run without a project ID or Job ID 
<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
