### PR TITLE
fix(truss): console fix for training

### DIFF
--- a/truss/cli/train_commands.py
+++ b/truss/cli/train_commands.py
@@ -86,7 +86,10 @@ def push_training_job(config: Path, remote: Optional[str], tail: bool):
         )
         job_resp = deployment.create_training_job_from_file(remote_provider, config)
 
-        _handle_post_create_logic(job_resp, remote_provider, tail)
+    # Note: This post create logic needs to happen outside the context
+    # of the above context manager, as only one console session can be active
+    # at a time.
+    _handle_post_create_logic(job_resp, remote_provider, tail)
 
 
 @train.command(name="recreate")


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
* move post push logic outside of console context manager
* From the https://github.com/basetenlabs/truss/pull/1742, we introduced a regression that kept the `--tail` functionality from working 
<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
* Tested manually. 
* Filed https://linear.app/baseten/issue/BT-14952/truss-train-integration-tests so that we can discuss our strategy here
