### PR TITLE
Allow building base images via CI with manual inputs

### DIFF
--- a/.github/workflows/_build_truss_server_base_images_if_needed_shared.yml
+++ b/.github/workflows/_build_truss_server_base_images_if_needed_shared.yml
@@ -1,6 +1,16 @@
 name: Build and Push Truss Base Images (if needed)
 
 on:
+  workflow_dispatch:
+    inputs:
+      new_base_image_version:
+        required: true
+        type: string
+        description: "New base image version"
+      build_base_images:
+        required: true
+        type: string
+        description: "Build base images flag"
   workflow_call:
     inputs:
       new_base_image_version:


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
As part of a recent bug, we want to release new base images so that we're more up to date. Building base images locally is _very_ slow, so it'll be nice to delegate this work to CI.

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
