### PR TITLE
Use non-problematic parameter for truss integration test

### DIFF
--- a/truss/tests/test_truss_handle.py
+++ b/truss/tests/test_truss_handle.py
@@ -370,12 +370,12 @@ def test_local_no_params_init_custom_model(no_params_init_custom_model):
 @pytest.mark.integration
 def test_custom_python_requirement(custom_model_truss_dir_with_pre_and_post):
     th = TrussHandle(custom_model_truss_dir_with_pre_and_post)
-    th.add_python_requirement("theano")
+    th.add_python_requirement("pandas")
     th.add_python_requirement("scipy")
     tag = "test-custom-python-req-tag:0.0.1"
     container = th.docker_run(tag=tag, local_port=None)
     try:
-        verify_python_requirement_installed_on_container(container, "theano")
+        verify_python_requirement_installed_on_container(container, "pandas")
         verify_python_requirement_installed_on_container(container, "scipy")
     finally:
         Docker.client().kill(container)


### PR DESCRIPTION
## :rocket: What

Replace requirement `theano` with `pandas` for an integration test. This test was failing because of an outdated transitive dependency (versioneer, originating from theano). [Example failing test](https://github.com/basetenlabs/truss/actions/runs/15422557040/job/43401318459)

Error:
```
#10 2.546         File "<string>", line 74, in <module>
#10 2.546         File "/tmp/pip-install-ordx6t6p/theano_9c9be419cb5246099f45040aa85b97c6/versioneer.py", line 1412, in get_versions
#10 2.546           cfg = get_config_from_root(root)
#10 2.546         File "/tmp/pip-install-ordx6t6p/theano_9c9be419cb5246099f45040aa85b97c6/versioneer.py", line 342, in get_config_from_root
#10 2.546           parser = configparser.SafeConfigParser()
#10 2.546                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
#10 2.546       AttributeError: module 'configparser' has no attribute 'SafeConfigParser'. Did you mean: 'RawConfigParser'?
```

## :computer: How

Replace the dependency string in integration test.

## :microscope: Testing

Tested on CI. [Integration tests passing](https://github.com/basetenlabs/truss/actions/runs/15424827587/job/43409068284).