### PR TITLE
Validate LoRA rank, use reasonable default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,6 +184,7 @@ markers = [
     "integration: marks tests as integration (deselect with '-m \"not integration\"').",
     "asyncio: marks tests as async.",
 ]
+# specify basetemp because the default `/private/var/...` interferes with truss_ignore, which also has a var/ pattern
 addopts = "--ignore=smoketests --ignore=baseten-performance-client/tests --basetemp=/tmp/pytest-temp"
 
 [tool.ruff]

--- a/truss-train/truss_train/definitions.py
+++ b/truss-train/truss_train/definitions.py
@@ -1,10 +1,14 @@
 from typing import Dict, List, Optional, Union
 
 import pydantic
+from pydantic import field_validator
 
 from truss.base import custom_types, truss_config
 
 DEFAULT_LORA_RANK = 16
+
+# Allowed LoRA rank values for vLLM
+ALLOWED_LORA_RANKS = {8, 16, 32, 64, 128, 256, 320, 512}
 
 
 class SecretReference(custom_types.SafeModel):
@@ -80,6 +84,15 @@ class Checkpoint(custom_types.SafeModel):
     lora_rank: Optional[int] = (
         None  # lora rank will be fetched through the API if available.
     )
+
+    @field_validator("lora_rank")
+    @classmethod
+    def validate_lora_rank(cls, v):
+        if v is not None and v not in ALLOWED_LORA_RANKS:
+            raise ValueError(
+                f"lora_rank ({v}) must be one of {sorted(ALLOWED_LORA_RANKS)}"
+            )
+        return v
 
     def to_truss_config(self) -> truss_config.Checkpoint:
         return truss_config.Checkpoint(

--- a/truss/cli/train/deploy_checkpoints.py
+++ b/truss/cli/train/deploy_checkpoints.py
@@ -260,14 +260,12 @@ def _get_lora_rank(checkpoint_resp: dict) -> int:
     lora_adapter_config = checkpoint_resp.get("lora_adapter_config") or {}
     lora_rank = lora_adapter_config.get("r") or DEFAULT_LORA_RANK
 
-    # If the API returns an invalid value, use the default instead
+    # If the API returns an invalid value, raise an error
     if lora_rank not in ALLOWED_LORA_RANKS:
-        console.print(
+        raise ValueError(
             f"LoRA rank {lora_rank} from checkpoint is not in allowed values {sorted(ALLOWED_LORA_RANKS)}. "
-            f"Using default value: {DEFAULT_LORA_RANK}",
-            style="yellow",
+            f"Please use a valid LoRA rank."
         )
-        return DEFAULT_LORA_RANK
 
     return lora_rank
 

--- a/truss/cli/train/deploy_checkpoints.py
+++ b/truss/cli/train/deploy_checkpoints.py
@@ -17,6 +17,7 @@ from truss.cli.train.types import (
 from truss.cli.utils.output import console
 from truss.remote.baseten.remote import BasetenRemote
 from truss_train.definitions import (
+    ALLOWED_LORA_RANKS,
     DEFAULT_LORA_RANK,
     Checkpoint,
     CheckpointList,
@@ -257,7 +258,18 @@ def _hydrate_checkpoints(
 
 def _get_lora_rank(checkpoint_resp: dict) -> int:
     lora_adapter_config = checkpoint_resp.get("lora_adapter_config") or {}
-    return lora_adapter_config.get("r") or DEFAULT_LORA_RANK
+    lora_rank = lora_adapter_config.get("r") or DEFAULT_LORA_RANK
+
+    # If the API returns an invalid value, use the default instead
+    if lora_rank not in ALLOWED_LORA_RANKS:
+        console.print(
+            f"LoRA rank {lora_rank} from checkpoint is not in allowed values {sorted(ALLOWED_LORA_RANKS)}. "
+            f"Using default value: {DEFAULT_LORA_RANK}",
+            style="yellow",
+        )
+        return DEFAULT_LORA_RANK
+
+    return lora_rank
 
 
 def _get_hf_secret_name(user_input: Union[str, SecretReference, None]) -> str:

--- a/truss/tests/cli/train/test_deploy_checkpoints.py
+++ b/truss/tests/cli/train/test_deploy_checkpoints.py
@@ -1,4 +1,5 @@
 import os
+import re
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -311,7 +312,15 @@ def test_get_lora_rank():
     assert _get_lora_rank(checkpoint_resp) == 16  # DEFAULT_LORA_RANK
     # Test with invalid rank from API
     checkpoint_resp = {"lora_adapter_config": {"r": 1}}
-    assert _get_lora_rank(checkpoint_resp) == 16
+    with pytest.raises(
+        ValueError,
+        match=re.escape("LoRA rank 1 from checkpoint is not in allowed values"),
+    ):
+        _get_lora_rank(checkpoint_resp)
     # Test with another invalid rank
     checkpoint_resp = {"lora_adapter_config": {"r": 1000}}
-    assert _get_lora_rank(checkpoint_resp) == 16
+    with pytest.raises(
+        ValueError,
+        match=re.escape("LoRA rank 1000 from checkpoint is not in allowed values"),
+    ):
+        _get_lora_rank(checkpoint_resp)


### PR DESCRIPTION
## :rocket: What
Saw this error from vllm [1], so added:
* type validation
* use default value for cases where we have already stored bad values
* tests

[1]
```
  File "/usr/local/lib/python3.12/dist-packages/vllm/engine/arg_utils.py", line 1187, in create_engine_config 
    lora_config = LoRAConfig( 
                  ^^^^^^^^^^^ 
  File "/usr/local/lib/python3.12/dist-packages/pydantic/_internal/_dataclasses.py", line 120, in __init__ 
    s.__pydantic_validator__.validate_python(ArgsKwargs(args, kwargs), self_instance=s) 
pydantic_core._pydantic_core.ValidationError: 1 validation error for LoRAConfig 
  Value error, max_lora_rank (1) must be one of (8, 16, 32, 64, 128, 256, 320, 512). [type=value_error, input_value=ArgsKwargs((), {'bias_ena... 'max_cpu_loras': None}), input_type=ArgsKwargs] 
```

## :computer: How
* Add type validation for max-lora-rank
* Use default value if not in range

## :microscope: Testing
Added tests. Verified by running `deploy_checkpoints` on the new version.

```
❯ truss train deploy_checkpoints --job-id 7wld7qd
? 🎮 Which remote do you want to connect to? baseten-dev
Fetching checkpoints for training job 7wld7qd...
LoRA rank 1 from checkpoint is not in allowed values [8, 16, 32, 64, 128, 256, 320, 512]. Using default value: 16    
```
