### PR TITLE
Clean up dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,7 +85,7 @@ jobs:
       - uses: ./.github/actions/setup-python/
 
       - name: Install poetry packages
-        run: poetry install --extras=all
+        run: poetry install --only=main
 
       - name: Build
         run: poetry build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
       - uses: ./.github/actions/setup-python/
 
       - name: Install poetry packages
-        run: poetry install --extras=all
+        run: poetry install --only=main
 
       - name: Build
         run: poetry build

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 python 3.13.3
-poetry 2.0.0
+poetry 2.1.3

--- a/poetry.lock
+++ b/poetry.lock
@@ -4681,4 +4681,4 @@ all = []
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<3.14"
-content-hash = "74a5f0bded7f62231c91d2e0ec6652409666d3ee27901f74ce0f509f611d9c26"
+content-hash = "9ec8fa0fefd198949629340082f8b19e048d46738c4c3828d40ee25fa15efb24"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.116"
+version = "0.9.117rc1"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ requests = { version = ">=2.31", optional = false }
 rich = { version = "^13.4.2", optional = false }
 rich-click = { version = "^1.6.1", optional = false }
 ruff = { version = ">=0.4.8", optional = false }  # Not a dev dep, needed for chains code gen.
-tenacity = { version = "^8.0.1", optional = false }
+tenacity = { version = ">=8.0.1", optional = false }
 watchfiles = { version = "^0.19.0", optional = false }
 truss_transfer= { version = "0.0.17", optional = false }
 


### PR DESCRIPTION

## :rocket: What

Fixes a couple issues:
* A customer complained that truss is not compatible with latest version of tenacity. Expanded the range & tested, there is no reason to pin it to 8
* We've been unnecessarily bundling dev dependencies with every truss release

## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing

Build an RC `0.9.117rc1`, and ensured deploying a model works.