### PR TITLE
Truss Auto-Upgrade and persistent config. BT-14412

### DIFF
--- a/docs/examples/frameworks/pytorch.mdx
+++ b/docs/examples/frameworks/pytorch.mdx
@@ -1,4 +1,0 @@
----
-title: PyTorch
-description: "Description"
----

--- a/docs/examples/frameworks/sklearn.mdx
+++ b/docs/examples/frameworks/sklearn.mdx
@@ -1,4 +1,0 @@
----
-title: scikit-learn
-description: "Description"
----

--- a/docs/examples/frameworks/tensorflow.mdx
+++ b/docs/examples/frameworks/tensorflow.mdx
@@ -1,4 +1,0 @@
----
-title: Tensorflow
-description: "Description"
----

--- a/docs/examples/frameworks/xgboost.mdx
+++ b/docs/examples/frameworks/xgboost.mdx
@@ -1,4 +1,0 @@
----
-title: XGBoost
-description: "Description"
----

--- a/poetry.lock
+++ b/poetry.lock
@@ -3935,7 +3935,7 @@ version = "0.13.2"
 description = "Style preserving TOML library"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "tomlkit-0.13.2-py3-none-any.whl", hash = "sha256:7a974427f6e119197f670fbbbeae7bef749a6c14e793db934baefc1b5f03efde"},
     {file = "tomlkit-0.13.2.tar.gz", hash = "sha256:fff5fe59a87295b278abd31bec92c15d9bc4a06885ab12bcea52c71119392e79"},
@@ -4695,4 +4695,4 @@ all = []
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<=3.13.3"
-content-hash = "e4ebc7f052648052851f06c5644535d604a012d44aa48253a084612fb33ae05b"
+content-hash = "ca8f1b9869c6bce22bb37ddfc8929102f87d8f4ad76e3e6897c846594479ee9e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.88rc0"
+version = "0.9.88rc101"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"
@@ -102,6 +102,7 @@ rich = { version = "^13.4.2", optional = false }
 rich-click = { version = "^1.6.1", optional = false }
 ruff = { version = ">=0.4.8", optional = false }  # Not a dev dep, needed for chains code gen.
 tenacity = { version = "^8.0.1", optional = false }
+tomlkit = { version = ">=0.13.2", optional = false }
 watchfiles = { version = "^0.19.0", optional = false }
 
 
@@ -127,6 +128,7 @@ rich = { components = "other" }
 rich-click = { components = "other" }
 ruff = { components = "other" }
 tenacity = { components = "other" }
+tomlkit = { components = "other" }
 watchfiles = { components = "other" }
 
 [tool.poetry.group.dev.dependencies]
@@ -146,7 +148,6 @@ pytest-check = "^2.4.1"
 pytest-cov = "^3.0.0"
 pytest-split = ">=0.10.0"
 requests-mock = ">=1.11.0"
-tomlkit = ">=0.12"
 types-PyYAML = "^6.0.12.12"
 types-aiofiles = ">=24.1.0"
 types-requests = "==2.31.0.2"

--- a/truss-chains/truss_chains/deployment/deployment_client.py
+++ b/truss-chains/truss_chains/deployment/deployment_client.py
@@ -32,7 +32,7 @@ from truss.remote.baseten import error as b10_errors
 from truss.remote.baseten import remote as b10_remote
 from truss.remote.baseten import service as b10_service
 from truss.truss_handle import truss_handle
-from truss.util import log_utils
+from truss.util import log_utils, user_config
 from truss.util import path as truss_path
 from truss_chains import framework, private_types, public_types
 from truss_chains.deployment import code_gen
@@ -472,7 +472,7 @@ def _create_baseten_chain(
         remote_factory.RemoteFactory.create(remote=baseten_options.remote),
     )
 
-    if remote_provider.include_git_info or baseten_options.include_git_info:
+    if user_config.settings.include_git_info or baseten_options.include_git_info:
         truss_user_env = b10_types.TrussUserEnv.collect_with_git_info(
             baseten_options.working_dir
         )

--- a/truss/base/constants.py
+++ b/truss/base/constants.py
@@ -1,15 +1,6 @@
 import pathlib
-from typing import Set
 
-SKLEARN = "sklearn"
-TENSORFLOW = "tensorflow"
-KERAS = "keras"
-XGBOOST = "xgboost"
-PYTORCH = "pytorch"
 CUSTOM = "custom"
-HUGGINGFACE_TRANSFORMER = "huggingface_transformer"
-LIGHTGBM = "lightgbm"
-
 
 _TRUSS_ROOT = pathlib.Path(__file__).parent.parent.resolve()
 
@@ -74,7 +65,6 @@ TRUSS_MODIFIED_TIME = "truss_modified_time"
 TRUSS_DIR = "truss_dir"
 TRUSS_HASH = "truss_hash"
 
-HUGGINGFACE_TRANSFORMER_MODULE_NAME: Set[str] = set({})
 
 INFERENCE_SERVER_PORT = 8080
 

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -89,45 +89,14 @@ click.rich_click.COMMAND_GROUPS = {
     ]
 }
 
+_INCLUDE_GIT_INFO_DOC = (
+    "Whether to attach git versioning info (sha, branch, tag) to deployments made from "
+    "within a git repo. If set to True in `.trussrc`, it will always be attached."
+)
+
+
 console = Console()
-
-error_console = Console(stderr=True, style="bold red")
-
-is_humanfriendly_log_level = True
-
-
-def error_handling(f: Callable[..., object]):
-    @wraps(f)
-    def wrapper(*args, **kwargs):
-        try:
-            f(*args, **kwargs)
-        except click.UsageError as e:
-            raise e  # You can re-raise the exception or handle it different
-        except Exception as e:
-            if is_humanfriendly_log_level:
-                console.print(
-                    f"[bold red]ERROR {type(e).__name__}[/bold red]: {e}",
-                    highlight=True,
-                )
-            else:
-                console.print_exception(show_locals=True)
-
-            ctx = click.get_current_context()
-            ctx.exit(1)
-
-    return wrapper
-
-
-def upgrade_dialogue(f: Callable[..., object]):
-    @wraps(f)
-    def wrapper(*args, **kwargs):
-        if common.check_is_interactive() and user_config.settings.enable_auto_upgrade:
-            self_upgrade.upgrade_dialogue(truss.version(), console)
-        f(*args, **kwargs)
-
-    return wrapper
-
-
+_error_console = Console(stderr=True, style="bold red")
 _HUMANFRIENDLY_LOG_LEVEL = "humanfriendly"
 _log_level_str_to_level = {
     _HUMANFRIENDLY_LOG_LEVEL: logging.INFO,
@@ -145,8 +114,10 @@ def _set_logging_level(log_level: Union[str, int]) -> None:
         level = _log_level_str_to_level[log_level]
     else:
         level = log_level
+
     root_logger = logging.getLogger()
     root_logger.setLevel(level)
+    root_logger.handlers.clear()
 
     if log_level == _HUMANFRIENDLY_LOG_LEVEL:
         rich_handler = rich.logging.RichHandler(
@@ -155,10 +126,7 @@ def _set_logging_level(log_level: Union[str, int]) -> None:
     else:
         # Rich handler adds time, levels, file location etc.
         rich_handler = rich.logging.RichHandler()
-        global is_humanfriendly_log_level
-        is_humanfriendly_log_level = False
 
-    root_logger.handlers = []  # Clear existing handlers
     root_logger.addHandler(rich_handler)
     # Enable deprecation warnings raised in this module.
     warnings.filterwarnings(
@@ -166,49 +134,190 @@ def _set_logging_level(log_level: Union[str, int]) -> None:
     )
 
 
-def log_level_option(f):
-    def callback(ctx, param, value):
+def _log_level_option(f: Callable[..., object]) -> Callable[..., object]:
+    def callback(ctx: click.Context, param: click.Parameter, value: str) -> str:
         _set_logging_level(value)
         return value
 
     return click.option(
         "--log",
         default=_HUMANFRIENDLY_LOG_LEVEL,
-        expose_value=False,
         help="Customizes logging.",
         type=click.Choice(list(_log_level_str_to_level.keys()), case_sensitive=False),
         callback=callback,
+        expose_value=False,
     )(f)
+
+
+def _error_handling(f: Callable[..., object]) -> Callable[..., object]:
+    @wraps(f)
+    def wrapper(*args: object, **kwargs: object) -> None:
+        try:
+            f(*args, **kwargs)
+        except click.UsageError as e:
+            raise e
+        except Exception as e:
+            ctx = click.get_current_context()
+            log_level = ctx.params.get("log")
+            if log_level == _HUMANFRIENDLY_LOG_LEVEL:
+                console.print(
+                    f"[bold red]ERROR {type(e).__name__}[/bold red]: {e}",
+                    highlight=True,
+                )
+            else:
+                console.print_exception(show_locals=True)
+            ctx.exit(1)
+
+    return wrapper
+
+
+def _non_interactive_option(f: Callable[..., object]) -> Callable[..., object]:
+    return click.option(
+        "--non-interactive",
+        is_flag=True,
+        default=False,
+        help="Disables interactive prompts, use in CI / automated execution contexts.",
+        expose_value=False,
+    )(f)
+
+
+def _upgrade_dialogue(f: Callable[..., object]) -> Callable[..., object]:
+    @wraps(f)
+    def wrapper(*args: object, **kwargs: object) -> None:
+        ctx = click.get_current_context()
+        if (
+            not ctx.params.get("non_interactive", False)
+            and common.check_is_interactive()
+            and user_config.settings.enable_auto_upgrade
+        ):
+            self_upgrade.upgrade_dialogue(truss.version(), console)
+        f(*args, **kwargs)
+
+    return wrapper
+
+
+def common_options(
+    with_error_handling: bool = True, with_upgrade_dialogue: bool = True
+) -> Callable[[Callable[..., object]], Callable[..., object]]:
+    def decorator(f: Callable[..., object]) -> Callable[..., object]:
+        if with_error_handling:
+            f = _error_handling(f)
+        if with_upgrade_dialogue:
+            f = _upgrade_dialogue(f)
+        f = _log_level_option(f)
+        f = _non_interactive_option(f)
+        return f
+
+    return decorator
 
 
 def _format_link(text: str) -> str:
     return f"[link={text}]{text}[/link]"
 
 
-def print_help() -> None:
+def _print_help() -> None:
     ctx = click.get_current_context()
     click.echo(ctx.get_help())
+
+
+def _get_truss_from_directory(target_directory: Optional[str] = None):
+    """Gets Truss from directory. If none, use the current directory"""
+    if target_directory is None:
+        target_directory = os.getcwd()
+    if not os.path.isfile(target_directory):
+        return load(target_directory)
+    # These imports are delayed, to handle pydantic v1 envs gracefully.
+    from truss_chains.deployment import code_gen
+
+    truss_dir = code_gen.gen_truss_model_from_source(Path(target_directory))
+    return load(truss_dir)
+
+
+### Top-level & utility commands. ######################################################
 
 
 @click.group(name="truss", invoke_without_command=True)  # type: ignore
 @click.pass_context
 @click.version_option(truss.version())
-@log_level_option
-@upgrade_dialogue
+@common_options()
 def truss_cli(ctx) -> None:
     """truss: The simplest way to serve models in production"""
     if not ctx.invoked_subcommand:
         click.echo(ctx.get_help())
 
 
-@click.group()
-def container():
-    """Subcommands for truss container"""
+@truss_cli.command()
+@click.option(
+    "--api-key",
+    type=str,
+    required=False,
+    help="Name of the remote in .trussrc to patch changes to",
+)
+@common_options()
+def login(api_key: Optional[str]):
+    from truss.api import login
+
+    if not api_key:
+        remote_config = remote_cli.inquire_remote_config()
+        RemoteFactory.update_remote_config(remote_config)
+    else:
+        login(api_key)
 
 
-@click.group()
-def image():
-    """Subcommands for truss image"""
+@truss_cli.command()
+@click.option(
+    "--remote",
+    type=str,
+    required=False,
+    help="Name of the remote in .trussrc to check whoami.",
+)
+@common_options()
+def whoami(remote: Optional[str]):
+    """
+    Shows user information and exit.
+    """
+    from truss.api import whoami
+
+    if not remote:
+        remote = remote_cli.inquire_remote_name()
+
+    user = whoami(remote)
+
+    console.print(f"{user.workspace_name}\\{user.user_email}")
+
+
+@truss_cli.command()
+def configure():
+    # Read the original file content
+    with open(USER_TRUSSRC_PATH, "r") as f:
+        original_content = f.read()
+
+    # Open the editor and get the modified content
+    edited_content = click.edit(original_content)
+
+    # If the content was modified, save it
+    if edited_content is not None and edited_content != original_content:
+        with open(USER_TRUSSRC_PATH, "w") as f:
+            f.write(edited_content)
+            click.echo(f"Changes saved to {USER_TRUSSRC_PATH}")
+    else:
+        click.echo("No changes made.")
+
+
+@truss_cli.command()
+@common_options()
+def cleanup() -> None:
+    """
+    Clean up truss data.
+
+    Truss creates temporary directories for various operations
+    such as for building docker images. This command clears
+    that data to free up disk space.
+    """
+    _cleanup()
+
+
+### Truss (model) commands. ############################################################
 
 
 @truss_cli.command()
@@ -227,9 +336,7 @@ def image():
     default=False,
     help="Uses the code first tooling to build models.",
 )
-@log_level_option
-@error_handling
-@upgrade_dialogue
+@common_options()
 def init(target_directory, backend, name, python_config) -> None:
     """Create a new truss.
 
@@ -253,871 +360,6 @@ def init(target_directory, backend, name, python_config) -> None:
         python_config=python_config,
     )
     click.echo(f"Truss {model_name} was created in {tr_path.absolute()}")
-
-
-@image.command()  # type: ignore
-@click.argument("build_dir")
-@click.argument("target_directory", required=False)
-@log_level_option
-@error_handling
-@upgrade_dialogue
-def build_context(build_dir, target_directory: str) -> None:
-    """
-    Create a docker build context for a Truss.
-
-    BUILD_DIR: Folder where image context is built for Truss
-
-    TARGET_DIRECTORY: A Truss directory. If none, use current directory.
-    """
-    tr = _get_truss_from_directory(target_directory=target_directory)
-    tr.docker_build_setup(build_dir=Path(build_dir))
-
-
-@image.command()  # type: ignore
-@click.argument("target_directory", required=False)
-@click.argument("build_dir", required=False)
-@click.option("--tag", help="Docker image tag")
-@click.option(
-    "--use_host_network",
-    is_flag=True,
-    default=False,
-    help="Use host network for docker build",
-)
-@log_level_option
-@error_handling
-@upgrade_dialogue
-def build(target_directory: str, build_dir: Path, tag, use_host_network) -> None:
-    """
-    Builds the docker image for a Truss.
-
-    TARGET_DIRECTORY: A Truss directory. If none, use current directory.
-
-    BUILD_DIR: Image context. If none, a temp directory is created.
-    """
-    tr = _get_truss_from_directory(target_directory=target_directory)
-    if build_dir:
-        build_dir = Path(build_dir)
-    if use_host_network:
-        tr.build_serving_docker_image(build_dir=build_dir, tag=tag, network="host")
-        return
-    tr.build_serving_docker_image(build_dir=build_dir, tag=tag)
-
-
-@image.command()  # type: ignore
-@click.argument("target_directory", required=False)
-@click.argument("build_dir", required=False)
-@click.option("--tag", help="Docker build image tag")
-@click.option("--port", type=int, default=8080, help="Local port used to run image")
-@click.option(
-    "--attach", is_flag=True, default=False, help="Flag for attaching the process"
-)
-@click.option(
-    "--use_host_network",
-    is_flag=True,
-    default=False,
-    help="Use host network for docker build",
-)
-@log_level_option
-@error_handling
-@upgrade_dialogue
-def run(
-    target_directory: str, build_dir: Path, tag, port, attach, use_host_network
-) -> None:
-    """
-    Runs the docker image for a Truss.
-
-    TARGET_DIRECTORY: A Truss directory. If none, use current directory.
-
-    BUILD_DIR: Image context. If none, a temp directory is created.
-    """
-    tr = _get_truss_from_directory(target_directory=target_directory)
-    if build_dir:
-        build_dir = Path(build_dir)
-    urls = tr.get_urls_from_truss()
-    if urls:
-        click.confirm(
-            f"Container already exists at {urls}. Are you sure you want to continue?"
-        )
-    if use_host_network:
-        tr.docker_run(
-            build_dir=build_dir,
-            tag=tag,
-            local_port=port,
-            detach=not attach,
-            network="host",
-        )
-        return
-    tr.docker_run(build_dir=build_dir, tag=tag, local_port=port, detach=not attach)
-
-
-@truss_cli.command()
-@click.option(
-    "--api-key",
-    type=str,
-    required=False,
-    help="Name of the remote in .trussrc to patch changes to",
-)
-@error_handling
-def login(api_key: Optional[str]):
-    from truss.api import login
-
-    if not api_key:
-        remote_config = remote_cli.inquire_remote_config()
-        RemoteFactory.update_remote_config(remote_config)
-    else:
-        login(api_key)
-
-
-@truss_cli.command()
-@click.option(
-    "--remote",
-    type=str,
-    required=False,
-    help="Name of the remote in .trussrc to check whoami.",
-)
-@error_handling
-def whoami(remote: Optional[str]):
-    """
-    Shows user information and exit.
-    """
-    from truss.api import whoami
-
-    if not remote:
-        remote = remote_cli.inquire_remote_name()
-
-    user = whoami(remote)
-
-    console.print(f"{user.workspace_name}\\{user.user_email}")
-
-
-@truss_cli.command()
-@click.argument("target_directory", required=False, default=os.getcwd())
-@click.option(
-    "--remote",
-    type=str,
-    required=False,
-    help="Name of the remote in .trussrc to patch changes to",
-)
-@log_level_option
-@error_handling
-@upgrade_dialogue
-def watch(target_directory: str, remote: str) -> None:
-    """
-    Seamless remote development with truss
-
-    TARGET_DIRECTORY: A Truss directory. If none, use current directory.
-    """
-    # TODO: ensure that provider support draft
-    if not remote:
-        remote = remote_cli.inquire_remote_name()
-
-    remote_provider = RemoteFactory.create(remote=remote)
-
-    tr = _get_truss_from_directory(target_directory=target_directory)
-    model_name = tr.spec.config.model_name
-    if not model_name:
-        console.print(
-            "🧐 NoneType model_name provided in config.yaml. "
-            "Please check that you have the correct model name in your config file."
-        )
-        sys.exit(1)
-
-    service = remote_provider.get_service(model_identifier=ModelName(model_name))
-    console.print(
-        f"🪵  View logs for your deployment at {_format_link(service.logs_url)}"
-    )
-
-    if not os.path.isfile(target_directory):
-        remote_provider.sync_truss_to_dev_version_by_name(
-            model_name, target_directory, console, error_console
-        )
-    else:
-        # These imports are delayed, to handle pydantic v1 envs gracefully.
-        from truss_chains.deployment import deployment_client
-
-        deployment_client.watch_model(
-            source=Path(target_directory),
-            model_name=model_name,
-            remote_provider=remote_provider,
-            console=console,
-            error_console=error_console,
-        )
-
-
-# Chains Stuff #########################################################################
-
-
-@click.group()
-def chains():
-    """Subcommands for truss chains"""
-
-
-def _make_chains_curl_snippet(run_remote_url: str, environment: Optional[str]) -> str:
-    if environment:
-        idx = run_remote_url.find("deployment")
-        if idx != -1:
-            run_remote_url = (
-                run_remote_url[:idx] + f"environments/{environment}/run_remote"
-            )
-    return (
-        f"curl -X POST '{run_remote_url}' \\\n"
-        '    -H "Authorization: Api-Key $BASETEN_API_KEY" \\\n'
-        "    -d '<JSON_INPUT>'"
-    )
-
-
-def _create_chains_table(service) -> Tuple[rich.table.Table, List[str]]:
-    """Creates a status table similar to:
-
-                                          ⛓️   ItestChain - Chain  ⛓️
-
-                         🌐 Status page: https://app.baseten.co/chains/p7qrm93v/overview
-    ╭──────────────────────┬──────────────────────────────┬─────────────────────────────────────────────╮
-    │ Status               │ Chainlet                     │ Logs URL                                   │
-    ├──────────────────────┼──────────────────────────────┼────────────────────────────────────────────┤
-    │ 🛠️  BUILDING         │ ItestChain (entrypoint)      │ https://app.baseten.co/chains/.../logs/... │
-    ├──────────────────────┼──────────────────────────────┼────────────────────────────────────────────┤
-    │ 👾  DEPLOYING        │ GENERATE_DATA (internal)     │ https://app.baseten.co/chains/.../logs/... │
-    │ 👾  DEPLOYING        │ SplitTextFailOnce (internal) │ https://app.baseten.co/chains/.../logs/... │
-    │ 👾  DEPLOYING        │ TextReplicator (internal)    │ https://app.baseten.co/chains/.../logs/... │
-    │ 🛠️  BUILDING         │ TextToNum (internal)         │ https://app.baseten.co/chains/.../logs/... │
-    ╰──────────────────────┴──────────────────────────────┴────────────────────────────────────────────╯
-
-    """
-    title = (
-        f"⛓️   {service.name} - Chain  ⛓️\n\n "
-        f"🌐 Status page: {_format_link(service.status_page_url)}"
-    )
-    table = rich.table.Table(
-        show_header=True,
-        header_style="bold yellow",
-        title=title,
-        box=rich.table.box.ROUNDED,
-        border_style="blue",
-    )
-    table.add_column("Status", style="dim", min_width=20)
-    table.add_column("Chainlet", min_width=20)
-    table.add_column("Logs URL")
-    statuses = []
-    status_iterable = service.get_info()
-    # Organize status_iterable s.t. entrypoint is first.
-    entrypoint = next(x for x in status_iterable if x.is_entrypoint)
-    sorted_chainlets = sorted(
-        (x for x in status_iterable if not x.is_entrypoint), key=lambda x: x.name
-    )
-    for i, chainlet in enumerate([entrypoint] + sorted_chainlets):
-        displayable_status = get_displayable_status(chainlet.status)
-        if displayable_status == ACTIVE_STATUS:
-            spinner_name = "active"
-        elif displayable_status in DEPLOYING_STATUSES:
-            if displayable_status == "BUILDING":
-                spinner_name = "building"
-            elif displayable_status == "LOADING":
-                spinner_name = "loading"
-            else:
-                spinner_name = "deploying"
-        else:
-            spinner_name = "failed"
-        spinner = rich.spinner.Spinner(spinner_name, text=displayable_status)
-        if chainlet.is_entrypoint:
-            display_name = f"{chainlet.name} (entrypoint)"
-        else:
-            display_name = f"{chainlet.name} (internal)"
-
-        table.add_row(spinner, display_name, _format_link(chainlet.logs_url))
-        # Add section divider after entrypoint, entrypoint must be first.
-        if chainlet.is_entrypoint:
-            table.add_section()
-        statuses.append(displayable_status)
-    return table, statuses
-
-
-include_git_info_doc = (
-    "Whether to attach git versioning info (sha, branch, tag) to deployments made from "
-    "within a git repo. If set to True in `.trussrc`, it will always be attached."
-)
-
-
-@chains.command(name="push")  # type: ignore
-@click.argument("source", type=Path, required=True)
-@click.argument("entrypoint", type=str, required=False)
-@click.option(
-    "--name",
-    type=str,
-    required=False,
-    help="Name of the chain to be deployed, if not given, the entrypoint name is used.",
-)
-@click.option(
-    "--publish/--no-publish",
-    type=bool,
-    default=False,
-    help="Create chainlets as published deployments.",
-)
-@click.option(
-    "--promote/--no-promote",
-    type=bool,
-    default=False,
-    help="Replace production chainlets with newly deployed chainlets.",
-)
-@click.option(
-    "--environment",
-    type=str,
-    required=False,
-    help=(
-        "Deploy the chain as a published deployment to the specified environment."
-        "If specified, --publish is implied and the supplied value of --promote will be ignored."
-    ),
-)
-@click.option(
-    "--wait/--no-wait",
-    type=bool,
-    default=True,
-    help="Wait until all chainlets are ready (or deployment failed).",
-)
-@click.option(
-    "--watch/--no-watch",
-    type=bool,
-    default=False,
-    help=(
-        "Watches the chains source code and applies live patches. Using this option "
-        "will wait for the chain to be deployed (i.e. `--wait` flag is applied), "
-        "before starting to watch for changes. This option required the deployment "
-        "to be a development deployment (i.e. `--no-promote` and `--no-publish`."
-    ),
-)
-@click.option(
-    "--dryrun",
-    type=bool,
-    default=False,
-    is_flag=True,
-    help="Produces only generated files, but doesn't deploy anything.",
-)
-@click.option(
-    "--remote",
-    type=str,
-    required=False,
-    help="Name of the remote in .trussrc to push to.",
-)
-@click.option(
-    "--experimental-watch-chainlet-names",
-    type=str,
-    required=False,
-    help=(
-        "Runs `watch`, but only applies patches to specified chainlets. The option is "
-        "a comma-separated list of chainlet (display) names. This option can give "
-        "faster dev loops, but also lead to inconsistent deployments. Use with caution "
-        "and refer to docs."
-    ),
-)
-@click.option(
-    "--include-git-info",
-    type=bool,
-    is_flag=True,
-    required=False,
-    default=False,
-    help=include_git_info_doc,
-)
-@log_level_option
-@error_handling
-@upgrade_dialogue
-def push_chain(
-    source: Path,
-    entrypoint: Optional[str],
-    name: Optional[str],
-    publish: bool,
-    promote: bool,
-    wait: bool,
-    watch: bool,
-    dryrun: bool,
-    remote: Optional[str],
-    environment: Optional[str],
-    experimental_watch_chainlet_names: Optional[str],
-    include_git_info: bool = False,
-) -> None:
-    """
-    Deploys a chain remotely.
-
-    SOURCE: Path to a python file that contains the entrypoint chainlet.
-
-    ENTRYPOINT: Class name of the entrypoint chainlet in source file. May be omitted
-    if a chainlet definition in SOURCE is tagged with `@chains.mark_entrypoint`.
-    """
-    # These imports are delayed, to handle pydantic v1 envs gracefully.
-    from truss_chains import framework
-    from truss_chains import private_types as chains_def
-    from truss_chains.deployment import deployment_client
-
-    if experimental_watch_chainlet_names:
-        watch = True
-
-    if watch:
-        if publish or promote:
-            raise ValueError(
-                "When using `--watch`, the deployment cannot be published or promoted."
-            )
-        if not wait:
-            console.print(
-                "`--watch` is used. Will wait for deployment before watching files."
-            )
-            wait = True
-
-    if promote and environment:
-        promote_warning = (
-            "`promote` flag and `environment` flag were both specified. "
-            "Ignoring the value of `promote`."
-        )
-        console.print(promote_warning, style="yellow")
-
-    if not remote:
-        remote = remote_cli.inquire_remote_name()
-
-    if not include_git_info:
-        include_git_info = user_config.settings.include_git_info
-
-    with framework.ChainletImporter.import_target(source, entrypoint) as entrypoint_cls:
-        chain_name = (
-            name or entrypoint_cls.meta_data.chain_name or entrypoint_cls.display_name
-        )
-        options = chains_def.PushOptionsBaseten.create(
-            chain_name=chain_name,
-            promote=promote,
-            publish=publish,
-            only_generate_trusses=dryrun,
-            remote=remote,
-            environment=environment,
-            include_git_info=include_git_info,
-            working_dir=source.parent if source.is_file() else source.resolve(),
-        )
-        service = deployment_client.push(
-            entrypoint_cls, options, progress_bar=progress.Progress
-        )
-
-    if dryrun:
-        return
-
-    assert isinstance(service, deployment_client.BasetenChainService)
-    curl_snippet = _make_chains_curl_snippet(
-        service.run_remote_url, options.environment
-    )
-
-    table, statuses = _create_chains_table(service)
-    status_check_wait_sec = 2
-    if wait:
-        num_services = len(statuses)
-        success = False
-        num_failed = 0
-        # Logging inferences with live display (even when using richHandler)
-        # -> capture logs and print later.
-        with (
-            LogInterceptor() as log_interceptor,
-            rich.live.Live(table, console=console, refresh_per_second=4) as live,
-        ):
-            while True:
-                table, statuses = _create_chains_table(service)
-                live.update(table)
-                num_active = sum(s == ACTIVE_STATUS for s in statuses)
-                num_deploying = sum(s in DEPLOYING_STATUSES for s in statuses)
-                if num_active == num_services:
-                    success = True
-                    break
-                elif num_failed := num_services - num_active - num_deploying:
-                    break
-                time.sleep(status_check_wait_sec)
-
-            intercepted_logs = log_interceptor.get_logs()
-
-        # Prints must be outside `Live` context.
-        if intercepted_logs:
-            console.print("Logs intercepted during waiting:", style="blue")
-            for log in intercepted_logs:
-                console.print(f"\t{log}")
-        if success:
-            deploy_success_text = "Deployment succeeded."
-            if environment:
-                deploy_success_text = (
-                    "Your chain has been deployed into "
-                    f"the {options.environment} environment."
-                )
-            console.print(deploy_success_text, style="bold green")
-            console.print(f"You can run the chain with:\n{curl_snippet}")
-
-            if watch:  # Note that this command will print a startup message.
-                if experimental_watch_chainlet_names:
-                    included_chainlets = [
-                        x.strip() for x in experimental_watch_chainlet_names.split(",")
-                    ]
-                else:
-                    included_chainlets = None
-                deployment_client.watch(
-                    source,
-                    entrypoint,
-                    name,
-                    remote,
-                    console,
-                    error_console,
-                    show_stack_trace=not is_humanfriendly_log_level,
-                    included_chainlets=included_chainlets,
-                )
-        else:
-            console.print(f"Deployment failed ({num_failed} failures).", style="red")
-    else:
-        console.print(table)
-        console.print(
-            "Once all chainlets are deployed, "
-            f"you can run the chain with:\n\n{curl_snippet}"
-        )
-
-
-@chains.command(name="watch")  # type: ignore
-@click.argument("source", type=Path, required=True)
-@click.argument("entrypoint", type=str, required=False)
-@click.option(
-    "--name",
-    type=str,
-    required=False,
-    help="Name of the chain to be deployed, if not given, the entrypoint name is used.",
-)
-@click.option(
-    "--remote",
-    type=str,
-    required=False,
-    help="Name of the remote in .trussrc to push to.",
-)
-@click.option(
-    "--experimental-chainlet-names",
-    type=str,
-    required=False,
-    help=(
-        "Runs `watch`, but only applies patches to specified chainlets. The option is "
-        "a comma-separated list of chainlet (display) names. This option can give "
-        "faster dev loops, but also lead to inconsistent deployments. Use with caution "
-        "and refer to docs."
-    ),
-)
-@log_level_option
-@error_handling
-@upgrade_dialogue
-def watch_chains(
-    source: Path,
-    entrypoint: Optional[str],
-    name: Optional[str],
-    remote: Optional[str],
-    experimental_chainlet_names: Optional[str],
-) -> None:
-    """
-    Watches the chains source code and applies live patches to a development deployment.
-
-    The development deployment must have been deployed before running this command.
-
-    SOURCE: Path to a python file that contains the entrypoint chainlet.
-
-    ENTRYPOINT: Class name of the entrypoint chainlet in source file. May be omitted
-    if a chainlet definition in SOURCE is tagged with `@chains.mark_entrypoint`.
-    """
-    # These imports are delayed, to handle pydantic v1 envs gracefully.
-    from truss_chains.deployment import deployment_client
-
-    if not remote:
-        remote = remote_cli.inquire_remote_name()
-
-    if experimental_chainlet_names:
-        included_chainlets = [x.strip() for x in experimental_chainlet_names.split(",")]
-    else:
-        included_chainlets = None
-
-    deployment_client.watch(
-        source,
-        entrypoint,
-        name,
-        remote,
-        console,
-        error_console,
-        show_stack_trace=not is_humanfriendly_log_level,
-        included_chainlets=included_chainlets,
-    )
-
-
-@chains.command(name="init")  # type: ignore
-@click.argument("directory", type=Path, required=False)
-@log_level_option
-@error_handling
-@upgrade_dialogue
-def init_chain(directory: Optional[Path]) -> None:
-    """
-    Initializes a chains project directory.
-
-    DIRECTORY: A name of new or existing directory to create the chain in,
-      it must be empty. If not specified, the current directory is used.
-
-    """
-    if not directory:
-        directory = Path.cwd()
-    if directory.exists():
-        if not directory.is_dir():
-            raise ValueError(f"The path {directory} must be a directory.")
-        if any(directory.iterdir()):
-            raise ValueError(f"Directory {directory} must be empty.")
-    else:
-        directory.mkdir()
-
-    filename = inquirer.text(
-        qmark="",
-        message="Enter the python file name for the chain.",
-        default="my_chain.py",
-    ).execute()
-    filepath = directory / str(filename).strip()
-    console.print(f"Creating and populating {filepath}...\n")
-    source_code = _load_example_chainlet_code()
-    filepath.write_text(source_code)
-    console.print(
-        "Next steps:\n",
-        f"💻 Run [bold green]`python {filepath}`[/bold green] for local debug "
-        "execution.\n"
-        f"🚢 Run [bold green]`truss chains deploy {filepath}`[/bold green] "
-        "to deploy the chain to Baseten.\n",
-    )
-
-
-def _load_example_chainlet_code() -> str:
-    try:
-        from truss_chains.reference_code import reference_chainlet
-    # if the example is faulty, a validation error would be raised
-    except Exception as e:
-        raise Exception("Failed to load starter code. Please notify support.") from e
-
-    source = Path(reference_chainlet.__file__).read_text()
-    return source
-
-
-# End Chains Stuff #####################################################################
-
-
-# Start Training Stuff ####################################################################
-@click.group()
-def train():
-    """Subcommands for truss train"""
-
-
-@train.command(name="push")
-@click.argument("config", type=Path, required=True)
-@click.option("--remote", type=str, required=False, help="Remote to use")
-@click.option(
-    "--tail", type=bool, is_flag=True, help="Tail for status + logs after push."
-)
-@log_level_option
-@error_handling
-@upgrade_dialogue
-def push_training_job(config: Path, remote: Optional[str], tail: bool):
-    """Run a training job"""
-    from truss_train import deployment, loader
-
-    if not remote:
-        remote = remote_cli.inquire_remote_name()
-
-    remote_provider: BasetenRemote = cast(
-        BasetenRemote, RemoteFactory.create(remote=remote)
-    )
-    with loader.import_training_project(config) as training_project:
-        with console.status("Creating training job...", spinner="dots"):
-            project_resp = remote_provider.api.upsert_training_project(
-                training_project=training_project
-            )
-
-            prepared_job = deployment.prepare_push(
-                remote_provider.api, config, training_project.job
-            )
-            job_resp = remote_provider.api.create_training_job(
-                project_id=project_resp["id"], job=prepared_job
-            )
-
-        console.print("✨ Training job successfully created!", style="green")
-        console.print(
-            f"🪵 View logs for your job via "
-            f"[cyan]`truss train logs --job-id {job_resp['id']} [--tail]`[/cyan]\n"
-            f"🔍 View metrics for your job via "
-            f"[cyan]`truss train metrics --job-id {job_resp['id']}`[/cyan]"
-        )
-
-    if tail:
-        project_id, job_id = project_resp["id"], job_resp["id"]
-        watcher = TrainingLogWatcher(remote_provider.api, project_id, job_id, console)
-        for log in watcher.watch():
-            cli_log_utils.output_log(log, console)
-
-
-@train.command(name="logs")
-@click.option("--remote", type=str, required=False, help="Remote to use")
-@click.option("--project-id", type=str, required=False, help="Project ID.")
-@click.option("--job-id", type=str, required=False, help="Job ID.")
-@click.option("--tail", type=bool, is_flag=True, help="Tail for ongoing logs.")
-@log_level_option
-@error_handling
-@upgrade_dialogue
-def get_job_logs(
-    remote: Optional[str], project_id: Optional[str], job_id: Optional[str], tail: bool
-):
-    """Fetch logs for a training job"""
-
-    if not remote:
-        remote = remote_cli.inquire_remote_name()
-
-    remote_provider: BasetenRemote = cast(
-        BasetenRemote, RemoteFactory.create(remote=remote)
-    )
-    project_id, job_id = train_cli.get_most_recent_job(
-        console, remote_provider, project_id, job_id
-    )
-
-    if not tail:
-        logs = remote_provider.api.get_training_job_logs(project_id, job_id)
-        for log in cli_log_utils.parse_logs(logs):
-            cli_log_utils.output_log(log, console)
-    else:
-        log_watcher = TrainingLogWatcher(
-            remote_provider.api, project_id, job_id, console
-        )
-        for log in log_watcher.watch():
-            cli_log_utils.output_log(log, console)
-
-
-@train.command(name="stop")
-@click.option("--project-id", type=str, required=False, help="Project ID.")
-@click.option("--job-id", type=str, required=False, help="Job ID.")
-@click.option("--all", type=bool, is_flag=True, help="Stop all running jobs.")
-@click.option("--remote", type=str, required=False, help="Remote to use")
-@log_level_option
-@error_handling
-@upgrade_dialogue
-def stop_job(
-    project_id: Optional[str], job_id: Optional[str], all: bool, remote: Optional[str]
-):
-    """Stop a training job"""
-
-    if not remote:
-        remote = remote_cli.inquire_remote_name()
-
-    remote_provider: BasetenRemote = cast(
-        BasetenRemote, RemoteFactory.create(remote=remote)
-    )
-    if all:
-        train_cli.stop_all_jobs(console, remote_provider, project_id)
-    else:
-        project_id, job_id = train_cli.get_args_for_stop(
-            console, remote_provider, project_id, job_id
-        )
-        remote_provider.api.stop_training_job(project_id, job_id)
-        console.print("Training job stopped successfully.", style="green")
-
-
-@train.command(name="view")
-@click.option(
-    "--project-id", type=str, required=False, help="View training jobs for a project."
-)
-@click.option(
-    "--job-id", type=str, required=False, help="View a specific training job."
-)
-@click.option("--remote", type=str, required=False, help="Remote to use")
-@log_level_option
-@error_handling
-@upgrade_dialogue
-def view_training(
-    project_id: Optional[str], job_id: Optional[str], remote: Optional[str]
-):
-    """List all training jobs for a project"""
-
-    if not remote:
-        remote = remote_cli.inquire_remote_name()
-
-    remote_provider: BasetenRemote = cast(
-        BasetenRemote, RemoteFactory.create(remote=remote)
-    )
-    train_cli.view_training_details(console, remote_provider, project_id, job_id)
-
-
-@train.command(name="metrics")
-@click.option("--project-id", type=str, required=False, help="Project ID.")
-@click.option("--job-id", type=str, required=False, help="Job ID.")
-@click.option("--remote", type=str, required=False, help="Remote to use")
-@log_level_option
-@error_handling
-@upgrade_dialogue
-def get_job_metrics(
-    project_id: Optional[str], job_id: Optional[str], remote: Optional[str]
-):
-    """Get metrics for a training job"""
-
-    if not remote:
-        remote = remote_cli.inquire_remote_name()
-
-    remote_provider: BasetenRemote = cast(
-        BasetenRemote, RemoteFactory.create(remote=remote)
-    )
-    train_cli.view_training_job_metrics(console, remote_provider, project_id, job_id)
-
-
-@train.command(name="deploy_checkpoints")
-@click.option("--project-id", type=str, required=False, help="Project ID.")
-@click.option("--job-id", type=str, required=False, help="Job ID.")
-@click.option(
-    "--config",
-    type=str,
-    required=False,
-    help="path to a python file that defines a DeployCheckpointsConfig",
-)
-@click.option(
-    "--dry-run",
-    type=bool,
-    is_flag=True,
-    help="Generate a truss config without deploying",
-)
-@click.option("--remote", type=str, required=False, help="Remote to use")
-@log_level_option
-@error_handling
-def deploy_checkpoints(
-    project_id: Optional[str],
-    job_id: Optional[str],
-    config: Optional[str],
-    remote: Optional[str],
-    dry_run: bool,
-):
-    """
-    Deploy a checkpoint. Some early assumptions about this are:
-    - We are deploying a vllm model
-    - The checkpoint is a lora
-    - Base Model is coming from Huggingface
-    """
-
-    if not remote:
-        remote = remote_cli.inquire_remote_name()
-
-    remote_provider: BasetenRemote = cast(
-        BasetenRemote, RemoteFactory.create(remote=remote)
-    )
-    prepare_checkpoint_result = train_cli.prepare_checkpoint_deploy(
-        console,
-        remote_provider,
-        train_cli.PrepareCheckpointArgs(
-            project_id=project_id, job_id=job_id, deploy_config_path=config
-        ),
-    )
-
-    ctx = click.Context(push, obj={})
-    ctx.params = {
-        "target_directory": prepare_checkpoint_result.truss_directory,
-        "remote": remote,
-        "model_name": prepare_checkpoint_result.checkpoint_deploy_config.model_name,
-        "publish": True,
-        "deployment_name": prepare_checkpoint_result.checkpoint_deploy_config.deployment_name,
-    }
-    if dry_run:
-        console.print("--dry-run flag provided, not deploying", style="yellow")
-    else:
-        push.invoke(ctx)
-
-    train_cli.print_deploy_checkpoints_success_message(prepare_checkpoint_result)
-
-
-# End Training Stuff #####################################################################
 
 
 def _extract_and_validate_model_identifier(
@@ -1204,7 +446,7 @@ def _extract_request_data(data: Optional[str], file: Optional[Path]):
     help="ID of model deployment to call",
 )
 @click.option("--model", type=str, required=False, help="ID of model to call")
-@log_level_option
+@_log_level_option
 def predict(
     target_directory: str,
     remote: str,
@@ -1283,8 +525,8 @@ def run_python(script, target_directory):
         )
 
     tr = _get_truss_from_directory(target_directory=target_directory)
-    container = tr.run_python_script(Path(script))
-    for output in container.logs():
+    container_ = tr.run_python_script(Path(script))
+    for output in container_.logs():
         output_type = output[0]
         output_content = output[1]
 
@@ -1400,7 +642,7 @@ def run_python(script, target_directory):
     is_flag=True,
     required=False,
     default=False,
-    help=include_git_info_doc,
+    help=_INCLUDE_GIT_INFO_DOC,
 )
 @click.option("--tail", type=bool, is_flag=True)
 @click.option(
@@ -1416,9 +658,7 @@ def run_python(script, target_directory):
         "Default is --preserve-env-instance-type."
     ),
 )
-@log_level_option
-@error_handling
-@upgrade_dialogue
+@common_options()
 def push(
     target_directory: str,
     remote: str,
@@ -1611,9 +851,7 @@ def push(
 @click.option("--model-id", type=str, required=True)
 @click.option("--deployment-id", type=str, required=True)
 @click.option("--tail", type=bool, is_flag=True, help="Tail for ongoing logs.")
-@log_level_option
-@error_handling
-@upgrade_dialogue
+@common_options()
 def model_logs(
     remote: Optional[str], model_id: str, deployment_id: str, tail: bool = False
 ) -> None:
@@ -1637,26 +875,171 @@ def model_logs(
 
 
 @truss_cli.command()
-def configure():
-    # Read the original file content
-    with open(USER_TRUSSRC_PATH, "r") as f:
-        original_content = f.read()
+@click.argument("target_directory", required=False, default=os.getcwd())
+@click.option(
+    "--remote",
+    type=str,
+    required=False,
+    help="Name of the remote in .trussrc to patch changes to",
+)
+@common_options()
+def watch(target_directory: str, remote: str) -> None:
+    """
+    Seamless remote development with truss
 
-    # Open the editor and get the modified content
-    edited_content = click.edit(original_content)
+    TARGET_DIRECTORY: A Truss directory. If none, use current directory.
+    """
+    # TODO: ensure that provider support draft
+    if not remote:
+        remote = remote_cli.inquire_remote_name()
 
-    # If the content was modified, save it
-    if edited_content is not None and edited_content != original_content:
-        with open(USER_TRUSSRC_PATH, "w") as f:
-            f.write(edited_content)
-            click.echo(f"Changes saved to {USER_TRUSSRC_PATH}")
+    remote_provider = RemoteFactory.create(remote=remote)
+
+    tr = _get_truss_from_directory(target_directory=target_directory)
+    model_name = tr.spec.config.model_name
+    if not model_name:
+        console.print(
+            "🧐 NoneType model_name provided in config.yaml. "
+            "Please check that you have the correct model name in your config file."
+        )
+        sys.exit(1)
+
+    service = remote_provider.get_service(model_identifier=ModelName(model_name))
+    console.print(
+        f"🪵  View logs for your deployment at {_format_link(service.logs_url)}"
+    )
+
+    if not os.path.isfile(target_directory):
+        remote_provider.sync_truss_to_dev_version_by_name(
+            model_name, target_directory, console, _error_console
+        )
     else:
-        click.echo("No changes made.")
+        # These imports are delayed, to handle pydantic v1 envs gracefully.
+        from truss_chains.deployment import deployment_client
+
+        deployment_client.watch_model(
+            source=Path(target_directory),
+            model_name=model_name,
+            remote_provider=remote_provider,
+            console=console,
+            error_console=_error_console,
+        )
+
+
+### Image commands. ####################################################################
+
+
+@click.group()
+def image():
+    """Subcommands for truss image"""
+
+
+truss_cli.add_command(image)
+
+
+@image.command()  # type: ignore
+@click.argument("build_dir")
+@click.argument("target_directory", required=False)
+@common_options()
+def build_context(build_dir, target_directory: str) -> None:
+    """
+    Create a docker build context for a Truss.
+
+    BUILD_DIR: Folder where image context is built for Truss
+
+    TARGET_DIRECTORY: A Truss directory. If none, use current directory.
+    """
+    tr = _get_truss_from_directory(target_directory=target_directory)
+    tr.docker_build_setup(build_dir=Path(build_dir))
+
+
+@image.command()  # type: ignore
+@click.argument("target_directory", required=False)
+@click.argument("build_dir", required=False)
+@click.option("--tag", help="Docker image tag")
+@click.option(
+    "--use_host_network",
+    is_flag=True,
+    default=False,
+    help="Use host network for docker build",
+)
+@common_options()
+def build(target_directory: str, build_dir: Path, tag, use_host_network) -> None:
+    """
+    Builds the docker image for a Truss.
+
+    TARGET_DIRECTORY: A Truss directory. If none, use current directory.
+
+    BUILD_DIR: Image context. If none, a temp directory is created.
+    """
+    tr = _get_truss_from_directory(target_directory=target_directory)
+    if build_dir:
+        build_dir = Path(build_dir)
+    if use_host_network:
+        tr.build_serving_docker_image(build_dir=build_dir, tag=tag, network="host")
+        return
+    tr.build_serving_docker_image(build_dir=build_dir, tag=tag)
+
+
+@image.command()  # type: ignore
+@click.argument("target_directory", required=False)
+@click.argument("build_dir", required=False)
+@click.option("--tag", help="Docker build image tag")
+@click.option("--port", type=int, default=8080, help="Local port used to run image")
+@click.option(
+    "--attach", is_flag=True, default=False, help="Flag for attaching the process"
+)
+@click.option(
+    "--use_host_network",
+    is_flag=True,
+    default=False,
+    help="Use host network for docker build",
+)
+@common_options()
+def run(
+    target_directory: str, build_dir: Path, tag, port, attach, use_host_network
+) -> None:
+    """
+    Runs the docker image for a Truss.
+
+    TARGET_DIRECTORY: A Truss directory. If none, use current directory.
+
+    BUILD_DIR: Image context. If none, a temp directory is created.
+    """
+    tr = _get_truss_from_directory(target_directory=target_directory)
+    if build_dir:
+        build_dir = Path(build_dir)
+    urls = tr.get_urls_from_truss()
+    if urls:
+        click.confirm(
+            f"Container already exists at {urls}. Are you sure you want to continue?"
+        )
+    if use_host_network:
+        tr.docker_run(
+            build_dir=build_dir,
+            tag=tag,
+            local_port=port,
+            detach=not attach,
+            network="host",
+        )
+        return
+    tr.docker_run(build_dir=build_dir, tag=tag, local_port=port, detach=not attach)
+
+
+# Container commands. ##################################################################
+
+
+@click.group()
+def container():
+    """Subcommands for truss container"""
+
+
+truss_cli.add_command(container)
 
 
 @container.command()  # type: ignore
 @click.argument("target_directory", required=False)
-@error_handling
+@common_options()
 def logs(target_directory) -> None:
     """
     Get logs in a container is running for a truss
@@ -1687,36 +1070,664 @@ def kill_all() -> None:
     docker.kill_all()
 
 
-@truss_cli.command()
-@error_handling
-def cleanup() -> None:
-    """
-    Clean up truss data.
-
-    Truss creates temporary directories for various operations
-    such as for building docker images. This command clears
-    that data to free up disk space.
-    """
-    _cleanup()
+# Chains Stuff #########################################################################
 
 
-def _get_truss_from_directory(target_directory: Optional[str] = None):
-    """Gets Truss from directory. If none, use the current directory"""
-    if target_directory is None:
-        target_directory = os.getcwd()
-    if not os.path.isfile(target_directory):
-        return load(target_directory)
-    # These imports are delayed, to handle pydantic v1 envs gracefully.
-    from truss_chains.deployment import code_gen
-
-    truss_dir = code_gen.gen_truss_model_from_source(Path(target_directory))
-    return load(truss_dir)
+@click.group()
+def chains():
+    """Subcommands for truss chains"""
 
 
-truss_cli.add_command(container)
-truss_cli.add_command(image)
 truss_cli.add_command(chains)
+
+
+def _load_example_chainlet_code() -> str:
+    try:
+        from truss_chains.reference_code import reference_chainlet
+    # if the example is faulty, a validation error would be raised
+    except Exception as e:
+        raise Exception("Failed to load starter code. Please notify support.") from e
+
+    source = Path(reference_chainlet.__file__).read_text()
+    return source
+
+
+def _make_chains_curl_snippet(run_remote_url: str, environment: Optional[str]) -> str:
+    if environment:
+        idx = run_remote_url.find("deployment")
+        if idx != -1:
+            run_remote_url = (
+                run_remote_url[:idx] + f"environments/{environment}/run_remote"
+            )
+    return (
+        f"curl -X POST '{run_remote_url}' \\\n"
+        '    -H "Authorization: Api-Key $BASETEN_API_KEY" \\\n'
+        "    -d '<JSON_INPUT>'"
+    )
+
+
+def _create_chains_table(service) -> Tuple[rich.table.Table, List[str]]:
+    """Creates a status table similar to:
+
+                                          ⛓️   ItestChain - Chain  ⛓️
+
+                         🌐 Status page: https://app.baseten.co/chains/p7qrm93v/overview
+    ╭──────────────────────┬──────────────────────────────┬─────────────────────────────────────────────╮
+    │ Status               │ Chainlet                     │ Logs URL                                   │
+    ├──────────────────────┼──────────────────────────────┼────────────────────────────────────────────┤
+    │ 🛠️  BUILDING         │ ItestChain (entrypoint)      │ https://app.baseten.co/chains/.../logs/... │
+    ├──────────────────────┼──────────────────────────────┼────────────────────────────────────────────┤
+    │ 👾  DEPLOYING        │ GENERATE_DATA (internal)     │ https://app.baseten.co/chains/.../logs/... │
+    │ 👾  DEPLOYING        │ SplitTextFailOnce (internal) │ https://app.baseten.co/chains/.../logs/... │
+    │ 👾  DEPLOYING        │ TextReplicator (internal)    │ https://app.baseten.co/chains/.../logs/... │
+    │ 🛠️  BUILDING         │ TextToNum (internal)         │ https://app.baseten.co/chains/.../logs/... │
+    ╰──────────────────────┴──────────────────────────────┴────────────────────────────────────────────╯
+
+    """
+    title = (
+        f"⛓️   {service.name} - Chain  ⛓️\n\n "
+        f"🌐 Status page: {_format_link(service.status_page_url)}"
+    )
+    table = rich.table.Table(
+        show_header=True,
+        header_style="bold yellow",
+        title=title,
+        box=rich.table.box.ROUNDED,
+        border_style="blue",
+    )
+    table.add_column("Status", style="dim", min_width=20)
+    table.add_column("Chainlet", min_width=20)
+    table.add_column("Logs URL")
+    statuses = []
+    status_iterable = service.get_info()
+    # Organize status_iterable s.t. entrypoint is first.
+    entrypoint = next(x for x in status_iterable if x.is_entrypoint)
+    sorted_chainlets = sorted(
+        (x for x in status_iterable if not x.is_entrypoint), key=lambda x: x.name
+    )
+    for i, chainlet in enumerate([entrypoint] + sorted_chainlets):
+        displayable_status = get_displayable_status(chainlet.status)
+        if displayable_status == ACTIVE_STATUS:
+            spinner_name = "active"
+        elif displayable_status in DEPLOYING_STATUSES:
+            if displayable_status == "BUILDING":
+                spinner_name = "building"
+            elif displayable_status == "LOADING":
+                spinner_name = "loading"
+            else:
+                spinner_name = "deploying"
+        else:
+            spinner_name = "failed"
+        spinner = rich.spinner.Spinner(spinner_name, text=displayable_status)
+        if chainlet.is_entrypoint:
+            display_name = f"{chainlet.name} (entrypoint)"
+        else:
+            display_name = f"{chainlet.name} (internal)"
+
+        table.add_row(spinner, display_name, _format_link(chainlet.logs_url))
+        # Add section divider after entrypoint, entrypoint must be first.
+        if chainlet.is_entrypoint:
+            table.add_section()
+        statuses.append(displayable_status)
+    return table, statuses
+
+
+@chains.command(name="push")  # type: ignore
+@click.argument("source", type=Path, required=True)
+@click.argument("entrypoint", type=str, required=False)
+@click.option(
+    "--name",
+    type=str,
+    required=False,
+    help="Name of the chain to be deployed, if not given, the entrypoint name is used.",
+)
+@click.option(
+    "--publish/--no-publish",
+    type=bool,
+    default=False,
+    help="Create chainlets as published deployments.",
+)
+@click.option(
+    "--promote/--no-promote",
+    type=bool,
+    default=False,
+    help="Replace production chainlets with newly deployed chainlets.",
+)
+@click.option(
+    "--environment",
+    type=str,
+    required=False,
+    help=(
+        "Deploy the chain as a published deployment to the specified environment."
+        "If specified, --publish is implied and the supplied value of --promote will be ignored."
+    ),
+)
+@click.option(
+    "--wait/--no-wait",
+    type=bool,
+    default=True,
+    help="Wait until all chainlets are ready (or deployment failed).",
+)
+@click.option(
+    "--watch/--no-watch",
+    type=bool,
+    default=False,
+    help=(
+        "Watches the chains source code and applies live patches. Using this option "
+        "will wait for the chain to be deployed (i.e. `--wait` flag is applied), "
+        "before starting to watch for changes. This option required the deployment "
+        "to be a development deployment (i.e. `--no-promote` and `--no-publish`."
+    ),
+)
+@click.option(
+    "--dryrun",
+    type=bool,
+    default=False,
+    is_flag=True,
+    help="Produces only generated files, but doesn't deploy anything.",
+)
+@click.option(
+    "--remote",
+    type=str,
+    required=False,
+    help="Name of the remote in .trussrc to push to.",
+)
+@click.option(
+    "--experimental-watch-chainlet-names",
+    type=str,
+    required=False,
+    help=(
+        "Runs `watch`, but only applies patches to specified chainlets. The option is "
+        "a comma-separated list of chainlet (display) names. This option can give "
+        "faster dev loops, but also lead to inconsistent deployments. Use with caution "
+        "and refer to docs."
+    ),
+)
+@click.option(
+    "--include-git-info",
+    type=bool,
+    is_flag=True,
+    required=False,
+    default=False,
+    help=_INCLUDE_GIT_INFO_DOC,
+)
+@click.pass_context
+@common_options()
+def push_chain(
+    ctx: click.Context,
+    source: Path,
+    entrypoint: Optional[str],
+    name: Optional[str],
+    publish: bool,
+    promote: bool,
+    wait: bool,
+    watch: bool,
+    dryrun: bool,
+    remote: Optional[str],
+    environment: Optional[str],
+    experimental_watch_chainlet_names: Optional[str],
+    include_git_info: bool = False,
+) -> None:
+    """
+    Deploys a chain remotely.
+
+    SOURCE: Path to a python file that contains the entrypoint chainlet.
+
+    ENTRYPOINT: Class name of the entrypoint chainlet in source file. May be omitted
+    if a chainlet definition in SOURCE is tagged with `@chains.mark_entrypoint`.
+    """
+    # These imports are delayed, to handle pydantic v1 envs gracefully.
+    from truss_chains import framework
+    from truss_chains import private_types as chains_def
+    from truss_chains.deployment import deployment_client
+
+    if experimental_watch_chainlet_names:
+        watch = True
+
+    if watch:
+        if publish or promote:
+            raise ValueError(
+                "When using `--watch`, the deployment cannot be published or promoted."
+            )
+        if not wait:
+            console.print(
+                "`--watch` is used. Will wait for deployment before watching files."
+            )
+            wait = True
+
+    if promote and environment:
+        promote_warning = (
+            "`promote` flag and `environment` flag were both specified. "
+            "Ignoring the value of `promote`."
+        )
+        console.print(promote_warning, style="yellow")
+
+    if not remote:
+        remote = remote_cli.inquire_remote_name()
+
+    if not include_git_info:
+        include_git_info = user_config.settings.include_git_info
+
+    with framework.ChainletImporter.import_target(source, entrypoint) as entrypoint_cls:
+        chain_name = (
+            name or entrypoint_cls.meta_data.chain_name or entrypoint_cls.display_name
+        )
+        options = chains_def.PushOptionsBaseten.create(
+            chain_name=chain_name,
+            promote=promote,
+            publish=publish,
+            only_generate_trusses=dryrun,
+            remote=remote,
+            environment=environment,
+            include_git_info=include_git_info,
+            working_dir=source.parent if source.is_file() else source.resolve(),
+        )
+        service = deployment_client.push(
+            entrypoint_cls, options, progress_bar=progress.Progress
+        )
+
+    if dryrun:
+        return
+
+    assert isinstance(service, deployment_client.BasetenChainService)
+    curl_snippet = _make_chains_curl_snippet(
+        service.run_remote_url, options.environment
+    )
+
+    table, statuses = _create_chains_table(service)
+    status_check_wait_sec = 2
+    if wait:
+        num_services = len(statuses)
+        success = False
+        num_failed = 0
+        # Logging inferences with live display (even when using richHandler)
+        # -> capture logs and print later.
+        with (
+            LogInterceptor() as log_interceptor,
+            rich.live.Live(table, console=console, refresh_per_second=4) as live,
+        ):
+            while True:
+                table, statuses = _create_chains_table(service)
+                live.update(table)
+                num_active = sum(s == ACTIVE_STATUS for s in statuses)
+                num_deploying = sum(s in DEPLOYING_STATUSES for s in statuses)
+                if num_active == num_services:
+                    success = True
+                    break
+                elif num_failed := num_services - num_active - num_deploying:
+                    break
+                time.sleep(status_check_wait_sec)
+
+            intercepted_logs = log_interceptor.get_logs()
+
+        # Prints must be outside `Live` context.
+        if intercepted_logs:
+            console.print("Logs intercepted during waiting:", style="blue")
+            for log in intercepted_logs:
+                console.print(f"\t{log}")
+        if success:
+            deploy_success_text = "Deployment succeeded."
+            if environment:
+                deploy_success_text = (
+                    "Your chain has been deployed into "
+                    f"the {options.environment} environment."
+                )
+            console.print(deploy_success_text, style="bold green")
+            console.print(f"You can run the chain with:\n{curl_snippet}")
+
+            if watch:  # Note that this command will print a startup message.
+                if experimental_watch_chainlet_names:
+                    included_chainlets = [
+                        x.strip() for x in experimental_watch_chainlet_names.split(",")
+                    ]
+                else:
+                    included_chainlets = None
+                deployment_client.watch(
+                    source,
+                    entrypoint,
+                    name,
+                    remote,
+                    console,
+                    _error_console,
+                    show_stack_trace=ctx.params.get("log") != _HUMANFRIENDLY_LOG_LEVEL,
+                    included_chainlets=included_chainlets,
+                )
+        else:
+            console.print(f"Deployment failed ({num_failed} failures).", style="red")
+    else:
+        console.print(table)
+        console.print(
+            "Once all chainlets are deployed, "
+            f"you can run the chain with:\n\n{curl_snippet}"
+        )
+
+
+@chains.command(name="watch")  # type: ignore
+@click.argument("source", type=Path, required=True)
+@click.argument("entrypoint", type=str, required=False)
+@click.option(
+    "--name",
+    type=str,
+    required=False,
+    help="Name of the chain to be deployed, if not given, the entrypoint name is used.",
+)
+@click.option(
+    "--remote",
+    type=str,
+    required=False,
+    help="Name of the remote in .trussrc to push to.",
+)
+@click.option(
+    "--experimental-chainlet-names",
+    type=str,
+    required=False,
+    help=(
+        "Runs `watch`, but only applies patches to specified chainlets. The option is "
+        "a comma-separated list of chainlet (display) names. This option can give "
+        "faster dev loops, but also lead to inconsistent deployments. Use with caution "
+        "and refer to docs."
+    ),
+)
+@click.pass_context
+@common_options()
+def watch_chains(
+    ctx: click.Context,
+    source: Path,
+    entrypoint: Optional[str],
+    name: Optional[str],
+    remote: Optional[str],
+    experimental_chainlet_names: Optional[str],
+) -> None:
+    """
+    Watches the chains source code and applies live patches to a development deployment.
+
+    The development deployment must have been deployed before running this command.
+
+    SOURCE: Path to a python file that contains the entrypoint chainlet.
+
+    ENTRYPOINT: Class name of the entrypoint chainlet in source file. May be omitted
+    if a chainlet definition in SOURCE is tagged with `@chains.mark_entrypoint`.
+    """
+    # These imports are delayed, to handle pydantic v1 envs gracefully.
+    from truss_chains.deployment import deployment_client
+
+    if not remote:
+        remote = remote_cli.inquire_remote_name()
+
+    if experimental_chainlet_names:
+        included_chainlets = [x.strip() for x in experimental_chainlet_names.split(",")]
+    else:
+        included_chainlets = None
+
+    deployment_client.watch(
+        source,
+        entrypoint,
+        name,
+        remote,
+        console,
+        _error_console,
+        show_stack_trace=ctx.params.get("log") != _HUMANFRIENDLY_LOG_LEVEL,
+        included_chainlets=included_chainlets,
+    )
+
+
+@chains.command(name="init")  # type: ignore
+@click.argument("directory", type=Path, required=False)
+@common_options()
+def init_chain(directory: Optional[Path]) -> None:
+    """
+    Initializes a chains project directory.
+
+    DIRECTORY: A name of new or existing directory to create the chain in,
+      it must be empty. If not specified, the current directory is used.
+
+    """
+    if not directory:
+        directory = Path.cwd()
+    if directory.exists():
+        if not directory.is_dir():
+            raise ValueError(f"The path {directory} must be a directory.")
+        if any(directory.iterdir()):
+            raise ValueError(f"Directory {directory} must be empty.")
+    else:
+        directory.mkdir()
+
+    filename = inquirer.text(
+        qmark="",
+        message="Enter the python file name for the chain.",
+        default="my_chain.py",
+    ).execute()
+    filepath = directory / str(filename).strip()
+    console.print(f"Creating and populating {filepath}...\n")
+    source_code = _load_example_chainlet_code()
+    filepath.write_text(source_code)
+    console.print(
+        "Next steps:\n",
+        f"💻 Run [bold green]`python {filepath}`[/bold green] for local debug "
+        "execution.\n"
+        f"🚢 Run [bold green]`truss chains deploy {filepath}`[/bold green] "
+        "to deploy the chain to Baseten.\n",
+    )
+
+
+### Training Commands. #################################################################
+
+
+@click.group()
+def train():
+    """Subcommands for truss train"""
+
+
 truss_cli.add_command(train)
+
+
+@train.command(name="push")
+@click.argument("config", type=Path, required=True)
+@click.option("--remote", type=str, required=False, help="Remote to use")
+@click.option(
+    "--tail", type=bool, is_flag=True, help="Tail for status + logs after push."
+)
+@common_options()
+def push_training_job(config: Path, remote: Optional[str], tail: bool):
+    """Run a training job"""
+    from truss_train import deployment, loader
+
+    if not remote:
+        remote = remote_cli.inquire_remote_name()
+
+    remote_provider: BasetenRemote = cast(
+        BasetenRemote, RemoteFactory.create(remote=remote)
+    )
+    with loader.import_training_project(config) as training_project:
+        with console.status("Creating training job...", spinner="dots"):
+            project_resp = remote_provider.api.upsert_training_project(
+                training_project=training_project
+            )
+
+            prepared_job = deployment.prepare_push(
+                remote_provider.api, config, training_project.job
+            )
+            job_resp = remote_provider.api.create_training_job(
+                project_id=project_resp["id"], job=prepared_job
+            )
+
+        console.print("✨ Training job successfully created!", style="green")
+        console.print(
+            f"🪵 View logs for your job via "
+            f"[cyan]`truss train logs --job-id {job_resp['id']} [--tail]`[/cyan]\n"
+            f"🔍 View metrics for your job via "
+            f"[cyan]`truss train metrics --job-id {job_resp['id']}`[/cyan]"
+        )
+
+    if tail:
+        project_id, job_id = project_resp["id"], job_resp["id"]
+        watcher = TrainingLogWatcher(remote_provider.api, project_id, job_id, console)
+        for log in watcher.watch():
+            cli_log_utils.output_log(log, console)
+
+
+@train.command(name="logs")
+@click.option("--remote", type=str, required=False, help="Remote to use")
+@click.option("--project-id", type=str, required=False, help="Project ID.")
+@click.option("--job-id", type=str, required=False, help="Job ID.")
+@click.option("--tail", type=bool, is_flag=True, help="Tail for ongoing logs.")
+@common_options()
+def get_job_logs(
+    remote: Optional[str], project_id: Optional[str], job_id: Optional[str], tail: bool
+):
+    """Fetch logs for a training job"""
+
+    if not remote:
+        remote = remote_cli.inquire_remote_name()
+
+    remote_provider: BasetenRemote = cast(
+        BasetenRemote, RemoteFactory.create(remote=remote)
+    )
+    project_id, job_id = train_cli.get_most_recent_job(
+        console, remote_provider, project_id, job_id
+    )
+
+    if not tail:
+        logs = remote_provider.api.get_training_job_logs(project_id, job_id)
+        for log in cli_log_utils.parse_logs(logs):
+            cli_log_utils.output_log(log, console)
+    else:
+        log_watcher = TrainingLogWatcher(
+            remote_provider.api, project_id, job_id, console
+        )
+        for log in log_watcher.watch():
+            cli_log_utils.output_log(log, console)
+
+
+@train.command(name="stop")
+@click.option("--project-id", type=str, required=False, help="Project ID.")
+@click.option("--job-id", type=str, required=False, help="Job ID.")
+@click.option("--all", type=bool, is_flag=True, help="Stop all running jobs.")
+@click.option("--remote", type=str, required=False, help="Remote to use")
+@common_options()
+def stop_job(
+    project_id: Optional[str], job_id: Optional[str], all: bool, remote: Optional[str]
+):
+    """Stop a training job"""
+
+    if not remote:
+        remote = remote_cli.inquire_remote_name()
+
+    remote_provider: BasetenRemote = cast(
+        BasetenRemote, RemoteFactory.create(remote=remote)
+    )
+    if all:
+        train_cli.stop_all_jobs(console, remote_provider, project_id)
+    else:
+        project_id, job_id = train_cli.get_args_for_stop(
+            console, remote_provider, project_id, job_id
+        )
+        remote_provider.api.stop_training_job(project_id, job_id)
+        console.print("Training job stopped successfully.", style="green")
+
+
+@train.command(name="view")
+@click.option(
+    "--project-id", type=str, required=False, help="View training jobs for a project."
+)
+@click.option(
+    "--job-id", type=str, required=False, help="View a specific training job."
+)
+@click.option("--remote", type=str, required=False, help="Remote to use")
+@common_options()
+def view_training(
+    project_id: Optional[str], job_id: Optional[str], remote: Optional[str]
+):
+    """List all training jobs for a project"""
+
+    if not remote:
+        remote = remote_cli.inquire_remote_name()
+
+    remote_provider: BasetenRemote = cast(
+        BasetenRemote, RemoteFactory.create(remote=remote)
+    )
+    train_cli.view_training_details(console, remote_provider, project_id, job_id)
+
+
+@train.command(name="metrics")
+@click.option("--project-id", type=str, required=False, help="Project ID.")
+@click.option("--job-id", type=str, required=False, help="Job ID.")
+@click.option("--remote", type=str, required=False, help="Remote to use")
+@common_options()
+def get_job_metrics(
+    project_id: Optional[str], job_id: Optional[str], remote: Optional[str]
+):
+    """Get metrics for a training job"""
+
+    if not remote:
+        remote = remote_cli.inquire_remote_name()
+
+    remote_provider: BasetenRemote = cast(
+        BasetenRemote, RemoteFactory.create(remote=remote)
+    )
+    train_cli.view_training_job_metrics(console, remote_provider, project_id, job_id)
+
+
+@train.command(name="deploy_checkpoints")
+@click.option("--project-id", type=str, required=False, help="Project ID.")
+@click.option("--job-id", type=str, required=False, help="Job ID.")
+@click.option(
+    "--config",
+    type=str,
+    required=False,
+    help="path to a python file that defines a DeployCheckpointsConfig",
+)
+@click.option(
+    "--dry-run",
+    type=bool,
+    is_flag=True,
+    help="Generate a truss config without deploying",
+)
+@click.option("--remote", type=str, required=False, help="Remote to use")
+@common_options()
+def deploy_checkpoints(
+    project_id: Optional[str],
+    job_id: Optional[str],
+    config: Optional[str],
+    remote: Optional[str],
+    dry_run: bool,
+):
+    """
+    Deploy a checkpoint. Some early assumptions about this are:
+    - We are deploying a vllm model
+    - The checkpoint is a lora
+    - Base Model is coming from Huggingface
+    """
+
+    if not remote:
+        remote = remote_cli.inquire_remote_name()
+
+    remote_provider: BasetenRemote = cast(
+        BasetenRemote, RemoteFactory.create(remote=remote)
+    )
+    prepare_checkpoint_result = train_cli.prepare_checkpoint_deploy(
+        console,
+        remote_provider,
+        train_cli.PrepareCheckpointArgs(
+            project_id=project_id, job_id=job_id, deploy_config_path=config
+        ),
+    )
+
+    ctx = click.Context(push, obj={})
+    ctx.params = {
+        "target_directory": prepare_checkpoint_result.truss_directory,
+        "remote": remote,
+        "model_name": prepare_checkpoint_result.checkpoint_deploy_config.model_name,
+        "publish": True,
+        "deployment_name": prepare_checkpoint_result.checkpoint_deploy_config.deployment_name,
+    }
+    if dry_run:
+        console.print("--dry-run flag provided, not deploying", style="yellow")
+    else:
+        push.invoke(ctx)
+
+    train_cli.print_deploy_checkpoints_success_message(prepare_checkpoint_result)
+
 
 if __name__ == "__main__":
     truss_cli()

--- a/truss/cli/common.py
+++ b/truss/cli/common.py
@@ -1,3 +1,4 @@
+import sys
 from typing import Optional, Tuple, cast
 
 import rich_click as click
@@ -6,6 +7,12 @@ from rich.console import Console
 from truss.remote.baseten.remote import BasetenRemote
 
 POLL_INTERVAL_SEC = 2
+
+
+def check_is_interactive() -> bool:
+    """Detects if CLI is operated interactively by human, so we can ask things,
+    that we would want to skip for automated subprocess/CI contexts."""
+    return sys.stdin.isatty() and sys.stdout.isatty()
 
 
 def get_most_recent_job(

--- a/truss/cli/remote_cli.py
+++ b/truss/cli/remote_cli.py
@@ -23,14 +23,6 @@ class NonEmptyValidator(Validator):
             )
 
 
-def inquire_include_git_info_consent() -> bool:
-    return inquirer.confirm(
-        message="🏷️  Are you okay with attaching git versioning info (sha, branch, tag) "
-        "to deployments made from within a git repo?",
-        qmark="",
-    ).execute()
-
-
 def inquire_remote_config() -> RemoteConfig:
     # TODO(bola): extract questions from remote
     rich.print("💻 Let's add a Baseten remote!")
@@ -40,36 +32,14 @@ def inquire_remote_config() -> RemoteConfig:
     api_key = inquirer.secret(
         message="🤫 Quietly paste your API_KEY:", qmark="", validate=NonEmptyValidator()
     ).execute()
-    # TODO: until git version info is shown customer-facing, we don't ask everyone.
-    # include_git_info_consent = inquire_include_git_info_consent()
     return RemoteConfig(
         name="baseten",
         configs={
             "remote_provider": "baseten",
             "api_key": api_key,
             "remote_url": remote_url,
-            # "include_git_info": include_git_info_consent,
         },
     )
-
-
-def determine_include_git_info_consent(remote_name: str) -> bool:
-    remote_config = RemoteFactory.load_remote_config(remote_name=remote_name)
-    if "include_git_info" in remote_config.configs:
-        return RemoteConfig.parse_bool(remote_config.configs["include_git_info"])
-
-    # TODO: until git version info is shown customer-facing, we don't ask everyone.
-    # if check_is_interactive():
-    #     include_git_info_consent = inquire_include_git_info_consent()
-    #
-    #     remote_config.configs["include_git_info"] = include_git_info_consent
-    #     RemoteFactory.update_remote_config(remote_config)
-    #     rich.print(
-    #         f"💾 Remote config `{remote_config.name}` saved to `{USER_TRUSSRC_PATH}`."
-    #     )
-    #     return include_git_info_consent
-
-    return False
 
 
 def inquire_remote_name() -> str:

--- a/truss/cli/utils/self_upgrade.py
+++ b/truss/cli/utils/self_upgrade.py
@@ -1,0 +1,127 @@
+import logging
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+
+import rich.console
+import rich.prompt
+from InquirerPy import inquirer
+
+from truss.cli.utils import user_config
+
+
+def _run_upgrade(command: str, console: rich.console.Console) -> bool:
+    console.print(f"[bold]Running:[/bold] '{command}'")
+    returncode = subprocess.run(command, shell=True).returncode
+    if returncode == 0:
+        console.print("[green]✅ Upgrade complete. Please re-run your command.[/green]")
+        return True
+    else:
+        console.print(
+            f"[bold red]😤 Command failed with exit code {returncode}. "
+            "Try upgrading manually.[/bold red]"
+        )
+        return False
+
+
+def _is_poetry_venv() -> bool:
+    # Typical pattern: poetry puts a `pyvenv.cfg` file inside the venv root
+    venv_cfg_path = pathlib.Path(sys.prefix) / "pyvenv.cfg"
+    if not venv_cfg_path.exists():
+        return False
+
+    text = venv_cfg_path.read_text().lower()
+    return "poetry" in text or "virtualenv" in text
+
+
+def _make_upgrade_command_candidates(latest_version: str) -> list[tuple[str, str]]:
+    candidates = []
+    if "CONDA_PREFIX" in os.environ:
+        candidates.append(("conda", f"conda install truss={latest_version}"))
+    if shutil.which("pipx"):
+        candidates.append(("pipx", "pipx upgrade truss"))
+    if _is_poetry_venv():
+        candidates.append(("poetry", f"poetry add truss>={latest_version}"))
+    # Pip fallback.
+    candidates.append(
+        ("pip", f"python -m pip install --upgrade truss=={latest_version}")
+    )
+    if shutil.which("pipenv"):
+        candidates.append(("pipenv", "pipenv update truss"))
+    if shutil.which("pdm"):
+        candidates.append(("pdm", f"pdm add truss=={latest_version}"))
+    if shutil.which("hatch"):
+        candidates.append(("hatch", f"hatch dep add truss@{latest_version}"))
+    if shutil.which("uv"):
+        candidates.append(("uv", f"uv pip install --upgrade truss=={latest_version}"))
+    if shutil.which("rye"):
+        candidates.append(("rye", f"rye add truss@{latest_version}"))
+    return candidates
+
+
+def upgrade_dialogue(current_version: str, console: rich.console.Console) -> None:
+    settings_wrapper = user_config.SettingsWrapper.read_or_create()
+    state_wrapper = user_config.StateWrapper.read_or_create()
+    update_info = state_wrapper.should_upgrade(current_version)
+    latest_version = str(update_info.latest_version)
+    logging.debug(f"Truss package update info: {update_info}")
+    if not update_info.upgrade_recommended:
+        return
+
+    if auto_upgrade_command_template := settings_wrapper.auto_upgrade_command_template:
+        console.print(
+            f"[bold yellow]🪄 Automatically upgrading truss to '{latest_version}'.[/bold yellow]"
+        )
+        command = auto_upgrade_command_template.format(
+            version=update_info.latest_version
+        )
+        if _run_upgrade(command, console):
+            sys.exit(0)
+        else:
+            console.print(
+                f"[bold]🖊️  You can edit or remove 'auto_upgrade_command_template' in '{settings_wrapper.path()}'[/bold]"
+            )
+            sys.exit(1)
+
+    console.print(
+        f"[bold yellow]⬆️  Please upgrade truss. {update_info.reason} → new version "
+        f"✨'{latest_version}'✨.[/bold yellow]"
+    )
+
+    candidates = _make_upgrade_command_candidates(latest_version)
+    do_nothing_cmd = "Do nothing."
+    candidates.append(("🫥", do_nothing_cmd))
+    options = [f"[{env}] {cmd}" for env, cmd in candidates]
+
+    selection = inquirer.select(
+        message="Pick a command for upgrading (you can edit before running):",
+        choices=options,
+        default=options[0],
+    ).execute()
+
+    selected_cmd = next(cmd for label, cmd in candidates if f"[{label}]" in selection)
+    if selected_cmd == do_nothing_cmd:
+        return
+
+    edited_cmd = inquirer.text(
+        message="🖊️  Optionally edit:", default=selected_cmd
+    ).execute()
+
+    if inquirer.confirm(
+        message="▶️  Run command in this shell?", default=True
+    ).execute():
+        if _run_upgrade(edited_cmd, console):
+            settings_path = settings_wrapper.path()
+            if inquirer.confirm(
+                message="💾 Do you want next time to run the same command automatically "
+                f"(with newer version)? After memorizing the command, you can edit the "
+                f"it in '{settings_path}'?",
+                default=True,
+            ).execute():
+                template = edited_cmd.replace(f"{latest_version}", "{version}")
+                settings_wrapper.auto_upgrade_command_template = template
+            sys.exit(0)
+        else:
+            sys.exit(1)

--- a/truss/cli/utils/user_config.py
+++ b/truss/cli/utils/user_config.py
@@ -1,0 +1,270 @@
+"""Tools to configure and track the Truss CLI state and behavior, e.g. auto-upgrades."""
+
+import datetime
+import os
+import pathlib
+import shutil
+import subprocess
+from typing import Any, Optional, Union
+
+import packaging.version
+import pydantic
+import requests
+import tomlkit
+import tomlkit.container
+import tomlkit.items
+
+from truss.remote.remote_factory import load_config
+
+_SETTINGS_FiLE = "settings.toml"
+_STATE_FILE = "state.json"
+_PYPI_VERSION_URL = "https://pypi.org/pypi/truss/json"
+
+
+def _get_dir() -> pathlib.Path:
+    if "XDG_CONFIG_HOME" in os.environ:
+        base_dir = pathlib.Path(os.environ["XDG_CONFIG_HOME"])
+    else:
+        base_dir = pathlib.Path.home() / ".config"
+
+    settings_path = base_dir / "truss"
+    settings_path.mkdir(parents=True, exist_ok=True)
+    return settings_path
+
+
+def _truss_is_git_branch() -> bool:
+    if shutil.which("git") is None:
+        return False
+    try:
+        subprocess.run(
+            ["git", "rev-parse", "--is-inside-work-tree"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=True,
+        )
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+
+class Preferences(pydantic.BaseModel):
+    include_git_info: bool = False
+    auto_upgrade_command_template: Optional[str] = None
+    b10_beta_features: bool = False
+
+
+class AppSettings(pydantic.BaseModel):
+    preferences: Preferences = Preferences()
+
+
+def _strip_none(d: dict[str, Any]) -> dict[str, Any]:
+    return {
+        k: _strip_none(v) if isinstance(v, dict) else v
+        for k, v in d.items()
+        if v is not None
+    }
+
+
+def _update_toml_document(doc, data: dict[str, Any]) -> None:
+    """Update the values, but keep structure (esp. comments)."""
+    # NOTE: this does not remove keys that are not in `data` from the toml doc.
+    data = _strip_none(data)
+    for key, value in data.items():
+        if isinstance(value, dict) and key in doc:
+            _update_toml_document(doc[key], value)
+        else:
+            if value is None:
+                if key in doc:
+                    del doc[key]
+            else:
+                doc[key] = value
+
+
+class SettingsWrapper:
+    def __init__(
+        self, settings: AppSettings, toml_doc: tomlkit.TOMLDocument, write: bool = False
+    ):
+        self._settings = settings
+        self._toml_doc = toml_doc
+
+        if write:
+            self._write()
+
+    @staticmethod
+    def path() -> pathlib.Path:
+        return _get_dir() / _SETTINGS_FiLE
+
+    @classmethod
+    def read_or_create(cls) -> "SettingsWrapper":
+        if cls.path().exists():
+            toml_doc = tomlkit.parse(cls.path().read_text(encoding="utf-8"))
+            settings = AppSettings(**toml_doc.unwrap())
+            write = False
+        else:
+            settings = AppSettings()
+            truss_rc = load_config()
+            has_git_info_consent = any(
+                truss_rc.get(section, "include_git_info", fallback="false")
+                .strip()
+                .lower()
+                == "true"
+                for section in truss_rc.sections()
+            )
+            if has_git_info_consent:
+                settings.preferences.include_git_info = True
+            toml_doc = tomlkit.document()
+            write = True
+
+        return cls(settings, toml_doc, write)
+
+    def _write(self) -> None:
+        # The contract is that all manipulations are done on `settings`, not on `toml_doc`.
+        _update_toml_document(self._toml_doc, self._settings.model_dump())
+        self.path().write_text(tomlkit.dumps(self._toml_doc), encoding="utf-8")
+
+    @property
+    def include_git_info(self) -> bool:
+        return self._settings.preferences.include_git_info
+
+    @property
+    def b10_beta_features(self) -> bool:
+        return self._settings.preferences.b10_beta_features
+
+    @property
+    def auto_upgrade_command_template(self) -> Optional[str]:
+        return self._settings.preferences.auto_upgrade_command_template
+
+    @auto_upgrade_command_template.setter
+    def auto_upgrade_command_template(self, cmd: Optional[str]) -> None:
+        self._settings.preferences.auto_upgrade_command_template = cmd
+        self._write()
+
+
+class VersionInfo(pydantic.BaseModel):
+    latest_version: Optional[packaging.version.Version] = None
+    yanked_versions: set[packaging.version.Version] = pydantic.Field(
+        default_factory=set
+    )
+    last_check: datetime.datetime = datetime.datetime.min
+
+    @pydantic.field_validator("latest_version", mode="before")
+    @classmethod
+    def _parse_latest(
+        cls, value: Optional[Union[str, packaging.version.Version]]
+    ) -> Optional[packaging.version.Version]:
+        if value is None or isinstance(value, packaging.version.Version):
+            return value
+        return packaging.version.Version(value)
+
+    @pydantic.field_validator("yanked_versions", mode="before")
+    @classmethod
+    def _parse_yanked(
+        cls, value: list[Union[str, packaging.version.Version]]
+    ) -> list[packaging.version.Version]:
+        return [
+            v
+            if isinstance(v, packaging.version.Version)
+            else packaging.version.Version(v)
+            for v in value
+        ]
+
+    model_config = {
+        "json_encoders": {packaging.version.Version: lambda v: str(v)},
+        "arbitrary_types_allowed": True,
+    }
+
+
+class State(pydantic.BaseModel):
+    version_info: VersionInfo = VersionInfo()
+
+
+class UpdateInfo(pydantic.BaseModel):
+    upgrade_recommended: bool
+    reason: str
+    latest_version: str
+
+
+class StateWrapper:
+    def __init__(self, state: State, write: bool = False):
+        self._state = state
+        if write:
+            self._write()
+
+    @staticmethod
+    def _path() -> pathlib.Path:
+        return _get_dir() / _STATE_FILE
+
+    @classmethod
+    def read_or_create(cls):
+        if cls._path().exists():
+            state = State.model_validate_json(
+                cls._path().read_text(encoding="utf-8") or "{}"
+            )
+            write = False
+        else:
+            state = State()
+            write = True
+
+        return cls(state, write)
+
+    def _write(self) -> None:
+        self._path().write_text(self._state.model_dump_json(indent=2), encoding="utf-8")
+
+    def _should_check_for_updates(self) -> bool:
+        return (
+            self._state.version_info.last_check
+            < datetime.datetime.now() - datetime.timedelta(days=1)
+        )
+
+    def _update_version_info(self) -> None:
+        response = requests.get(_PYPI_VERSION_URL, timeout=5)
+        response.raise_for_status()
+        data = response.json()
+
+        latest_version = packaging.version.Version(data["info"]["version"])
+        assert latest_version, data["info"]["version"]
+        yanked_versions = [
+            packaging.version.Version(version)
+            for version, files in data["releases"].items()
+            if any(file.get("yanked", False) for file in files)
+        ]
+        self._state.version_info = VersionInfo(
+            latest_version=latest_version,
+            yanked_versions=set(yanked_versions),
+            last_check=datetime.datetime.now(),
+        )
+        self._write()
+
+    def should_upgrade(self, current_version: str) -> UpdateInfo:
+        local_version = packaging.version.Version(current_version)
+        upgrade_recommended = False
+        reason = "Up to date."
+
+        if self._should_check_for_updates():
+            self._update_version_info()
+
+        latest_version = self._state.version_info.latest_version
+        assert latest_version
+
+        # Note: these conditions are *supposed* to overwrite previous ones.
+        if local_version < latest_version:
+            reason = f"🐌 The current version '{local_version}' is outdated."
+            upgrade_recommended = True
+
+        if local_version.is_devrelease or local_version.is_prerelease:
+            reason = "Local version is for dev - upgrades are not applied."
+            upgrade_recommended = False
+
+        if local_version in self._state.version_info.yanked_versions:
+            reason = f"🧨 The current version '{local_version}' is yanked ."
+            upgrade_recommended = True
+
+        if upgrade_recommended and _truss_is_git_branch():
+            upgrade_recommended = False
+            reason = "Truss is in a git branch, upgrades are not applied."
+
+        return UpdateInfo(
+            upgrade_recommended=upgrade_recommended,
+            reason=reason,
+            latest_version=str(latest_version),
+        )

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -2,7 +2,7 @@ import enum
 import logging
 import re
 from pathlib import Path
-from typing import TYPE_CHECKING, List, NamedTuple, Optional, Tuple, Type, Union
+from typing import TYPE_CHECKING, List, NamedTuple, Optional, Tuple, Type
 
 import yaml
 from requests import ReadTimeout
@@ -37,7 +37,7 @@ from truss.remote.baseten.core import (
 from truss.remote.baseten.error import ApiError, RemoteError
 from truss.remote.baseten.service import BasetenService, URLConfig
 from truss.remote.baseten.utils.transfer import base64_encoded_json_str
-from truss.remote.truss_remote import RemoteConfig, RemoteUser, TrussRemote
+from truss.remote.truss_remote import RemoteUser, TrussRemote
 from truss.truss_handle import build as truss_build
 from truss.truss_handle.truss_handle import TrussHandle
 from truss.util.path import is_ignored, load_trussignore_patterns_from_truss_dir
@@ -71,21 +71,14 @@ class FinalPushData(custom_types.OracleData):
 
 
 class BasetenRemote(TrussRemote):
-    def __init__(
-        self, remote_url: str, api_key: str, include_git_info: Union[str, bool] = False
-    ):
+    def __init__(self, remote_url: str, api_key: str):
         super().__init__(remote_url)
         self._auth_service = AuthService(api_key=api_key)
         self._api = BasetenApi(remote_url, self._auth_service)
-        self._include_git_info = RemoteConfig.parse_bool(include_git_info)
 
     @property
     def api(self) -> BasetenApi:
         return self._api
-
-    @property
-    def include_git_info(self) -> bool:
-        return self._include_git_info
 
     def get_chainlets(
         self, chain_deployment_id: str
@@ -225,7 +218,7 @@ class BasetenRemote(TrussRemote):
             progress_bar=progress_bar,
         )
 
-        if self._include_git_info or include_git_info:
+        if include_git_info:
             truss_user_env = b10_types.TrussUserEnv.collect_with_git_info(working_dir)
         else:
             truss_user_env = b10_types.TrussUserEnv.collect()

--- a/truss/tests/remote/baseten/test_remote.py
+++ b/truss/tests/remote/baseten/test_remote.py
@@ -19,7 +19,7 @@ _TEST_REMOTE_GRAPHQL_PATH = "http://test_remote.com/graphql/"
 
 @pytest.fixture
 def remote():
-    return BasetenRemote(_TEST_REMOTE_URL, "api_key", include_git_info=True)
+    return BasetenRemote(_TEST_REMOTE_URL, "api_key")
 
 
 def assert_request_matches_expected_query(request, expected_query) -> None:


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
* Introduce persistent, user-editable settings in comment-retaining toml file.
* Introduce machine-readable app state file (e.g. for caching queries of available and yanked versions).
* Extract `include_git_info` from `.trussrc` and move it to the user settings.
* Auto-upgrading (behind `enable_auto_upgrade` feature flag setting):
    * Check for updates and cache daily (if CLI is run at all), hooked into all CLI commands.
    * Skip updating for dev/pre releases (except yanked) and truss inside a git branch (this is assumed to be internal dev use cases).
    * If upgrade recommended, suggest editable install commands to users and run in current shell (after confirmation), option to skip.
    * If upgrade was successful, offer to rembering choice and auto-upgrade next time (templating the version in the command).
    * Next time automatically apply same command with latest version substituted.
    

See [demo video](https://basetenlabs.slack.com/archives/C088VNXM0US/p1746229302349439).

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
* Locally tests various worklows in poetry and pip venv.
