### PR TITLE
Notify on slack if post-commit failure

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
       run_only_integration: false
 
   report_to_slack:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: always() && github.ref == 'refs/heads/main'
     needs:
       - all-tests
@@ -47,7 +47,7 @@ jobs:
             {
               attachments: [{
                 color: "${{ needs.all-tests.result == 'failure' && 'danger' || 'good' }}",
-                text: `Truss post-commit tests Result: ${{ needs.all-tests.result }}: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`,
+                text: `Truss post-commit tests ${{ needs.all-tests.result }}: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`,
               }]
             }
         env:


### PR DESCRIPTION
## :rocket: What

Add a GHA job to notify on Slack if tests fail after commit to main.

Notifications will come on #truss Slack channel.

## :computer: How

Add a job in `workflows/main.yml`. Adapt from [truss-examples](https://github.com/basetenlabs/truss-examples/blob/272caac1317f8c1cc1be7a909851e7fabab54d3d/.github/workflows/test-examples.yml#L47).

## :microscope: Testing
Tested with `pr.yml` on tests run on PRs.

<img width="581" alt="Screenshot 2025-06-02 at 11 59 40 AM" src="https://github.com/user-attachments/assets/323b2448-7044-4666-9aa4-4a920cfffd2f" />
