### PR TITLE
set graphql validation error message to be the error description

### DIFF
--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -109,6 +109,8 @@ class BasetenApi:
         if errors:
             message = errors[0]["message"]
             error_code = errors[0].get("extensions", {}).get("code")
+            if errors[0].get("extensions", {}).get("description") is not None:
+                message = errors[0].get("extensions", {}).get("description")
             raise ApiError(message, error_code)
 
         return resp_dict


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Currently, GraphQL validation errors from the backend cause the message "Resource validation failed" to be printed. In some cases, like trying to promote a deployment while a different promotion is in progress, this doesn't communicate what caused the error. This PR prints the `description` property instead of the `message` property, if it is present.

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
- Tried to promote a deployment while a different deployment for the same model was in progress, and validated that a descriptive error message is shown.
<img width="641" alt="image" src="https://github.com/user-attachments/assets/2af216e9-e0d3-4ca7-926d-411004a79eaf" />
