### PR TITLE
Add served_model_name to TrussTRTLLMRuntimeConfiguration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.79rc001"
+version = "0.9.79rc002"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/base/trt_llm_config.py
+++ b/truss/base/trt_llm_config.py
@@ -131,6 +131,7 @@ class TrussTRTLLMRuntimeConfiguration(BaseModel):
         TrussTRTLLMBatchSchedulerPolicy.GUARANTEED_NO_EVICT
     )
     request_default_max_tokens: Optional[int] = None
+    served_model_name: Optional[str] = None
     total_token_limit: int = 500000
     webserver_default_route: Optional[
         Literal["/v1/embeddings", "/rerank", "/predict"]

--- a/truss/tests/trt_llm/test_trt_llm_config.py
+++ b/truss/tests/trt_llm/test_trt_llm_config.py
@@ -49,6 +49,7 @@ def test_trt_llm_configuration_init_and_migrate_deprecated_runtime_fields(
         "batch_scheduler_policy": TrussTRTLLMBatchSchedulerPolicy.MAX_UTILIZATION.value,
         "request_default_max_tokens": 10,
         "total_token_limit": 50,
+        "served_model_name": None,
         "webserver_default_route": None,
     }
 


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What

Adds `trt_llm.runtime.served_model_name` field to configuration.

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
