### PR TITLE
fix reference to 'truss chains deploy' in 'truss chains init'

### DIFF
--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -1505,7 +1505,7 @@ def init_chain(directory: Optional[Path]) -> None:
         "Next steps:\n",
         f"💻 Run [bold green]`python {filepath}`[/bold green] for local debug "
         "execution.\n"
-        f"🚢 Run [bold green]`truss chains deploy {filepath}`[/bold green] "
+        f"🚢 Run [bold green]`truss chains push {filepath}`[/bold green] "
         "to deploy the chain to Baseten.\n",
     )
 


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
This PR updates the message printed when 'truss chains init' is called, to include 'truss chains push' instead of 'truss chains deploy'.

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
- Checked that 'truss chains init' prints the correct message.
<img width="566" alt="image" src="https://github.com/user-attachments/assets/5e5ccb44-03e9-4f1b-94f5-0aa858eb19ac" />