### PR TITLE
Add UV_HTTP_TIMEOUT to installation commands

### DIFF
--- a/truss/templates/base.Dockerfile.jinja
+++ b/truss/templates/base.Dockerfile.jinja
@@ -9,10 +9,18 @@ FROM {{ base_image_name_and_tag }} AS truss_server
 ENV PYTHON_EXECUTABLE="{{ python_executable }}"
 
 {%- set UV_VERSION = "0.7.19" %}
-{# Use the python executable currently on the path, will respect activated virtual envs. #}
-{# We use `unsafe-best-match` since `uv` is stricter about having multiple registries, but sometimes #}
-{# we need to search for versions across multiple. #}
-{%- set sys_pip_install_command = "uv pip install --index-strategy unsafe-best-match --python " + python_exec_path %}
+{#
+NB(nikhil): We use a semi-complex uv installation command across the board:
+- A generous UV_HTTP_TIMEOUT (5m) for packages that take a long time to install.
+- We use `unsafe-best-match` since `uv` is stricter about having multiple registries, and we often need to search multiple.
+- Use the python executable currently on the path, will respect activated virtual envs.
+#}
+{%- set sys_pip_install_command =
+    "UV_HTTP_TIMEOUT=${UV_HTTP_TIMEOUT:-300} " +
+    "uv pip install " +
+    "--index-strategy unsafe-best-match " +
+    "--python " + python_exec_path
+%}
 
 {% block fail_fast %}
 RUN grep -w 'ID=debian\|ID_LIKE=debian' /etc/os-release || { echo "ERROR: Supplied base image is not a debian image"; exit 1; }

--- a/truss/tests/test_data/server.Dockerfile
+++ b/truss/tests/test_data/server.Dockerfile
@@ -27,9 +27,9 @@ RUN apt update && \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 COPY ./base_server_requirements.txt base_server_requirements.txt
-RUN uv pip install --index-strategy unsafe-best-match --python /usr/local/bin/python3 -r base_server_requirements.txt --no-cache-dir
+RUN UV_HTTP_TIMEOUT=${UV_HTTP_TIMEOUT:-300} uv pip install --index-strategy unsafe-best-match --python /usr/local/bin/python3 -r base_server_requirements.txt --no-cache-dir
 COPY ./requirements.txt requirements.txt
-RUN uv pip install --index-strategy unsafe-best-match --python /usr/local/bin/python3 -r requirements.txt --no-cache-dir
+RUN UV_HTTP_TIMEOUT=${UV_HTTP_TIMEOUT:-300} uv pip install --index-strategy unsafe-best-match --python /usr/local/bin/python3 -r requirements.txt --no-cache-dir
 ENV APP_HOME="/app"
 WORKDIR $APP_HOME
 COPY ./data /app/data


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
[Some](https://basetenlabs.slack.com/archives/C06CZ3RSXRU/p1754149634393439) packages take longer than 30s to install, so we should set this `UV_HTTP_TIMEOUT` to a larger number (5m for now) so users can successfully install them.

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
