### PR TITLE
Use python 3.12 in contro server, BT-14388

### DIFF
--- a/bin/generate_base_images.py
+++ b/bin/generate_base_images.py
@@ -177,7 +177,7 @@ if __name__ == "__main__":
     if args.python_version == "all":
         python_versions = SUPPORTED_PYTHON_VERSIONS
     else:
-        python_versions = args.python_version
+        python_versions = [args.python_version]
 
     if args.job_type == "all":
         job_types = ["server"]

--- a/bin/generate_base_images.py
+++ b/bin/generate_base_images.py
@@ -6,7 +6,7 @@ import sys
 import tempfile
 from argparse import ArgumentParser, BooleanOptionalAction  # type: ignore
 from pathlib import Path
-from typing import List, Optional, Set
+from typing import Iterable, List, Optional
 
 from jinja2 import Environment, FileSystemLoader
 
@@ -105,22 +105,13 @@ def _build(
 
 
 def _build_all(
-    job_types: Optional[List[str]] = None,
-    python_versions: Optional[Set[str]] = None,
-    use_gpu_values: Optional[List[bool]] = None,
+    job_types: Iterable[str] = ("server",),
+    python_versions: Iterable[str] = SUPPORTED_PYTHON_VERSIONS,
+    use_gpu_values: Iterable[bool] = (True, False),
     push: bool = False,
     version_tag: Optional[str] = None,
     dry_run: bool = False,
 ):
-    if job_types is None:
-        job_types = ["server"]
-
-    if python_versions is None:
-        python_versions = SUPPORTED_PYTHON_VERSIONS
-
-    if use_gpu_values is None:
-        use_gpu_values = [True, False]
-
     for job_type in job_types:
         for python_version in python_versions:
             for use_gpu in use_gpu_values:
@@ -186,7 +177,7 @@ if __name__ == "__main__":
     if args.python_version == "all":
         python_versions = SUPPORTED_PYTHON_VERSIONS
     else:
-        python_versions = {args.python_version}
+        python_versions = args.python_version
 
     if args.job_type == "all":
         job_types = ["server"]

--- a/truss/base/constants.py
+++ b/truss/base/constants.py
@@ -27,8 +27,8 @@ SHARED_SERVING_AND_TRAINING_CODE_DIR: pathlib.Path = (
 CONTROL_SERVER_CODE_DIR: pathlib.Path = TEMPLATES_DIR / "control"
 CHAINS_CODE_DIR: pathlib.Path = _TRUSS_ROOT.parent / "truss-chains" / "truss_chains"
 TRUSS_CODE_DIR: pathlib.Path = _TRUSS_ROOT.parent / "truss"
-
-SUPPORTED_PYTHON_VERSIONS = {"3.8", "3.9", "3.10", "3.11"}
+# Must be sorted ascendingly.
+SUPPORTED_PYTHON_VERSIONS = ["3.8", "3.9", "3.10", "3.11"]
 MAX_SUPPORTED_PYTHON_VERSION_IN_CUSTOM_BASE_IMAGE = "3.12"
 MIN_SUPPORTED_PYTHON_VERSION_IN_CUSTOM_BASE_IMAGE = "3.8"
 

--- a/truss/contexts/image_builder/serving_image_builder.py
+++ b/truss/contexts/image_builder/serving_image_builder.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
@@ -36,6 +37,7 @@ from truss.base.constants import (
     SERVER_REQUIREMENTS_TXT_FILENAME,
     SHARED_SERVING_AND_TRAINING_CODE_DIR,
     SHARED_SERVING_AND_TRAINING_CODE_DIR_NAME,
+    SUPPORTED_PYTHON_VERSIONS,
     SYSTEM_PACKAGES_TXT_FILENAME,
     TEMPLATES_DIR,
     TRTLLM_BASE_IMAGE,
@@ -726,6 +728,7 @@ class ServingImageBuilder(ImageBuilder):
             should_install_user_requirements_file=should_install_user_requirements_file,
             config=config,
             python_version=python_version,
+            control_python_version=SUPPORTED_PYTHON_VERSIONS[-1],  # Use highest.
             live_reload=config.live_reload,
             data_dir_exists=data_dir.exists(),
             model_dir_exists=model_dir.exists(),
@@ -746,6 +749,9 @@ class ServingImageBuilder(ImageBuilder):
             use_local_src=config.use_local_src,
             **FILENAME_CONSTANTS_MAP,
         )
-
+        # Consolidate repeated empty lines to single empty lines.
+        dockerfile_contents = re.sub(
+            r"(\r?\n){3,}", r"\n\n", dockerfile_contents
+        ).strip()
         docker_file_path = build_dir / MODEL_DOCKERFILE_NAME
         docker_file_path.write_text(dockerfile_contents)

--- a/truss/templates/base.Dockerfile.jinja
+++ b/truss/templates/base.Dockerfile.jinja
@@ -1,12 +1,16 @@
-ARG PYVERSION={{config.python_version}}
-FROM {{base_image_name_and_tag}} AS truss_server
-
+ARG PYVERSION={{ config.python_version }}
+FROM {{ base_image_name_and_tag }} AS truss_server
 ENV PYTHON_EXECUTABLE="{{ config.base_image.python_executable_path or 'python3' }}"
 
 {% block fail_fast %}
 RUN grep -w 'ID=debian\|ID_LIKE=debian' /etc/os-release || { echo "ERROR: Supplied base image is not a debian image"; exit 1; }
-RUN $PYTHON_EXECUTABLE -c "import sys; sys.exit(0) if sys.version_info.major == {{supported_python_major_version_in_custom_base_image}} and sys.version_info.minor >={{min_supported_python_minor_version_in_custom_base_image}} and sys.version_info.minor <={{max_supported_python_minor_version_in_custom_base_image}} else sys.exit(1)" \
-    || { echo "ERROR: Supplied base image does not have {{min_supported_python_version_in_custom_base_image}} <= python <= {{max_supported_python_version_in_custom_base_image}}"; exit 1; }
+RUN $PYTHON_EXECUTABLE -c "import sys; \
+    sys.exit(0) \
+    if sys.version_info.major == {{ supported_python_major_version_in_custom_base_image }} \
+    and sys.version_info.minor >= {{ min_supported_python_minor_version_in_custom_base_image }} \
+    and sys.version_info.minor <= {{ max_supported_python_minor_version_in_custom_base_image }} \
+    else sys.exit(1)" \
+    || { echo "ERROR: Supplied base image does not have {{ min_supported_python_version_in_custom_base_image }} <= python <= {{ max_supported_python_version_in_custom_base_image }}"; exit 1; }
 {% endblock %}
 
 RUN pip install --upgrade pip --no-cache-dir \
@@ -20,15 +24,15 @@ RUN pip install --upgrade pip --no-cache-dir \
 # HuggingFace pytorch gpu support needs mkl
 RUN pip install mkl
     {% endif %}
-{% endif%}
+{% endif %}
 
 {% block post_base %}
 {% endblock %}
 
 {% block install_system_requirements %}
     {%- if should_install_system_requirements %}
-COPY ./{{system_packages_filename}} {{system_packages_filename}}
-RUN apt-get update && apt-get install --yes --no-install-recommends $(cat {{system_packages_filename}}) \
+COPY ./{{ system_packages_filename }} {{ system_packages_filename }}
+RUN apt-get update && apt-get install --yes --no-install-recommends $(cat {{ system_packages_filename }}) \
     && apt-get autoremove -y \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
@@ -38,13 +42,13 @@ RUN apt-get update && apt-get install --yes --no-install-recommends $(cat {{syst
 
 {% block install_requirements %}
     {%- if should_install_user_requirements_file %}
-COPY ./{{user_supplied_requirements_filename}} {{user_supplied_requirements_filename}}
-RUN pip install -r {{user_supplied_requirements_filename}} --no-cache-dir && rm -rf /root/.cache/pip
+COPY ./{{ user_supplied_requirements_filename }} {{ user_supplied_requirements_filename }}
+RUN pip install -r {{ user_supplied_requirements_filename }} --no-cache-dir && rm -rf /root/.cache/pip
     {%- endif %}
     {%- if should_install_requirements %}
-COPY ./{{config_requirements_filename}} {{config_requirements_filename}}
-RUN pip install -r {{config_requirements_filename}} --no-cache-dir && rm -rf /root/.cache/pip
-    {%- endif %}
+COPY ./{{ config_requirements_filename }} {{ config_requirements_filename }}
+RUN pip install -r {{ config_requirements_filename }} --no-cache-dir && rm -rf /root/.cache/pip
+{%- endif %}
 {% endblock %}
 
 
@@ -60,8 +64,8 @@ WORKDIR $APP_HOME
 
 {% block bundled_packages_copy %}
     {%- if bundled_packages_dir_exists %}
-COPY ./{{config.bundled_packages_dir}} /packages
-    {%- endif %}
+COPY ./{{ config.bundled_packages_dir }} /packages
+{%- endif %}
 {% endblock %}
 
 

--- a/truss/templates/control/requirements.txt
+++ b/truss/templates/control/requirements.txt
@@ -5,11 +5,8 @@ httpx>=0.27.0
 loguru>=0.7.2
 python-json-logger>=2.0.2
 tenacity>=8.1.0
- # To avoid divergence, this should follow the latest release. However, this is blocked by us
- # supporting still py3.8 trusses and newer truss-package releases requiring >=3.9.
- # A possible solution is to run the control server with a newer python verion even if the truss
- # server needs 3.8.
-truss==0.9.50
+ # To avoid divergence, this should follow the latest release.
+truss==0.9.84
 uvicorn>=0.24.0
 uvloop>=0.19.0
 websockets>=10.0

--- a/truss/templates/server.Dockerfile.jinja
+++ b/truss/templates/server.Dockerfile.jinja
@@ -1,25 +1,3 @@
-{%- macro ensure_python_version_for_control(version) -%}
-{#
-# Macro to ensure a specific Python version (e.g., python3.10) interpreter is available.
-# Installs interpreter from deadsnakes PPA if not found.
-# Venv package installation is handled in a separate RUN step.
-#}
-ENV CONDA_DIR=/opt/conda-control
-RUN if ! command -v python{{ version }} > /dev/null; then \
-    echo "Python {{ version }} not found, installing via Miniforge..."; \
-    curl -fsSL -o miniforge.sh https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh && \
-    bash miniforge.sh -b -p ${CONDA_DIR} && \
-    rm miniforge.sh && \
-    ${CONDA_DIR}/bin/conda install -y python={{ version }} && \
-    ln -s ${CONDA_DIR}/bin/python /usr/local/bin/python{{ version }} && \
-    ln -s ${CONDA_DIR}/bin/pip /usr/local/bin/pip{{ version }} && \
-    ${CONDA_DIR}/bin/conda clean -afy && \
-    rm -rf ${CONDA_DIR}/pkgs; \
-else \
-    echo "Python {{ version }} already present, skipping install."; \
-fi
-{%- endmacro -%} {#- endmacro ensure_python_version_for_control #}
-
 {%- if model_cache_v1 %}
 {%- include "cache.Dockerfile.jinja" %}
 {%- endif %} {#- endif model_cache_v1 #}
@@ -51,7 +29,7 @@ RUN pip install -r {{ base_server_requirements_filename }} --no-cache-dir && rm 
 
     {%- if config.live_reload and not config.docker_server %}
     {# Create symlink for inference server IF a user base image is supplied and live_reload is enabled. #}
-    {# This links the base image's primary python executable path to /usr/local/bin/python. #}
+    {# This links the base images primary python executable path to /usr/local/bin/python. #}
     {# This is specific to the user-provided base image scenario. #}
 RUN readlink {{ config.base_image.python_executable_path }} &>/dev/null \
     && echo "WARNING: Overwriting existing link at /usr/local/bin/python"
@@ -114,10 +92,25 @@ COPY ./truss /app/truss
 COPY ./config.yaml /app/config.yaml
     {%- if config.live_reload and not config.docker_server %}
 COPY ./control /control
-{{ ensure_python_version_for_control(control_python_version) }}
-RUN python{{ version }} -m pip install virtualenv && \
-    python{{ version }} -m virtualenv /control/.env && \
-    /control/.env/bin/pip install -r /control/requirements.txt
+# Step 1: Ensure a usable python{{ control_python_version }} is available
+RUN if python{{ control_python_version }} -c 'import venv; venv.EnvBuilder(with_pip=True).create("/tmp/__probe_env")' > /dev/null 2>&1; then \
+      echo "Using system python{{ control_python_version }}"; \
+      python{{ control_python_version }} -m pip install --upgrade pip virtualenv && \
+      python{{ control_python_version }} -m virtualenv /control/.env; \
+    else \
+      echo "Installing Miniforge-based python{{ control_python_version }}..."; \
+      curl -fsSL -o miniforge.sh https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh && \
+      bash miniforge.sh -b -p /opt/conda-control && \
+      rm miniforge.sh && \
+      /opt/conda-control/bin/conda create -y -p /opt/conda-control/envs/py{{ control_python_version }} python={{ control_python_version }} && \
+      /opt/conda-control/envs/py{{ control_python_version }}/bin/pip install --upgrade pip virtualenv && \
+      /opt/conda-control/bin/conda clean -afy && \
+      rm -rf /opt/conda-control/pkgs && \
+      /opt/conda-control/envs/py{{ control_python_version }}/bin/python -m virtualenv /control/.env; \
+    fi
+
+# Step 2: Install requirements into the freshly created venv
+RUN /control/.env/bin/pip install -r /control/requirements.txt
     {%- endif %} {#- endif config.live_reload and not config.docker_server (for control server setup) #}
 {%- if model_dir_exists %}
 COPY ./{{ config.model_module_dir }} /app/model

--- a/truss/templates/server.Dockerfile.jinja
+++ b/truss/templates/server.Dockerfile.jinja
@@ -1,16 +1,39 @@
+{%- macro ensure_python_version_for_control(version) -%}
+{#
+# Macro to ensure a specific Python version (e.g., python3.10) interpreter is available.
+# Installs interpreter from deadsnakes PPA if not found.
+# Venv package installation is handled in a separate RUN step.
+#}
+ENV CONDA_DIR=/opt/conda-control
+RUN if ! command -v python{{ version }} > /dev/null; then \
+    echo "Python {{ version }} not found, installing via Miniforge..."; \
+    curl -fsSL -o miniforge.sh https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh && \
+    bash miniforge.sh -b -p ${CONDA_DIR} && \
+    rm miniforge.sh && \
+    ${CONDA_DIR}/bin/conda install -y python={{ version }} && \
+    ln -s ${CONDA_DIR}/bin/python /usr/local/bin/python{{ version }} && \
+    ln -s ${CONDA_DIR}/bin/pip /usr/local/bin/pip{{ version }} && \
+    ${CONDA_DIR}/bin/conda clean -afy && \
+    rm -rf ${CONDA_DIR}/pkgs; \
+else \
+    echo "Python {{ version }} already present, skipping install."; \
+fi
+{%- endmacro -%} {#- endmacro ensure_python_version_for_control #}
+
 {%- if model_cache_v1 %}
 {%- include "cache.Dockerfile.jinja" %}
-{%- endif %}
+{%- endif %} {#- endif model_cache_v1 #}
 
 {% extends "base.Dockerfile.jinja" %}
 
 {% block base_image_patch %}
-# If user base image is supplied in config, apply build commands from truss base image
+{# If user base image is supplied in config, apply build commands from truss base image #}
 {% if config.base_image %}
     {%- if not config.docker_server %}
 ENV PYTHONUNBUFFERED="True"
 ENV DEBIAN_FRONTEND="noninteractive"
 
+{# Install common dependencies #}
 RUN apt update && \
     apt install -y bash \
                 build-essential \
@@ -22,59 +45,53 @@ RUN apt update && \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 
-COPY ./{{base_server_requirements_filename}} {{base_server_requirements_filename}}
-RUN pip install -r {{base_server_requirements_filename}} --no-cache-dir && rm -rf /root/.cache/pip
-    {%- endif %}
+COPY ./{{ base_server_requirements_filename }} {{ base_server_requirements_filename }}
+RUN pip install -r {{ base_server_requirements_filename }} --no-cache-dir && rm -rf /root/.cache/pip
+    {%- endif %} {#- endif not config.docker_server #}
 
-    {%- if config.live_reload  and not config.docker_server%}
-RUN $PYTHON_EXECUTABLE -m venv -h >/dev/null \
-    || { pythonVersion=$(echo $($PYTHON_EXECUTABLE --version) | cut -d" " -f2 | cut -d"." -f1,2) \
-    && add-apt-repository -y ppa:deadsnakes/ppa \
-    && apt update -y && apt install -y --no-install-recommends python$pythonVersion-venv \
-    && apt-get autoremove -y \
-    && apt-get clean -y \
-    && rm -rf /var/lib/apt/lists/*; }
-# Create symlink for control server to start inference server process with correct python executable
-RUN readlink {{config.base_image.python_executable_path}} &>/dev/null \
+    {%- if config.live_reload and not config.docker_server %}
+    {# Create symlink for inference server IF a user base image is supplied and live_reload is enabled. #}
+    {# This links the base image's primary python executable path to /usr/local/bin/python. #}
+    {# This is specific to the user-provided base image scenario. #}
+RUN readlink {{ config.base_image.python_executable_path }} &>/dev/null \
     && echo "WARNING: Overwriting existing link at /usr/local/bin/python"
-RUN ln -sf {{config.base_image.python_executable_path}} /usr/local/bin/python
-    {%- endif %}
-{% endif %}
+RUN ln -sf {{ config.base_image.python_executable_path }} /usr/local/bin/python
+    {%- endif %} {#- endif config.live_reload and not config.docker_server (for symlink) #}
+{% endif %} {#- endif config.base_image #}
 
-{% endblock %}
+{% endblock %} {#- endblock base_image_patch #}
 
 {% block install_requirements %}
     {%- if should_install_server_requirements %}
-COPY ./{{server_requirements_filename}} {{server_requirements_filename}}
-RUN pip install -r {{server_requirements_filename}} --no-cache-dir && rm -rf /root/.cache/pip
-    {%- endif %}
+COPY ./{{ server_requirements_filename }} {{ server_requirements_filename }}
+RUN pip install -r {{ server_requirements_filename }} --no-cache-dir && rm -rf /root/.cache/pip
+    {%- endif %} {#- endif should_install_server_requirements #}
 {{ super() }}
-{% endblock %}
+{% endblock %} {#- endblock install_requirements #}
 
 
 {% block app_copy %}
 {%- if model_cache_v1 %}
 # Copy data before code for better caching
-    {%- include "copy_cache_files.Dockerfile.jinja"%}
-{%- endif %}
+{%- include "copy_cache_files.Dockerfile.jinja" -%}
+{%- endif %} {#- endif model_cache_v1 #}
 
 {%- if external_data_files %}
 {% for url, dst in external_data_files %}
 RUN mkdir -p {{ dst.parent }}; curl -L "{{ url }}" -o {{ dst }}
-{% endfor %}
-{%- endif  %}
-
+{% endfor %} {#- endfor external_data_files #}
+{%- endif %} {#- endif external_data_files #}
 
 {%- if build_commands %}
 {% for command in build_commands %}
-RUN {% for secret,path in config.build.secret_to_path_mapping.items() %} --mount=type=secret,id={{secret}},target={{path}}{% endfor %} {{ command }}
-{% endfor %}
-{%- endif  %}
+RUN {% for secret,path in config.build.secret_to_path_mapping.items() %} --mount=type=secret,id={{ secret }},target={{ path }}{%- endfor %} {{ command }}
+{% endfor %} {#- endfor build_commands #}
+{%- endif %} {#- endif build_commands #}
 
-# Copy data before code for better caching
+{# Copy data before code for better caching #}
 {%- if data_dir_exists %}
-COPY ./{{config.data_dir}} /app/data
-{%- endif %}
+COPY ./{{ config.data_dir }} /app/data
+{%- endif %} {#- endif data_dir_exists #}
 
 {%- if model_cache_v2 %}
 # v0.0.9, keep synced with server_requirements.txt
@@ -82,28 +99,30 @@ RUN curl -sSL --fail --retry 5 --retry-delay 2 -o /usr/local/bin/truss-transfer-
 RUN chmod +x /usr/local/bin/truss-transfer-cli
 RUN mkdir /bptr
 COPY ./bptr-manifest /bptr/bptr-manifest
-{%- endif %}
+{%- endif %} {#- endif model_cache_v2 #}
 
 {%- if not config.docker_server %}
 COPY ./server /app
-{%- endif %}
+{%- endif %} {#- endif not config.docker_server #}
 
 {%- if use_local_src %}
 {# This path takes precedence over site-packages. #}
 COPY ./truss_chains /app/truss_chains
 COPY ./truss /app/truss
-{%- endif %}
+{%- endif %} {#- endif use_local_src #}
 
 COPY ./config.yaml /app/config.yaml
-    {%- if config.live_reload and not config.docker_server%}
+    {%- if config.live_reload and not config.docker_server %}
 COPY ./control /control
-RUN python3 -m venv /control/.env \
-    && /control/.env/bin/pip3 install -r /control/requirements.txt
-    {%- endif %}
+{{ ensure_python_version_for_control(control_python_version) }}
+RUN python{{ version }} -m pip install virtualenv && \
+    python{{ version }} -m virtualenv /control/.env && \
+    /control/.env/bin/pip install -r /control/requirements.txt
+    {%- endif %} {#- endif config.live_reload and not config.docker_server (for control server setup) #}
 {%- if model_dir_exists %}
 COPY ./{{ config.model_module_dir }} /app/model
-{%- endif %}
-{% endblock %}
+{%- endif %} {#- endif model_dir_exists #}
+{% endblock %} {#- endblock app_copy #}
 
 
 {% block run %}
@@ -123,15 +142,15 @@ COPY supervisord.conf {{ supervisor_config_path }}
 ENV SUPERVISOR_SERVER_URL="{{ supervisor_server_url }}"
 ENV SERVER_START_CMD="supervisord -c {{ supervisor_config_path }}"
 ENTRYPOINT ["supervisord", "-c", "{{ supervisor_config_path }}"]
-    {%- elif config.live_reload %}
-ENV HASH_TRUSS="{{truss_hash}}"
+    {%- elif config.live_reload %} {#- elif config.live_reload #}
+ENV HASH_TRUSS="{{ truss_hash }}"
 ENV CONTROL_SERVER_PORT="8080"
 ENV INFERENCE_SERVER_PORT="8090"
-ENV SERVER_START_CMD="/control/.env/bin/python3 /control/control/server.py"
-ENTRYPOINT ["/control/.env/bin/python3", "/control/control/server.py"]
-    {%- else %}
+ENV SERVER_START_CMD="/control/.env/bin/python /control/control/server.py"
+ENTRYPOINT ["/control/.env/bin/python", "/control/control/server.py"]
+    {%- else %} {#- else (default inference server) #}
 ENV INFERENCE_SERVER_PORT="8080"
-ENV SERVER_START_CMD="{{(config.base_image.python_executable_path or "python3") ~ " /app/main.py"}}"
-ENTRYPOINT ["{{config.base_image.python_executable_path or "python3"}}", "/app/main.py"]
-    {%- endif %}
-{% endblock %}
+ENV SERVER_START_CMD="{{ (config.base_image.python_executable_path | default("python3", true)) ~ " /app/main.py" }}"
+ENTRYPOINT ["{{ (config.base_image.python_executable_path | default("python3", true)) }}", "/app/main.py"]
+    {%- endif %} {#- endif config.docker_server / live_reload #}
+{% endblock %} {#- endblock run #}

--- a/truss/tests/contexts/image_builder/test_serving_image_builder.py
+++ b/truss/tests/contexts/image_builder/test_serving_image_builder.py
@@ -47,7 +47,9 @@ def test_serving_image_dockerfile_from_user_base_image(
         # Remove both empty lines + comments
         def filter_unneeded_lines(lines):
             return [
-                stripped for line in lines if (stripped := line.strip()) and not stripped.startswith("#")
+                stripped
+                for line in lines
+                if (stripped := line.strip()) and not stripped.startswith("#")
             ]
 
         gen_docker_lines = filter_unneeded_lines(gen_docker_lines)

--- a/truss/tests/contexts/image_builder/test_serving_image_builder.py
+++ b/truss/tests/contexts/image_builder/test_serving_image_builder.py
@@ -46,7 +46,9 @@ def test_serving_image_dockerfile_from_user_base_image(
 
         # Remove both empty lines + comments
         def filter_unneeded_lines(lines):
-            return [x for x in lines if x.strip() and not x.strip().startswith("#")]
+            return [
+                x.strip() for x in lines if x.strip() and not x.strip().startswith("#")
+            ]
 
         gen_docker_lines = filter_unneeded_lines(gen_docker_lines)
         server_docker_lines = filter_unneeded_lines(server_docker_lines)

--- a/truss/tests/contexts/image_builder/test_serving_image_builder.py
+++ b/truss/tests/contexts/image_builder/test_serving_image_builder.py
@@ -47,7 +47,7 @@ def test_serving_image_dockerfile_from_user_base_image(
         # Remove both empty lines + comments
         def filter_unneeded_lines(lines):
             return [
-                x.strip() for x in lines if x.strip() and not x.strip().startswith("#")
+                stripped for line in lines if (stripped := line.strip()) and not stripped.startswith("#")
             ]
 
         gen_docker_lines = filter_unneeded_lines(gen_docker_lines)

--- a/truss/tests/test_config.py
+++ b/truss/tests/test_config.py
@@ -3,10 +3,12 @@ import tempfile
 from contextlib import nullcontext as does_not_raise
 from pathlib import Path
 
+import packaging.version
 import pydantic
 import pytest
 import yaml
 
+from truss.base import constants
 from truss.base.trt_llm_config import TrussTRTLLMQuantizationType
 from truss.base.truss_config import (
     DEFAULT_CPU,
@@ -877,3 +879,11 @@ def test_not_supported_python_minor_versions():
 def test_not_supported_python_major_versions():
     with pytest.raises(NotImplementedError, match="Only python version 3 is supported"):
         _map_to_supported_python_version("py211")
+
+
+def test_supported_versions_are_sorted():
+    semvers = [packaging.version.parse(v) for v in constants.SUPPORTED_PYTHON_VERSIONS]
+    semvers_sorted = sorted(semvers)
+    assert semvers == semvers_sorted, (
+        f"{constants.SUPPORTED_PYTHON_VERSIONS} must be sorted ascendingly"
+    )

--- a/truss/tests/test_data/server.Dockerfile
+++ b/truss/tests/test_data/server.Dockerfile
@@ -1,19 +1,18 @@
 ARG PYVERSION=py39
 FROM baseten/truss-server-base:3.9-v0.4.3 AS truss_server
-
 ENV PYTHON_EXECUTABLE="/usr/local/bin/python3"
-
 RUN grep -w 'ID=debian\|ID_LIKE=debian' /etc/os-release || { echo "ERROR: Supplied base image is not a debian image"; exit 1; }
-RUN $PYTHON_EXECUTABLE -c "import sys; sys.exit(0) if sys.version_info.major == 3 and sys.version_info.minor >=8 and sys.version_info.minor <=12 else sys.exit(1)" \
+RUN $PYTHON_EXECUTABLE -c "import sys; \
+    sys.exit(0) \
+    if sys.version_info.major == 3 \
+    and sys.version_info.minor >= 8 \
+    and sys.version_info.minor <= 12 \
+    else sys.exit(1)" \
     || { echo "ERROR: Supplied base image does not have 3.8 <= python <= 3.12"; exit 1; }
-
 RUN pip install --upgrade pip --no-cache-dir \
     && rm -rf /root/.cache/pip
-
-# If user base image is supplied in config, apply build commands from truss base image
 ENV PYTHONUNBUFFERED="True"
 ENV DEBIAN_FRONTEND="noninteractive"
-
 RUN apt update && \
     apt install -y bash \
                 build-essential \
@@ -24,24 +23,17 @@ RUN apt update && \
     && apt-get autoremove -y \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
-
 COPY ./base_server_requirements.txt base_server_requirements.txt
 RUN pip install -r base_server_requirements.txt --no-cache-dir && rm -rf /root/.cache/pip
-
 COPY ./requirements.txt requirements.txt
 RUN pip install -r requirements.txt --no-cache-dir && rm -rf /root/.cache/pip
-
 ENV APP_HOME="/app"
 WORKDIR $APP_HOME
-
-# Copy data before code for better caching
 COPY ./data /app/data
 COPY ./server /app
 COPY ./config.yaml /app/config.yaml
 COPY ./model /app/model
-
 COPY ./packages /packages
-
 ENV INFERENCE_SERVER_PORT="8080"
 ENV SERVER_START_CMD="/usr/local/bin/python3 /app/main.py"
 ENTRYPOINT ["/usr/local/bin/python3", "/app/main.py"]


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
For dev models, assert that a python 3.12 env (or specifically the latest supported python version) is available to install the control server in. This way we can use newer truss versions as dependency in the control server.

Note that this will change the source of installing python from `ppa:deadsnakes` to `miniforge.sh https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh` becasue deadsnakes is not available in some base images that we support.

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
