### PR TITLE
feat(truss): optional unzip flag for truss train download

### DIFF
--- a/truss-train/tests/test_download.py
+++ b/truss-train/tests/test_download.py
@@ -33,6 +33,7 @@ def test_download_training_job_success(tmp_path, mock_remote, mock_job_response)
         remote_provider=mock_remote,
         job_id="test_job_123",
         target_directory=str(tmp_path),
+        unzip=False,
     )
 
     # Assert
@@ -59,7 +60,10 @@ def test_download_training_job_no_job_found(mock_remote):
         RuntimeError, match="No training job found with ID: nonexistent_job"
     ):
         train_cli.download_training_job_data(
-            remote_provider=mock_remote, job_id="nonexistent_job", target_directory=None
+            remote_provider=mock_remote,
+            job_id="nonexistent_job",
+            target_directory=None,
+            unzip=False,
         )
 
 
@@ -78,7 +82,10 @@ def test_download_training_job_default_directory(
     with patch("pathlib.Path.cwd") as mock_cwd:
         mock_cwd.return_value = test_dir
         result = train_cli.download_training_job_data(
-            remote_provider=mock_remote, job_id="test_job_123", target_directory=None
+            remote_provider=mock_remote,
+            job_id="test_job_123",
+            target_directory=None,
+            unzip=False,
         )
 
     # Assert
@@ -110,6 +117,7 @@ def test_download_training_job_different_directories(
             remote_provider=mock_remote,
             job_id="test_job_123",
             target_directory=str(full_path) if target_dir else None,
+            unzip=False,
         )
 
     # Assert

--- a/truss/cli/train/core.py
+++ b/truss/cli/train/core.py
@@ -295,6 +295,11 @@ def download_training_job_data(
             temp_path.write_bytes(content)
 
             unzip_dir = output_dir / f"{project_name}_{job_id}"
+            if unzip_dir.exists():
+                raise click.ClickException(
+                    f"Error: Directory '{unzip_dir}' already exists. Please remove it or specify a different target directory."
+                )
+
             unzip_dir.mkdir(parents=True, exist_ok=True)
             with tarfile.open(temp_path, "r:*") as tar:
                 tar.extractall(path=unzip_dir)

--- a/truss/cli/train/core.py
+++ b/truss/cli/train/core.py
@@ -1,3 +1,5 @@
+import tarfile
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Optional, Tuple
@@ -290,9 +292,6 @@ def download_training_job_data(
     content = remote_provider.api.get_from_presigned_url(presigned_url)
 
     if unzip:
-        import tarfile
-        import tempfile
-
         with tempfile.NamedTemporaryFile() as temp_file:
             temp_path = Path(temp_file.name)
             temp_path.write_bytes(content)

--- a/truss/cli/train_commands.py
+++ b/truss/cli/train_commands.py
@@ -243,9 +243,18 @@ def deploy_checkpoints(
     required=False,
     help="Directory where the file should be downloaded. Defaults to current directory.",
 )
+@click.option(
+    "--unzip/--no-unzip",
+    is_flag=True,
+    default=True,
+    help="Whether to unzip the downloaded file. Defaults to True.",
+)
 @common.common_options()
 def download_training_job(
-    job_id: str, remote: Optional[str], target_directory: Optional[str]
+    job_id: str,
+    remote: Optional[str],
+    target_directory: Optional[str],
+    unzip: bool = True,
 ) -> None:
     if not job_id:
         error_console.print("Job ID is required")
@@ -266,6 +275,7 @@ def download_training_job(
                 remote_provider=remote_provider,
                 job_id=job_id,
                 target_directory=target_directory,
+                unzip=unzip,
             )
 
         console.print(

--- a/truss/cli/train_commands.py
+++ b/truss/cli/train_commands.py
@@ -243,18 +243,10 @@ def deploy_checkpoints(
     required=False,
     help="Directory where the file should be downloaded. Defaults to current directory.",
 )
-@click.option(
-    "--unzip/--no-unzip",
-    is_flag=True,
-    default=True,
-    help="Whether to unzip the downloaded file. Defaults to True.",
-)
+@click.option("--no-unzip", is_flag=True, help="Whether to not unzip the file")
 @common.common_options()
 def download_training_job(
-    job_id: str,
-    remote: Optional[str],
-    target_directory: Optional[str],
-    unzip: bool = True,
+    job_id: str, remote: Optional[str], target_directory: Optional[str], no_unzip: bool
 ) -> None:
     if not job_id:
         error_console.print("Job ID is required")
@@ -275,7 +267,7 @@ def download_training_job(
                 remote_provider=remote_provider,
                 job_id=job_id,
                 target_directory=target_directory,
-                unzip=unzip,
+                unzip=not no_unzip,
             )
 
         console.print(

--- a/truss/cli/train_commands.py
+++ b/truss/cli/train_commands.py
@@ -243,7 +243,7 @@ def deploy_checkpoints(
     required=False,
     help="Directory where the file should be downloaded. Defaults to current directory.",
 )
-@click.option("--no-unzip", is_flag=True, help="Whether to not unzip the file")
+@click.option("--no-unzip", is_flag=True, help="Instructs truss to not unzip the folder upon download.")
 @common.common_options()
 def download_training_job(
     job_id: str, remote: Optional[str], target_directory: Optional[str], no_unzip: bool

--- a/truss/cli/train_commands.py
+++ b/truss/cli/train_commands.py
@@ -243,7 +243,11 @@ def deploy_checkpoints(
     required=False,
     help="Directory where the file should be downloaded. Defaults to current directory.",
 )
-@click.option("--no-unzip", is_flag=True, help="Instructs truss to not unzip the folder upon download.")
+@click.option(
+    "--no-unzip",
+    is_flag=True,
+    help="Instructs truss to not unzip the folder upon download.",
+)
 @common.common_options()
 def download_training_job(
     job_id: str, remote: Optional[str], target_directory: Optional[str], no_unzip: bool


### PR DESCRIPTION
## 🚀 What

Improves the `truss train download` command by automatically unzipping the downloaded file. Previously, it saved a `.tgz` archive, requiring users to manually extract it using the correct command — not ideal for a smooth developer experience. Now, the file is unzipped by default, with an option to disable this behavior via the `--no-unzip` flag (or enable it explicitly with `--unzip`).

[Video](https://www.loom.com/share/98ccc499e10b41c2b304d86f019a3c73?sid=e46d5725-0e3c-4b25-b465-62069f7b3000)
---

## 💻 How

- Added an optional `--unzip/--no-unzip` flag.
- If unzipping is enabled, the `.tgz` file is written to a temporary file and extracted using Python’s built-in `tarfile` module.
- Output is placed in a structured directory under the specified target location.

---

## 🔬 Testing

Manually tested the download and extraction flow. Chose not to add unit tests due to the heavy use of mocking and minimal logic beyond standard library calls.
