### PR TITLE
Account for yanked releases

### DIFF
--- a/bin/bump_truss_version.sh
+++ b/bin/bump_truss_version.sh
@@ -18,6 +18,36 @@ fi
 CURRENT_VERSION="$1"
 BUMP_TYPE="${2:-patch}"  # Default bump type is "patch" (micro)
 
+# Function to check if a specific version exists on PyPI
+version_exists_on_pypi() {
+  local version="$1"
+  curl -s -o /dev/null -w "%{http_code}" "https://pypi.org/pypi/truss/${version}/json" | grep -q "200"
+}
+
+# Function to increment version based on bump type
+bump_version() {
+  local bump_type="$1"
+  local major="$2"
+  local minor="$3"
+  local patch="$4"
+
+  case "$bump_type" in
+    major)
+      echo "$((major + 1)) 0 0"
+      ;;
+    minor)
+      echo "$major $((minor + 1)) 0"
+      ;;
+    patch)
+      echo "$major $minor $((patch + 1))"
+      ;;
+    *)
+      echo "Invalid bump type: $bump_type. Use 'major', 'minor', or 'patch'."
+      exit 1
+      ;;
+  esac
+}
+
 # Strip any suffix beyond the semver (retain only X.Y.Z)
 semver=$(echo "$CURRENT_VERSION" | sed -E 's/^([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
 
@@ -25,27 +55,17 @@ semver=$(echo "$CURRENT_VERSION" | sed -E 's/^([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
 IFS='.' read -r major minor patch <<< "$semver"
 
 # Bump the version based on the bump type argument
-case "$BUMP_TYPE" in
-  major)
-    major=$((major + 1))
-    minor=0
-    patch=0
-    ;;
-  minor)
-    minor=$((minor + 1))
-    patch=0
-    ;;
-  patch)
-    patch=$((patch + 1))
-    ;;
-  *)
-    echo "Invalid bump type: $BUMP_TYPE. Use 'major', 'minor', or 'patch'."
-    exit 1
-    ;;
-esac
+read -r major minor patch <<< "$(bump_version "$BUMP_TYPE" "$major" "$minor" "$patch")"
+
+# Find next available version, accounting for yanked releases
+while version_exists_on_pypi "${major}.${minor}.${patch}"; do
+  echo "Version ${major}.${minor}.${patch} already exists on PyPI, trying next..."
+  read -r major minor patch <<< "$(bump_version "$BUMP_TYPE" "$major" "$minor" "$patch")"
+done
 
 # Construct the new version string
 new_version="${major}.${minor}.${patch}"
+echo "Using version: $new_version"
 
 # Set the new version using Poetry
 poetry version "$new_version"


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Our current logic to generate the next release number doesn't account for yanked releases, since the default behavior for PyPI is to return the latest _eligible_ release.

This PR adds some small logic to the bash script to just make sure the current number is eligible, else keep applying the semvar increments. 

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing

Manually ran the release action against this [commit](https://github.com/basetenlabs/truss/pull/1828/commits/26f98fa90f62602ed3640cf7b40c4357ccaaf3a0), and it correctly [produced](https://github.com/basetenlabs/truss/pull/1828) 0.9.120
