### PR TITLE
[BT-14521] Limit supervisord changes to checkpoint deployments only

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.120rc0"
+version = "0.9.120rc50"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/contexts/image_builder/serving_image_builder.py
+++ b/truss/contexts/image_builder/serving_image_builder.py
@@ -392,7 +392,13 @@ def generate_docker_server_supervisord_config(build_dir, config):
         "docker_server.start_command is required to use custom server"
     )
     supervisord_contents = supervisord_template.render(
-        start_command=config.docker_server.start_command
+        start_command=config.docker_server.start_command,
+        # With training checkpoints, we want to keep a static supervisord.conf file
+        # that doesn't have any template variables to render.
+        # This keeps the build hash stable, and allows us to use the same
+        # container when only the training checkpoints change.
+        # The start command is set at runtime instead through an environment variable.
+        is_deploy_checkpoints=config.training_checkpoints is not None,
     )
     supervisord_filepath = build_dir / "supervisord.conf"
     supervisord_filepath.write_text(supervisord_contents)

--- a/truss/contexts/image_builder/serving_image_builder.py
+++ b/truss/contexts/image_builder/serving_image_builder.py
@@ -391,15 +391,16 @@ def generate_docker_server_supervisord_config(build_dir, config):
     assert config.docker_server.start_command is not None, (
         "docker_server.start_command is required to use custom server"
     )
-    supervisord_contents = supervisord_template.render(
-        start_command=config.docker_server.start_command,
+    if config.training_checkpoints is not None:
         # With training checkpoints, we want to keep a static supervisord.conf file
         # that doesn't have any template variables to render.
         # This keeps the build hash stable, and allows us to use the same
         # container when only the training checkpoints change.
         # The start command is set at runtime instead through an environment variable.
-        is_deploy_checkpoints=config.training_checkpoints is not None,
-    )
+        start_command = "%(ENV_BT_DOCKER_SERVER_START_CMD)s"
+    else:
+        start_command = config.docker_server.start_command
+    supervisord_contents = supervisord_template.render(start_command=start_command)
     supervisord_filepath = build_dir / "supervisord.conf"
     supervisord_filepath.write_text(supervisord_contents)
 

--- a/truss/templates/docker_server/supervisord.conf.jinja
+++ b/truss/templates/docker_server/supervisord.conf.jinja
@@ -4,7 +4,11 @@ logfile=/dev/null            ; Disable logging to file (send logs to /dev/null)
 logfile_maxbytes=0           ; No size limit on logfile (since logging is disabled)
 
 [program:model-server]
+{%- if is_deploy_checkpoints %}
+command=%(ENV_BT_DOCKER_SERVER_START_CMD)s        ; Note: supervisord will look for the environment variable FOO if we give here ENV_FOO
+{%- else %}
 command={{start_command}}    ; Command to start the model server (provided by Jinja variable)
+{%- endif %}
 startsecs=30                 ; Wait 30 seconds before assuming the server is running
 autostart=true               ; Automatically start the program when supervisord starts
 autorestart=true             ; Always restart the program if it exits, no matter what the exit code

--- a/truss/templates/docker_server/supervisord.conf.jinja
+++ b/truss/templates/docker_server/supervisord.conf.jinja
@@ -4,11 +4,7 @@ logfile=/dev/null            ; Disable logging to file (send logs to /dev/null)
 logfile_maxbytes=0           ; No size limit on logfile (since logging is disabled)
 
 [program:model-server]
-{%- if is_deploy_checkpoints %}
-command=%(ENV_BT_DOCKER_SERVER_START_CMD)s        ; Note: supervisord will look for the environment variable FOO if we give here ENV_FOO
-{%- else %}
 command={{start_command}}    ; Command to start the model server (provided by Jinja variable)
-{%- endif %}
 startsecs=30                 ; Wait 30 seconds before assuming the server is running
 autostart=true               ; Automatically start the program when supervisord starts
 autorestart=true             ; Always restart the program if it exits, no matter what the exit code

--- a/truss/truss_handle/truss_handle.py
+++ b/truss/truss_handle/truss_handle.py
@@ -309,7 +309,7 @@ class TrussHandle:
                 envs["PATCH_PING_URL_TRUSS"] = patch_ping_url
             if disable_json_logging:
                 envs["DISABLE_JSON_LOGGING"] = "true"
-            if self.spec.config.docker_server:
+            if self.spec.config.docker_server and self.spec.config.training_checkpoints:
                 envs["BT_DOCKER_SERVER_START_CMD"] = (
                     self.spec.config.docker_server.start_command
                 )


### PR DESCRIPTION
## :rocket: What
Keep supervisord.conf as-is for all configurations, except for `truss train deploy_checkpoints`.

For that specific command, refer to an environment variable that we know is set on the server end.

## :computer: How
Add if-else branching within supervisord.conf population.

## :microscope: Testing
Tested locally with:
* custom server
* truss server
* checkpoint deployment

[Integration tests passing](https://github.com/basetenlabs/truss/actions/runs/16714028855)