### PR TITLE
DNS Cache for async client.

### DIFF
--- a/truss-chains/truss_chains/remote_chainlet/stub.py
+++ b/truss-chains/truss_chains/remote_chainlet/stub.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
     import aiohttp
 
 
-DEFAULT_DNS_CACHE_TIMEOUT = 300
+DEFAULT_DNS_CACHE_TIMEOUT_SECONDS = 300
 
 
 _RetryPolicyT = TypeVar("_RetryPolicyT", tenacity.AsyncRetrying, tenacity.Retrying)
@@ -179,7 +179,7 @@ class BasetenSession:
                     limit = self._client_limits.max_connections
                     assert limit is not None
                     connector = aiohttp.TCPConnector(
-                        limit=limit, ttl_dns_cache=DEFAULT_DNS_CACHE_TIMEOUT
+                        limit=limit, ttl_dns_cache=DEFAULT_DNS_CACHE_TIMEOUT_SECONDS
                     )
                     self._cached_async_client = (
                         aiohttp.ClientSession(

--- a/truss-chains/truss_chains/remote_chainlet/stub.py
+++ b/truss-chains/truss_chains/remote_chainlet/stub.py
@@ -34,6 +34,9 @@ if TYPE_CHECKING:
     import aiohttp
 
 
+DEFAULT_DNS_CACHE_TIMEOUT = 300
+
+
 _RetryPolicyT = TypeVar("_RetryPolicyT", tenacity.AsyncRetrying, tenacity.Retrying)
 InputT = TypeVar("InputT", pydantic.BaseModel, Any)  # Any signifies "JSON".
 OutputModelT = TypeVar("OutputModelT", bound=pydantic.BaseModel)
@@ -175,7 +178,9 @@ class BasetenSession:
                         )
                     limit = self._client_limits.max_connections
                     assert limit is not None
-                    connector = aiohttp.TCPConnector(limit=limit)
+                    connector = aiohttp.TCPConnector(
+                        limit=limit, ttl_dns_cache=DEFAULT_DNS_CACHE_TIMEOUT
+                    )
                     self._cached_async_client = (
                         aiohttp.ClientSession(
                             headers=self._headers,


### PR DESCRIPTION

## :rocket: What

On some clusters, there's an intermittant DNS Resoution failure. This has a particularly bad outcome for Chains because there's a DNS lookup on each request to downstream chainlet (cached by default for 10s).

aiohttp supports longer DNS caching, so we can actually cache this longer. This doesn't fully solve the problem, but will likely drastically drive down the number of occurrences. 

## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
