### PR TITLE
Fix model wrapper integration test

### DIFF
--- a/truss/tests/conftest.py
+++ b/truss/tests/conftest.py
@@ -685,14 +685,14 @@ class Helpers:
     @staticmethod
     @contextlib.contextmanager
     def sys_paths(*paths: Path):
-        num_paths = len(paths)
+        original_sys_path = sys.path[:]
         try:
             for path in paths:
-                sys.path.append(str(path))
+                # NB(nikhil): Insert at the beginning of the path to prefer the newest model being loaded.
+                sys.path.insert(0, str(path))
             yield
         finally:
-            for _ in range(num_paths):
-                sys.path.pop()
+            sys.path[:] = original_sys_path
 
     @staticmethod
     @contextlib.contextmanager

--- a/truss/tests/templates/server/test_model_wrapper.py
+++ b/truss/tests/templates/server/test_model_wrapper.py
@@ -1,4 +1,3 @@
-import asyncio
 import importlib
 import os
 import sys
@@ -12,6 +11,12 @@ import opentelemetry.sdk.trace as sdk_trace
 import pytest
 import yaml
 from starlette.requests import Request
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
 
 
 @pytest.fixture
@@ -164,6 +169,18 @@ async def test_trt_llm_truss_missing_model_py(
         expected_predict_response = "test"
         mock_predict_called = False
 
+        # Need to import from the same path as ModelWrapper for retries to work.
+        errors_module = sys.modules["common.errors"]
+
+        # NB(nikhil): The underlying .load() takes longer on CI, so we wrap predict until the model is ready.
+        @retry(
+            retry=retry_if_exception_type(errors_module.ModelNotReady),
+            stop=stop_after_attempt(10),
+            wait=wait_exponential(multiplier=1, min=1, max=10),
+        )
+        async def predict_with_retry(model_wrapper):
+            return await model_wrapper.predict({}, connected_request)
+
         async def mock_predict(return_value, request: Request):
             nonlocal mock_predict_called
             mock_predict_called = True
@@ -178,8 +195,7 @@ async def test_trt_llm_truss_missing_model_py(
         ):
             model_wrapper = model_wrapper_class(config, sdk_trace.NoOpTracer())
             model_wrapper.load()
-            await asyncio.sleep(0.05)  # Allow load thread to execute
-            resp = await model_wrapper.predict({}, connected_request)
+            resp = await predict_with_retry(model_wrapper)
             mock_extension.load.assert_called()
             mock_extension.model_override.assert_called()
             assert mock_predict_called

--- a/truss/tests/templates/server/test_model_wrapper.py
+++ b/truss/tests/templates/server/test_model_wrapper.py
@@ -11,12 +11,7 @@ import opentelemetry.sdk.trace as sdk_trace
 import pytest
 import yaml
 from starlette.requests import Request
-from tenacity import (
-    retry,
-    retry_if_exception_type,
-    stop_after_attempt,
-    wait_exponential,
-)
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_fixed
 
 
 @pytest.fixture
@@ -175,8 +170,8 @@ async def test_trt_llm_truss_missing_model_py(
         # NB(nikhil): The underlying .load() takes longer on CI, so we wrap predict until the model is ready.
         @retry(
             retry=retry_if_exception_type(errors_module.ModelNotReady),
-            stop=stop_after_attempt(10),
-            wait=wait_exponential(multiplier=1, min=1, max=10),
+            stop=stop_after_attempt(2),
+            wait=wait_fixed(0.5),
         )
         async def predict_with_retry(model_wrapper):
             return await model_wrapper.predict({}, connected_request)


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
We have a test that is semi-flaky when waiting for a model to load. This PR adds retries to the model wrapper predict so that the underlying load has time to complete. 

Integration test run here: https://github.com/basetenlabs/truss/actions/runs/16451227754

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
