### PR TITLE
Use `unsafe-best-match` for `uv install`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.115rc18"
+version = "0.9.115rc19"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/templates/base.Dockerfile.jinja
+++ b/truss/templates/base.Dockerfile.jinja
@@ -10,7 +10,9 @@ ENV PYTHON_EXECUTABLE="{{ python_executable }}"
 
 {%- set UV_VERSION = "0.7.19" %}
 {# Use the python executable currently on the path, will respect activated virtual envs. #}
-{%- set sys_pip_install_command = "uv pip install --python " + python_exec_path %}
+{# We use `unsafe-best-match` since `uv` is stricter about having multiple registries, but sometimes #}
+{# we need to search for versions across multiple. #}
+{%- set sys_pip_install_command = "uv pip install --index-strategy unsafe-best-match --python " + python_exec_path %}
 
 {% block fail_fast %}
 RUN grep -w 'ID=debian\|ID_LIKE=debian' /etc/os-release || { echo "ERROR: Supplied base image is not a debian image"; exit 1; }

--- a/truss/tests/test_data/server.Dockerfile
+++ b/truss/tests/test_data/server.Dockerfile
@@ -27,9 +27,9 @@ RUN apt update && \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 COPY ./base_server_requirements.txt base_server_requirements.txt
-RUN uv pip install --python /usr/local/bin/python3 -r base_server_requirements.txt --no-cache-dir
+RUN uv pip install --index-strategy unsafe-best-match --python /usr/local/bin/python3 -r base_server_requirements.txt --no-cache-dir
 COPY ./requirements.txt requirements.txt
-RUN uv pip install --python /usr/local/bin/python3 -r requirements.txt --no-cache-dir
+RUN uv pip install --index-strategy unsafe-best-match --python /usr/local/bin/python3 -r requirements.txt --no-cache-dir
 ENV APP_HOME="/app"
 WORKDIR $APP_HOME
 COPY ./data /app/data


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Our whisper trusses rely on multiple python module registries, and `uv` by default is much stricter about where it finds compatible version numbers. `--index-strategy unsafe-best-match` allows us to search across multiple registries to preserve the old `pip` behavior.

In general, this flag is considered slightly unsafe, but if we trust users to only use registries that are well known, the impact is much lower. 

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
