### PR TITLE
Ensure `curl` is installed for `uv` installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.112rc007"
+version = "0.9.112rc009"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/templates/base.Dockerfile.jinja
+++ b/truss/templates/base.Dockerfile.jinja
@@ -17,8 +17,11 @@ RUN $PYTHON_EXECUTABLE -c "import sys; \
 {% endblock %}
 
 {% block install_uv %}
-{# Install `uv` if not already present in the image. #}
-RUN if ! command -v uv >/dev/null 2>&1; then (curl -LsSf https://astral.sh/uv/{{ UV_VERSION }}/install.sh | sh) >/dev/null 2>&1; fi
+{# Install `uv` and `curl` if not already present in the image. #}
+RUN if ! command -v uv >/dev/null 2>&1; then \
+    command -v curl >/dev/null 2>&1 || (apt update && apt install -y curl) && \
+    curl -LsSf https://astral.sh/uv/{{ UV_VERSION }}/install.sh | sh >/dev/null 2>&1; \
+fi
 ENV PATH="/root/.local/bin:$PATH"
 {% endblock %}
 

--- a/truss/tests/test_data/server.Dockerfile
+++ b/truss/tests/test_data/server.Dockerfile
@@ -9,7 +9,10 @@ RUN $PYTHON_EXECUTABLE -c "import sys; \
     and sys.version_info.minor <= 13 \
     else sys.exit(1)" \
     || { echo "ERROR: Supplied base image does not have 3.8 <= python <= 3.13"; exit 1; }
-RUN if ! command -v uv >/dev/null 2>&1; then (curl -LsSf https://astral.sh/uv/0.7.19/install.sh | sh) >/dev/null 2>&1; fi
+RUN if ! command -v uv >/dev/null 2>&1; then \
+    command -v curl >/dev/null 2>&1 || (apt update && apt install -y curl) && \
+    curl -LsSf https://astral.sh/uv/0.7.19/install.sh | sh >/dev/null 2>&1; \
+fi
 ENV PATH="/root/.local/bin:$PATH"
 ENV PYTHONUNBUFFERED="True"
 ENV DEBIAN_FRONTEND="noninteractive"


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Previous [PR](https://github.com/basetenlabs/truss/pull/1759) had a potential bug for custom base images that did not have `curl` installed, so the `uv` installation would fail. To fix, we just ensure `curl` is installed earlier on in the Docker build process.

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
```
$ poetry run pytest truss/tests/test_truss_handle.py
$ poetry run pytest truss-chains/tests/test_e2e.py
```

passing
