### PR TITLE
Bump version on main to 0.9.103

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.103rc001"
+version = "0.9.103"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Noticed that the CI job to bring the new version into main is reliably failing: https://github.com/basetenlabs/truss/actions/runs/15570026065/job/43844257348

While we investigate, I'll just true up the version on `main`

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
