### PR TITLE
Close WebSocket connection if inference server has not started

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.114"
+version = "0.9.115rc4"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/templates/control/control/endpoints.py
+++ b/truss/templates/control/control/endpoints.py
@@ -5,6 +5,7 @@ from typing import Any, Callable, Dict
 import httpx
 from fastapi import APIRouter, WebSocket
 from fastapi.responses import JSONResponse, StreamingResponse
+from httpx_ws import _exceptions as httpx_ws_exceptions
 from httpx_ws import aconnect_ws
 from starlette.requests import ClientDisconnect, Request
 from starlette.responses import Response
@@ -125,35 +126,40 @@ async def _safe_close_ws(ws: WebSocket, logger: logging.Logger):
 
 
 async def proxy_ws(client_ws: WebSocket):
-    await client_ws.accept()
     proxy_client: httpx.AsyncClient = client_ws.app.state.proxy_client
     logger = client_ws.app.state.logger
 
     for attempt in inference_retries():
         with attempt:
-            async with aconnect_ws("/v1/websocket", proxy_client) as server_ws:  # type: ignore
-                # Unfortunate, but FastAPI and httpx-ws have slightly different abstractions
-                # for sending data, so it's not easy to create a unified wrapper.
-                async def forward_to_server():
-                    while True:
-                        message = await client_ws.receive()
-                        if "text" in message:
-                            await server_ws.send_text(message["text"])
-                        elif "bytes" in message:
-                            await server_ws.send_bytes(message["bytes"])
+            try:
+                async with aconnect_ws("/v1/websocket", proxy_client) as server_ws:  # type: ignore
+                    # Unfortunate, but FastAPI and httpx-ws have slightly different abstractions
+                    # for sending data, so it's not easy to create a unified wrapper.
+                    async def forward_to_server():
+                        while True:
+                            message = await client_ws.receive()
+                            if "text" in message:
+                                await server_ws.send_text(message["text"])
+                            elif "bytes" in message:
+                                await server_ws.send_bytes(message["bytes"])
 
-                async def forward_to_client():
-                    while True:
-                        message = await server_ws.receive()
-                        if isinstance(message, TextMessage):
-                            await client_ws.send_text(message.data)
-                        elif isinstance(message, BytesMessage):
-                            await client_ws.send_bytes(message.data)
+                    async def forward_to_client():
+                        while True:
+                            message = await server_ws.receive()
+                            if isinstance(message, TextMessage):
+                                await client_ws.send_text(message.data)
+                            elif isinstance(message, BytesMessage):
+                                await client_ws.send_bytes(message.data)
 
-                try:
-                    await asyncio.gather(forward_to_client(), forward_to_server())
-                finally:
-                    await _safe_close_ws(client_ws, logger)
+                    await client_ws.accept()
+                    try:
+                        await asyncio.gather(forward_to_client(), forward_to_server())
+                    finally:
+                        await _safe_close_ws(client_ws, logger)
+            except httpx_ws_exceptions.HTTPXWSException as e:
+                logger.warning(f"WebSocket connection rejected: {e}")
+                await _safe_close_ws(client_ws, logger)
+                break
 
 
 control_app.add_websocket_route("/v1/websocket", proxy_ws)

--- a/truss/templates/control/control/endpoints.py
+++ b/truss/templates/control/control/endpoints.py
@@ -138,6 +138,8 @@ async def proxy_ws(client_ws: WebSocket):
                     async def forward_to_server():
                         while True:
                             message = await client_ws.receive()
+                            if message.get("type") == "websocket.disconnect":
+                                break
                             if "text" in message:
                                 await server_ws.send_text(message["text"])
                             elif "bytes" in message:
@@ -146,6 +148,8 @@ async def proxy_ws(client_ws: WebSocket):
                     async def forward_to_client():
                         while True:
                             message = await server_ws.receive()
+                            if message is None:
+                                break
                             if isinstance(message, TextMessage):
                                 await client_ws.send_text(message.data)
                             elif isinstance(message, BytesMessage):

--- a/truss/tests/templates/control/control/test_endpoints.py
+++ b/truss/tests/templates/control/control/test_endpoints.py
@@ -1,0 +1,131 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI, WebSocket
+from httpx import AsyncClient, Response
+from httpx_ws import AsyncWebSocketSession
+from httpx_ws import _exceptions as httpx_ws_exceptions
+from wsproto.events import BytesMessage, TextMessage
+
+from truss.templates.control.control.endpoints import proxy_ws
+
+
+@pytest.fixture
+def app():
+    app = FastAPI()
+    app.state.proxy_client = AsyncClient(base_url="http://localhost:8080")
+    app.state.logger = MagicMock()
+    return app
+
+
+@pytest.fixture
+def client_ws(app):
+    ws = WebSocket({"type": "websocket", "app": app}, None, None)  # type: ignore
+    ws.receive = AsyncMock()
+    ws.send_text = AsyncMock()
+    ws.send_bytes = AsyncMock()
+    ws.accept = AsyncMock()
+    ws.close = AsyncMock()
+    return ws
+
+
+@pytest.mark.asyncio
+async def test_proxy_ws_text_message(client_ws):
+    client_ws.receive.side_effect = [
+        {"type": "websocket.receive", "text": "hello"},
+        {"type": "websocket.disconnect"},
+    ]
+
+    mock_server_ws = AsyncMock(spec=AsyncWebSocketSession)
+    mock_server_ws.receive.side_effect = [
+        TextMessage(data="response"),
+        None,  # server closing connection
+    ]
+    mock_server_ws.__aenter__.return_value = mock_server_ws
+    mock_server_ws.__aexit__.return_value = None
+
+    with patch(
+        "truss.templates.control.control.endpoints.aconnect_ws",
+        return_value=mock_server_ws,
+    ):
+        await proxy_ws(client_ws)
+
+    # Verify interactions
+    client_ws.accept.assert_called_once()
+    mock_server_ws.send_text.assert_called_once_with("hello")
+    client_ws.send_text.assert_called_once_with("response")
+    client_ws.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_proxy_ws_binary_message(client_ws):
+    test_bytes = b"binary data"
+    client_ws.receive.side_effect = [
+        {"type": "websocket.receive", "bytes": test_bytes},
+        {"type": "websocket.disconnect"},
+    ]
+
+    mock_server_ws = AsyncMock(spec=AsyncWebSocketSession)
+    mock_server_ws.receive.side_effect = [
+        BytesMessage(data=b"binary response"),
+        None,  # server closing connection
+    ]
+    mock_server_ws.__aenter__.return_value = mock_server_ws
+    mock_server_ws.__aexit__.return_value = None
+
+    with patch(
+        "truss.templates.control.control.endpoints.aconnect_ws",
+        return_value=mock_server_ws,
+    ):
+        await proxy_ws(client_ws)
+
+    # Verify interactions
+    client_ws.accept.assert_called_once()
+    mock_server_ws.send_bytes.assert_called_once_with(test_bytes)
+    client_ws.send_bytes.assert_called_once_with(b"binary response")
+    client_ws.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_proxy_ws_closes_client_upon_server_connection_error(client_ws):
+    with patch(
+        "truss.templates.control.control.endpoints.aconnect_ws",
+        side_effect=httpx_ws_exceptions.WebSocketUpgradeError(
+            Response(status_code=503)
+        ),
+    ):
+        await proxy_ws(client_ws)
+
+    client_ws.close.assert_called_once()
+    assert client_ws.app.state.logger.warning.called
+
+
+@pytest.mark.asyncio
+async def test_proxy_ws_bidirectional_messaging(client_ws):
+    """Test that both directions of communication work and clean up properly"""
+    client_ws.receive.side_effect = [
+        {"type": "websocket.receive", "text": "msg1"},
+        {"type": "websocket.receive", "text": "msg2"},
+        {"type": "websocket.disconnect"},
+    ]
+
+    mock_server_ws = AsyncMock(spec=AsyncWebSocketSession)
+    mock_server_ws.receive.side_effect = [
+        TextMessage(data="response1"),
+        TextMessage(data="response2"),
+        None,  # server closing connection
+    ]
+    mock_server_ws.__aenter__.return_value = mock_server_ws
+    mock_server_ws.__aexit__.return_value = None
+
+    with patch(
+        "truss.templates.control.control.endpoints.aconnect_ws",
+        return_value=mock_server_ws,
+    ):
+        await proxy_ws(client_ws)
+
+    assert mock_server_ws.send_text.call_count == 2
+    assert mock_server_ws.send_text.call_args_list == [(("msg1",),), (("msg2",),)]
+    assert client_ws.send_text.call_count == 2
+    assert client_ws.send_text.call_args_list == [(("response1",),), (("response2",),)]
+    client_ws.close.assert_called_once()


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
- This PR ensures the server closes the WebSocket connection with the client if the inference server is not running yet
- Example output:
```
% websocat -H="Authorization: Api-Key $BASETEN_API_KEY" \
    wss://model-{MODEL_ID}.api.baseten.co/development/websocket
websocat: WebSocketError: WebSocketError: Received unexpected status code (503 Service Unavailable)
websocat: error running
```
- It also resolves the below error which currently happens when the client disconnects from the websocket connection:
<img width="1172" height="666" alt="image" src="https://github.com/user-attachments/assets/9f93b54b-07d3-4166-ab05-2068a149a116" />

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
- Checked that connection is closed from client side