### PR TITLE
feat(truss): python sdk for pushing training jobs 

### DIFF
--- a/truss-train/truss_train/__init__.py
+++ b/truss-train/truss_train/__init__.py
@@ -5,5 +5,13 @@ from truss_train.definitions import (
     TrainingJob,
     TrainingProject,
 )
+from truss_train.public_api import push
 
-__all__ = ["Compute", "Runtime", "SecretReference", "TrainingJob", "TrainingProject"]
+__all__ = [
+    "Compute",
+    "Runtime",
+    "SecretReference",
+    "TrainingJob",
+    "TrainingProject",
+    "push",
+]

--- a/truss-train/truss_train/public_api.py
+++ b/truss-train/truss_train/public_api.py
@@ -8,6 +8,17 @@ from truss_train.deployment import create_training_job
 
 
 def push(training_project: TrainingProject, config: Path, remote: str = "baseten"):
+    """
+    push
+    * creates or updates a training_project
+    * creates the training_job in the training_project
+    * returns a dictionary with the format:
+        {
+            "training_project": TrainingProject,
+            "training_job": TrainingJob,
+        }. The definitions of TrainingProject and TrainingJob can be found in the API docs.
+        https://docs.baseten.co/reference/training-api/get-training-job
+    """
     remote_provider: BasetenRemote = cast(
         BasetenRemote, RemoteFactory.create(remote=remote)
     )

--- a/truss-train/truss_train/public_api.py
+++ b/truss-train/truss_train/public_api.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+from typing import cast
+
+from truss.remote.baseten.remote import BasetenRemote
+from truss.remote.remote_factory import RemoteFactory
+from truss_train.definitions import TrainingProject
+from truss_train.deployment import create_training_job
+
+
+def push(training_project: TrainingProject, config: Path, remote: str = "baseten"):
+    remote_provider: BasetenRemote = cast(
+        BasetenRemote, RemoteFactory.create(remote=remote)
+    )
+    job_resp = create_training_job(
+        remote_provider=remote_provider,
+        training_project=training_project,
+        config=config,
+    )
+    return job_resp

--- a/truss/cli/train_commands.py
+++ b/truss/cli/train_commands.py
@@ -85,15 +85,10 @@ def push_training_job(config: Path, remote: Optional[str], tail: bool):
     )
     with loader.import_training_project(config) as training_project:
         with console.status("Creating training job...", spinner="dots"):
-            project_resp = remote_provider.api.upsert_training_project(
-                training_project=training_project
-            )
-
-            prepared_job = deployment.prepare_push(
-                remote_provider.api, config, training_project.job
-            )
-            job_resp = remote_provider.api.create_training_job(
-                project_id=project_resp["id"], job=prepared_job
+            job_resp = deployment.create_training_job(
+                remote_provider=remote_provider,
+                training_project=training_project,
+                config=config,
             )
 
         _handle_post_create_logic(job_resp, remote_provider, tail)


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
* Allow customers to push jobs via python SDK
<!--
  How was the change described above implemented?
-->
## :computer: How
* This was surprisingly simple - ended up moving the "create" logic into a shared function. Added a "push" call to the truss public api. 
<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
Ran `python deploy_config.py`, which looked like this: 

```

training_job = definitions.TrainingJob(
    compute=definitions.Compute(
        cpu_count=0,
        memory="0Mi",
        accelerator=truss_config.AcceleratorSpec(
            accelerator=truss_config.Accelerator.L4,
            count=1,
        ),
        node_count=1,
    ),
    runtime=runtime,
    image=definitions.Image(base_image="python:3-slim"),
)

first_project = definitions.TrainingProject(name="spin", job=training_job)

push(first_project, pathlib.Path(__file__))
```