### PR TITLE
Fix Docker emulation for integration tests

### DIFF
--- a/truss/contexts/local_loader/docker_build_emulator.py
+++ b/truss/contexts/local_loader/docker_build_emulator.py
@@ -53,6 +53,10 @@ class DockerBuildEmulator:
             if cmd.instruction == DockerInstruction.ENTRYPOINT:
                 result.entrypoint = list(values)
             if cmd.instruction == DockerInstruction.COPY:
+                # NB(nikhil): Skip COPY commands with --from flag (multi-stage builds)
+                if len(values) != 2:
+                    continue
+
                 src, dst = values
                 src = src.replace("./", "", 1)
                 dst = dst.replace("/", "", 1)


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Integration tests are broken because of the new COPY syntax introduced via https://github.com/basetenlabs/truss/pull/1693. Our integration tests try to emulate the Docker build step, but it doesn't actually need the multi stage portion to work. For now, we just skip that for our integration tests.

We have better smoke / integration tests that actually ensure this works end to end. 

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
Confirmed that `$ poetry run pytest truss/tests/templates/control/control/test_server_integration.py::test_truss_control_server_binary_websocket` works now
