### PR TITLE
Build 0.9.117 base images, with compression

### DIFF
--- a/.github/workflows/_build_truss_server_base_images_if_needed_shared.yml
+++ b/.github/workflows/_build_truss_server_base_images_if_needed_shared.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python_version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python_version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         use_gpu: ["y", "n"]
     steps:
       - uses: docker/setup-buildx-action@v3

--- a/bin/generate_base_images.py
+++ b/bin/generate_base_images.py
@@ -74,17 +74,19 @@ def _build(
         shutil.copytree(
             str(templates_path / "control"), str(build_ctx_path / "control")
         )
+
+        output_params = f"type=image,name={image_with_tag},compression=estargz,force-compression=true,oci-mediatypes=true"
+        if push:
+            output_params += ",push=true"
         cmd = [
             "docker",
             "buildx",
             "build",
             "--platform=linux/arm64,linux/amd64",
             ".",
-            "-t",
-            image_with_tag,
+            "--output",
+            output_params,
         ]
-        if push:
-            cmd.append("--push")
 
         # Needed to support multi-arch build.
         subprocess.run(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.117rc1"
+version = "0.9.117rc2"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/contexts/image_builder/util.py
+++ b/truss/contexts/image_builder/util.py
@@ -6,7 +6,7 @@ from truss import __version__
 # This needs to be updated whenever we want to update
 # base images on a merge. Updating this version will cause
 # base images to be pushed with this tag.
-TRUSS_BASE_IMAGE_VERSION_TAG = "v0.9.103"
+TRUSS_BASE_IMAGE_VERSION_TAG = "v0.9.117"
 
 
 def file_is_empty(path: Path, ignore_hash_style_comments: bool = True) -> bool:


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
After talking to Depot, we learned that we are incurring a decent amount of work to re-compress our base images with estargz, now that it's globally rolled out. 

I manually rebuilt our images using [estargz](https://github.com/basetenlabs/truss/actions/runs/16571710808), and then pushed a very slim truss. Before (~111s), After (2s), which is a massive difference!

I believe we should make an effort to build all of the images we own with `estargz`, and then we can communicate with FDE that this is a potential build time speedup option for our customers. However, this is leaking implementation details, so we should be careful here. 

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
