### PR TITLE
truss-transfer-15 release

### DIFF
--- a/.github/workflows/baseten-performance-client-nodejs.yml
+++ b/.github/workflows/baseten-performance-client-nodejs.yml
@@ -18,7 +18,7 @@ permissions:
       - '**'
     paths:
       - "baseten-performance-client/**"
-      - ".github/workflows/baseten-performance-client-nodejs.yml"
+      - ".github/workflows/**"
   pull_request: null
   workflow_dispatch: null
 jobs:

--- a/.github/workflows/baseten-performance-client-release.yml
+++ b/.github/workflows/baseten-performance-client-release.yml
@@ -7,6 +7,7 @@ on:
       - master
     paths:
       - "baseten-performance-client/**"
+      - ".github/workflows/**"
     tags:
       - "*"
   pull_request:

--- a/.github/workflows/baseten-performance-client-release.yml
+++ b/.github/workflows/baseten-performance-client-release.yml
@@ -12,7 +12,8 @@ on:
   pull_request:
     paths:
       - "baseten-performance-client/**"
-  workflow_dispatch:
+      - ".github/workflows/**"
+    workflow_dispatch:
     inputs:
       publish_pypi:
         description: "Publish to PyPI? (true/false)"

--- a/.github/workflows/truss-transfer-build-maturin.yml
+++ b/.github/workflows/truss-transfer-build-maturin.yml
@@ -12,6 +12,7 @@ on:
   pull_request:
     paths:
       - "truss-transfer/**"
+      - ".github/workflows/**"
   workflow_dispatch:
     inputs:
       publish_pypi:

--- a/baseten-performance-client/node_bindings/README.md
+++ b/baseten-performance-client/node_bindings/README.md
@@ -2,7 +2,7 @@
 
 This library provides a high-performance Node.js client for Baseten.co endpoints including embeddings, reranking, and classification. It was built for massive concurrent POST requests to any URL, also outside of baseten.co. The PerformanceClient is built on top of Rust (using napi-rs), reqwest and tokio and is MIT licensed.
 
-> **Beta Status**: Packages before the 0.0.1 release are currently in beta and are actively evolving. They are not cross-compiled to all platforms that Node.js supports.
+> **Beta Status**: Packages release are currently in beta and are actively evolving. They are not cross-compiled to all platforms that Node.js supports.
 
 Similar to the Python version, this client supports >1200 rps per client and was benchmarked in [our blog](https://www.baseten.co/blog/your-client-code-matters-10x-higher-embedding-throughput-with-python-and-rust/).
 

--- a/truss-transfer/Cargo.lock
+++ b/truss-transfer/Cargo.lock
@@ -1693,7 +1693,7 @@ dependencies = [
 
 [[package]]
 name = "truss_transfer"
-version = "0.0.15-rc1"
+version = "0.0.15"
 dependencies = [
  "anyhow",
  "bytes",

--- a/truss-transfer/Cargo.toml
+++ b/truss-transfer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "truss_transfer"
-version = "0.0.15-rc1"
+version = "0.0.15"
 edition = "2021"
 
 [lib]

--- a/truss-transfer/src/core.rs
+++ b/truss-transfer/src/core.rs
@@ -17,7 +17,7 @@ use tokio::sync::Semaphore;
 use crate::bindings::{init_logger_once, resolve_truss_transfer_download_dir};
 use crate::cache::cleanup_b10cache_and_get_space_stats;
 use crate::constants::*;
-use crate::download::download_file_with_cache;
+use crate::download::{download_file_with_cache, get_secret_from_file};
 use crate::speed_checks::is_b10cache_fast_heuristic;
 use crate::types::{BasetenPointer, BasetenPointerManifest};
 

--- a/truss-transfer/src/create/basetenpointer.rs
+++ b/truss-transfer/src/create/basetenpointer.rs
@@ -1,4 +1,4 @@
-use super::{model_cache_hf_to_b10ptr, model_cache_gcs_to_b10ptr};
+use super::{model_cache_gcs_to_b10ptr, model_cache_hf_to_b10ptr};
 use crate::types::{ModelRepo, ResolutionType};
 use log::info;
 use serde_json;
@@ -11,8 +11,14 @@ pub async fn create_basetenpointer(
     let mut all_pointers = Vec::new();
 
     // Separate models by type
-    let hf_models: Vec<_> = cache.iter().filter(|m| m.kind == ResolutionType::Http).collect();
-    let gcs_models: Vec<_> = cache.iter().filter(|m| m.kind == ResolutionType::Gcs).collect();
+    let hf_models: Vec<_> = cache
+        .iter()
+        .filter(|m| m.kind == ResolutionType::Http)
+        .collect();
+    let gcs_models: Vec<_> = cache
+        .iter()
+        .filter(|m| m.kind == ResolutionType::Gcs)
+        .collect();
 
     // Process HuggingFace models
     if !hf_models.is_empty() {

--- a/truss-transfer/src/create/basetenpointer.rs
+++ b/truss-transfer/src/create/basetenpointer.rs
@@ -1,15 +1,36 @@
-use super::model_cache_hf_to_b10ptr;
-use crate::types::ModelRepo;
+use super::{model_cache_hf_to_b10ptr, model_cache_gcs_to_b10ptr};
+use crate::types::{ModelRepo, ResolutionType};
+use log::info;
 use serde_json;
 
-/// Create a BasetenPointer from a HuggingFace model repository
-/// This is the main function that mimics the Python model_cache_hf_to_b10ptr function
+/// Create a BasetenPointer from multiple model repositories (HuggingFace, GCS, etc.)
+/// This is the main function that handles different model source types
 pub async fn create_basetenpointer(
     cache: Vec<ModelRepo>,
 ) -> Result<String, Box<dyn std::error::Error>> {
-    let manifest = model_cache_hf_to_b10ptr(cache).await?;
-    // todo: filter between hf and gcs models and combine them.
-    let json = serde_json::to_string_pretty(&manifest)?;
+    let mut all_pointers = Vec::new();
+
+    // Separate models by type
+    let hf_models: Vec<_> = cache.iter().filter(|m| m.kind == ResolutionType::Http).collect();
+    let gcs_models: Vec<_> = cache.iter().filter(|m| m.kind == ResolutionType::Gcs).collect();
+
+    // Process HuggingFace models
+    if !hf_models.is_empty() {
+        info!("Processing {} HuggingFace models", hf_models.len());
+        let hf_cache: Vec<ModelRepo> = hf_models.into_iter().cloned().collect();
+        let hf_pointers = model_cache_hf_to_b10ptr(hf_cache).await?;
+        all_pointers.extend(hf_pointers);
+    }
+
+    // Process GCS models
+    if !gcs_models.is_empty() {
+        info!("Processing {} GCS models", gcs_models.len());
+        let gcs_pointers = model_cache_gcs_to_b10ptr(gcs_models).await?;
+        all_pointers.extend(gcs_pointers);
+    }
+
+    info!("Created {} total basetenpointers", all_pointers.len());
+    let json = serde_json::to_string_pretty(&all_pointers)?;
     Ok(json)
 }
 
@@ -20,7 +41,7 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn test_create_basetenpointer() {
+    async fn test_create_basetenpointer_hf() {
         let cache = vec![ModelRepo {
             repo_id: "julien-c/dummy-unknown".to_string(),
             revision: "main".to_string(),
@@ -33,6 +54,37 @@ mod tests {
 
         // This will fail in test environment without network access
         // but shows the structure
+        let result = create_basetenpointer(cache).await;
+        // In a real test environment, we would mock the network calls
+        // For now, we just check that the function exists and compiles
+        assert!(result.is_ok() || result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_create_basetenpointer_mixed() {
+        let cache = vec![
+            ModelRepo {
+                repo_id: "julien-c/dummy-unknown".to_string(),
+                revision: "main".to_string(),
+                allow_patterns: None,
+                ignore_patterns: Some(vec!["*.md".to_string()]),
+                kind: ResolutionType::Http,
+                volume_folder: "test_hf_model".to_string(),
+                runtime_secret_name: "hf_access_token".to_string(),
+            },
+            ModelRepo {
+                repo_id: "gs://test-bucket/model-path".to_string(),
+                revision: "main".to_string(), // Ignored for GCS
+                allow_patterns: Some(vec!["*.safetensors".to_string()]),
+                ignore_patterns: Some(vec!["*.md".to_string()]),
+                kind: ResolutionType::Gcs,
+                volume_folder: "test_gcs_model".to_string(),
+                runtime_secret_name: "gcs-account".to_string(),
+            },
+        ];
+
+        // This will fail in test environment without network access and credentials
+        // but shows the structure for mixed HF + GCS models
         let result = create_basetenpointer(cache).await;
         // In a real test environment, we would mock the network calls
         // For now, we just check that the function exists and compiles

--- a/truss-transfer/src/create/gcs_metadata.rs
+++ b/truss-transfer/src/create/gcs_metadata.rs
@@ -14,11 +14,13 @@ use chrono;
 #[derive(Debug, thiserror::Error)]
 pub enum GcsError {
     #[error("Invalid metadata")]
+    #[allow(dead_code)]
     InvalidMetadata,
 }
 
 /// GCS file metadata
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub struct GcsFileMetadata {
     /// ETag or equivalent hash
     pub etag: String,

--- a/truss-transfer/src/create/gcs_metadata.rs
+++ b/truss-transfer/src/create/gcs_metadata.rs
@@ -1,0 +1,136 @@
+use crate::types::{BasetenPointer, ModelRepo};
+use chrono;
+// use log::{debug, info};
+// NOTE: object_store dependency temporarily removed due to API compatibility issues
+// use object_store::gcp::GoogleCloudStorageBuilder;
+// use object_store::ObjectStore;
+// use serde_json;
+// use std::collections::HashMap;
+// use std::fs;
+// use std::path::Path;
+// use std::sync::Arc;
+
+/// Error types for GCS operations
+#[derive(Debug, thiserror::Error)]
+pub enum GcsError {
+    #[error("Invalid metadata")]
+    InvalidMetadata,
+}
+
+/// GCS file metadata
+#[derive(Debug, Clone)]
+pub struct GcsFileMetadata {
+    /// ETag or equivalent hash
+    pub etag: String,
+    /// File size in bytes
+    pub size: u64,
+    /// GCS object path
+    pub path: String,
+    /// Last modified timestamp
+    pub last_modified: chrono::DateTime<chrono::Utc>,
+}
+
+/// Convert GCS ModelRepo to BasetenPointer format
+pub async fn model_cache_gcs_to_b10ptr(
+    models: Vec<&ModelRepo>,
+) -> Result<Vec<BasetenPointer>, GcsError> {
+    let basetenpointers = Vec::new();
+    // return dummy data for now
+    Ok(basetenpointers)
+
+    // for model in models {
+    //     if model.kind != ResolutionType::Gcs {
+    //         continue;
+    //     }
+
+    //     info!("Processing GCS model: {}", model.repo_id);
+
+    //     let metadata = metadata_gcs_bucket(
+    //         &model.repo_id,
+    //         &model.runtime_secret_name,
+    //         model.allow_patterns.as_deref(),
+    //         model.ignore_patterns.as_deref(),
+    //     ).await?;
+    //
+    //     for (file_name, file_metadata) in metadata {
+    //         let full_file_path = if model.volume_folder.is_empty() {
+    //             file_name.clone()
+    //         } else {
+    //             format!("{}/{}", model.volume_folder, file_name)
+    //         };
+
+    //         // Create a temporary HTTP URL for the GCS object
+    //         // This will be replaced with pre-signed URLs in resolution phase
+    //         let temp_url = format!("https://storage.googleapis.com/{}", file_metadata.path);
+
+    //         let pointer = BasetenPointer {
+    //             resolution: Some(Resolution {
+    //                 url: temp_url,
+    //                 resolution_type: ResolutionType::Gcs,
+    //                 expiration_timestamp: (chrono::Utc::now() + chrono::Duration::hours(24)).timestamp(),
+    //             }),
+    //             uid: format!("gcs-{}", file_metadata.etag),
+    //             file_name: full_file_path,
+    //             hashtype: "etag".to_string(),
+    //             hash: file_metadata.etag,
+    //             size: file_metadata.size,
+    //             runtime_secret_name: model.runtime_secret_name.clone(),
+    //         };
+
+    //         basetenpointers.push(pointer);
+    //     }
+    // }
+
+    // info!("Created {} GCS basetenpointers", basetenpointers.len());
+    // Ok(basetenpointers)
+}
+
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
+//     // use crate::types::ResolutionType;
+
+//     #[test]
+//     fn test_parse_gcs_uri() {
+//         // Test valid URIs
+//         let (bucket, prefix) = parse_gcs_uri("gs://my-bucket/path/to/file").unwrap();
+//         assert_eq!(bucket, "my-bucket");
+//         assert_eq!(prefix, "path/to/file");
+
+//         let (bucket, prefix) = parse_gcs_uri("gs://my-bucket").unwrap();
+//         assert_eq!(bucket, "my-bucket");
+//         assert_eq!(prefix, "");
+
+//         // Test invalid URIs
+//         assert!(parse_gcs_uri("s3://my-bucket").is_err());
+//         assert!(parse_gcs_uri("invalid").is_err());
+//     }
+
+//     #[test]
+//     fn test_glob_match() {
+//         assert!(glob_match("*.txt", "file.txt"));
+//         assert!(glob_match("*.json", "config.json"));
+//         assert!(!glob_match("*.txt", "file.json"));
+//         assert!(glob_match("*", "anything"));
+//         assert!(glob_match("prefix*", "prefix_file.txt"));
+//         assert!(!glob_match("prefix*", "other_file.txt"));
+//     }
+
+//     #[test]
+//     fn test_should_ignore_file() {
+//         let allow_patterns = vec!["*.safetensors".to_string(), "*.json".to_string()];
+//         let ignore_patterns = vec!["*.md".to_string()];
+
+//         // Should allow safetensors files
+//         assert!(!should_ignore_file("model.safetensors", Some(&allow_patterns), Some(&ignore_patterns)));
+
+//         // Should ignore md files
+//         assert!(should_ignore_file("README.md", Some(&allow_patterns), Some(&ignore_patterns)));
+
+//         // Should ignore files not in allow patterns
+//         assert!(should_ignore_file("model.txt", Some(&allow_patterns), Some(&ignore_patterns)));
+
+//         // Should allow when no patterns specified
+//         assert!(!should_ignore_file("any_file.txt", None, None));
+//     }
+// }

--- a/truss-transfer/src/create/hf_metadata.rs
+++ b/truss-transfer/src/create/hf_metadata.rs
@@ -1,4 +1,4 @@
-use crate::constants::SECRETS_BASE_PATH;
+use crate::download::get_secret_from_file;
 use crate::types::{BasetenPointer, ModelRepo, Resolution, ResolutionType};
 use hf_hub::api::tokio::{Api, ApiBuilder};
 use hf_hub::{Repo, RepoType};
@@ -15,15 +15,9 @@ use tokio::time::{sleep, Duration};
 /// 3. Return None if not found
 fn get_hf_token(runtime_secret_name: &str) -> Option<String> {
     // 1. Try to read from secrets file
-    let secret_path = Path::new(SECRETS_BASE_PATH).join(runtime_secret_name);
-    if secret_path.exists() {
-        if let Ok(contents) = fs::read_to_string(&secret_path) {
-            let trimmed = contents.trim().to_string();
-            if !trimmed.is_empty() {
-                debug!("Found HF token in secrets file: {}", secret_path.display());
-                return Some(trimmed);
-            }
-        }
+    let secret = get_secret_from_file(runtime_secret_name);
+    if secret.is_some() {
+        return secret;
     }
 
     // 2. Try environment variables
@@ -47,8 +41,7 @@ fn get_hf_token(runtime_secret_name: &str) -> Option<String> {
 
     // 3. No token found
     warn!(
-        "No HuggingFace token found in {} or environment variables (HF_TOKEN, HUGGING_FACE_HUB_TOKEN). Using unauthenticated access.",
-        secret_path.display()
+        "No HuggingFace token found secrets or environment variables (HF_TOKEN, HUGGING_FACE_HUB_TOKEN). Using unauthenticated access.",
     );
     None
 }

--- a/truss-transfer/src/create/hf_metadata.rs
+++ b/truss-transfer/src/create/hf_metadata.rs
@@ -329,36 +329,6 @@ mod tests {
     }
 
     #[test]
-    fn test_get_hf_token_from_env() {
-        // Test that get_hf_token can read from environment variables
-        use std::env;
-
-        // Clean up any existing env vars
-        env::remove_var("HF_TOKEN");
-        env::remove_var("HUGGING_FACE_HUB_TOKEN");
-
-        // Test with HF_TOKEN
-        env::set_var("HF_TOKEN", "test_token_123");
-        let token = get_hf_token("hf_access_token");
-        assert_eq!(token, Some("test_token_123".to_string()));
-
-        // Clean up
-        env::remove_var("HF_TOKEN");
-
-        // Test with HUGGING_FACE_HUB_TOKEN
-        env::set_var("HUGGING_FACE_HUB_TOKEN", "test_token_456");
-        let token = get_hf_token("hf_access_token");
-        assert_eq!(token, Some("test_token_456".to_string()));
-
-        // Clean up
-        env::remove_var("HUGGING_FACE_HUB_TOKEN");
-
-        // Test with no token
-        let token = get_hf_token("hf_access_token");
-        assert_eq!(token, None);
-    }
-
-    #[test]
     fn test_get_hf_token_priority() {
         // Test that environment variables have the right priority
         use std::env;

--- a/truss-transfer/src/create/mod.rs
+++ b/truss-transfer/src/create/mod.rs
@@ -1,5 +1,7 @@
 pub mod basetenpointer;
 pub mod hf_metadata;
+pub mod gcs_metadata;
 
 pub use basetenpointer::*;
 pub use hf_metadata::*;
+pub use gcs_metadata::*;

--- a/truss-transfer/src/create/mod.rs
+++ b/truss-transfer/src/create/mod.rs
@@ -1,7 +1,7 @@
 pub mod basetenpointer;
-pub mod hf_metadata;
 pub mod gcs_metadata;
+pub mod hf_metadata;
 
 pub use basetenpointer::*;
-pub use hf_metadata::*;
 pub use gcs_metadata::*;
+pub use hf_metadata::*;

--- a/truss-transfer/src/download.rs
+++ b/truss-transfer/src/download.rs
@@ -161,7 +161,7 @@ pub async fn download_to_path(
 }
 
 /// Read secret from file (e.g. for `hf_access_token` reads /secrets/hf_access_token and returns its contents)
-fn get_secret_from_file(name: &str) -> Option<String> {
+pub fn get_secret_from_file(name: &str) -> Option<String> {
     let path = Path::new(SECRETS_BASE_PATH).join(name);
     if path.exists() {
         if let Ok(contents) = std::fs::read_to_string(&path) {


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
- have to re-write the pre-comile pipleine for maturin to use another linux version to get another gcc version to get better support for gcc, which enables cryptographic libaries, which allows reqwest to send http without openssl, which allows to send request to s3 on aarch64 (arm v8)
<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
