### PR TITLE
Update truss train "push" in Python SDK 

### DIFF
--- a/truss-train/truss_train/__init__.py
+++ b/truss-train/truss_train/__init__.py
@@ -5,7 +5,7 @@ from truss_train.definitions import (
     TrainingJob,
     TrainingProject,
 )
-from truss_train.public_api import push
+from truss_train.public_api import push, push_from_file
 
 __all__ = [
     "Compute",
@@ -14,4 +14,5 @@ __all__ = [
     "TrainingJob",
     "TrainingProject",
     "push",
+    "push_from_file",
 ]

--- a/truss-train/truss_train/__init__.py
+++ b/truss-train/truss_train/__init__.py
@@ -5,7 +5,7 @@ from truss_train.definitions import (
     TrainingJob,
     TrainingProject,
 )
-from truss_train.public_api import push, push_from_file
+from truss_train.public_api import push
 
 __all__ = [
     "Compute",
@@ -14,5 +14,4 @@ __all__ = [
     "TrainingJob",
     "TrainingProject",
     "push",
-    "push_from_file",
 ]

--- a/truss-train/truss_train/deployment.py
+++ b/truss-train/truss_train/deployment.py
@@ -8,6 +8,7 @@ from truss.remote.baseten.api import BasetenApi
 from truss.remote.baseten.core import archive_dir
 from truss.remote.baseten.remote import BasetenRemote
 from truss.remote.baseten.utils import transfer
+from truss_train import loader
 from truss_train.definitions import TrainingJob, TrainingProject
 
 
@@ -59,4 +60,14 @@ def create_training_job(
     job_resp = remote_provider.api.create_training_job(
         project_id=project_resp["id"], job=prepared_job
     )
+    return job_resp
+
+
+def create_training_job_from_file(remote_provider: BasetenRemote, config: Path):
+    with loader.import_training_project(config) as training_project:
+        job_resp = create_training_job(
+            remote_provider=remote_provider,
+            training_project=training_project,
+            config=config,
+        )
     return job_resp

--- a/truss-train/truss_train/deployment.py
+++ b/truss-train/truss_train/deployment.py
@@ -63,7 +63,7 @@ def create_training_job(
     return job_resp
 
 
-def create_training_job_from_file(remote_provider: BasetenRemote, config: Path):
+def create_training_job_from_file(remote_provider: BasetenRemote, config: Path) -> dict:
     with loader.import_training_project(config) as training_project:
         job_resp = create_training_job(
             remote_provider=remote_provider,

--- a/truss-train/truss_train/public_api.py
+++ b/truss-train/truss_train/public_api.py
@@ -3,37 +3,29 @@ from typing import cast
 
 from truss.remote.baseten.remote import BasetenRemote
 from truss.remote.remote_factory import RemoteFactory
-from truss_train.definitions import TrainingProject
-from truss_train.deployment import create_training_job, create_training_job_from_file
+from truss_train.deployment import create_training_job_from_file
 
 
-def push(training_project: TrainingProject, config: Path, remote: str = "baseten"):
-    """
-    push
-    * creates or updates a training_project
-    * creates the training_job in the training_project
-    * returns a dictionary with the format:
-        {
-            "training_project": TrainingProject,
-            "training_job": TrainingJob,
-        }. The definitions of TrainingProject and TrainingJob can be found in the API docs.
+def push(config: Path, remote: str = "baseten"):
+    """Create or update a training project and create a training job.
+
+    This function performs the following operations:
+    1. Creates or updates a training project
+    2. Creates a training job within the training project
+
+    Args:
+        config: Path to the Python file that defines the training project and job.
+        remote: The remote provider to use. Defaults to "baseten".
+
+    Returns:
+        dict: A dictionary containing the created training project and job:
+            {
+                "training_project": TrainingProject,
+                "training_job": TrainingJob,
+            }
+
+        For detailed definitions of TrainingProject and TrainingJob, see the API docs:
         https://docs.baseten.co/reference/training-api/get-training-job
-    """
-    remote_provider: BasetenRemote = cast(
-        BasetenRemote, RemoteFactory.create(remote=remote)
-    )
-    job_resp = create_training_job(
-        remote_provider=remote_provider,
-        training_project=training_project,
-        config=config,
-    )
-    return job_resp
-
-
-def push_from_file(config: Path, remote: str = "baseten"):
-    """
-    push_from_file does the same as push, but expects the passed in file
-    to be a python file that defines a TrainingProject and TrainingJob.
     """
     remote_provider: BasetenRemote = cast(
         BasetenRemote, RemoteFactory.create(remote=remote)

--- a/truss-train/truss_train/public_api.py
+++ b/truss-train/truss_train/public_api.py
@@ -4,7 +4,7 @@ from typing import cast
 from truss.remote.baseten.remote import BasetenRemote
 from truss.remote.remote_factory import RemoteFactory
 from truss_train.definitions import TrainingProject
-from truss_train.deployment import create_training_job
+from truss_train.deployment import create_training_job, create_training_job_from_file
 
 
 def push(training_project: TrainingProject, config: Path, remote: str = "baseten"):
@@ -28,3 +28,14 @@ def push(training_project: TrainingProject, config: Path, remote: str = "baseten
         config=config,
     )
     return job_resp
+
+
+def push_from_file(config: Path, remote: str = "baseten"):
+    """
+    push_from_file does the same as push, but expects the passed in file
+    to be a python file that defines a TrainingProject and TrainingJob.
+    """
+    remote_provider: BasetenRemote = cast(
+        BasetenRemote, RemoteFactory.create(remote=remote)
+    )
+    return create_training_job_from_file(remote_provider, config)

--- a/truss/cli/train_commands.py
+++ b/truss/cli/train_commands.py
@@ -75,21 +75,16 @@ def _prepare_click_context(f: click.Command, params: dict) -> click.Context:
 @common.common_options()
 def push_training_job(config: Path, remote: Optional[str], tail: bool):
     """Run a training job"""
-    from truss_train import deployment, loader
+    from truss_train import deployment
 
     if not remote:
         remote = remote_cli.inquire_remote_name()
 
-    remote_provider: BasetenRemote = cast(
-        BasetenRemote, RemoteFactory.create(remote=remote)
-    )
-    with loader.import_training_project(config) as training_project:
-        with console.status("Creating training job...", spinner="dots"):
-            job_resp = deployment.create_training_job(
-                remote_provider=remote_provider,
-                training_project=training_project,
-                config=config,
-            )
+    with console.status("Creating training job...", spinner="dots"):
+        remote_provider: BasetenRemote = cast(
+            BasetenRemote, RemoteFactory.create(remote=remote)
+        )
+        job_resp = deployment.create_training_job_from_file(remote_provider, config)
 
         _handle_post_create_logic(job_resp, remote_provider, tail)
 


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Allow a push_from_file which more closely mirrors `truss train push config.py` 

In previous world, customer would need to import the `training_project` from the config file - and pass in the config file. This makes more sense to me. No one's using yet - so i think it's safe to update
<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
