### PR TITLE
Prevent development gRPC deployments

### DIFF
--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -15,7 +15,7 @@ from truss.base.constants import (
     TRTLLM_MIN_MEMORY_REQUEST_GI,
 )
 from truss.base.trt_llm_config import TrussTRTLLMQuantizationType
-from truss.base.truss_config import Build, ModelServer
+from truss.base.truss_config import Build, ModelServer, TransportKind
 from truss.cli import remote_cli
 from truss.cli.logs import utils as cli_log_utils
 from truss.cli.logs.model_log_watcher import ModelDeploymentLogWatcher
@@ -526,9 +526,13 @@ def push(
 
     """
     tr = _get_truss_from_directory(target_directory=target_directory)
-    if tr.spec.config.runtime.transport.kind == "grpc" and not publish and not promote:
+    if (
+        tr.spec.config.runtime.transport.kind == TransportKind.GRPC
+        and not publish
+        and not promote
+    ):
         raise click.UsageError(
-            "Truss with gRPC transport cannot be used as a development deployment. Please rerun the command with --promote or --publish."
+            "Truss with gRPC transport cannot be used as a development deployment. Please rerun the command with --publish or --promote."
         )
 
     if not remote:

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -525,6 +525,12 @@ def push(
     TARGET_DIRECTORY: A Truss directory. If none, use current directory.
 
     """
+    tr = _get_truss_from_directory(target_directory=target_directory)
+    if tr.spec.config.runtime.transport.kind == "grpc" and not publish and not promote:
+        raise click.UsageError(
+            "Truss with gRPC transport cannot be used as a development deployment. Please rerun the command with --promote or --publish."
+        )
+
     if not remote:
         remote = remote_cli.inquire_remote_name()
 
@@ -532,7 +538,6 @@ def push(
         include_git_info = user_config.settings.include_git_info
 
     remote_provider = RemoteFactory.create(remote=remote)
-    tr = _get_truss_from_directory(target_directory=target_directory)
 
     model_name = model_name or tr.spec.config.model_name
     if not model_name:

--- a/truss/tests/cli/test_cli.py
+++ b/truss/tests/cli/test_cli.py
@@ -1,0 +1,25 @@
+from unittest.mock import Mock, patch
+
+from click.testing import CliRunner
+
+from truss.cli.cli import truss_cli
+
+
+def test_push_with_grpc_transport_fails_for_development_deployment():
+    mock_truss = Mock()
+    mock_truss.spec.config.runtime.transport.kind = "grpc"
+
+    runner = CliRunner()
+
+    with patch("truss.cli.cli._get_truss_from_directory", return_value=mock_truss):
+        with patch("truss.cli.remote_cli.inquire_remote_name", return_value="remote1"):
+            result = runner.invoke(
+                truss_cli,
+                ["push", "test_truss", "--remote", "remote1", "--model-name", "name"],
+            )
+
+    assert result.exit_code == 2
+    assert (
+        "Truss with gRPC transport cannot be used as a development deployment"
+        in result.output
+    )


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
- This PR raises an error if the user attempts to deploy a development gRPC Truss, since this is not supported
<img width="864" height="137" alt="image" src="https://github.com/user-attachments/assets/5751d39d-1cf2-48c1-85be-03db50cf6832" />

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
- Checked that the appropriate error shows when running the command