### PR TITLE
Fix `wait_for_server` behavior

### DIFF
--- a/truss/truss_handle/truss_handle.py
+++ b/truss/truss_handle/truss_handle.py
@@ -1048,18 +1048,16 @@ def _wait_for_docker_build(container) -> None:
 
 
 def _wait_for_model_server(url: str, stop: stop_after_delay) -> Response:  # type: ignore[return]
-    for attempt in Retrying(
+    retry_config = Retrying(
         stop=stop,
-        wait=wait_fixed(2),
+        wait=wait_fixed(0.5),
         retry=(
             retry_if_result(lambda response: response.status_code in [502, 503])
             | retry_if_exception_type(exceptions.ConnectionError)
         ),
         reraise=True,
-    ):
-        with attempt:
-            response = requests.get(url)
-            return response
+    )
+    return retry_config(requests.get, url)
 
 
 def wait_for_truss(


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
After some manual investigation for the failures [here](https://basetenlabs.slack.com/archives/C04NM3YA2DT/p1752018936998799), it seemed like our logic to wait for the server to be ready in tests wasn't actually working. 

The underlying reason is a little opaque to me, but my best guess is that the `with attempt` block was interfering with tenacity's ability to inspect the response and appropriately retry. The end result was that we weren't actually waiting for the server to be ready.

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
Final broken tests now pass:
```
$ poetry run pytest truss/tests/test_truss_handle.py::test_control_truss_local_update_that_crashes_inference_server
$ poetry run pytest truss/tests/templates/server/test_model_wrapper.py::test_trt_llm_truss_missing_model_py
$ poetry run pytest truss-chains/tests/test_e2e.py::test_traditional_truss
```
