### PR TITLE
Change checkpoints file name to be continuous/have no spaces

### DIFF
--- a/truss/cli/train/core.py
+++ b/truss/cli/train/core.py
@@ -385,7 +385,7 @@ def download_checkpoint_artifacts(
         "checkpoint_artifacts": checkpoint_artifacts,
     }
 
-    urls_file = output_dir / f"{project_name}_{job_id}_checkpoints.json"
+    urls_file = output_dir / f"{project_name.replace(' ', '-')}_{job_id}_checkpoints.json"
     with open(urls_file, "w") as f:
         json.dump(output, f, indent=2)
 

--- a/truss/cli/train/core.py
+++ b/truss/cli/train/core.py
@@ -385,7 +385,9 @@ def download_checkpoint_artifacts(
         "checkpoint_artifacts": checkpoint_artifacts,
     }
 
-    urls_file = output_dir / f"{project_name.replace(' ', '-')}_{job_id}_checkpoints.json"
+    urls_file = (
+        output_dir / f"{project_name.replace(' ', '-')}_{job_id}_checkpoints.json"
+    )
     with open(urls_file, "w") as f:
         json.dump(output, f, indent=2)
 


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What

Makes file being written to have a filename with no spaces for easier access from terminal/shell/python.

Changes output from this
<img width="1015" height="49" alt="Screenshot 2025-08-13 at 10 35 56 AM" src="https://github.com/user-attachments/assets/8e69ad98-0fb0-449c-b3f0-58d7946f5b32" />

to this
<img width="1073" height="46" alt="Screenshot 2025-08-13 at 10 39 49 AM" src="https://github.com/user-attachments/assets/3c1bc3f7-f510-4fc3-8e21-16e3244471ae" />


<!--
  How was the change described above implemented?
-->
## :computer: How
Replace spaces with -

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
Only filename change, test proof in the above screenshots
