### PR TITLE
fix(truss): remove path details in favor of path strings

### DIFF
--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -594,8 +594,15 @@ class TrainingArtifactReference(custom_types.ConfigModel):
 
 
 class CheckpointList(custom_types.ConfigModel):
-    download_folder: str = DEFAULT_TRAINING_CHECKPOINT_FOLDER
-    checkpoints: list[Checkpoint] = pydantic.Field(default_factory=list)
+    download_folder: str = pydantic.Field(
+        default=DEFAULT_TRAINING_CHECKPOINT_FOLDER,
+        description="The folder to download the checkpoints to.",
+        examples=["/tmp/training_checkpoints"],
+    )
+    # TODO: Remove this field once deploy_checkpoints uses artifact_references instead.
+    checkpoints: list[Checkpoint] = pydantic.Field(
+        default_factory=list, deprecated="Prefer artifact_references instead."
+    )
     artifact_references: list[TrainingArtifactReference] = pydantic.Field(
         default_factory=list
     )

--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -554,6 +554,7 @@ class DockerServer(custom_types.ConfigModel):
     liveness_endpoint: str
 
 
+# TODO: aghilann: remove this once we have LoRA checkpoints
 class Checkpoint(custom_types.ConfigModel):
     # NB(rcano): The id here is a formatted string of the form <training_job_id>/<checkpoint_id>
     # We do this because the vLLM command requires knowledge of where the checkpoint
@@ -563,33 +564,13 @@ class Checkpoint(custom_types.ConfigModel):
     name: str
 
 
-class TrainingArtifactReferencePathDetails(custom_types.ConfigModel):
-    path_reference: str = pydantic.Field(
-        ...,
-        description="Relative path to the artifact",
-        examples=[
-            "rank-0/checkpoint-10/adapter_model.safetensors",
-            "rank-0/checkpoint-10/",
-        ],
-    )
-    recursive: bool = pydantic.Field(
-        ...,
-        description="Whether to recursively download the artifact. Do not set true when path_reference is a file.",
-        examples=[True, False],
-    )
-
-
 class TrainingArtifactReference(custom_types.ConfigModel):
     training_job_id: str = pydantic.Field(
         ..., description="The training job id that the artifact reference belongs to."
     )
-    path_details: list[TrainingArtifactReferencePathDetails] = pydantic.Field(
-        default_factory=list, description="The path details of the artifact reference."
-    )
-    model_weight_format: Optional[ModelWeightsFormat] = pydantic.Field(
-        default=None,
-        description="Predefined model weight format to use for deploy_checkpoints",
-        examples=[ModelWeightsFormat.LORA],
+    paths: list[str] = pydantic.Field(
+        default_factory=list,
+        description="The paths of the files to download which can contain * or ?.",
     )
 
 
@@ -598,10 +579,6 @@ class CheckpointList(custom_types.ConfigModel):
         default=DEFAULT_TRAINING_CHECKPOINT_FOLDER,
         description="The folder to download the checkpoints to.",
         examples=["/tmp/training_checkpoints"],
-    )
-    # TODO: Remove this field once deploy_checkpoints uses artifact_references instead.
-    checkpoints: list[Checkpoint] = pydantic.Field(
-        default_factory=list, deprecated="Prefer artifact_references instead."
     )
     artifact_references: list[TrainingArtifactReference] = pydantic.Field(
         default_factory=list

--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -580,6 +580,10 @@ class CheckpointList(custom_types.ConfigModel):
         description="The folder to download the checkpoints to.",
         examples=["/tmp/training_checkpoints"],
     )
+    # TODO: Remove this field once deploy_checkpoints uses artifact_references instead.
+    checkpoints: list[Checkpoint] = pydantic.Field(
+        default_factory=list, deprecated="Prefer artifact_references instead."
+    )
     artifact_references: list[TrainingArtifactReference] = pydantic.Field(
         default_factory=list
     )


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Removes the path details type in Truss since that is no longer used in favor of a paths string which can support wildcards.

<!--
  How was the change described above implemented?
-->
## :computer: How
Added the type and removed the path details. This is a sample truss. Note we cannot remove `artifact_references` and place paths directly under `training_checkpoints` because each list of paths must also have an associated `training_job_id`.
```
model_name: aghilan-inference11
training_checkpoints:
  download_folder: /tmp/training_checkpoints
  artifact_references:
    - training_job_id: n4q95w5
      paths:
        - rank-0/README.md
        - rank-0/adapter_model.safetensors
        - rank-0/*.json
        - rank-0/adapter_confi?.json
        - .cache/
```

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing

