### PR TITLE
force http1.1 in custom server reverse proxy

### DIFF
--- a/truss/templates/docker_server/proxy.conf.jinja
+++ b/truss/templates/docker_server/proxy.conf.jinja
@@ -18,6 +18,7 @@ server {
     location = / {
         proxy_redirect off;
         proxy_read_timeout 18030s;
+        proxy_http_version 1.1;
 
         rewrite ^/$ {{liveness_endpoint}} break;
 
@@ -27,6 +28,7 @@ server {
     location ~ ^/v1/models/model$ {
         proxy_redirect off;
         proxy_read_timeout 18000s;
+        proxy_http_version 1.1;
 
         rewrite ^/v1/models/model$ {{readiness_endpoint}} break;
 
@@ -36,6 +38,7 @@ server {
     location ~ ^/v1/models/model:predict$ {
         proxy_redirect off;
         proxy_read_timeout 18030s;
+        proxy_http_version 1.1;
 
         rewrite ^/v1/models/model:predict$ {{server_endpoint}} break;
 
@@ -46,6 +49,7 @@ server {
     location / {
         proxy_redirect off;
         proxy_read_timeout 18030s;
+        proxy_http_version 1.1;
 
         proxy_set_header Upgrade $upgrade_header;
         proxy_set_header Connection $connection_header;


### PR DESCRIPTION
By default, nginx forwards requests as HTTP 1.0. To support websockets, we must bump this up to 1.1. This _shouldn't_ break anything, because nothing should natively be relying on HTTP 1.0, but we will need to perform some manual E2E tests to verify.