### PR TITLE
Relax python version bounds, bump control server dep

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4682,5 +4682,5 @@ all = []
 
 [metadata]
 lock-version = "2.1"
-python-versions = ">=3.9,<=3.13.3"
-content-hash = "7bf73a7aff90bffadf081fa7867b66fcaf57a2df61a107b86ee1cffdebc2c2da"
+python-versions = ">=3.9,<=3.14"
+content-hash = "13dd4a3b946a58b8c05f5b4bc26770b96276006e19e4b5dd030c3f2eb47856aa"

--- a/poetry.lock
+++ b/poetry.lock
@@ -4682,5 +4682,5 @@ all = []
 
 [metadata]
 lock-version = "2.1"
-python-versions = ">=3.9,<=3.14"
-content-hash = "13dd4a3b946a58b8c05f5b4bc26770b96276006e19e4b5dd030c3f2eb47856aa"
+python-versions = ">=3.9,<3.14"
+content-hash = "6a3771a7a17e67ff614f9c4a6a3917266ed970106fa5b24351bd097315b1939b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ truss-docker-build-setup = "truss.contexts.docker_build_setup:docker_build_setup
 #  isolated.
 [tool.poetry.dependencies]
 # "base" dependencies.
-python = ">=3.9,<=3.14"
+python = ">=3.9,<3.14"
 huggingface_hub = ">=0.25.0"
 pydantic = ">=2.10.0"
 PyYAML = ">=6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ truss-docker-build-setup = "truss.contexts.docker_build_setup:docker_build_setup
 #  isolated.
 [tool.poetry.dependencies]
 # "base" dependencies.
-python = ">=3.9,<=3.13.3"
+python = ">=3.9,<=3.14"
 huggingface_hub = ">=0.25.0"
 pydantic = ">=2.10.0"
 PyYAML = ">=6.0"

--- a/truss/templates/control/requirements.txt
+++ b/truss/templates/control/requirements.txt
@@ -6,7 +6,7 @@ loguru>=0.7.2
 python-json-logger>=2.0.2
 tenacity>=8.1.0
  # To avoid divergence, this should follow the latest release.
-truss==0.9.96
+truss==0.9.100
 uvicorn>=0.24.0
 uvloop>=0.19.0
 websockets>=10.0


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Development models are likely broken for most versions of python base images right now: https://basetenlabs.slack.com/archives/C04NM3YA2DT/p1749074709344789?thread_ts=1749071822.898879&cid=C04NM3YA2DT

This will relax the version bounds, and then bump the control server dep so newer patch versions of 3.13 work

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
