### PR TITLE
Revert all the Dockerfile changes to support `uv` builds

### DIFF
--- a/truss/templates/base.Dockerfile.jinja
+++ b/truss/templates/base.Dockerfile.jinja
@@ -2,9 +2,6 @@ ARG PYVERSION={{ config.python_version }}
 FROM {{ base_image_name_and_tag }} AS truss_server
 ENV PYTHON_EXECUTABLE="{{ config.base_image.python_executable_path or 'python3' }}"
 
-{%- set UV_VERSION = "0.7.19" %}
-{%- set sys_pip_install_command = "uv pip install --system" %}
-
 {% block fail_fast %}
 RUN grep -w 'ID=debian\|ID_LIKE=debian' /etc/os-release || { echo "ERROR: Supplied base image is not a debian image"; exit 1; }
 RUN $PYTHON_EXECUTABLE -c "import sys; \
@@ -16,19 +13,18 @@ RUN $PYTHON_EXECUTABLE -c "import sys; \
     || { echo "ERROR: Supplied base image does not have {{ min_supported_python_version_in_custom_base_image }} <= python <= {{ max_supported_python_version_in_custom_base_image }}"; exit 1; }
 {% endblock %}
 
-{% block install_uv %}
-{# Install `uv` if not already present in the image. #}
-RUN if ! command -v uv >/dev/null 2>&1; then (curl -LsSf https://astral.sh/uv/{{ UV_VERSION }}/install.sh | sh) >/dev/null 2>&1; fi
-ENV PATH="/root/.local/bin:$PATH"
-{% endblock %}
+# NB(nikhil): Only run `pip` if present in image, certain custom servers don't have it.
+RUN if command -v pip >/dev/null 2>&1; then \
+      pip install --upgrade pip --no-cache-dir && rm -rf /root/.cache/pip; \
+    fi
 
 {% block base_image_patch %}
 {% endblock %}
 
 {% if config.model_framework.value == 'huggingface_transformer' %}
     {% if config.resources.use_gpu %}
-{# HuggingFace pytorch gpu support needs mkl. #}
-RUN {{ sys_pip_install_command }} install mkl
+# HuggingFace pytorch gpu support needs mkl
+RUN pip install mkl
     {% endif %}
 {% endif %}
 
@@ -49,11 +45,11 @@ RUN apt-get update && apt-get install --yes --no-install-recommends $(cat {{ sys
 {% block install_requirements %}
     {%- if should_install_user_requirements_file %}
 COPY ./{{ user_supplied_requirements_filename }} {{ user_supplied_requirements_filename }}
-RUN {{ sys_pip_install_command }} -r {{ user_supplied_requirements_filename }} --no-cache-dir
+RUN pip install -r {{ user_supplied_requirements_filename }} --no-cache-dir && rm -rf /root/.cache/pip
     {%- endif %}
     {%- if should_install_requirements %}
 COPY ./{{ config_requirements_filename }} {{ config_requirements_filename }}
-RUN {{ sys_pip_install_command }} -r {{ config_requirements_filename }} --no-cache-dir
+RUN pip install -r {{ config_requirements_filename }} --no-cache-dir && rm -rf /root/.cache/pip
 {%- endif %}
 {% endblock %}
 

--- a/truss/templates/control_venv.Dockerfile.jinja
+++ b/truss/templates/control_venv.Dockerfile.jinja
@@ -1,0 +1,8 @@
+{%- if requires_live_reload %}
+FROM python:{{ control_python_version }}-slim as control-server-venv
+
+RUN echo "Creating venv for py{{ control_python_version }}";
+RUN python -m pip install --upgrade pip
+RUN python -m venv --copies /control/.env
+RUN echo "Created venv for py{{ control_python_version }}";
+{%- endif %} {#- endif requires_live_reload #}

--- a/truss/templates/server.Dockerfile.jinja
+++ b/truss/templates/server.Dockerfile.jinja
@@ -4,7 +4,12 @@
 
 {%- set requires_live_reload = config.live_reload and not config.docker_server %}
 
+{%- if requires_live_reload %}
+{% include "control_venv.Dockerfile.jinja" %}
+{%- endif %} {#- endif requires_live_reload #}
+
 {% extends "base.Dockerfile.jinja" %}
+
 
 {% block base_image_patch %}
 {# If user base image is supplied in config, apply build commands from truss base image #}
@@ -26,7 +31,7 @@ RUN apt update && \
     && rm -rf /var/lib/apt/lists/*
 
 COPY ./{{ base_server_requirements_filename }} {{ base_server_requirements_filename }}
-RUN {{ sys_pip_install_command }} -r {{ base_server_requirements_filename }} --no-cache-dir
+RUN pip install -r {{ base_server_requirements_filename }} --no-cache-dir && rm -rf /root/.cache/pip
     {%- endif %} {#- endif not config.docker_server #}
 
     {%- if requires_live_reload %}
@@ -44,7 +49,7 @@ RUN ln -sf {{ config.base_image.python_executable_path }} /usr/local/bin/python
 {% block install_requirements %}
     {%- if should_install_server_requirements %}
 COPY ./{{ server_requirements_filename }} {{ server_requirements_filename }}
-RUN {{ sys_pip_install_command }} -r {{ server_requirements_filename }} --no-cache-dir
+RUN pip install -r {{ server_requirements_filename }} --no-cache-dir && rm -rf /root/.cache/pip
     {%- endif %} {#- endif should_install_server_requirements #}
 {{ super() }}
 {% endblock %} {#- endblock install_requirements #}
@@ -94,11 +99,16 @@ COPY ./truss /app/truss
 
 COPY ./config.yaml /app/config.yaml
 {%- if requires_live_reload %}
-RUN uv python install {{ control_python_version }}
-RUN uv venv /control/.env --python {{ control_python_version }}
-
 COPY ./control /control
-RUN uv pip install -r /control/requirements.txt --python /control/.env/bin/python
+
+# NB(nikhil): Copy the virtual env, and system dependencies for the
+# python version specific to the control server. We need to run ldconfig
+# so dynamic linking works.
+COPY --from=control-server-venv /usr/local/lib/ /usr/local/lib/
+COPY --from=control-server-venv /control/.env /control/.env
+RUN ldconfig
+
+RUN /control/.env/bin/pip install -r /control/requirements.txt
 {%- endif %} {#- endif requires_live_reload #}
 
 {%- if model_dir_exists %}
@@ -112,7 +122,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
         curl nginx python3-pip && \
         rm -rf /var/lib/apt/lists/*
 COPY ./docker_server_requirements.txt /app/docker_server_requirements.txt
-RUN {{ sys_pip_install_command }} -r /app/docker_server_requirements.txt --no-cache-dir && rm -rf /root/.cache/pip
+RUN pip install -r /app/docker_server_requirements.txt --no-cache-dir && rm -rf /root/.cache/pip
 {% set proxy_config_path = "/etc/nginx/conf.d/proxy.conf" %}
 {% set supervisor_config_path = "/etc/supervisor/supervisord.conf" %}
 {% set supervisor_log_dir = "/var/log/supervisor" %}

--- a/truss/tests/test_data/server.Dockerfile
+++ b/truss/tests/test_data/server.Dockerfile
@@ -9,8 +9,9 @@ RUN $PYTHON_EXECUTABLE -c "import sys; \
     and sys.version_info.minor <= 13 \
     else sys.exit(1)" \
     || { echo "ERROR: Supplied base image does not have 3.8 <= python <= 3.13"; exit 1; }
-RUN if ! command -v uv >/dev/null 2>&1; then (curl -LsSf https://astral.sh/uv/0.7.19/install.sh | sh) >/dev/null 2>&1; fi
-ENV PATH="/root/.local/bin:$PATH"
+RUN if command -v pip >/dev/null 2>&1; then \
+      pip install --upgrade pip --no-cache-dir && rm -rf /root/.cache/pip; \
+    fi
 ENV PYTHONUNBUFFERED="True"
 ENV DEBIAN_FRONTEND="noninteractive"
 RUN apt update && \
@@ -24,9 +25,9 @@ RUN apt update && \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 COPY ./base_server_requirements.txt base_server_requirements.txt
-RUN uv pip install --system -r base_server_requirements.txt --no-cache-dir
+RUN pip install -r base_server_requirements.txt --no-cache-dir && rm -rf /root/.cache/pip
 COPY ./requirements.txt requirements.txt
-RUN uv pip install --system -r requirements.txt --no-cache-dir
+RUN pip install -r requirements.txt --no-cache-dir && rm -rf /root/.cache/pip
 ENV APP_HOME="/app"
 WORKDIR $APP_HOME
 COPY ./data /app/data

--- a/truss/tests/test_truss_handle.py
+++ b/truss/tests/test_truss_handle.py
@@ -136,8 +136,6 @@ def _generate_base_image_variations(
         ("python:alpine", "/usr/local/bin/python3", True),
         ("python:2.7-slim", "/usr/local/bin/python", True),
         ("python:3.7-slim", "/usr/local/bin/python3", True),
-        # Base image with `uv` already included.
-        ("ghcr.io/astral-sh/uv:python3.11-bookworm", "/usr/local/bin/python3", True),
     ],
 )
 def test_build_serving_docker_image_from_user_base_image_live_reload(


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
There have been a series of PRs to improve build behavior:
- https://github.com/basetenlabs/truss/pull/1759
- https://github.com/basetenlabs/truss/pull/1760
- https://github.com/basetenlabs/truss/pull/1765

This PR reverts the main behavior changes, while keeping the other test improvements from the PRs around.

I do *not* expect to need this PR, but this is just protection in case there are issues while I'm out.

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
