### PR TITLE
Allow skip build job for v2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "truss"
-version = "0.10.2rc1"
+version = "0.10.2rc5"
 description = "A seamless bridge from model development to model delivery"
 authors = [
     { name = "Pankaj Gupta", email = "no-reply@baseten.co" },

--- a/truss/base/trt_llm_config.py
+++ b/truss/base/trt_llm_config.py
@@ -552,6 +552,7 @@ class TRTLLMConfigurationV2(PydanticTrTBaseModel):
             "checkpoint_repository",
             "quantization_type",
             "quantization_config",
+            "skip_build_result",
         ]
 
         build_settings = self.build.model_dump(exclude_unset=True)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.9, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -3292,7 +3292,7 @@ wheels = [
 
 [[package]]
 name = "truss"
-version = "0.9.121rc6"
+version = "0.10.2rc5"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
@@ -3392,7 +3392,7 @@ requires-dist = [
     { name = "ruff", specifier = ">=0.4.8" },
     { name = "tenacity", specifier = ">=8.0.1" },
     { name = "tomlkit", specifier = ">=0.13.2" },
-    { name = "truss-transfer", specifier = "==0.0.21" },
+    { name = "truss-transfer", specifier = "==0.0.22" },
     { name = "watchfiles", specifier = ">=0.19.0,<0.20" },
 ]
 
@@ -3436,32 +3436,32 @@ dev-server = [
 
 [[package]]
 name = "truss-transfer"
-version = "0.0.21"
+version = "0.0.22"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f6/26/148819d0db587d9c1a5596db2a798652d39a2647445e82a891410df126e4/truss_transfer-0.0.21.tar.gz", hash = "sha256:1681e77757f79dc9d850093eb64225f571ca207d1adeb89b2a9e7040e51befce", size = 60682, upload-time = "2025-08-11T17:32:07.339Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/58/fc4a2f58b6f1854589fbd561a148b7faa57dd8c13eaf77dd670b405f1adf/truss_transfer-0.0.22.tar.gz", hash = "sha256:a7bf1140ad73f673a5e22a4828cb38ba4b6fade7281f98d833eeeb16346fbb04", size = 60894, upload-time = "2025-08-12T21:48:09.18Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/5f/d2c205f18058db509811cbd638576bc8fba976afc02b427c840d17444431/truss_transfer-0.0.21-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:d8f2bcaa2cc09af1d346ff48808099856ac5260a9f538c9c3f7ea0c5f2b8d5f3", size = 3655448, upload-time = "2025-08-11T17:31:48.677Z" },
-    { url = "https://files.pythonhosted.org/packages/63/50/d5fee92f6be810eb791c490caf0fa6994dbf7c39656097a20428b4aa6cbb/truss_transfer-0.0.21-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:7831c0e9dcd5ec05becbe129a8131e214cf157f2dccbf31a42d96698b162a441", size = 3495772, upload-time = "2025-08-11T17:31:43.967Z" },
-    { url = "https://files.pythonhosted.org/packages/68/46/de8a7e1cbd14fa3993a1f9aa8a23299dd96cc26408a96332e0bd0eff3463/truss_transfer-0.0.21-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9c35711a18f1c2e4a61e3d64970645a247a43f070257bcc8768f9fdb94a4fabd", size = 4066791, upload-time = "2025-08-11T17:31:35.317Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/2d/e0e152f3278055d6a0522e46d169b822af147f6cb4d5b3e44341e24c3161/truss_transfer-0.0.21-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0b975ab03b3bf64b75fc6c27d90f6ea4daa4f4b3f9c4d6c42e2c57bbf7d6246a", size = 4895253, upload-time = "2025-08-11T17:31:30.937Z" },
-    { url = "https://files.pythonhosted.org/packages/60/43/adca2db465d168ca49aba03c17dda87a9a82023c8a4fe17aeaacd34ee514/truss_transfer-0.0.21-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6258b79c1c69fd784502447c6bc67ef8331ce6814be3a2a4a90f8bf83deb462b", size = 3951177, upload-time = "2025-08-11T17:31:39.927Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/b9/f999d36712e26f63d9c142f30eb3449585c53c9275ac0c9c09f60e177cf0/truss_transfer-0.0.21-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:14fcc0d8b93679c7c71978d26d88aa531154d54489cfc3c07f298733851698ef", size = 4046945, upload-time = "2025-08-11T17:31:52.283Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/72/1ab22a9ae0d468ef097768f322140bd19af66617acba28534f70f158f7c1/truss_transfer-0.0.21-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:ec90e28de93c38846ba4663ff5bddcaa7244759557141e6ab55561b68bf95d7b", size = 3911771, upload-time = "2025-08-11T17:31:56.253Z" },
-    { url = "https://files.pythonhosted.org/packages/38/7d/a1d3d00d56fed832b6d1fa4c7068f11a8a5f24ffe704bff61d41f486fc8e/truss_transfer-0.0.21-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:cfb884bc677cf95d77c0e28285e9ef3d9875ce708b25d9544fd80ef0b1894b65", size = 4029508, upload-time = "2025-08-11T17:32:00.423Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/3a/8c1242854284406fadfc64013962e8e13ff610364ddd1508140c0d1a6866/truss_transfer-0.0.21-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a9f166702a2089072223b321e33dc8cdbe279cec96c50346ce036366a3a71747", size = 4114976, upload-time = "2025-08-11T17:32:04.201Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/fe/39b105ac04df97110d6b1428ce04cdd99ff32825e92717767f522d3d3404/truss_transfer-0.0.21-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c46b6a322400f64a79a501bb55bfea21e488acd154e43a96971fe4a0dedc546a", size = 3660910, upload-time = "2025-08-11T17:31:50.369Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/0c/4d43b671eb34356477e9b70167e3c82676db14f176248890a542b6f2aeed/truss_transfer-0.0.21-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:c243be725baef52000cafda9064cf02a2823c598ccc435b1e21d3aaed2e27d40", size = 3503149, upload-time = "2025-08-11T17:31:46.964Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/ec/c42bd552a16896572ea43a355bbe079d41b0d2e4ef93d549eb4d86e93d47/truss_transfer-0.0.21-cp38-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b824212487c1acb6f35a9d78cb8f69f10f123d0346b38714b79b8be998598598", size = 4071660, upload-time = "2025-08-11T17:31:37.819Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/d6/5eba07d01afdf99322aacc85d9acf7309f20bd4e21dd670b098f720a5ca4/truss_transfer-0.0.21-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:959d3ca127d48c74a3b12284ffc4828996e22d1cb7a768e4b2cda5ff937cfa44", size = 4898228, upload-time = "2025-08-11T17:31:33.193Z" },
-    { url = "https://files.pythonhosted.org/packages/11/5d/60fee8234bc6b102c07f2cce837609167ed860b9fb8f797188174014aefb/truss_transfer-0.0.21-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0758a2df4f27fa45008f26e5d8f2715e188950f43c7722df038b284bd0210901", size = 3953172, upload-time = "2025-08-11T17:31:42.206Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/03/989392e76761efb212aa2cd527e605ef705b7ddc7b5ef401fa3dcbb7c51e/truss_transfer-0.0.21-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:33e76b6b7864a10b2866137c08bf6bffea08baaa77dd8a60e2e9b43c26f9e18d", size = 3875492, upload-time = "2025-08-11T17:31:25.67Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/40/a6f2a4dba040bfdb4950601dfb9a38da28bfb96a3596a38b31967ed220eb/truss_transfer-0.0.21-cp38-abi3-manylinux_2_28_armv7l.whl", hash = "sha256:dd0f19db5c308357d178fb9e0fb1bd10f204ef037b659fcbd95008a605873dfe", size = 3689010, upload-time = "2025-08-11T17:31:28.421Z" },
-    { url = "https://files.pythonhosted.org/packages/38/44/84762dbc6dbeec084d704c0f133072e1bcdc6b018861e673e4150b1b9930/truss_transfer-0.0.21-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ff0bfb19776af907e14400b240b0165e98bd202a7ad558f0ad6bf7ee1e09f0b2", size = 4041724, upload-time = "2025-08-11T17:31:54.443Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/c4/620ad4b5557418832887ecc74ea2f56792fad7300be833c5d4ef3053d45b/truss_transfer-0.0.21-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:261cd9a72edc2e59039eaee609cc80d1be242c3f1cafbad2e9de4cc0cee2f573", size = 3914397, upload-time = "2025-08-11T17:31:58.306Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/ee/776c0720537e61a9a33615abcc451e8223fa8ce49ce16afc7d2f30424077/truss_transfer-0.0.21-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:563e553f15bc2338cd972a2e397c525240255ff958aaeb4019fa41a42b7fe179", size = 4033811, upload-time = "2025-08-11T17:32:02.394Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/7f/3ef6bdb119fa4ee4dd5342168151edbdd78fb0b87cf091d0b6511493c56f/truss_transfer-0.0.21-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:cdf08c6c4d078e87fca8d06ab4b1b1656f5da9476d8453758dbdc4775ead9020", size = 4119593, upload-time = "2025-08-11T17:32:05.947Z" },
-    { url = "https://files.pythonhosted.org/packages/af/c1/7f7364a9ea2eaaa48bf62cc2070c8cabbc5842f34d93897764f9685961ad/truss_transfer-0.0.21-cp38-abi3-win32.whl", hash = "sha256:6142cf67912d70c1067c710efa15774f44bb07bbfb58c8f28069710fdbe08806", size = 2851162, upload-time = "2025-08-11T17:32:10.587Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/49/a77f1fec23483a0afb5adbcd3d60d4a0554494a285e08eb35167c4f7aaf8/truss_transfer-0.0.21-cp38-abi3-win_amd64.whl", hash = "sha256:9c6cefa243b1e4393dfe071881c20c474fb3955d3b03a2fe5529ba15b20a3a66", size = 3264387, upload-time = "2025-08-11T17:32:08.584Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/9c/4b0383ae639924708ac76c248e00fbc5d720eff1bff061e3e570597f000b/truss_transfer-0.0.22-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:f66886255c9b2b4b610038deb5900b331c559a9f49ee4f0d4c476bd093ebc15b", size = 3654419, upload-time = "2025-08-12T21:47:53.225Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/d6/b7c86c51eb37993c3b92c38468fa161f26861afd95acd2eedf09f1dac05c/truss_transfer-0.0.22-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3f45d04e8b098dd30512a76141277f30ded55a96489239d75707b842143fcddb", size = 3497854, upload-time = "2025-08-12T21:47:50.057Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/cf/dcd4a544642fd66ddf08b9c05e09572981aab22cec0023fbc767e2670946/truss_transfer-0.0.22-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0db230b549a1193437c3625e756ff8939863090a1a22183961ffc79d09e58de6", size = 4068829, upload-time = "2025-08-12T21:47:42.628Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/c9/888c29735ae4e76403e29b3cd2e7d8302e65e3ebeaeec0c2776884de87f9/truss_transfer-0.0.22-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:482b1e99eed0b87328ad78e496c0f920eebeb848373b41ccd8da2430e8a29930", size = 4896458, upload-time = "2025-08-12T21:47:38.752Z" },
+    { url = "https://files.pythonhosted.org/packages/de/2b/3faceb8e6c10e466fe8ead43288911b19617b799fd3234719238fde8bb13/truss_transfer-0.0.22-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f238411c898da41d972f66d1300f89e35aee6de89d8a61bb3e78ad13ee12a035", size = 3954061, upload-time = "2025-08-12T21:47:46.211Z" },
+    { url = "https://files.pythonhosted.org/packages/00/15/d5a81de573aa9c76f2664e7f01cbabf920bc9504917e1cb3cdf35213fdc4/truss_transfer-0.0.22-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:14e7734a1ab13061de6ca4ab1b94bc97fdd3bb3f369316a053d51650334a313f", size = 4045548, upload-time = "2025-08-12T21:47:56.352Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/79/5531664ff5dde9766d52205390d2132239c2a11a6ff7590b294d17ea3486/truss_transfer-0.0.22-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:ad0bf7484f0d1fbc6cba65bc51db7c1d9549d638b2fe9235da41d6e0d2d8d893", size = 3916327, upload-time = "2025-08-12T21:47:59.51Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ae/78acaa30259c35044f03ce53b3e12faefdb282397c8300ab04d06a09f1e2/truss_transfer-0.0.22-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:824a1c371ea26bfaed6ccd7764382a649d31de5111c363445f0f7c54e9fe56cb", size = 4032915, upload-time = "2025-08-12T21:48:02.853Z" },
+    { url = "https://files.pythonhosted.org/packages/da/77/7f5492ba09610ecb686c6f0f1b9c4379976799345b683dd7e50482bb5687/truss_transfer-0.0.22-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:45673f0586bde1d5234811f75827b188a80bc066f655214a2282ea8dbe7d57a0", size = 4117807, upload-time = "2025-08-12T21:48:05.961Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/2a/ced97477a5619416c5e987e14ca78a9cd3a436f487e8421c8a61d5928b2e/truss_transfer-0.0.22-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:3d8ff9187f3b991859295a81adc1b73b93444634a27722dd81b7f14083764164", size = 3659360, upload-time = "2025-08-12T21:47:54.98Z" },
+    { url = "https://files.pythonhosted.org/packages/df/3e/45a700763c54e81fc219a23741fed64b4946fe98a63e87fd20a5e9b915be/truss_transfer-0.0.22-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:5e2f20053bd06e1629bde9962dfd3ff9cf57f261476ec946bf1a1a3b076ca383", size = 3500626, upload-time = "2025-08-12T21:47:51.428Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/00/d5f4901219382ffba89201c7a55ce567c0ae920a2525d0fde4a9c9341863/truss_transfer-0.0.22-cp38-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bd5c5f15ac28641e75564873f1d2a6ff14cc89c1beff9cb4e68ac5dbee88019f", size = 4072150, upload-time = "2025-08-12T21:47:44.266Z" },
+    { url = "https://files.pythonhosted.org/packages/41/c9/00e3ca9e8d7c35f0d15b18a1208c2877baafe0c3419a9f9242d333e2b724/truss_transfer-0.0.22-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bf85743182123eb7b00cb8c451a86905f2ad258dbc0c6699171e86ecf2bd8a7e", size = 4897992, upload-time = "2025-08-12T21:47:40.847Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/c3/9aff28a8a1b712ddf71fa9fb81f18aefffce2f72a2e2e646eed6f0775cb5/truss_transfer-0.0.22-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:42bfebbde013f4c727ce3d0cd230a2285b7b3cddef0438229ee7d8d5ab79018b", size = 3956809, upload-time = "2025-08-12T21:47:47.972Z" },
+    { url = "https://files.pythonhosted.org/packages/48/29/2b50c773754cb551abe9ebe93734caf396d09ff7143d062c2e4d39730751/truss_transfer-0.0.22-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:95621510f22a1e73e78cd85052709afa65f0bd37faf67cdebefd1774764f9d44", size = 3880652, upload-time = "2025-08-12T21:47:35.132Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/c4/88b334287c1ef923eb4d4f929e9bfdc9e39f120a51f702d4912fe9328d73/truss_transfer-0.0.22-cp38-abi3-manylinux_2_28_armv7l.whl", hash = "sha256:d2f7a77344265f2e86974ce3a48f366cff4be5388e015ed4ba8ea63f75dfbd18", size = 3692463, upload-time = "2025-08-12T21:47:36.931Z" },
+    { url = "https://files.pythonhosted.org/packages/73/11/e7756da14a367ac6e632db982aa74b58ab66d35f1ec60521b57dd9833f40/truss_transfer-0.0.22-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:32ebb5bb212936d6ad80eb0f1324a351de69238660c7a545b614100d95dc1871", size = 4047601, upload-time = "2025-08-12T21:47:58.068Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/93/279c6dc1fb3bc6a97275ca7d25043fe2ec8abdfa04419660a8125c6b838e/truss_transfer-0.0.22-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:0257427d599a064c21fc5c33cc190658d3209e0a9827182cf68ab90249a12043", size = 3923229, upload-time = "2025-08-12T21:48:01.513Z" },
+    { url = "https://files.pythonhosted.org/packages/94/0e/cdfc3403c5d00228cc6da989b29541b0bf0c4172a3f8cc94a9cd2d4dd347/truss_transfer-0.0.22-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:a250abacd734569a3808d0bff1ac95fb1200123095cec3c323dfc11fbf0e2929", size = 4037997, upload-time = "2025-08-12T21:48:04.657Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/29/3d451ec131cde4581617b9050ea5e06d7dd94c325f8c9c27b5edbcb5f54b/truss_transfer-0.0.22-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:19ee65c3fb3958716d2e5fcc687f1a6f47a4bc7c9c6557bfb2f0b39a5a6c3614", size = 4120459, upload-time = "2025-08-12T21:48:07.503Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/52/8e5ff90de4eb5edc0e9435820af545aabc2309246d6c3c5bcd6c61c0af3d/truss_transfer-0.0.22-cp38-abi3-win32.whl", hash = "sha256:26caab26ad8672f383541355c2656f1f854ebd21362a8fd980bcbfbad3237616", size = 2849855, upload-time = "2025-08-12T21:48:11.698Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/96/2ed7c3809fcd8961d81f5c7c4112a6eb7ffd1cb8d670d2bae05c3ada708f/truss_transfer-0.0.22-cp38-abi3-win_amd64.whl", hash = "sha256:bb590cba35027b77bb5322462556673dcb279e49d6a3f89a612da04220440abe", size = 3267770, upload-time = "2025-08-12T21:48:10.158Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
```
truss push --remote baseten --publish
trt_llm.runtime.patch_kwargs is a preview feature. Fields may change in the future.           
ERROR ValidationError: 1 validation error for TrussConfig
trt_llm.v2
  Value error, Field trt_llm.build.skip_build_result is not allowed to be set when using v2 
inference stack.  [type=value_error, input_value={'build': {'checkpoint_re...tuner_enabled': 
False}}}, input_type=dict]
```

Skip build job not set in allowlist, using both truss 0.10.1 and truss 0.10.2rc2

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
