### PR TITLE
Pin truss base images to bookworm

### DIFF
--- a/truss-chains/tests/itest_chain/itest_chain.py
+++ b/truss-chains/tests/itest_chain/itest_chain.py
@@ -17,7 +17,7 @@ IMAGE_CUSTOM = chains.DockerImage(
     # TODO: Specifying py path gives a weird error during remote build (works locally)
     #   0.037 /bin/sh: 1: pip: Too many levels of symbolic links
     base_image=chains.CustomImage(
-        image="python:3.11-slim"  # , python_executable_path="/usr/local/bin/python"
+        image="python:3.11-slim-bookworm"  # , python_executable_path="/usr/local/bin/python"
     ),
     pip_requirements_file=chains.make_abs_path_here("requirements.txt"),
 )

--- a/truss/tests/test_truss_handle.py
+++ b/truss/tests/test_truss_handle.py
@@ -115,11 +115,8 @@ def _generate_base_image_variations(
             (base_template.format(version, version_tag), base_py3_path, False)
         )
 
-        # NB(nikhil): Python 3.8 base images currently don't have support for development models
-        # on GPUs.
-        fail = False if version != "3.8" else True
         variations.append(
-            (base_template.format(f"{version}-gpu", version_tag), gpu_py3_path, fail)
+            (base_template.format(f"{version}-gpu", version_tag), gpu_py3_path, False)
         )
     return variations
 
@@ -129,15 +126,15 @@ def _generate_base_image_variations(
     "base_image, path, expected_fail",
     _generate_base_image_variations()
     + [
-        ("python:3.8", "/usr/local/bin/python3", False),
-        ("python:3.10", "/usr/local/bin/python3", False),
-        ("python:3.11", "/usr/local/bin/python3", False),
-        ("python:3.13", "/usr/local/bin/python3", False),
+        ("python:3.8-bookworm", "/usr/local/bin/python3", False),
+        ("python:3.10-bookworm", "/usr/local/bin/python3", False),
+        ("python:3.11-bookworm", "/usr/local/bin/python3", False),
+        ("python:3.13-bookworm", "/usr/local/bin/python3", False),
         ("python:alpine", "/usr/local/bin/python3", True),
         ("python:2.7-slim", "/usr/local/bin/python", True),
         ("python:3.7-slim", "/usr/local/bin/python3", True),
         # Base image with `uv` already included.
-        ("ghcr.io/astral-sh/uv:python3.11-bookworm", "/usr/local/bin/python3", True),
+        ("ghcr.io/astral-sh/uv:python3.11-bookworm", "/usr/local/bin/python3", False),
     ],
 )
 def test_build_serving_docker_image_from_user_base_image_live_reload(
@@ -148,8 +145,9 @@ def test_build_serving_docker_image_from_user_base_image_live_reload(
     th.live_reload()
     try:
         th.build_serving_docker_image(cache=False)
+        assert not expected_fail
     except DockerException as exc:
-        assert expected_fail is True
+        assert expected_fail
         assert "It returned with code 1" in str(exc)
 
 


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Integration tests seem to be failing, I've narrowed it down to `software-properties-common` failing to install on `trixie` based Debian images, while they continue to work on `bookworm`. For now, we'll pin our tests to `bookworm` to unblock releases, but we need to figure out if we need to release a new version of truss ASAP.

Integration tests: https://github.com/basetenlabs/truss/actions/runs/16947811600

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
Works: `docker run -it --rm --platform linux/amd64 python:3.10-bookworm bash -c "apt update && apt install -y software-properties-common"`
Fails: `docker run -it --rm --platform linux/amd64 python:3.10-trixie bash -c "apt update && apt install -y software-properties-common"`
