### PR TITLE
feat(truss): enable b10 instance type

### DIFF
--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -50,6 +50,7 @@ def _is_numeric(number_like: str) -> bool:
 
 
 class Accelerator(str, enum.Enum):
+    B10 = "B10"
     T4 = "T4"
     L4 = "L4"
     A10G = "A10G"


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
* in order to test b10 instance type in different environments (staging, prod), we need to enable truss to support it (at library level and context builder level)
<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
