### PR TITLE
Add the preserve-env-instance-type flag to 'truss push'

### DIFF
--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -1326,7 +1326,7 @@ def run_python(script, target_directory):
 )
 @click.option("--tail", type=bool, is_flag=True)
 @click.option(
-    "--preserve-env-instance-type/--preserve-env-instance-type",
+    "--preserve-env-instance-type/--no-preserve-env-instance-type",
     type=bool,
     is_flag=True,
     required=False,
@@ -1377,7 +1377,7 @@ def push(
     if promote and not environment:
         environment = PRODUCTION_ENVIRONMENT_NAME
     if preserve_env_instance_type and not environment:
-        preserve_env_warning = "`preserve-env-instance-type` flag specifiec without the `environment` parameter. Ignoring the value of `preserve-env-instance-type`"
+        preserve_env_warning = "`preserve-env-instance-type` flag specified without the `environment` parameter. Ignoring the value of `preserve-env-instance-type`"
         console.print(preserve_env_warning, style="yellow")
 
     # Write model name to config if it's not already there

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -1331,7 +1331,12 @@ def run_python(script, target_directory):
     is_flag=True,
     required=False,
     default=False,
-    help="When pushing a truss to an environment, whether to use the resources specified in the truss config to resolve the instance type or preserve the instance type configured in the specified environment.",
+    help=(
+        "When pushing a truss to an environment, whether to use the resources specified "
+        "in the truss config to resolve the instance type or preserve the instance type "
+        "configured in the specified environment. It will be ignored if --environment is not specified. "
+        "Default is --no-preserve-env-instance-type."
+    ),
 )
 @log_level_option
 @error_handling

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -1376,9 +1376,17 @@ def push(
         console.print(promote_warning, style="yellow")
     if promote and not environment:
         environment = PRODUCTION_ENVIRONMENT_NAME
+
     if preserve_env_instance_type and not environment:
         preserve_env_warning = "`preserve-env-instance-type` flag specified without the `environment` parameter. Ignoring the value of `preserve-env-instance-type`"
         console.print(preserve_env_warning, style="yellow")
+    if environment:
+        if preserve_env_instance_type:
+            preserve_env_info = f"`preserve-env-instance-type` flag specified. Resources from the config will be ignored and the current instance type of the {environment} environment will be used."
+            console.print(preserve_env_info, style="green")
+        else:
+            preserve_env_info = f"`preserve-env-instance-type` flag not specified. Instance type will be derived from the config and updated in the {environment} environment."
+            console.print(preserve_env_info, style="green")
 
     # Write model name to config if it's not already there
     if model_name != tr.spec.config.model_name:

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -68,30 +68,22 @@ click.rich_click.COMMAND_GROUPS = {
         {
             "name": "Main usage",
             "commands": ["init", "push", "watch", "predict", "model_logs"],
-            "table_styles": {  # type: ignore
-                "row_styles": ["green"]
-            },
+            "table_styles": {"row_styles": ["green"]},  # type: ignore
         },
         {
             "name": "Advanced Usage",
             "commands": ["image", "container", "cleanup"],
-            "table_styles": {  # type: ignore
-                "row_styles": ["yellow"]
-            },
+            "table_styles": {"row_styles": ["yellow"]},  # type: ignore
         },
         {
             "name": "Chains",
             "commands": ["chains"],
-            "table_styles": {  # type: ignore
-                "row_styles": ["red"]
-            },
+            "table_styles": {"row_styles": ["red"]},  # type: ignore
         },
         {
             "name": "Train",
             "commands": ["train"],
-            "table_styles": {  # type: ignore
-                "row_styles": ["magenta"]
-            },
+            "table_styles": {"row_styles": ["magenta"]},  # type: ignore
         },
     ]
 }
@@ -1333,6 +1325,14 @@ def run_python(script, target_directory):
     help=include_git_info_doc,
 )
 @click.option("--tail", type=bool, is_flag=True)
+@click.option(
+    "--preserve-env-instance-type/--preserve-env-instance-type",
+    type=bool,
+    is_flag=True,
+    required=False,
+    default=False,
+    help="When pushing a truss to an environment, whether to use the resources specified in the truss config to resolve the instance type or preserve the instance type configured in the specified environment.",
+)
 @log_level_option
 @error_handling
 def push(
@@ -1350,6 +1350,7 @@ def push(
     environment: Optional[str] = None,
     include_git_info: bool = False,
     tail: bool = False,
+    preserve_env_instance_type: bool = False,
 ) -> None:
     """
     Pushes a truss to a TrussRemote.
@@ -1375,6 +1376,9 @@ def push(
         console.print(promote_warning, style="yellow")
     if promote and not environment:
         environment = PRODUCTION_ENVIRONMENT_NAME
+    if preserve_env_instance_type and not environment:
+        preserve_env_warning = "`preserve-env-instance-type` flag specifiec without the `environment` parameter. Ignoring the value of `preserve-env-instance-type`"
+        console.print(preserve_env_warning, style="yellow")
 
     # Write model name to config if it's not already there
     if model_name != tr.spec.config.model_name:
@@ -1434,6 +1438,7 @@ def push(
         disable_truss_download=disable_truss_download,
         progress_bar=progress.Progress,
         include_git_info=include_git_info,
+        preserve_env_instance_type=preserve_env_instance_type,
     )  # type: ignore
 
     click.echo(f"✨ Model {model_name} was successfully pushed ✨")

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -158,6 +158,9 @@ class BasetenApi:
                             name
                             hostname
                         }}
+                        instance_type {{
+                            name
+                        }}
                     }}
                 }}
             }}
@@ -195,7 +198,12 @@ class BasetenApi:
                     model_version {{
                         id
                         oracle {{
+                            id
+                            name
                             hostname
+                        }}
+                        instance_type {{
+                            name
                         }}
                     }}
                 }}
@@ -231,6 +239,9 @@ class BasetenApi:
                             id
                             name
                             hostname
+                        }}
+                        instance_type {{
+                            name
                         }}
                     }}
                 }}

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -177,6 +177,7 @@ class BasetenApi:
         preserve_previous_prod_deployment: bool = False,
         deployment_name: Optional[str] = None,
         environment: Optional[str] = None,
+        preserve_env_instance_type: bool = False,
     ):
         query_string = f"""
             mutation ($trussUserEnv: String) {{
@@ -187,6 +188,7 @@ class BasetenApi:
                     semver_bump: "{semver_bump}"
                     truss_user_env: $trussUserEnv
                     scale_down_old_production: {"false" if preserve_previous_prod_deployment else "true"}
+                    preserve_env_instance_type: {"true" if preserve_env_instance_type else "false"}
                     {f'name: "{deployment_name}"' if deployment_name else ""}
                     {f'environment_name: "{environment}"' if environment else ""}
                 ) {{

--- a/truss/remote/baseten/core.py
+++ b/truss/remote/baseten/core.py
@@ -73,6 +73,7 @@ class ModelVersionHandle(NamedTuple):
     version_id: str
     model_id: str
     hostname: str
+    instance_type_name: Optional[str] = None
 
 
 def get_chain_id_by_name(api: BasetenApi, chain_name: str) -> Optional[str]:
@@ -376,6 +377,11 @@ def create_truss_service(
             version_id=model_version_json["id"],
             model_id=model_version_json["oracle"]["id"],
             hostname=model_version_json["oracle"]["hostname"],
+            instance_type_name=(
+                model_version_json["instance_type"]["name"]
+                if model_version_json["instance_type"]
+                else None
+            ),
         )
 
     if model_id is None:
@@ -397,6 +403,11 @@ def create_truss_service(
             version_id=model_version_json["id"],
             model_id=model_version_json["oracle"]["id"],
             hostname=model_version_json["oracle"]["hostname"],
+            instance_type_name=(
+                model_version_json["instance_type"]["name"]
+                if model_version_json["instance_type"]
+                else None
+            ),
         )
 
     try:
@@ -426,6 +437,11 @@ def create_truss_service(
         version_id=model_version_json["id"],
         model_id=model_id,
         hostname=model_version_json["oracle"]["hostname"],
+        instance_type_name=(
+            model_version_json["instance_type"]["name"]
+            if model_version_json["instance_type"]
+            else None
+        ),
     )
 
 

--- a/truss/remote/baseten/core.py
+++ b/truss/remote/baseten/core.py
@@ -342,6 +342,7 @@ def create_truss_service(
     deployment_name: Optional[str] = None,
     origin: Optional[b10_types.ModelOrigin] = None,
     environment: Optional[str] = None,
+    preserve_env_instance_type: bool = False,
 ) -> ModelVersionHandle:
     """
     Create a model in the Baseten remote.
@@ -408,6 +409,7 @@ def create_truss_service(
             preserve_previous_prod_deployment=preserve_previous_prod_deployment,
             deployment_name=deployment_name,
             environment=environment,
+            preserve_env_instance_type=preserve_env_instance_type,
         )
     except ApiError as e:
         if (

--- a/truss/remote/baseten/core.py
+++ b/truss/remote/baseten/core.py
@@ -379,7 +379,7 @@ def create_truss_service(
             hostname=model_version_json["oracle"]["hostname"],
             instance_type_name=(
                 model_version_json["instance_type"]["name"]
-                if model_version_json["instance_type"]
+                if "instance_type" in model_version_json
                 else None
             ),
         )
@@ -405,7 +405,7 @@ def create_truss_service(
             hostname=model_version_json["oracle"]["hostname"],
             instance_type_name=(
                 model_version_json["instance_type"]["name"]
-                if model_version_json["instance_type"]
+                if "instance_type" in model_version_json
                 else None
             ),
         )
@@ -439,7 +439,7 @@ def create_truss_service(
         hostname=model_version_json["oracle"]["hostname"],
         instance_type_name=(
             model_version_json["instance_type"]["name"]
-            if model_version_json["instance_type"]
+            if "instance_type" in model_version_json
             else None
         ),
     )

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -210,6 +210,7 @@ class BasetenRemote(TrussRemote):
         environment: Optional[str] = None,
         progress_bar: Optional[Type["progress.Progress"]] = None,
         include_git_info: bool = False,
+        preserve_env_instance_type: bool = False,
     ) -> BasetenService:
         push_data = self._prepare_push(
             truss_handle=truss_handle,
@@ -246,6 +247,7 @@ class BasetenRemote(TrussRemote):
             origin=push_data.origin,
             environment=push_data.environment,
             truss_user_env=truss_user_env,
+            preserve_env_instance_type=preserve_env_instance_type,
         )
 
         return BasetenService(

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -250,6 +250,11 @@ class BasetenRemote(TrussRemote):
             preserve_env_instance_type=preserve_env_instance_type,
         )
 
+        if model_version_handle.instance_type_name:
+            logging.info(
+                f"Deploying truss using {model_version_handle.instance_type_name} instance type."
+            )
+
         return BasetenService(
             model_version_handle=model_version_handle,
             is_draft=push_data.is_draft,

--- a/truss/tests/remote/baseten/test_api.py
+++ b/truss/tests/remote/baseten/test_api.py
@@ -46,7 +46,17 @@ def mock_create_model_version_response():
     response.json = mock.Mock(
         return_value={
             "data": {
-                "create_model_version_from_truss": {"model_version": {"id": "12345"}}
+                "create_model_version_from_truss": {
+                    "model_version": {
+                        "id": "12345",
+                        "oracle": {
+                            "id": "67890",
+                            "name": "model-1",
+                            "hostname": "localhost:1234",
+                        },
+                        "instance_type": {"name": "1x4"},
+                    }
+                }
             }
         }
     )
@@ -58,7 +68,19 @@ def mock_create_model_response():
     response.status_code = 200
     response.json = mock.Mock(
         return_value={
-            "data": {"create_model_from_truss": {"model_version": {"id": "12345"}}}
+            "data": {
+                "create_model_version_from_truss": {
+                    "model_version": {
+                        "id": "12345",
+                        "oracle": {
+                            "id": "67890",
+                            "name": "model-1",
+                            "hostname": "localhost:1234",
+                        },
+                        "instance_type": {"name": "1x4"},
+                    }
+                }
+            }
         }
     )
     return response

--- a/truss/tests/remote/baseten/test_api.py
+++ b/truss/tests/remote/baseten/test_api.py
@@ -149,6 +149,7 @@ def test_create_model_version_from_truss(mock_post, baseten_api):
     assert "scale_down_old_production: true" in gql_mutation
     assert 'name: "deployment_name"' in gql_mutation
     assert 'environment_name: "production"' in gql_mutation
+    assert "preserve_env_instance_type: false" in gql_mutation
 
 
 @mock.patch("requests.post", return_value=mock_create_model_version_response())
@@ -163,6 +164,7 @@ def test_create_model_version_from_truss_does_not_send_deployment_name_if_not_sp
         b10_types.TrussUserEnv.collect(),
         False,
         deployment_name=None,
+        preserve_env_instance_type=False,
     )
 
     gql_mutation = mock_post.call_args[1]["json"]["query"]
@@ -176,6 +178,7 @@ def test_create_model_version_from_truss_does_not_send_deployment_name_if_not_sp
     assert "scale_down_old_production: true" in gql_mutation
     assert " name: " not in gql_mutation
     assert "environment_name: " not in gql_mutation
+    assert "preserve_env_instance_type: false" in gql_mutation
 
 
 @mock.patch("requests.post", return_value=mock_create_model_version_response())
@@ -191,9 +194,11 @@ def test_create_model_version_from_truss_does_not_scale_old_prod_to_zero_if_keep
         True,
         deployment_name=None,
         environment="staging",
+        preserve_env_instance_type=True,
     )
 
     gql_mutation = mock_post.call_args[1]["json"]["query"]
+
     assert 'model_id: "model_id"' in gql_mutation
     assert 's3_key: "s3key"' in gql_mutation
     assert 'config: "config_str"' in gql_mutation
@@ -204,6 +209,7 @@ def test_create_model_version_from_truss_does_not_scale_old_prod_to_zero_if_keep
     assert "scale_down_old_production: false" in gql_mutation
     assert " name: " not in gql_mutation
     assert 'environment_name: "staging"' in gql_mutation
+    assert "preserve_env_instance_type: true" in gql_mutation
 
 
 @mock.patch("requests.post", return_value=mock_create_model_response())

--- a/truss/tests/remote/baseten/test_api.py
+++ b/truss/tests/remote/baseten/test_api.py
@@ -69,7 +69,7 @@ def mock_create_model_response():
     response.json = mock.Mock(
         return_value={
             "data": {
-                "create_model_version_from_truss": {
+                "create_model_from_truss": {
                     "model_version": {
                         "id": "12345",
                         "oracle": {

--- a/truss/tests/remote/baseten/test_core.py
+++ b/truss/tests/remote/baseten/test_core.py
@@ -116,6 +116,7 @@ def test_create_truss_services_handles_is_draft(model_id):
     return_value = {
         "id": "model_version_id",
         "oracle": {"id": "model_id", "hostname": "hostname"},
+        "instance_type": {"name": "1x2"},
     }
     api.create_development_model_from_truss.return_value = return_value
     version_handle = create_truss_service(
@@ -159,6 +160,7 @@ def test_create_truss_service_handles_existing_model(inputs):
     return_value = {
         "id": "model_version_id",
         "oracle": {"id": "model_id", "hostname": "hostname"},
+        "instance_type": {"name": "1x2"},
     }
     api.create_model_version_from_truss.return_value = return_value
     version_handle = create_truss_service(


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Add the `--preserve-env-instance-type` flag to the `truss push` command. When used with the `--environment` parameter, it will use the instance type of the specified environment. If not used, the instance type will be derived from the `resources` field of the truss config.

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
Add unit test coverage and tested the truss changes locally with baseten staging environment
