### PR TITLE
baseten-perf-client: http2 multi client + multi-stream upgrade

### DIFF
--- a/baseten-performance-client/Cargo.lock
+++ b/baseten-performance-client/Cargo.lock
@@ -52,7 +52,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "baseten_performance_client"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "futures",
  "ndarray",

--- a/baseten-performance-client/Cargo.toml
+++ b/baseten-performance-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "baseten_performance_client"
-version = "0.0.5"
+version = "0.0.6"
 edition = "2021"
 
 [dependencies]

--- a/baseten-performance-client/scripts/compare_latency_openai.py
+++ b/baseten-performance-client/scripts/compare_latency_openai.py
@@ -63,7 +63,7 @@ async def run_baseten_benchmark(length, client=client_b):
 
     # Warm-up run
     _ = await client.async_embed(
-        input=["Hello world"] * 512,
+        input=["Hello world"] * 1024,
         model="text-embedding-3-small",
         max_concurrent_requests=512,
         batch_size=1,

--- a/baseten-performance-client/scripts/compare_latency_openai.py
+++ b/baseten-performance-client/scripts/compare_latency_openai.py
@@ -16,7 +16,7 @@ if not api_key:
 api_base_embed = "https://model-yqv4yjjq.api.baseten.co/environments/production/sync"
 
 # Benchmark settings: list of lengths to test.
-benchmark_lengths = [128, 512, 2048, 8192, 32768, 131072]
+benchmark_lengths = [64, 128, 256, 384, 512, 2048, 8192, 32768, 131072]
 micro_batch_size = (
     16  # For AsyncOpenAI client; also used for the PerformanceClient batch
 )
@@ -63,7 +63,7 @@ async def run_baseten_benchmark(length, client=client_b):
 
     # Warm-up run
     _ = await client.async_embed(
-        input=full_input_texts[:512],
+        input=["Hello world"] * 512,
         model="text-embedding-3-small",
         max_concurrent_requests=512,
         batch_size=1,

--- a/baseten-performance-client/src/lib.rs
+++ b/baseten-performance-client/src/lib.rs
@@ -123,6 +123,7 @@ struct OpenAIEmbeddingData {
 #[pymethods]
 impl OpenAIEmbeddingData {
     #[getter]
+    #[allow(deprecated)]
     fn embedding(&self, py: Python) -> PyObject {
         match &self.embedding_internal {
             EmbeddingVariant::Base64(s) => s.to_object(py),
@@ -222,7 +223,7 @@ impl OpenAIEmbeddingsResponse {
             .map_err(|e| {
                 PyValueError::new_err(format!("Failed to create ndarray from embeddings: {}", e))
             })?;
-
+        #[allow(deprecated)]
         Ok(array.into_pyarray_bound(py))
     }
 }
@@ -1049,6 +1050,7 @@ impl PerformanceClient {
                     idx, e
                 ))
             })?;
+            #[allow(deprecated)]
             collected_headers_py.push(headers_py_obj.to_object(py));
 
             individual_request_times_collected.push(duration.as_secs_f64());
@@ -1132,6 +1134,7 @@ impl PerformanceClient {
                             idx, e
                         ))
                     })?;
+                    #[allow(deprecated)]
                     results_py.push(py_obj_bound.into_py(py_gil));
 
                     let headers_py_obj = pythonize(py_gil, &headers_map).map_err(|e| {
@@ -1140,6 +1143,7 @@ impl PerformanceClient {
                             idx, e
                         ))
                     })?;
+                    #[allow(deprecated)]
                     collected_headers_py.push(headers_py_obj.to_object(py_gil));
 
                     individual_request_times_collected.push(duration.as_secs_f64());


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What

HTTP2 is slow, lets fix it. Duplicats clients for http2 to limit http2 concurrency challenges with multi-plexing at exterme scale.

Before:
```
Running benchmark for length: 64, concurrent requests 4
PerformanceClient HTTP1: duration=0.0487 s, max_cpu=119.70%, max_ram=76.38 MB
PerformanceClient HTTP2: duration=0.0178 s, max_cpu=10.00%, max_ram=79.62 MB
AsyncOpenAI            : duration=0.0277 s, max_cpu=19.80%

Running benchmark for length: 128, concurrent requests 8
PerformanceClient HTTP1: duration=0.0393 s, max_cpu=29.90%, max_ram=91.00 MB
PerformanceClient HTTP2: duration=0.0436 s, max_cpu=10.00%, max_ram=92.62 MB
AsyncOpenAI            : duration=0.0419 s, max_cpu=19.80%

Running benchmark for length: 256, concurrent requests 16
PerformanceClient HTTP1: duration=0.0356 s, max_cpu=10.00%, max_ram=100.75 MB
PerformanceClient HTTP2: duration=0.0261 s, max_cpu=10.00%, max_ram=102.38 MB
AsyncOpenAI            : duration=0.0752 s, max_cpu=69.30%

Running benchmark for length: 384, concurrent requests 24
PerformanceClient HTTP1: duration=0.0398 s, max_cpu=20.00%, max_ram=112.12 MB
PerformanceClient HTTP2: duration=0.0389 s, max_cpu=20.00%, max_ram=112.12 MB
AsyncOpenAI            : duration=0.1226 s, max_cpu=109.60%

Running benchmark for length: 512, concurrent requests 32
PerformanceClient HTTP1: duration=0.0404 s, max_cpu=39.90%, max_ram=113.75 MB
PerformanceClient HTTP2: duration=0.0354 s, max_cpu=39.90%, max_ram=115.38 MB
AsyncOpenAI            : duration=0.1728 s, max_cpu=99.70%

Running benchmark for length: 2048, concurrent requests 128
PerformanceClient HTTP1: duration=0.0588 s, max_cpu=129.70%, max_ram=126.75 MB
PerformanceClient HTTP2: duration=0.1168 s, max_cpu=69.90%, max_ram=126.39 MB
AsyncOpenAI            : duration=0.7604 s, max_cpu=109.70%

Running benchmark for length: 8192, concurrent requests 512
PerformanceClient HTTP1: duration=0.1544 s, max_cpu=339.30%, max_ram=168.18 MB
PerformanceClient HTTP2: duration=0.4043 s, max_cpu=189.60%, max_ram=169.73 MB
AsyncOpenAI            : duration=3.0243 s, max_cpu=109.80%

Running benchmark for length: 32768, concurrent requests 2048
PerformanceClient HTTP1: duration=0.3545 s, max_cpu=708.70%, max_ram=295.81 MB
PerformanceClient HTTP2: duration=1.2845 s, max_cpu=274.20%, max_ram=311.38 MB
AsyncOpenAI            : duration=13.3444 s, max_cpu=109.70%

Running benchmark for length: 131072, concurrent requests 8192
PerformanceClient HTTP1: duration=1.5465 s, max_cpu=648.70%, max_ram=1011.70 MB
PerformanceClient HTTP2: duration=5.4537 s, max_cpu=239.60%, max_ram=1155.71 MB
```

AFTER:

```
Running benchmark for length: 64, concurrent requests 4
PerformanceClient HTTP1: duration=0.0345 s, max_cpu=0.00%, max_ram=141.38 MB
PerformanceClient HTTP2: duration=0.0402 s, max_cpu=10.00%, max_ram=146.25 MB
AsyncOpenAI            : duration=0.0282 s, max_cpu=9.90%

Running benchmark for length: 128, concurrent requests 8
PerformanceClient HTTP1: duration=0.0371 s, max_cpu=29.90%, max_ram=156.00 MB
PerformanceClient HTTP2: duration=0.0546 s, max_cpu=49.80%, max_ram=157.62 MB
AsyncOpenAI            : duration=0.0396 s, max_cpu=29.90%

Running benchmark for length: 256, concurrent requests 16
PerformanceClient HTTP1: duration=0.0395 s, max_cpu=10.00%, max_ram=162.50 MB
PerformanceClient HTTP2: duration=0.0528 s, max_cpu=29.90%, max_ram=167.38 MB
AsyncOpenAI            : duration=0.0865 s, max_cpu=69.80%

Running benchmark for length: 384, concurrent requests 24
PerformanceClient HTTP1: duration=0.0372 s, max_cpu=29.90%, max_ram=177.12 MB
PerformanceClient HTTP2: duration=0.0553 s, max_cpu=59.80%, max_ram=178.75 MB
AsyncOpenAI            : duration=0.1237 s, max_cpu=119.40%

Running benchmark for length: 512, concurrent requests 32
PerformanceClient HTTP1: duration=0.0476 s, max_cpu=119.60%, max_ram=182.00 MB
PerformanceClient HTTP2: duration=0.0685 s, max_cpu=178.10%, max_ram=182.00 MB
AsyncOpenAI            : duration=0.5995 s, max_cpu=107.10%

Running benchmark for length: 2048, concurrent requests 128
PerformanceClient HTTP1: duration=0.0911 s, max_cpu=617.30%, max_ram=185.25 MB
PerformanceClient HTTP2: duration=0.1703 s, max_cpu=565.10%, max_ram=186.61 MB
AsyncOpenAI            : duration=1.8458 s, max_cpu=109.40%

Running benchmark for length: 8192, concurrent requests 512
PerformanceClient HTTP1: duration=0.1685 s, max_cpu=906.60%, max_ram=228.00 MB
PerformanceClient HTTP2: duration=0.1745 s, max_cpu=647.80%, max_ram=237.45 MB
AsyncOpenAI            : duration=2.9120 s, max_cpu=109.60%

Running benchmark for length: 32768, concurrent requests 2048
PerformanceClient HTTP1: duration=0.3535 s, max_cpu=838.10%, max_ram=398.38 MB
PerformanceClient HTTP2: duration=0.4366 s, max_cpu=788.40%, max_ram=415.17 MB
AsyncOpenAI            : duration=14.6808 s, max_cpu=109.80%

Running benchmark for length: 131072, concurrent requests 8192
PerformanceClient HTTP1: duration=1.4349 s, max_cpu=648.80%, max_ram=1094.72 MB
PerformanceClient HTTP2: duration=1.3018 s, max_cpu=4380.70%, max_ram=1290.70 MB
```

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
