### PR TITLE
Pydantic validation and fixes

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3785,18 +3785,6 @@ files = [
 ]
 
 [[package]]
-name = "single-source"
-version = "0.3.0"
-description = "Access to the project version in Python code for PEP 621-style projects"
-optional = false
-python-versions = ">=3.6,<4.0"
-groups = ["main"]
-files = [
-    {file = "single-source-0.3.0.tar.gz", hash = "sha256:b12705af958ca99d56ea9ce40bd9cc749378f4fe7ad03b1f9067e29daceef27d"},
-    {file = "single_source-0.3.0-py3-none-any.whl", hash = "sha256:7bc87168ced50f638b6ab0cda4cc1ce9e80ee0e1220014397050d336d021a597"},
-]
-
-[[package]]
 name = "six"
 version = "1.17.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -4695,4 +4683,4 @@ all = []
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<=3.13.3"
-content-hash = "ca8f1b9869c6bce22bb37ddfc8929102f87d8f4ad76e3e6897c846594479ee9e"
+content-hash = "2b2ddf1b402ea3e3bbc5870f5f02e3d4a4122786e22ec06733f68d5c370de463"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ python = ">=3.9,<=3.13.3"
 huggingface_hub = ">=0.25.0"
 pydantic = ">=2.10.0"
 PyYAML = ">=6.0"
-single-source = "^0.3.0"
+tomlkit = ">=0.13.2"
 # "non-base" dependencies.
 # TODO: until we have resolved the question on how users can install the local tools frictionless
 #  (extras cannot be marked to be included by default), all below packages are non-optional.
@@ -102,7 +102,6 @@ rich = { version = "^13.4.2", optional = false }
 rich-click = { version = "^1.6.1", optional = false }
 ruff = { version = ">=0.4.8", optional = false }  # Not a dev dep, needed for chains code gen.
 tenacity = { version = "^8.0.1", optional = false }
-tomlkit = { version = ">=0.13.2", optional = false }
 watchfiles = { version = "^0.19.0", optional = false }
 
 
@@ -128,7 +127,6 @@ rich = { components = "other" }
 rich-click = { components = "other" }
 ruff = { components = "other" }
 tenacity = { components = "other" }
-tomlkit = { components = "other" }
 watchfiles = { components = "other" }
 
 [tool.poetry.group.dev.dependencies]

--- a/truss-chains/truss_chains/deployment/code_gen.py
+++ b/truss-chains/truss_chains/deployment/code_gen.py
@@ -669,7 +669,7 @@ def _make_requirements(image: public_types.DockerImage) -> list[str]:
         )
 
     if not (truss_git or truss_pypy):
-        truss_pip = f"truss=={truss.version()}"
+        truss_pip = f"truss=={truss.__version__}"
         logging.debug(
             f"Truss not found in pip requirements, auto-adding: `{truss_pip}`."
         )

--- a/truss/base/custom_types.py
+++ b/truss/base/custom_types.py
@@ -37,9 +37,31 @@ class SafeModelNonSerializable(pydantic.BaseModel):
 
 
 class ConfigModel(pydantic.BaseModel):
+    # In general, we cannot be strict with forbidding extra keys, because server-side
+    # we might build the context with an older version that doesn't know these keys.
+    # Therefore we only check extra keys in a special method `validate_forbid_extra`
+    # that is invoked during push (CLI side).
+    # But in order to detect the keys then, we need to `allow` them at initial parsing,
+    # this way they will be included in the dump, but not on the programmatic API.
     model_config = pydantic.ConfigDict(
-        validate_assignment=True, extra="forbid", arbitrary_types_allowed=False
+        validate_assignment=True, extra="allow", arbitrary_types_allowed=False
     )
+
+    @pydantic.model_validator(mode="before")
+    def _maybe_forbid_extra(cls, data: dict, info: pydantic.ValidationInfo) -> dict:
+        if info.context and info.context.get("forbid_extra"):
+            extra_fields = set(data) - set(cls.model_fields)
+            if extra_fields:
+                raise ValueError(
+                    f"Extra fields not allowed: [{', '.join(sorted(extra_fields))}]. Possibly "
+                    "this field is only supported by newer truss versions, check for updates."
+                )
+        return data
+
+    def validate_forbid_extra(self) -> None:
+        type(self).model_validate(
+            self.model_dump(mode="json"), context={"forbid_extra": True}
+        )
 
     def to_dict(self, verbose: bool = False) -> dict[str, Any]:
         kwargs: dict[str, Any] = (

--- a/truss/base/custom_types.py
+++ b/truss/base/custom_types.py
@@ -37,6 +37,10 @@ class SafeModelNonSerializable(pydantic.BaseModel):
 
 
 class ConfigModel(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(
+        validate_assignment=True, extra="forbid", arbitrary_types_allowed=False
+    )
+
     def to_dict(self, verbose: bool = False) -> dict[str, Any]:
         kwargs: dict[str, Any] = (
             {"mode": "json"}

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -175,20 +175,6 @@ def _non_interactive_option(f: Callable[..., object]) -> Callable[..., object]:
     )(f)
 
 
-# def _format_validation_error(e: pydantic.ValidationError) -> str:
-#     lines = []
-#     for err in e.errors():
-#         loc = ".".join(str(x) for x in err["loc"])
-#         msg = err["msg"]
-#         typ = err.get("type", "unknown")
-#         input_value = repr(err.get("input", "<missing>"))
-#         input_type = type(err.get("input")).__name__ if "input" in err else "unknown"
-#         lines.append(
-#             f"{loc}: {msg} [type={typ}, input_value={input_value}, input_type={input_type}]"
-#         )
-#     return "\n".join(lines)
-
-
 def _error_handling(f: Callable[..., object]) -> Callable[..., object]:
     @wraps(f)
     def wrapper(*args: object, **kwargs: object) -> None:
@@ -231,11 +217,11 @@ def _upgrade_dialogue():
         and common.check_is_interactive()
         and user_config.settings.enable_auto_upgrade
     ):
-        self_upgrade.upgrade_dialogue(truss.version(), console)
+        self_upgrade.upgrade_dialogue(truss.__version__, console)
 
 
 def common_options(
-    add_middleware: bool = False,
+    add_middleware: bool = True,
 ) -> Callable[[Callable[..., object]], Callable[..., object]]:
     def decorator(f: Callable[..., object]) -> Callable[..., object]:
         @wraps(f)
@@ -276,7 +262,7 @@ def _get_truss_from_directory(target_directory: Optional[str] = None):
 
 @click.group(name="truss", invoke_without_command=True)  # type: ignore
 @click.pass_context
-@click.version_option(truss.version())
+@click.version_option(truss.__version__)
 @common_options(add_middleware=False)
 def truss_cli(ctx) -> None:
     """truss: The simplest way to serve models in production"""

--- a/truss/remote/baseten/core.py
+++ b/truss/remote/baseten/core.py
@@ -445,7 +445,7 @@ def create_truss_service(
     )
 
 
-def validate_truss_config(api: BasetenApi, config: str):
+def validate_truss_config_against_backend(api: BasetenApi, config: str):
     """
     Validate a truss config as well as the truss version.
 

--- a/truss/remote/baseten/custom_types.py
+++ b/truss/remote/baseten/custom_types.py
@@ -103,7 +103,7 @@ class TrussUserEnv(pydantic.BaseModel):
             mypy_version = None
 
         return cls(
-            truss_client_version=truss.version(),
+            truss_client_version=truss.__version__,
             python_version=f"{py_version.major}.{py_version.minor}.{py_version.micro}",
             pydantic_version=pydantic.version.VERSION,
             mypy_version=mypy_version,

--- a/truss/tests/patch/test_calc_patch.py
+++ b/truss/tests/patch/test_calc_patch.py
@@ -250,8 +250,8 @@ def test_calc_truss_patch_handles_requirements_file_name_change(
         filename = "requirements.txt"
         with (custom_model_truss_dir / filename).open("w") as req_file:
             req_file.write(requirements_contents)
-        config.requirements_file = filename
         config.requirements.clear()
+        config.requirements_file = filename
 
     patches = _apply_config_change_and_calc_patches(
         custom_model_truss_dir, config_op=config_op, config_pre_op=pre_config_op
@@ -445,8 +445,8 @@ def test_calc_truss_patch_handles_requirements_file_added_no_change(
         filename = "requirements.txt"
         with (custom_model_truss_dir / filename).open("w") as req_file:
             req_file.write(requirements_contents)
-        config.requirements_file = filename
         config.requirements.clear()
+        config.requirements_file = filename
 
     patches = _apply_config_change_and_calc_patches(
         custom_model_truss_dir, config_op=config_op, config_pre_op=pre_config_op

--- a/truss/tests/remote/baseten/test_core.py
+++ b/truss/tests/remote/baseten/test_core.py
@@ -235,13 +235,13 @@ def test_validate_truss_config():
     api = MagicMock()
     api.validate_truss.side_effect = mock_validate_truss
 
-    assert core.validate_truss_config(api, {}) is None
+    assert core.validate_truss_config_against_backend(api, {}) is None
     with pytest.raises(
         ValidationError, match="Validation failed with the following errors:\n  error"
     ):
-        core.validate_truss_config(api, {"hi": "hi"})
+        core.validate_truss_config_against_backend(api, {"hi": "hi"})
     with pytest.raises(
         ValidationError,
         match="Validation failed with the following errors:\n  error\n  and another one",
     ):
-        core.validate_truss_config(api, {"should_error": "hi"})
+        core.validate_truss_config_against_backend(api, {"should_error": "hi"})

--- a/truss/tests/test_config.py
+++ b/truss/tests/test_config.py
@@ -892,6 +892,24 @@ def test_validate_on_assignment():
         config.resources.node_count = -10
 
 
+def test_validate_extra_fields(tmp_path):
+    yaml_with_extra_content = """
+    model_name: My Model
+    what_is_this_field: true
+    """
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml_with_extra_content)
+
+    # Plain parsing should pass.
+    config = TrussConfig.from_yaml(config_path)
+    # Explicit validation with extras not.
+    with pytest.raises(
+        pydantic.ValidationError,
+        match="Extra fields not allowed: \[what_is_this_field\]",
+    ):
+        config.validate_forbid_extra()
+
+
 @pytest.mark.parametrize(
     "python_version, expected_python_version",
     [

--- a/truss/tests/test_config.py
+++ b/truss/tests/test_config.py
@@ -59,8 +59,7 @@ from truss.truss_handle.truss_handle import TrussHandle
         (
             {"accelerator": "V100"},
             Resources(
-                accelerator=AcceleratorSpec(accelerator=Accelerator.V100, count=1),
-                use_gpu=True,
+                accelerator=AcceleratorSpec(accelerator=Accelerator.V100, count=1)
             ),
             {
                 "cpu": DEFAULT_CPU,
@@ -71,10 +70,7 @@ from truss.truss_handle.truss_handle import TrussHandle
         ),
         (
             {"accelerator": "T4:1"},
-            Resources(
-                accelerator=AcceleratorSpec(accelerator=Accelerator.T4, count=1),
-                use_gpu=True,
-            ),
+            Resources(accelerator=AcceleratorSpec(accelerator=Accelerator.T4, count=1)),
             {
                 "cpu": DEFAULT_CPU,
                 "memory": DEFAULT_MEMORY,
@@ -85,8 +81,7 @@ from truss.truss_handle.truss_handle import TrussHandle
         (
             {"accelerator": "A10G:4"},
             Resources(
-                accelerator=AcceleratorSpec(accelerator=Accelerator.A10G, count=4),
-                use_gpu=True,
+                accelerator=AcceleratorSpec(accelerator=Accelerator.A10G, count=4)
             ),
             {
                 "cpu": DEFAULT_CPU,
@@ -875,6 +870,26 @@ def test_resources_transport_correct_serialize_from(tmp_path):
     dumped = yaml.safe_load(out_path.read_text())
     assert dumped["runtime"]["transport"]["kind"] == "websocket"
     assert dumped["runtime"]["is_websocket_endpoint"] is True
+
+
+def test_validate_on_assignment():
+    config = TrussConfig()
+    with pytest.raises(pydantic.ValidationError, match="should be a valid boolean"):
+        config.runtime.is_websocket_endpoint = 123
+
+    with pytest.raises(pydantic.ValidationError):
+        config.python_version = "3.7"
+
+    with pytest.raises(pydantic.ValidationError):
+        config.python_version = "py27"
+
+    with pytest.raises(pydantic.ValidationError):
+        config.python_version = "py27"
+
+    with pytest.raises(
+        pydantic.ValidationError, match="should be greater than or equal to 1"
+    ):
+        config.resources.node_count = -10
 
 
 @pytest.mark.parametrize(

--- a/truss/tests/test_data/test_truss/config.yaml
+++ b/truss/tests/test_data/test_truss/config.yaml
@@ -4,6 +4,7 @@ model_name: x-4
 python_version: py39
 resources:
   accelerator: null
-  cpu: '1'
+  cpu: 10000
   memory: 2Gi
   use_gpu: false
+  lalal: True

--- a/truss/tests/test_data/test_truss/config.yaml
+++ b/truss/tests/test_data/test_truss/config.yaml
@@ -4,7 +4,6 @@ model_name: x-4
 python_version: py39
 resources:
   accelerator: null
-  cpu: 10000
+  cpu: '1'
   memory: 2Gi
   use_gpu: false
-  lalal: True


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
* Validate `TrussConfig` on assignment and forbid extra fields.
* Show helper message in CLI if such validation errors appear prompting to upgrade.
* Bugfix: add update and error handling middleware back to all cli commands.
* Resolve truss version robustly against noisy neighbors.


<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
