### PR TITLE
feat(truss): add cache config field to runtime defintion

### DIFF
--- a/truss-train/tests/import/project_with_cache_config.py
+++ b/truss-train/tests/import/project_with_cache_config.py
@@ -1,0 +1,19 @@
+from truss_train import definitions
+
+cache_config = definitions.CacheConfig(enabled=True, enable_legacy_hf_mount=True)
+
+runtime_config = definitions.Runtime(
+    start_commands=["/bin/bash ./my-entrypoint.sh"],
+    environment_variables={
+        "FOO_VAR": "FOO_VAL",
+        "BAR_VAR": definitions.SecretReference(name="BAR_SECRET"),
+    },
+)
+
+training_job = definitions.TrainingJob(
+    image=definitions.Image(base_image="base-image"),
+    compute=definitions.Compute(node_count=1, cpu_count=4),
+    runtime_config=runtime_config,
+)
+
+first_project = definitions.TrainingProject(name="first-project", job=training_job)

--- a/truss-train/tests/test_loader.py
+++ b/truss-train/tests/test_loader.py
@@ -56,6 +56,13 @@ def test_import_deploy_checkpoints_config():
         )
 
 
+def test_import_cache_config():
+    job_src = TEST_ROOT / "import" / "project_with_cache_config.py"
+    with loader.import_cache_config(job_src) as cache_config:
+        assert cache_config.enabled
+        assert cache_config.enable_legacy_hf_mount
+
+
 def test_import_handles_training_project_with_deploy_checkpoints_config():
     job_src = TEST_ROOT / "import" / "project_with_deploy_checkpoints_config.py"
     with loader.import_training_project(job_src) as training_project:

--- a/truss-train/truss_train/loader.py
+++ b/truss-train/truss_train/loader.py
@@ -26,6 +26,12 @@ def import_deploy_checkpoints_config(
 
 
 @contextlib.contextmanager
+def import_cache_config(module_path: pathlib.Path) -> Iterator[definitions.CacheConfig]:
+    with import_target(module_path, definitions.CacheConfig) as cache_config:
+        yield cache_config
+
+
+@contextlib.contextmanager
 def import_target(module_path: pathlib.Path, target_type: Type[T]) -> Iterator[T]:
     module_name = module_path.stem
     if not os.path.isfile(module_path):

--- a/truss/cli/utils/common.py
+++ b/truss/cli/utils/common.py
@@ -182,6 +182,8 @@ def is_human_log_level(ctx: click.Context) -> bool:
 
 
 def format_localized_time(iso_timestamp: str) -> str:
+    if iso_timestamp.endswith("Z"):
+        iso_timestamp = iso_timestamp.replace("Z", "+00:00")
     utc_time = datetime.datetime.fromisoformat(iso_timestamp)
     local_time = utc_time.astimezone()
     return local_time.strftime("%Y-%m-%d %H:%M")


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What

The backend now prefers accepting a `cache_config` object over `enable_cache`, this change adds support for the new object and changes objects which use the enable_cache to instead populate the cache config field.

<!--
  How was the change described above implemented?
-->
## :computer: How

Modified the runtime definitions object

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing

Unit Tests, manually tested by making requests with different scenarios and checking the JSON body to ensure it is what I expect.
