### PR TITLE
fix(truss): broken timestamp conversion for timestamp in wrong format

### DIFF
--- a/truss/cli/utils/common.py
+++ b/truss/cli/utils/common.py
@@ -182,6 +182,8 @@ def is_human_log_level(ctx: click.Context) -> bool:
 
 
 def format_localized_time(iso_timestamp: str) -> str:
+    if iso_timestamp.endswith("Z"):
+        iso_timestamp = iso_timestamp.replace("Z", "+00:00")
     utc_time = datetime.datetime.fromisoformat(iso_timestamp)
     local_time = utc_time.astimezone()
     return local_time.strftime("%Y-%m-%d %H:%M")


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What

Fixes an issue where sometimes the backend send's a timestamp in a different format by adding a small check. 

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
`truss train view` was broken before, worked after this change
