### PR TITLE
fix(truss): With --wait don't error immediately after network errors.

### DIFF
--- a/truss/api/definitions.py
+++ b/truss/api/definitions.py
@@ -40,7 +40,7 @@ class ModelDeployment:
                 return True
 
             if deployment_status not in DEPLOYING_STATUSES:
-                raise Exception(f"Deployment failed with status: {deployment_status}")
+                raise ValueError(f"Deployment failed with status: {deployment_status}")
 
         raise RuntimeError("Error polling deployment status.")
 

--- a/truss/remote/baseten/service.py
+++ b/truss/remote/baseten/service.py
@@ -7,7 +7,6 @@ from typing import Any, Dict, Iterator, NamedTuple, Optional
 import requests
 from tenacity import retry, stop_after_delay, wait_fixed
 
-from truss.base.errors import RemoteNetworkError
 from truss.remote.baseten.api import BasetenApi
 from truss.remote.baseten.auth import AuthService
 from truss.remote.baseten.core import ModelVersionHandle
@@ -178,4 +177,4 @@ class BasetenService(TrussService):
                 deployment = self._fetch_deployment()
                 yield deployment["status"]
             except requests.exceptions.RequestException:
-                raise RemoteNetworkError("Could not reach backend.")
+                continue

--- a/truss/remote/baseten/service.py
+++ b/truss/remote/baseten/service.py
@@ -1,4 +1,5 @@
 import enum
+import logging
 import time
 import urllib.parse
 import warnings
@@ -15,6 +16,8 @@ from truss.truss_handle.truss_handle import TrussHandle
 
 # "classes created inside an enum will not become a member" -> intended here anyway.
 warnings.filterwarnings("ignore", category=DeprecationWarning, message=".*enum.*")
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_STREAM_ENCODING = "utf-8"
 
@@ -177,4 +180,5 @@ class BasetenService(TrussService):
                 deployment = self._fetch_deployment()
                 yield deployment["status"]
             except requests.exceptions.RequestException:
+                logger.warning("Network error, unable to reach Baseten")
                 continue


### PR DESCRIPTION

## :rocket: What

There's currently an issue where if there is a temporary network issue with truss, it will cause `truss push --wait` to fail, instead of tolerating failures up til the `timeout-seconds` is reached. 

## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing

Do a `truss push --wait` from laptop. Let it run for a bit, then turn off the wifi. Notice the warnings that get printed out, but the command will run until it finishes.