### PR TITLE
Training supports docker auth 

### DIFF
--- a/truss-train/truss_train/definitions.py
+++ b/truss-train/truss_train/definitions.py
@@ -86,8 +86,41 @@ class Runtime(custom_types.SafeModelNoExtra):
         return values
 
 
+class AWSIAMAuthSettings(custom_types.SafeModelNoExtra):
+    access_key_id_secret_name: str = truss_config.DEFAULT_AWS_ACCESS_KEY_SECRET_NAME
+    secret_access_key_secret_name: str = (
+        truss_config.DEFAULT_AWS_SECRET_ACCESS_KEY_SECRET_NAME
+    )
+
+
+class GCPServiceAccountJSONAuthSettings(custom_types.SafeModelNoExtra):
+    secret_name: str
+
+
+class DockerAuthSettings(custom_types.SafeModelNoExtra):
+    auth_method: truss_config.DockerAuthType
+    registry: Optional[str] = ""
+    aws_iam_auth_settings: Optional[AWSIAMAuthSettings] = None
+    gcp_service_account_json_auth_settings: Optional[
+        GCPServiceAccountJSONAuthSettings
+    ] = None
+
+    def __post_init__(self):
+        if self.auth_method == truss_config.DockerAuthType.AWS_IAM:
+            if self.aws_iam_auth_settings is None:
+                raise ValueError(
+                    "aws_iam_auth_settings is required when auth_method is AWS_IAM"
+                )
+        elif self.auth_method == truss_config.DockerAuthType.GCP_SERVICE_ACCOUNT_JSON:
+            if self.gcp_service_account_json_auth_settings is None:
+                raise ValueError(
+                    "gcp_service_account_json_auth_settings is required when auth_method is GCP_SERVICE_ACCOUNT_JSON"
+                )
+
+
 class Image(custom_types.SafeModelNoExtra):
     base_image: str
+    docker_auth_settings: Optional[DockerAuthSettings] = None
 
 
 class TrainingJob(custom_types.SafeModelNoExtra):

--- a/truss-train/truss_train/definitions.py
+++ b/truss-train/truss_train/definitions.py
@@ -105,18 +105,6 @@ class DockerAuthSettings(custom_types.SafeModelNoExtra):
         GCPServiceAccountJSONAuthSettings
     ] = None
 
-    def __post_init__(self):
-        if self.auth_method == truss_config.DockerAuthType.AWS_IAM:
-            if self.aws_iam_auth_settings is None:
-                raise ValueError(
-                    "aws_iam_auth_settings is required when auth_method is AWS_IAM"
-                )
-        elif self.auth_method == truss_config.DockerAuthType.GCP_SERVICE_ACCOUNT_JSON:
-            if self.gcp_service_account_json_auth_settings is None:
-                raise ValueError(
-                    "gcp_service_account_json_auth_settings is required when auth_method is GCP_SERVICE_ACCOUNT_JSON"
-                )
-
 
 class Image(custom_types.SafeModelNoExtra):
     base_image: str

--- a/truss-train/truss_train/definitions.py
+++ b/truss-train/truss_train/definitions.py
@@ -86,29 +86,25 @@ class Runtime(custom_types.SafeModelNoExtra):
         return values
 
 
-class AWSIAMAuthSettings(custom_types.SafeModelNoExtra):
-    access_key_id_secret_name: str = truss_config.DEFAULT_AWS_ACCESS_KEY_SECRET_NAME
-    secret_access_key_secret_name: str = (
-        truss_config.DEFAULT_AWS_SECRET_ACCESS_KEY_SECRET_NAME
-    )
+class AWSIAMAuthDetails(custom_types.SafeModelNoExtra):
+    access_key_secret_name: SecretReference
+    secret_access_key_secret_name: SecretReference
 
 
-class GCPServiceAccountJSONAuthSettings(custom_types.SafeModelNoExtra):
-    secret_name: str
+class GCPServiceAccountJSONAuthDetails(custom_types.SafeModelNoExtra):
+    service_account_json_secret_name: SecretReference
 
 
-class DockerAuthSettings(custom_types.SafeModelNoExtra):
+class DockerAuth(custom_types.SafeModelNoExtra):
     auth_method: truss_config.DockerAuthType
-    registry: Optional[str] = ""
-    aws_iam_auth_settings: Optional[AWSIAMAuthSettings] = None
-    gcp_service_account_json_auth_settings: Optional[
-        GCPServiceAccountJSONAuthSettings
-    ] = None
+    registry: str
+    aws_iam_details: Optional[AWSIAMAuthDetails] = None
+    gcp_service_account_details: Optional[GCPServiceAccountJSONAuthDetails] = None
 
 
 class Image(custom_types.SafeModelNoExtra):
     base_image: str
-    docker_auth_settings: Optional[DockerAuthSettings] = None
+    docker_auth: Optional[DockerAuth] = None
 
 
 class TrainingJob(custom_types.SafeModelNoExtra):

--- a/truss-train/truss_train/definitions.py
+++ b/truss-train/truss_train/definitions.py
@@ -86,20 +86,22 @@ class Runtime(custom_types.SafeModelNoExtra):
         return values
 
 
-class AWSIAMAuthDetails(custom_types.SafeModelNoExtra):
-    access_key_secret: SecretReference
-    secret_access_key_secret: SecretReference
+class AWSIAMDockerAuth(custom_types.SafeModelNoExtra):
+    access_key_secret_ref: SecretReference
+    secret_access_key_secret_ref: SecretReference
 
 
-class GCPServiceAccountJSONAuthDetails(custom_types.SafeModelNoExtra):
-    service_account_json_secret: SecretReference
+class GCPServiceAccountJSONDockerAuth(custom_types.SafeModelNoExtra):
+    service_account_json_secret_ref: SecretReference
 
 
 class DockerAuth(custom_types.SafeModelNoExtra):
     auth_method: truss_config.DockerAuthType
     registry: str
-    aws_iam_details: Optional[AWSIAMAuthDetails] = None
-    gcp_service_account_details: Optional[GCPServiceAccountJSONAuthDetails] = None
+    aws_iam_docker_auth: Optional[AWSIAMDockerAuth] = None
+    gcp_service_account_json_docker_auth: Optional[GCPServiceAccountJSONDockerAuth] = (
+        None
+    )
 
 
 class Image(custom_types.SafeModelNoExtra):

--- a/truss-train/truss_train/definitions.py
+++ b/truss-train/truss_train/definitions.py
@@ -87,12 +87,12 @@ class Runtime(custom_types.SafeModelNoExtra):
 
 
 class AWSIAMAuthDetails(custom_types.SafeModelNoExtra):
-    access_key_secret_name: SecretReference
-    secret_access_key_secret_name: SecretReference
+    access_key_secret: SecretReference
+    secret_access_key_secret: SecretReference
 
 
 class GCPServiceAccountJSONAuthDetails(custom_types.SafeModelNoExtra):
-    service_account_json_secret_name: SecretReference
+    service_account_json_secret: SecretReference
 
 
 class DockerAuth(custom_types.SafeModelNoExtra):


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
* Customers want to use private images
* This supports private images at the truss level by extending the `image` type

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
