### PR TITLE
Make tests pass on Mac

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,7 +184,7 @@ markers = [
     "integration: marks tests as integration (deselect with '-m \"not integration\"').",
     "asyncio: marks tests as async.",
 ]
-addopts = "--ignore=smoketests --ignore=baseten-performance-client/tests"
+addopts = "--ignore=smoketests --ignore=baseten-performance-client/tests --basetemp=/tmp/pytest-temp"
 
 [tool.ruff]
 src = [".", "truss-chains", "truss-train"]

--- a/truss/templates/control/control/helpers/truss_patch/model_code_patch_applier.py
+++ b/truss/templates/control/control/helpers/truss_patch/model_code_patch_applier.py
@@ -1,3 +1,4 @@
+import errno
 import logging
 import os
 from pathlib import Path
@@ -39,7 +40,9 @@ def apply_code_patch(relative_dir: Path, patch: Patch, logger: logging.Logger):
             try:
                 os.removedirs(filepath.parent)
             except OSError as e:
-                if e.errno == 39:  # Directory not empty
+                if (
+                    e.errno == errno.ENOTEMPTY
+                ):  # Directory not empty (actual number is different in Linux vs Mac)
                     pass
                 else:
                     raise

--- a/truss/tests/templates/core/server/test_lazy_data_resolver_v2.py
+++ b/truss/tests/templates/core/server/test_lazy_data_resolver_v2.py
@@ -10,6 +10,11 @@ import pytest
 
 from truss.templates.shared.lazy_data_resolver import LazyDataResolverV2
 
+pytestmark = pytest.mark.skipif(
+    sys.platform == "darwin",
+    reason="BPTR tests require a specific directory and will fail on macOS",
+)
+
 LAZY_DATA_RESOLVER_PATH = Path("/bptr/bptr-manifest")
 TARGET_FILE = Path("nested/config.json")
 

--- a/truss/tests/util/test_basetenpointer.py
+++ b/truss/tests/util/test_basetenpointer.py
@@ -4,6 +4,7 @@ from tempfile import TemporaryDirectory
 
 import pytest
 import requests
+from huggingface_hub.errors import HfHubHTTPError
 
 from truss.base.truss_config import ModelCache, ModelRepo
 from truss.util.basetenpointer import model_cache_hf_to_b10ptr
@@ -33,6 +34,10 @@ def test_dolly_12b():
                 "Skipping test due to ReadTimeout error from Hugging Face API, "
                 "this can happen for large models like Dolly-12b"
             )
+        except HfHubHTTPError as e:
+            if e.response.status_code == 429:
+                pytest.skip("Hugging Face API rate limit exceeded")
+            raise
     bptr_list = bptr.pointers
     expected = [
         {

--- a/truss/util/path.py
+++ b/truss/util/path.py
@@ -137,27 +137,14 @@ def is_ignored(
         bool: True if the path matches any of the ignore patterns (i.e., should be ignored),
             and False otherwise.
     """
+    ignore_spec = pathspec.PathSpec.from_lines(
+        pathspec.patterns.GitWildMatchPattern, patterns
+    )
+
     if base_dir:
         path = path.relative_to(base_dir)
 
-    path_str = str(path)
-
-    # Handle directory patterns separately to avoid false matches
-    for pattern in patterns:
-        if pattern.endswith("/"):
-            # For directories, check if the directory name matches the pattern
-            dir_name = pattern.rstrip("/")
-            if path.name == dir_name:
-                return True
-        else:
-            # For files, use pathspec for proper pattern matching
-            test_spec = pathspec.PathSpec.from_lines(
-                pathspec.patterns.GitWildMatchPattern, [pattern]
-            )
-            if test_spec.match_file(path_str):
-                return True
-
-    return False
+    return ignore_spec.match_file(path)
 
 
 def get_ignored_relative_paths(


### PR DESCRIPTION
## :rocket: What
Fixes to let truss tests succeed or skip as applicable on Mac.

## :computer: How
* Use a constant rather than a magic number
* Skip one file that is expected to run on Linux only
* Separate pattern-matching for files and directories
* Skip test if remote call fails with a rate-limit-exceeded error

## :microscope: Testing
Tested locally