### PR TITLE
Use newer image for integration tests

### DIFF
--- a/truss/tests/test_truss_handle.py
+++ b/truss/tests/test_truss_handle.py
@@ -104,7 +104,11 @@ def test_build_docker_image(custom_model_truss_dir_with_pre_and_post):
 @pytest.mark.parametrize(
     "base_image, path, expected_fail",
     [
-        ("baseten/truss-server-base:3.9-v0.4.8rc4", "/usr/local/bin/python3", False),
+        ("baseten/truss-server-base:3.9-v0.9.0", "/usr/local/bin/python3", False),
+        ("baseten/truss-server-base:3.10-v0.9.0", "/usr/local/bin/python3", False),
+        ("baseten/truss-server-base:3.11-v0.9.0", "/usr/local/bin/python3", False),
+        ("baseten/truss-server-base:3.12-v0.9.0", "/usr/local/bin/python3", False),
+        ("baseten/truss-server-base:3.13-v0.9.0", "/usr/local/bin/python3", False),
         ("python:3.8", "/usr/local/bin/python3", False),
         ("python:3.10", "/usr/local/bin/python3", False),
         ("python:3.11", "/usr/local/bin/python3", False),


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Version of the base image we use in integration tests is too old, and doesn't have the system `libc` version that python3.13 requires. We use newer versions in production, so it feels safe to use the same in integration tests.

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing

Confirmed that `$ poetry run pytest truss/tests/test_truss_handle.py::test_build_serving_docker_image_from_user_base_image_live_reload` now passes
