### PR TITLE
use checkpoint name instead of ID when converting to truss config

### DIFF
--- a/truss-train/truss_train/definitions.py
+++ b/truss-train/truss_train/definitions.py
@@ -96,7 +96,7 @@ class Checkpoint(custom_types.SafeModel):
 
     def to_truss_config(self) -> truss_config.Checkpoint:
         return truss_config.Checkpoint(
-            id=f"{self.training_job_id}/{self.id}", name=self.id
+            id=f"{self.training_job_id}/{self.id}", name=self.name
         )
 
 


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
* I believe this is a bug and we should be using the name
<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
