### PR TITLE
Propagate specified GPU count to vllm's tensor parallelism as well

### DIFF
--- a/truss/cli/train/deploy_checkpoints.py
+++ b/truss/cli/train/deploy_checkpoints.py
@@ -29,7 +29,7 @@ from truss_train.definitions import (
 VLLM_LORA_START_COMMAND = Template(
     'sh -c "{%if envvars %}{{ envvars }} {% endif %}vllm serve {{ base_model_id }}'
     + " --port 8000"
-    + " --tensor-parallel-size {{ gpu_count }}"
+    + "{{ specify_tensor_parallelism }}"
     + " --enable-lora"
     + " --max-lora-rank {{ max_lora_rank }}"
     + " --dtype bfloat16"
@@ -136,13 +136,18 @@ def _render_vllm_lora_truss_config(
             for checkpoint in checkpoint_deploy.checkpoint_details.checkpoints
         ]
     )
+    accelerator = checkpoint_deploy.compute.accelerator
+    if accelerator:
+        specify_tensor_parallelism = f" --tensor-parallel-size {accelerator.count}"
+    else:
+        specify_tensor_parallelism = ""
 
     start_command_args = {
         "base_model_id": checkpoint_deploy.checkpoint_details.base_model_id,
         "lora_modules": checkpoint_str,
         "envvars": start_command_envvars,
         "max_lora_rank": max_lora_rank,
-        "gpu_count": checkpoint_deploy.compute.accelerator.count,
+        "specify_tensor_parallelism": specify_tensor_parallelism,
     }
     truss_deploy_config.docker_server.start_command = VLLM_LORA_START_COMMAND.render(
         **start_command_args

--- a/truss/tests/cli/train/test_deploy_checkpoints.py
+++ b/truss/tests/cli/train/test_deploy_checkpoints.py
@@ -230,13 +230,14 @@ def test_prepare_checkpoint_deploy_complete_config(
     assert config.compute.accelerator.accelerator == "A100"
     assert config.compute.accelerator.count == 2
 
-    # open the config.yaml file and verify the tensor parallel size is 2
-    # additional tests can be added to verify the config.yaml file is correct
-    with open(result.truss_directory / "config.yaml", "r") as f:
-        config_yaml = f.read()
-    assert "--tensor-parallel-size 2" in config_yaml
-
     # Verify runtime config
     env_vars = config.runtime.environment_variables
     assert env_vars["HF_TOKEN"].name == "my_custom_secret"
     assert env_vars["CUSTOM_VAR"] == "custom_value"
+
+    # open the config.yaml file and verify the tensor parallel size is 2
+    # additional tests can be added to verify the config.yaml file is correct
+    truss_cfg = truss_config.TrussConfig.from_yaml(
+        Path(result.truss_directory, "config.yaml")
+    )
+    assert "--tensor-parallel-size 2" in truss_cfg.docker_server.start_command


### PR DESCRIPTION
Ready for review.

## :rocket: What
When deploying from checkpoints, set `--tensor-parallel-size` for `vllm` based on number of accelerators specified to truss.

Otherwise, if I specify a lower number of GPUs, then vllm will not start and deployment fails:

> WARNING 06-13 11:35:04 [ray_utils.py:341] The number of required GPUs exceeds the total number of available GPUs in the placement group.

## :computer: How
Propagate `accelerator.count` configuration value, add test.

## :microscope: Testing
Tested with unit test.