### PR TITLE
Revert commit 2ce6c22 for supervisord changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.118"
+version = "0.9.117rc51"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/contexts/image_builder/serving_image_builder.py
+++ b/truss/contexts/image_builder/serving_image_builder.py
@@ -385,10 +385,17 @@ def generate_docker_server_nginx_config(build_dir, config):
 
 
 def generate_docker_server_supervisord_config(build_dir, config):
-    # Copy the template file over, because we don't have any template variables to render
-    copy_tree_or_file(
-        DOCKER_SERVER_TEMPLATES_DIR / "supervisord.conf", build_dir / "supervisord.conf"
+    supervisord_template = read_template_from_fs(
+        DOCKER_SERVER_TEMPLATES_DIR, "supervisord.conf.jinja"
     )
+    assert config.docker_server.start_command is not None, (
+        "docker_server.start_command is required to use custom server"
+    )
+    supervisord_contents = supervisord_template.render(
+        start_command=config.docker_server.start_command
+    )
+    supervisord_filepath = build_dir / "supervisord.conf"
+    supervisord_filepath.write_text(supervisord_contents)
 
 
 class ServingImageBuilderContext(TrussContext):

--- a/truss/templates/docker_server/supervisord.conf.jinja
+++ b/truss/templates/docker_server/supervisord.conf.jinja
@@ -4,7 +4,7 @@ logfile=/dev/null            ; Disable logging to file (send logs to /dev/null)
 logfile_maxbytes=0           ; No size limit on logfile (since logging is disabled)
 
 [program:model-server]
-command=%(ENV_BT_DOCKER_SERVER_START_CMD)s        ; Note: if ENV_FOO here, supervisord will look for the envvar FOO.
+command={{start_command}}    ; Command to start the model server (provided by Jinja variable)
 startsecs=30                 ; Wait 30 seconds before assuming the server is running
 autostart=true               ; Automatically start the program when supervisord starts
 autorestart=true             ; Always restart the program if it exits, no matter what the exit code


### PR DESCRIPTION
## :rocket: What
Temporarily revert the commit for supervisord changes, as it is failing in some truss configurations.
RCA is TBD.

## :computer: How
Revert the associated commit, as per [rollout doc](https://www.notion.so/ml-infra/Rollout-Buildless-Deployment-22d91d24727380509d61d868f972ae4b?source=copy_link#22d91d2472738021b797f2321862ddae).

## :microscope: Testing
Tested the following scenarios:
- Truss server deployment
- custom server deployment
- training deploy_checkpoints

[Integration tests passing](https://github.com/basetenlabs/truss/actions/runs/16681934136)