### PR TITLE
preserve header when proxying in custom servers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.92"
+version = "0.9.93dev"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.93dev"
+version = "0.9.93dev100"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.93dev100"
+version = "0.9.92"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/templates/docker_server/proxy.conf.jinja
+++ b/truss/templates/docker_server/proxy.conf.jinja
@@ -1,3 +1,13 @@
+map $http_upgrade $upgrade_header {
+    default        $http_upgrade;
+    ''             '';
+}
+
+map $http_connection $connection_header {
+    default        $http_connection;
+    ''             '';
+}
+
 server {
     # We use the proxy_read_timeout directive here (instead of proxy_send_timeout) as it sets the timeout for reading a response from the proxied server vs. setting a timeout for sending a request to the proxied server.
     listen 8080;
@@ -36,6 +46,9 @@ server {
     location / {
         proxy_redirect off;
         proxy_read_timeout 300s;
+
+        proxy_set_header Upgrade $upgrade_header;
+        proxy_set_header Connection $connection_header;
 
         proxy_pass http://127.0.0.1:{{server_port}};
     }

--- a/truss/templates/docker_server/proxy.conf.jinja
+++ b/truss/templates/docker_server/proxy.conf.jinja
@@ -3,7 +3,6 @@ server {
     listen 8080;
     client_max_body_size {{client_max_body_size}};
     proxy_buffering off;
-    proxy_set_header Connection "";
 
     # Liveness endpoint override
     location = / {


### PR DESCRIPTION
This is important for websockets, so that the "connection: upgrade" header is preserved.