### PR TITLE
Model Cache Fix (extra files being downloaded)

### DIFF
--- a/truss/contexts/image_builder/serving_image_builder.py
+++ b/truss/contexts/image_builder/serving_image_builder.py
@@ -259,7 +259,7 @@ def get_credentials_to_cache(data_dir: Path) -> List[str]:
 
 
 def split_path(path, prefix="gs://"):
-    # Ensure path ends in slash
+    # Ensure path ends in slash so exact directory is retrieved when downloading model cache
     if path and not path.endswith("/"):
         path += "/"
 

--- a/truss/contexts/image_builder/serving_image_builder.py
+++ b/truss/contexts/image_builder/serving_image_builder.py
@@ -142,8 +142,10 @@ class GCSCache(RemoteCache):
         else:
             storage_client = storage.Client.create_anonymous_client()
 
-        bucket_name, prefix = split_path(self.repo_name, prefix="gs://")
-        blobs = storage_client.list_blobs(bucket_name, prefix=prefix)
+        bucket_name, path = split_path(self.repo_name, prefix="gs://")
+        if path and not path.endswith("/"):
+            path += "/"
+        blobs = storage_client.list_blobs(bucket_name, prefix=path)
 
         all_objects = []
         for blob in blobs:
@@ -185,6 +187,8 @@ class S3Cache(RemoteCache):
 
         # path may be like "folderA/folderB"
         bucket_name, path = split_path(self.repo_name, prefix="s3://")
+        if path and not path.endswith("/"):
+            path += "/"
         bucket = s3.Bucket(bucket_name)
 
         all_objects = []

--- a/truss/contexts/image_builder/serving_image_builder.py
+++ b/truss/contexts/image_builder/serving_image_builder.py
@@ -143,8 +143,6 @@ class GCSCache(RemoteCache):
             storage_client = storage.Client.create_anonymous_client()
 
         bucket_name, path = split_path(self.repo_name, prefix="gs://")
-        if path and not path.endswith("/"):
-            path += "/"
         blobs = storage_client.list_blobs(bucket_name, prefix=path)
 
         all_objects = []
@@ -187,8 +185,6 @@ class S3Cache(RemoteCache):
 
         # path may be like "folderA/folderB"
         bucket_name, path = split_path(self.repo_name, prefix="s3://")
-        if path and not path.endswith("/"):
-            path += "/"
         bucket = s3.Bucket(bucket_name)
 
         all_objects = []
@@ -263,6 +259,10 @@ def get_credentials_to_cache(data_dir: Path) -> List[str]:
 
 
 def split_path(path, prefix="gs://"):
+    # Ensure path ends in slash
+    if path and not path.endswith("/"):
+        path += "/"
+
     # Remove the 'gs://' prefix
     path = path.replace(prefix, "")
 


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Ensures that when a user specifies a directory for the model cache, it will only include that directory. For example, if the user specifies 'abc', then 'abc_copy' should not be included. This PR ensures that the desired behavior is what happens - currently we end up downloaded additional files. 

<!--
  How was the change described above implemented?
-->
## :computer: How
When extracting the bucket name and path from the repo name via the split_path helper function, we will ensure that the path for the model cache includes a trailing slash (appending it). This ensures that the blobs are from the exact directory specified.

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
Verified with a test S3 bucket and GCS bucket that contained a desired folder and an additional folder that was prefixed with the desired folder's name (i.e. 'bucket_name/llama' and 'bucket_name/llama_copy').

Tested locally in a jupyter notebook to ensure that the list directory function only outputs the desired files. Also tested by pushing to pypi (truss 0.9.95.dev101), pushing the truss with that version, and comparing original vs dev deployment logs. Specifically, I looked to ensure that there were no logs about downloading the undesired folders with the dev version (the logs were there for the original version).

Also verified these results by going into the pod's filesystem and ensuring the downloaded folders were exactly what we expected.