### PR TITLE
Add the preserve-env-instance-type flag to 'truss push'

### DIFF
--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -1302,12 +1302,12 @@ def run_python(script, target_directory):
     type=bool,
     is_flag=True,
     required=False,
-    default=False,
+    default=None,
     help=(
         "When pushing a truss to an environment, whether to use the resources specified "
         "in the truss config to resolve the instance type or preserve the instance type "
         "configured in the specified environment. It will be ignored if --environment is not specified. "
-        "Default is --no-preserve-env-instance-type."
+        "Default is --preserve-env-instance-type."
     ),
 )
 @log_level_option
@@ -1327,7 +1327,7 @@ def push(
     environment: Optional[str] = None,
     include_git_info: bool = False,
     tail: bool = False,
-    preserve_env_instance_type: bool = False,
+    preserve_env_instance_type: bool = True,
 ) -> None:
     """
     Pushes a truss to a TrussRemote.
@@ -1354,16 +1354,21 @@ def push(
     if promote and not environment:
         environment = PRODUCTION_ENVIRONMENT_NAME
 
-    if preserve_env_instance_type and not environment:
-        preserve_env_warning = "`preserve-env-instance-type` flag specified without the `environment` parameter. Ignoring the value of `preserve-env-instance-type`"
+    if preserve_env_instance_type is not None and not environment:
+        preserve_env_warning = "'preserve-env-instance-type' flag specified without the 'environment' parameter. Ignoring the value of `preserve-env-instance-type`"
         console.print(preserve_env_warning, style="yellow")
+    if preserve_env_instance_type is None:
+        # If the flag is not specified, we set it to True by default. We handle the default here instead of in click.options
+        # to only print the warning above when the flag was specified by the user.
+        preserve_env_instance_type = True
+
     if environment:
         if preserve_env_instance_type:
-            preserve_env_info = f"`preserve-env-instance-type` flag specified. Resources from the config will be ignored and the current instance type of the {environment} environment will be used."
-            console.print(preserve_env_info, style="green")
+            preserve_env_info = f"'preserve-env-instance-type' used. Resources from the config will be ignored and the current instance type of the '{environment}' environment will be used."
+            console.print(preserve_env_info)
         else:
-            preserve_env_info = f"`preserve-env-instance-type` flag not specified. Instance type will be derived from the config and updated in the {environment} environment."
-            console.print(preserve_env_info, style="green")
+            preserve_env_info = f"'no-preserve-env-instance-type' used. Instance type will be derived from the config and updated in the '{environment}' environment."
+            console.print(preserve_env_info)
 
     # Write model name to config if it's not already there
     if model_name != tr.spec.config.model_name:

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -158,6 +158,9 @@ class BasetenApi:
                             name
                             hostname
                         }}
+                        instance_type {{
+                            name
+                        }}
                     }}
                 }}
             }}
@@ -177,6 +180,7 @@ class BasetenApi:
         preserve_previous_prod_deployment: bool = False,
         deployment_name: Optional[str] = None,
         environment: Optional[str] = None,
+        preserve_env_instance_type: bool = False,
     ):
         query_string = f"""
             mutation ($trussUserEnv: String) {{
@@ -187,13 +191,19 @@ class BasetenApi:
                     semver_bump: "{semver_bump}"
                     truss_user_env: $trussUserEnv
                     scale_down_old_production: {"false" if preserve_previous_prod_deployment else "true"}
+                    preserve_env_instance_type: {"true" if preserve_env_instance_type else "false"}
                     {f'name: "{deployment_name}"' if deployment_name else ""}
                     {f'environment_name: "{environment}"' if environment else ""}
                 ) {{
                     model_version {{
                         id
                         oracle {{
+                            id
+                            name
                             hostname
+                        }}
+                        instance_type {{
+                            name
                         }}
                     }}
                 }}
@@ -229,6 +239,9 @@ class BasetenApi:
                             id
                             name
                             hostname
+                        }}
+                        instance_type {{
+                            name
                         }}
                     }}
                 }}

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -180,7 +180,7 @@ class BasetenApi:
         preserve_previous_prod_deployment: bool = False,
         deployment_name: Optional[str] = None,
         environment: Optional[str] = None,
-        preserve_env_instance_type: bool = False,
+        preserve_env_instance_type: bool = True,
     ):
         query_string = f"""
             mutation ($trussUserEnv: String) {{

--- a/truss/remote/baseten/core.py
+++ b/truss/remote/baseten/core.py
@@ -343,7 +343,7 @@ def create_truss_service(
     deployment_name: Optional[str] = None,
     origin: Optional[b10_types.ModelOrigin] = None,
     environment: Optional[str] = None,
-    preserve_env_instance_type: bool = False,
+    preserve_env_instance_type: bool = True,
 ) -> ModelVersionHandle:
     """
     Create a model in the Baseten remote.

--- a/truss/remote/baseten/core.py
+++ b/truss/remote/baseten/core.py
@@ -73,6 +73,7 @@ class ModelVersionHandle(NamedTuple):
     version_id: str
     model_id: str
     hostname: str
+    instance_type_name: Optional[str] = None
 
 
 def get_chain_id_by_name(api: BasetenApi, chain_name: str) -> Optional[str]:
@@ -342,6 +343,7 @@ def create_truss_service(
     deployment_name: Optional[str] = None,
     origin: Optional[b10_types.ModelOrigin] = None,
     environment: Optional[str] = None,
+    preserve_env_instance_type: bool = False,
 ) -> ModelVersionHandle:
     """
     Create a model in the Baseten remote.
@@ -375,6 +377,11 @@ def create_truss_service(
             version_id=model_version_json["id"],
             model_id=model_version_json["oracle"]["id"],
             hostname=model_version_json["oracle"]["hostname"],
+            instance_type_name=(
+                model_version_json["instance_type"]["name"]
+                if "instance_type" in model_version_json
+                else None
+            ),
         )
 
     if model_id is None:
@@ -396,6 +403,11 @@ def create_truss_service(
             version_id=model_version_json["id"],
             model_id=model_version_json["oracle"]["id"],
             hostname=model_version_json["oracle"]["hostname"],
+            instance_type_name=(
+                model_version_json["instance_type"]["name"]
+                if "instance_type" in model_version_json
+                else None
+            ),
         )
 
     try:
@@ -408,6 +420,7 @@ def create_truss_service(
             preserve_previous_prod_deployment=preserve_previous_prod_deployment,
             deployment_name=deployment_name,
             environment=environment,
+            preserve_env_instance_type=preserve_env_instance_type,
         )
     except ApiError as e:
         if (
@@ -424,6 +437,11 @@ def create_truss_service(
         version_id=model_version_json["id"],
         model_id=model_id,
         hostname=model_version_json["oracle"]["hostname"],
+        instance_type_name=(
+            model_version_json["instance_type"]["name"]
+            if "instance_type" in model_version_json
+            else None
+        ),
     )
 
 

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -210,7 +210,7 @@ class BasetenRemote(TrussRemote):
         environment: Optional[str] = None,
         progress_bar: Optional[Type["progress.Progress"]] = None,
         include_git_info: bool = False,
-        preserve_env_instance_type: bool = False,
+        preserve_env_instance_type: bool = True,
     ) -> BasetenService:
         push_data = self._prepare_push(
             truss_handle=truss_handle,

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -210,6 +210,7 @@ class BasetenRemote(TrussRemote):
         environment: Optional[str] = None,
         progress_bar: Optional[Type["progress.Progress"]] = None,
         include_git_info: bool = False,
+        preserve_env_instance_type: bool = False,
     ) -> BasetenService:
         push_data = self._prepare_push(
             truss_handle=truss_handle,
@@ -246,7 +247,13 @@ class BasetenRemote(TrussRemote):
             origin=push_data.origin,
             environment=push_data.environment,
             truss_user_env=truss_user_env,
+            preserve_env_instance_type=preserve_env_instance_type,
         )
+
+        if model_version_handle.instance_type_name:
+            logging.info(
+                f"Deploying truss using {model_version_handle.instance_type_name} instance type."
+            )
 
         return BasetenService(
             model_version_handle=model_version_handle,

--- a/truss/tests/remote/baseten/test_api.py
+++ b/truss/tests/remote/baseten/test_api.py
@@ -171,7 +171,7 @@ def test_create_model_version_from_truss(mock_post, baseten_api):
     assert "scale_down_old_production: true" in gql_mutation
     assert 'name: "deployment_name"' in gql_mutation
     assert 'environment_name: "production"' in gql_mutation
-    assert "preserve_env_instance_type: false" in gql_mutation
+    assert "preserve_env_instance_type: true" in gql_mutation
 
 
 @mock.patch("requests.post", return_value=mock_create_model_version_response())

--- a/truss/tests/remote/baseten/test_api.py
+++ b/truss/tests/remote/baseten/test_api.py
@@ -46,7 +46,17 @@ def mock_create_model_version_response():
     response.json = mock.Mock(
         return_value={
             "data": {
-                "create_model_version_from_truss": {"model_version": {"id": "12345"}}
+                "create_model_version_from_truss": {
+                    "model_version": {
+                        "id": "12345",
+                        "oracle": {
+                            "id": "67890",
+                            "name": "model-1",
+                            "hostname": "localhost:1234",
+                        },
+                        "instance_type": {"name": "1x4"},
+                    }
+                }
             }
         }
     )
@@ -58,7 +68,19 @@ def mock_create_model_response():
     response.status_code = 200
     response.json = mock.Mock(
         return_value={
-            "data": {"create_model_from_truss": {"model_version": {"id": "12345"}}}
+            "data": {
+                "create_model_from_truss": {
+                    "model_version": {
+                        "id": "12345",
+                        "oracle": {
+                            "id": "67890",
+                            "name": "model-1",
+                            "hostname": "localhost:1234",
+                        },
+                        "instance_type": {"name": "1x4"},
+                    }
+                }
+            }
         }
     )
     return response
@@ -149,6 +171,7 @@ def test_create_model_version_from_truss(mock_post, baseten_api):
     assert "scale_down_old_production: true" in gql_mutation
     assert 'name: "deployment_name"' in gql_mutation
     assert 'environment_name: "production"' in gql_mutation
+    assert "preserve_env_instance_type: false" in gql_mutation
 
 
 @mock.patch("requests.post", return_value=mock_create_model_version_response())
@@ -163,6 +186,7 @@ def test_create_model_version_from_truss_does_not_send_deployment_name_if_not_sp
         b10_types.TrussUserEnv.collect(),
         False,
         deployment_name=None,
+        preserve_env_instance_type=False,
     )
 
     gql_mutation = mock_post.call_args[1]["json"]["query"]
@@ -176,6 +200,7 @@ def test_create_model_version_from_truss_does_not_send_deployment_name_if_not_sp
     assert "scale_down_old_production: true" in gql_mutation
     assert " name: " not in gql_mutation
     assert "environment_name: " not in gql_mutation
+    assert "preserve_env_instance_type: false" in gql_mutation
 
 
 @mock.patch("requests.post", return_value=mock_create_model_version_response())
@@ -191,9 +216,11 @@ def test_create_model_version_from_truss_does_not_scale_old_prod_to_zero_if_keep
         True,
         deployment_name=None,
         environment="staging",
+        preserve_env_instance_type=True,
     )
 
     gql_mutation = mock_post.call_args[1]["json"]["query"]
+
     assert 'model_id: "model_id"' in gql_mutation
     assert 's3_key: "s3key"' in gql_mutation
     assert 'config: "config_str"' in gql_mutation
@@ -204,6 +231,7 @@ def test_create_model_version_from_truss_does_not_scale_old_prod_to_zero_if_keep
     assert "scale_down_old_production: false" in gql_mutation
     assert " name: " not in gql_mutation
     assert 'environment_name: "staging"' in gql_mutation
+    assert "preserve_env_instance_type: true" in gql_mutation
 
 
 @mock.patch("requests.post", return_value=mock_create_model_response())

--- a/truss/tests/remote/baseten/test_core.py
+++ b/truss/tests/remote/baseten/test_core.py
@@ -116,6 +116,7 @@ def test_create_truss_services_handles_is_draft(model_id):
     return_value = {
         "id": "model_version_id",
         "oracle": {"id": "model_id", "hostname": "hostname"},
+        "instance_type": {"name": "1x2"},
     }
     api.create_development_model_from_truss.return_value = return_value
     version_handle = create_truss_service(
@@ -159,6 +160,7 @@ def test_create_truss_service_handles_existing_model(inputs):
     return_value = {
         "id": "model_version_id",
         "oracle": {"id": "model_id", "hostname": "hostname"},
+        "instance_type": {"name": "1x2"},
     }
     api.create_model_version_from_truss.return_value = return_value
     version_handle = create_truss_service(


### PR DESCRIPTION
Bring back the code reverted by basetenlabs/truss#1563. It was reverted because it was not ready to go out.

Re-opening the PR to bring the code back and change the default value to `True`

---
## 🚀 What
Add the --preserve-env-instance-type flag to the truss push command. When used with the --environment parameter, it will use the instance type of the specified environment. If not used, the instance type will be derived from the resources field of the truss config.

## 🔬 Testing
Add unit test coverage and tested the truss changes locally with baseten staging environment