### PR TITLE
[Ready for review] Use default CPU resources when GPU type is None

### DIFF
--- a/truss/cli/train/deploy_checkpoints.py
+++ b/truss/cli/train/deploy_checkpoints.py
@@ -284,6 +284,10 @@ def _get_compute(compute: Optional[Compute]) -> Compute:
     if not compute:
         compute = Compute(cpu_count=0, memory="0Mi")
     compute.accelerator = _get_accelerator_if_specified(compute.accelerator)
+    # User did not specify an accelerator, so we default to CPU.
+    if not compute.accelerator:
+        compute.cpu_count = int(truss_config.DEFAULT_CPU)
+        compute.memory = truss_config.DEFAULT_MEMORY
     return compute
 
 


### PR DESCRIPTION
Ready for review.

## :rocket: What
When user specifies GPU type as "None", use default CPU count and memory size. Without this, truss sends "0" CPU and "0 MB" memory, causing deployment to fail with insufficient resources.

## :computer: How
Add code to set CPU count and memory, if accelerator is not specified.

## :microscope: Testing
Add mock for CPU config, add test