### PR TITLE
feat(truss): support to use artifact references format [BT-15044]

### DIFF
--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -586,9 +586,9 @@ class TrainingArtifactReference(custom_types.ConfigModel):
     path_details: list[TrainingArtifactReferencePathDetails] = pydantic.Field(
         default_factory=list, description="The path details of the artifact reference."
     )
-    model_weights_format: Optional[ModelWeightsFormat] = pydantic.Field(
+    model_weight_format: Optional[ModelWeightsFormat] = pydantic.Field(
         default=None,
-        description="Predefined model weights format to use for deploy_checkpoints",
+        description="Predefined model weight format to use for deploy_checkpoints",
         examples=[ModelWeightsFormat.LORA],
     )
 


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What

Added all the fields so user's can specify artifact references within their `config.yaml`, choose not to delete the `checkpoints` field in this PR and will do so in a subsequent one which modifies how `truss train get_checkpoint_urls` synthesizes the TrussConfig.

<!--
  How was the change described above implemented?
-->
## :computer: How

Added the fields.

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing

`truss push` to staging, went into pods and verified files were there there (E2E test)

```yaml
model_name: aghilan-inference
resources:
  accelerator: "L4"
training_checkpoints:
  download_folder: /tmp/training_checkpoints
  artifact_references:
    - training_job_id: 7qrp713
      # model_weight_format: "LoRA" (optional)
      path_details:
        - path_reference: rank-0/checkpoint-24/adapter_model.safetensors
          recursive: false
        - path_reference: rank-0/checkpoint-24/added_tokens.json
          recursive: false
        
  checkpoints: # Will be deleted soon
    - id: lqz4now/checkpoint-24
      name: checkpoint-24
```


### Release Notes
Wait until a deploy for the backend is done so this field will actually be used.