### PR TITLE
Fix external data for truss watch.

### DIFF
--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -1493,7 +1493,7 @@ def push(
                         sys.exit(1)
 
             except RemoteNetworkError:
-                console.print("Deployment failed: Could not reach remote.", style="red")
+                console.print("Could not reach remote.", style="red")
                 sys.exit(1)
     elif tail and isinstance(service, BasetenService):
         bt_remote = cast(BasetenRemote, remote_provider)

--- a/truss/tests/test_util.py
+++ b/truss/tests/test_util.py
@@ -1,5 +1,6 @@
 import os
-from unittest.mock import patch
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import requests_mock
 
@@ -37,3 +38,17 @@ def test_download_into_nested_subdir(tmp_path):
             content = f.read()
 
         assert content == mocked_download_content
+
+
+@patch("truss.util.download.download_from_url_using_requests")
+def test_download_with_absolute_path(mock_download_from_url_using_requests, tmp_path):
+    with patch("pathlib.Path.mkdir", MagicMock()):
+        data = ExternalData.from_list(
+            [{"local_data_path": "/foo/bar", "url": TEST_DOWNLOAD_URL}]
+        )
+
+        download_external_data(data, data_dir=tmp_path)
+
+    mock_download_from_url_using_requests.assert_called_once_with(
+        TEST_DOWNLOAD_URL, Path("/foo/bar")
+    )

--- a/truss/util/download.py
+++ b/truss/util/download.py
@@ -22,10 +22,6 @@ def download_external_data(external_data: Optional[ExternalData], data_dir: Path
     # ensure parent directories exist
     for item in external_data.items:
         path = data_dir / item.local_data_path
-        if data_dir not in path.parents:
-            raise ValueError(
-                "Local data path of external data cannot point to outside data directory"
-            )
         path.parent.mkdir(exist_ok=True, parents=True)
 
     if b10cp_path is not None:


### PR DESCRIPTION

## :rocket: What

* A while ago we updated the way external_data works to allow writing to any path on the machine
* We never updated this for truss watch, which 

Note: we should probably remove this feature in favor of build_commands at this point. The reason we cannot is because of truss watch, which doesn't fully support build_commands yet.

Note I also did some minor cleanup on a misleading error message.

## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing

Will test this with a custom context builder & truss watch
