### PR TITLE
feat(truss): train recreate command to recreate from an existing job BT-14830

### DIFF
--- a/truss-train/tests/test_recreate.py
+++ b/truss-train/tests/test_recreate.py
@@ -1,0 +1,126 @@
+from unittest.mock import MagicMock, patch
+
+import click
+import pytest
+
+from truss.cli.train import core as train_cli
+
+
+@pytest.fixture
+def mock_remote():
+    remote = MagicMock()
+    remote.api = MagicMock()
+    return remote
+
+
+class TestRecreateTrainingJob:
+    """Test cases for the recreate_training_job function."""
+
+    def test_recreate_training_job_success(self, mock_remote):
+        """Test recreating a training job with a specific job ID."""
+        mock_remote.api.recreate_training_job.return_value = {
+            "id": "test_job_124",
+            "training_project": {"id": "project_456", "name": "aghilan-anime-project"},
+        }
+
+        mock_remote.api.search_training_jobs.return_value = [
+            {
+                "id": "test_job_123",
+                "training_project": {
+                    "id": "project_456",
+                    "name": "aghilan-anime-project",
+                },
+            }
+        ]
+
+        result = train_cli.recreate_training_job(
+            remote_provider=mock_remote, job_id="test_job_123"
+        )
+
+        assert result["id"] == "test_job_124"
+        assert result["training_project"]["id"] == "project_456"
+        assert result["training_project"]["name"] == "aghilan-anime-project"
+
+        mock_remote.api.recreate_training_job.assert_called_once_with(
+            "project_456", "test_job_123"
+        )
+
+    def test_recreate_training_job_no_job_found(self, mock_remote):
+        """Test recreating a training job with a non-existent job ID."""
+        mock_remote.api.search_training_jobs.return_value = []
+
+        with pytest.raises(
+            RuntimeError, match="No training job found with ID: nonexistent_job"
+        ):
+            train_cli.recreate_training_job(
+                remote_provider=mock_remote, job_id="nonexistent_job"
+            )
+
+        mock_remote.api.search_training_jobs.assert_called_once_with(
+            job_id="nonexistent_job"
+        )
+        mock_remote.api.recreate_training_job.assert_not_called()
+
+    def test_recreate_training_job_without_job_id_success(self, mock_remote):
+        """Test recreating a training job without specifying job ID (uses latest active)."""
+        mock_remote.api.search_training_jobs.return_value = [
+            {
+                "id": "test_job_123",
+                "training_project": {
+                    "id": "project_456",
+                    "name": "aghilan-anime-project",
+                },
+            }
+        ]
+
+        mock_remote.api.recreate_training_job.return_value = {
+            "id": "test_job_124",
+            "training_project": {"id": "project_456", "name": "aghilan-anime-project"},
+        }
+
+        # Mock the confirmation dialog
+        with patch("truss.cli.train.core.inquirer.confirm") as mock_confirm:
+            mock_confirm.return_value.execute.return_value = True
+
+            result = train_cli.recreate_training_job(remote_provider=mock_remote)
+
+            assert result["id"] == "test_job_124"
+            assert result["training_project"]["id"] == "project_456"
+            assert result["training_project"]["name"] == "aghilan-anime-project"
+
+            # Verify the API calls
+            mock_remote.api.search_training_jobs.assert_called_once_with(
+                statuses=train_cli.ACTIVE_JOB_STATUSES,
+                order_by=[{"field": "created_at", "order": "desc"}],
+            )
+            mock_remote.api.recreate_training_job.assert_called_once_with(
+                "project_456", "test_job_123"
+            )
+
+    def test_recreate_training_job_without_job_id_no_active_jobs(self, mock_remote):
+        """Test recreating a training job when no active jobs exist."""
+        mock_remote.api.search_training_jobs.return_value = []
+
+        # Should raise ClickException when no active jobs found
+        with pytest.raises(click.ClickException, match="No active training jobs found"):
+            train_cli.recreate_training_job(remote_provider=mock_remote)
+
+    def test_recreate_training_job_without_job_id_user_cancels(self, mock_remote):
+        """Test recreating a training job when user cancels the confirmation."""
+        mock_remote.api.search_training_jobs.return_value = [
+            {
+                "id": "test_job_123",
+                "training_project": {
+                    "id": "project_456",
+                    "name": "aghilan-anime-project",
+                },
+            }
+        ]
+
+        # Mock the confirmation dialog to return False
+        with patch("truss.cli.train.core.inquirer.confirm") as mock_confirm:
+            mock_confirm.return_value.execute.return_value = False
+
+            # Should raise UsageError when user cancels
+            with pytest.raises(click.UsageError, match="Training job not recreated"):
+                train_cli.recreate_training_job(remote_provider=mock_remote)

--- a/truss-train/tests/test_recreate.py
+++ b/truss-train/tests/test_recreate.py
@@ -90,8 +90,7 @@ class TestRecreateTrainingJob:
 
             # Verify the API calls
             mock_remote.api.search_training_jobs.assert_called_once_with(
-                statuses=train_cli.ACTIVE_JOB_STATUSES,
-                order_by=[{"field": "created_at", "order": "desc"}],
+                order_by=[{"field": "created_at", "order": "desc"}]
             )
             mock_remote.api.recreate_training_job.assert_called_once_with(
                 "project_456", "test_job_123"
@@ -102,7 +101,10 @@ class TestRecreateTrainingJob:
         mock_remote.api.search_training_jobs.return_value = []
 
         # Should raise ClickException when no active jobs found
-        with pytest.raises(click.ClickException, match="No active training jobs found"):
+        with pytest.raises(
+            click.ClickException,
+            match="No training jobs found. Please start a job first.",
+        ):
             train_cli.recreate_training_job(remote_provider=mock_remote)
 
     def test_recreate_training_job_without_job_id_user_cancels(self, mock_remote):

--- a/truss/cli/train/core.py
+++ b/truss/cli/train/core.py
@@ -80,6 +80,21 @@ def display_training_jobs(
         display_training_job(job, remote_url, checkpoints_by_job_id.get(job["id"], []))
 
 
+def recreate_training_job(remote_provider: BasetenRemote, job_id: str) -> None:
+    jobs = remote_provider.api.search_training_jobs(job_id=job_id)
+    if not jobs:
+        raise click.UsageError(f"No training job found with ID: {job_id}")
+
+    project_id = jobs[0]["training_project"]["id"]
+
+    print(f"Recreating training job {job_id} in project {project_id}...")
+
+    # remote_provider.api.recreate_training_job(project_id, job_id)
+    console.print(f"Training job {job_id} recreated successfully.", style="green")
+
+    return jobs[0]
+
+
 def display_training_projects(projects: list[dict], remote_url: str) -> None:
     table = rich.table.Table(
         show_header=True,

--- a/truss/cli/train/core.py
+++ b/truss/cli/train/core.py
@@ -109,7 +109,7 @@ def recreate_training_job(
             raise click.UsageError("Training job not recreated.")
 
     project_id = jobs[0]["training_project"]["id"]
-    job_resp = remote_provider.api.recreate_training_job(project_id, job_id)
+    job_resp = remote_provider.api.recreate_training_job(project_id, job_id) # type: ignore[arg-type]
     return job_resp
 
 

--- a/truss/cli/train/core.py
+++ b/truss/cli/train/core.py
@@ -107,6 +107,7 @@ def recreate_training_job(
         job = _get_latest_job_by_job_id(remote_provider, job_id)
     else:
         job = _get_latest_active_job(remote_provider)
+        job_id = job["id"]
         confirm = inquirer.confirm(
             message=f"Recreate training job from most recent active job {job_id}?",
             default=False,

--- a/truss/cli/train/core.py
+++ b/truss/cli/train/core.py
@@ -374,8 +374,8 @@ def download_checkpoint_artifacts(
     checkpoint_artifacts = (
         remote_provider.api.get_training_job_checkpoint_presigned_url(
             project_id=project_id,
-            job_id=job_id, # type: ignore
-            page_size=1000,  
+            job_id=job_id,  # type: ignore
+            page_size=1000,
         )
     )
 

--- a/truss/cli/train/core.py
+++ b/truss/cli/train/core.py
@@ -109,7 +109,7 @@ def recreate_training_job(
             raise click.UsageError("Training job not recreated.")
 
     project_id = jobs[0]["training_project"]["id"]
-    job_resp = remote_provider.api.recreate_training_job(project_id, job_id) # type: ignore[arg-type]
+    job_resp = remote_provider.api.recreate_training_job(project_id, job_id)  # type: ignore[arg-type]
     return job_resp
 
 

--- a/truss/cli/train/core.py
+++ b/truss/cli/train/core.py
@@ -106,7 +106,7 @@ def recreate_training_job(
         job = _get_latest_job(remote_provider)
         job_id = job["id"]
         confirm = inquirer.confirm(
-            message=f"Recreate training job from most recent active job {job_id}?",
+            message=f"Recreate training job from most recent job {job_id}?",
             default=False,
         ).execute()
 

--- a/truss/cli/train/core.py
+++ b/truss/cli/train/core.py
@@ -27,22 +27,19 @@ ACTIVE_JOB_STATUSES = [
 ]
 
 
-def _get_latest_job_by_job_id(remote_provider: BasetenRemote, job_id: str) -> dict:
+def _get_job_by_job_id(remote_provider: BasetenRemote, job_id: str) -> dict:
     jobs = remote_provider.api.search_training_jobs(job_id=job_id)
     if not jobs:
         raise RuntimeError(f"No training job found with ID: {job_id}")
     return jobs[0]
 
 
-def _get_latest_active_job(remote_provider: BasetenRemote) -> dict:
+def _get_latest_job(remote_provider: BasetenRemote) -> dict:
     jobs = remote_provider.api.search_training_jobs(
-        statuses=ACTIVE_JOB_STATUSES,
-        order_by=[{"field": "created_at", "order": "desc"}],
+        order_by=[{"field": "created_at", "order": "desc"}]
     )
     if not jobs:
-        raise click.ClickException(
-            "No active training jobs found. Please start a job first or specify a job ID."
-        )
+        raise click.ClickException("No training jobs found. Please start a job first.")
     return jobs[0]
 
 
@@ -104,9 +101,9 @@ def recreate_training_job(
 ) -> Dict[str, Any]:
     job: dict
     if job_id:
-        job = _get_latest_job_by_job_id(remote_provider, job_id)
+        job = _get_job_by_job_id(remote_provider, job_id)
     else:
-        job = _get_latest_active_job(remote_provider)
+        job = _get_latest_job(remote_provider)
         job_id = job["id"]
         confirm = inquirer.confirm(
             message=f"Recreate training job from most recent active job {job_id}?",
@@ -318,7 +315,7 @@ def download_training_job_data(
     output_dir = Path(target_directory).resolve() if target_directory else Path.cwd()
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    job = _get_latest_job_by_job_id(remote_provider, job_id)
+    job = _get_job_by_job_id(remote_provider, job_id)
 
     project = job["training_project"]
     project_id = project["id"]
@@ -362,9 +359,9 @@ def download_checkpoint_artifacts(
     job: dict
 
     if job_id:
-        job = _get_latest_job_by_job_id(remote_provider, job_id)
+        job = _get_job_by_job_id(remote_provider, job_id)
     else:
-        job = _get_latest_active_job(remote_provider)
+        job = _get_latest_job(remote_provider)
 
     job_id = job["id"]
     project = job["training_project"]

--- a/truss/cli/train/core.py
+++ b/truss/cli/train/core.py
@@ -374,8 +374,8 @@ def download_checkpoint_artifacts(
     checkpoint_artifacts = (
         remote_provider.api.get_training_job_checkpoint_presigned_url(
             project_id=project_id,
-            job_id=job_id,
-            page_size=1000,  # type: ignore
+            job_id=job_id, # type: ignore
+            page_size=1000,  
         )
     )
 

--- a/truss/cli/train_commands.py
+++ b/truss/cli/train_commands.py
@@ -85,13 +85,13 @@ def push_training_job(config: Path, remote: Optional[str], tail: bool):
 @click.option(
     "--job-id",
     type=str,
-    required=True,
+    required=False,
     help="Existing Job ID of Training Job to recreate",
 )
 @click.option("--remote", type=str, required=False, help="Remote to use")
 @click.option("--tail", is_flag=True, help="Tail for status + logs after recreation.")
 @common.common_options()
-def recreate_training_job(job_id: str, remote: Optional[str], tail: bool):
+def recreate_training_job(job_id: Optional[str], remote: Optional[str], tail: bool):
     """Recreate an existing training job from an existing job ID"""
     if not remote:
         remote = remote_cli.inquire_remote_name()
@@ -100,24 +100,24 @@ def recreate_training_job(job_id: str, remote: Optional[str], tail: bool):
         BasetenRemote, RemoteFactory.create(remote=remote)
     )
 
-    with console.status("Creating training job...", spinner="dots"):
-        job_resp = train_cli.recreate_training_job(
-            remote_provider=remote_provider, job_id=job_id
-        )
-        print(job_resp)
+    console.print("Creating training job...", style="bold")
+    job_resp = train_cli.recreate_training_job(
+        remote_provider=remote_provider, job_id=job_id
+    )
 
-        console.print("✨ Training job successfully created!", style="green")
-        console.print(
-            f"🪵 View logs for your job via "
-            f"[cyan]'truss train logs --job-id {job_id} [--tail]'[/cyan]\n"
-            f"🔍 View metrics for your job via "
-            f"[cyan]'truss train metrics --job-id {job_id}'[/cyan]\n"
-            f"🌐 Status page: {common.format_link(core.status_page_url(remote_provider.remote_url, job_id))}"
-        )
+    project_id, recreated_job_id = job_resp["training_project"]["id"], job_resp["id"]
+
+    console.print("✨ Training job successfully created!", style="green")
+    console.print(
+        f"🪵 View logs for your job via "
+        f"[cyan]'truss train logs --job-id {recreated_job_id} [--tail]'[/cyan]\n"
+        f"🔍 View metrics for your job via "
+        f"[cyan]'truss train metrics --job-id {recreated_job_id}'[/cyan]\n"
+        f"🌐 Status page: {common.format_link(core.status_page_url(remote_provider.remote_url, recreated_job_id))}"
+    )
 
     if tail:
-        project_id, new_job_id = job_resp["training_project"]["id"], job_resp["id"]
-        watcher = TrainingLogWatcher(remote_provider.api, project_id, new_job_id)
+        watcher = TrainingLogWatcher(remote_provider.api, project_id, recreated_job_id)
         for log in watcher.watch():
             cli_log_utils.output_log(log)
 

--- a/truss/cli/train_commands.py
+++ b/truss/cli/train_commands.py
@@ -42,10 +42,7 @@ def _print_training_job_success_message(
 def _handle_post_create_logic(
     job_resp: dict, remote_provider: BasetenRemote, tail: bool
 ) -> None:
-    job_id = job_resp["id"]
-    project_id = job_resp.get("training_project", {}).get("id") or job_resp.get(
-        "project_id"
-    )
+    project_id, job_id = job_resp["training_project"]["id"], job_resp["id"]
 
     if job_resp.get("current_status", None) == "TRAINING_JOB_QUEUED":
         console.print(

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -630,6 +630,12 @@ class BasetenApi:
         )
         return resp_json
 
+    def recreate_training_job(self, project_id: str, job_id: str):
+        resp_json = self._rest_api_client.post(
+            f"v1/training_projects/{project_id}/jobs/{job_id}/recreate", body={}
+        )
+        return resp_json["training_job"]
+
     def list_training_job_checkpoints(self, project_id: str, job_id: str):
         resp_json = self._rest_api_client.get(
             f"v1/training_projects/{project_id}/jobs/{job_id}/checkpoints"


### PR DESCRIPTION
<!--  
  What does this PR add, remove, and/or change?  
-->

## \:rocket: What

This PR introduces the `truss train recreate --job-id=<id> --remote=<remote> --tail` command, where all arguments are optional:

* If `--tail` is not provided, logs will not be streamed.
* If `--remote` is not specified, a prompt will appear asking which remote to use.
* If `--job-id` is not provided, the command will search through your active running jobs, select the most recently created one, and prompt you to confirm whether you want to recreate the training job with that ID.

[Demo](https://www.loom.com/share/d79f067a1ae547898ddcc16878f683ac?sid=e229115c-d364-4eee-a7fd-097f2fd4068a)

<!--  
  How was the change described above implemented?  
-->

## \:computer: How

This feature was implemented by:

* Adding the new CLI command.
* Defining a function in the core logic to handle the recreation process.
* Adding an API layer function to call the `/recreate` endpoint.

<!--  
  How have I ensured release and ongoing quality of this change?  
-->

## \:microscope: Testing

Manually tested the feature against the production API. Verified that the recreated training jobs retained the expected state and behavior.
