### PR TITLE
Don't buffer in nginx.

### DIFF
--- a/truss/templates/docker_server/proxy.conf.jinja
+++ b/truss/templates/docker_server/proxy.conf.jinja
@@ -2,6 +2,8 @@ server {
     # We use the proxy_read_timeout directive here (instead of proxy_send_timeout) as it sets the timeout for reading a response from the proxied server vs. setting a timeout for sending a request to the proxied server.
     listen 8080;
     client_max_body_size {{client_max_body_size}};
+    proxy_buffering off;
+    proxy_set_header Connection "";
 
     # Liveness endpoint override
     location = / {


### PR DESCRIPTION
## :rocket: What

While working on Captions, we noticed that there was some buffering happening with streaming responses. 

This is causing weird behavior, like chunks of responses getting cut-off in the middle (since nginx is _not aware_ of SSE responses).

For more context -- this is an issue with **Custom Servers**. For Custom Servers, there is an nginx thing that runs that proxies requests to the /predict route.

## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing

This has been live for Captions for a while with no issues, they've been running off of a context builder.
