### PR TITLE
chore(truss): update push message to show when job is queued

### DIFF
--- a/truss/cli/train_commands.py
+++ b/truss/cli/train_commands.py
@@ -65,7 +65,12 @@ def push_training_job(config: Path, remote: Optional[str], tail: bool):
 
         job_id = job_resp["id"]
 
-        console.print("✨ Training job successfully created!", style="green")
+        if job_resp.get("current_status", None) == "TRAINING_JOB_QUEUED":
+            console.print(
+                "🟢 Training job is queued. Please wait for it to start.", style="green"
+            )
+        else:
+            console.print("✨ Training job successfully created!", style="green")
         console.print(
             f"🪵 View logs for your job via "
             f"[cyan]'truss train logs --job-id {job_id} [--tail]'[/cyan]\n"

--- a/truss/cli/train_commands.py
+++ b/truss/cli/train_commands.py
@@ -67,7 +67,8 @@ def push_training_job(config: Path, remote: Optional[str], tail: bool):
 
         if job_resp.get("current_status", None) == "TRAINING_JOB_QUEUED":
             console.print(
-                "🟢 Training job is queued. Please wait for it to start.", style="green"
+                f"🟢 Training job is queued. You can check the status of your job by running 'truss train view --job-id={job_id}'.",
+                style="green",
             )
         else:
             console.print("✨ Training job successfully created!", style="green")


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
- This PR updates the output of `truss train push` to tell the user when a job has been queued rather than deployed. New message:
```
$ truss train push [...]
🟢 Training job is queued. You can check the status of your job by running 'truss train view --job-id={job_id}'.
[...]
```

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
- Checked that the message only changes when a job is queued