### PR TITLE
fix(truss): Fix timeouts for custom servers.

### DIFF
--- a/truss/templates/docker_server/proxy.conf.jinja
+++ b/truss/templates/docker_server/proxy.conf.jinja
@@ -17,7 +17,7 @@ server {
     # Liveness endpoint override
     location = / {
         proxy_redirect off;
-        proxy_read_timeout 300s;
+        proxy_read_timeout 18030s;
 
         rewrite ^/$ {{liveness_endpoint}} break;
 
@@ -26,7 +26,7 @@ server {
     # Readiness endpoint override
     location ~ ^/v1/models/model$ {
         proxy_redirect off;
-        proxy_read_timeout 300s;
+        proxy_read_timeout 18000s;
 
         rewrite ^/v1/models/model$ {{readiness_endpoint}} break;
 
@@ -35,7 +35,7 @@ server {
     # Predict
     location ~ ^/v1/models/model:predict$ {
         proxy_redirect off;
-        proxy_read_timeout 300s;
+        proxy_read_timeout 18030s;
 
         rewrite ^/v1/models/model:predict$ {{server_endpoint}} break;
 
@@ -45,7 +45,7 @@ server {
     # Forward all other paths
     location / {
         proxy_redirect off;
-        proxy_read_timeout 300s;
+        proxy_read_timeout 18030s;
 
         proxy_set_header Upgrade $upgrade_header;
         proxy_set_header Connection $connection_header;


### PR DESCRIPTION

## :rocket: What

Custom servers are configured to have a timeout of 5 minutes. This is causing them to timeout on requests that take a while, and the error is fairly invisible to end users.

No components in our stack really should have timeouts, except for Beefeater. To get around this, I made the numbers here large.

Let's get this out quickly, this is actively impacting cambai in production.

## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
