### PR TITLE
Make builds `trixie` compatible

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "truss"
-version = "0.10.3rc001"
+version = "0.10.3rc002"
 description = "A seamless bridge from model development to model delivery"
 authors = [
     { name = "Pankaj Gupta", email = "no-reply@baseten.co" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "truss"
-version = "0.10.2"
+version = "0.10.3rc001"
 description = "A seamless bridge from model development to model delivery"
 authors = [
     { name = "Pankaj Gupta", email = "no-reply@baseten.co" },

--- a/truss/templates/server.Dockerfile.jinja
+++ b/truss/templates/server.Dockerfile.jinja
@@ -15,12 +15,7 @@ ENV DEBIAN_FRONTEND="noninteractive"
 
 {# Install common dependencies #}
 RUN apt update && \
-    apt install -y bash \
-                build-essential \
-                git \
-                curl \
-                ca-certificates \
-                software-properties-common \
+    apt install -y bash build-essential git curl ca-certificates \
     && apt-get autoremove -y \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*

--- a/truss/tests/test_data/server.Dockerfile
+++ b/truss/tests/test_data/server.Dockerfile
@@ -17,12 +17,7 @@ ENV PATH="/root/.local/bin:$PATH"
 ENV PYTHONUNBUFFERED="True"
 ENV DEBIAN_FRONTEND="noninteractive"
 RUN apt update && \
-    apt install -y bash \
-                build-essential \
-                git \
-                curl \
-                ca-certificates \
-                software-properties-common \
+    apt install -y bash build-essential git curl ca-certificates \
     && apt-get autoremove -y \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*

--- a/truss/tests/test_truss_handle.py
+++ b/truss/tests/test_truss_handle.py
@@ -129,7 +129,7 @@ def _generate_base_image_variations(
         ("python:3.8-bookworm", "/usr/local/bin/python3", False),
         ("python:3.10-bookworm", "/usr/local/bin/python3", False),
         ("python:3.11-bookworm", "/usr/local/bin/python3", False),
-        ("python:3.13-bookworm", "/usr/local/bin/python3", False),
+        ("python:3.13-trixie", "/usr/local/bin/python3", False),
         ("python:alpine", "/usr/local/bin/python3", True),
         ("python:2.7-slim", "/usr/local/bin/python", True),
         ("python:3.7-slim", "/usr/local/bin/python3", True),


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Builds on https://github.com/basetenlabs/truss/pull/1852, makes our builds compatible with `trixie` which [removed](https://github.com/wimpysworld/deb-get/issues/1215) `software-properties-common`. 

I don't think we actually need it on this path (from Claude), but will require some testing

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
Integration tests: https://github.com/basetenlabs/truss/actions/runs/16948613901
