### PR TITLE
truss client-side changes for buildless deployment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.110"
+version = "0.9.110rc002"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/contexts/docker_build_setup.py
+++ b/truss/contexts/docker_build_setup.py
@@ -17,7 +17,12 @@ from truss.truss_handle.patch import signature
 # Note: logging is not picked up in logs UI, only prints.
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 
-working_dir = pathlib.Path("/")
+# MacOS does not allow setting /build without disabling SIP, so allow override
+# This is useful for local builds, where we want to build in a different directory
+if os.environ.get("TRUSS_WORKING_DIR"):
+    working_dir = pathlib.Path(os.environ["TRUSS_WORKING_DIR"])
+else:
+    working_dir = pathlib.Path("/")
 
 TRUSS_SRC_DIR = working_dir / "build/model_scaffold"
 TRUSS_HASH_FILE = working_dir / "scaffold/truss_hash"

--- a/truss/contexts/image_builder/serving_image_builder.py
+++ b/truss/contexts/image_builder/serving_image_builder.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import re
+import shutil
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
@@ -693,6 +694,16 @@ class ServingImageBuilder(ImageBuilder):
             external_data_files,
             self._spec.build_commands,
         )
+        self._setup_build_hash_directory(build_dir)
+
+    def _setup_build_hash_directory(self, build_dir: Path) -> None:
+        build_hash_path = build_dir / "build_hash"
+        if build_hash_path.exists():
+            shutil.rmtree(build_hash_path)
+        shutil.copytree(build_dir, build_hash_path)
+        # remove the config.yaml file from the build_hash directory
+        # we will use only config_build_time.yaml to compute the hash
+        (build_hash_path / "config.yaml").unlink()
 
     def _render_dockerfile(
         self,


### PR DESCRIPTION
This PR goes with the server-side changes PR in baseten repo.

## :rocket: What
Changes on the side of truss to help with buildless deployment after training:
* Create a smaller subset of truss config to determine whether to rebuild
* Create a placeholder for checkpoint paths (will be filled at deployment time)
* Create a subdirectory to use for build-hash calculation purposes

## :computer: How
* Change `truss train deploy_checkpoints` command to generate, additionally, a `config_build_time.py`.
* Change `truss-docker-build-setup --truss_type server_regular` to  generate a `build_hash` subdirectory. This directory will not have config.yaml, instead it will have the smaller `config_build_time.py`.

## :microscope: Testing
* Tested on local dev-container
* Additional testing pending