### PR TITLE
Add check for `uv.lock` up to date

### DIFF
--- a/.github/workflows/create_release_pr.yml
+++ b/.github/workflows/create_release_pr.yml
@@ -31,11 +31,14 @@ jobs:
       id: bump-version
       run: ./bin/bump_truss_version.sh ${{ steps.get-version.outputs.curr_version }} ${{ github.event.inputs.release_type }}
 
+    - name: Update lock file
+      run: uv lock
+
     - name: Commit changes
       run: |
         git config --local user.email "96544894+basetenbot@users.noreply.github.com"
         git config --local user.name "basetenbot"
-        git add pyproject.toml
+        git add pyproject.toml uv.lock
         git commit -m "Bump version to $TARGET_VERSION"
       env:
         TARGET_VERSION: ${{ steps.bump-version.outputs.version }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,7 +22,6 @@ jobs:
           SKIP: ruff,ruff-format # In CI run ruff separately to only check, not fix.
       - name: ruff check
         run: |
-          uv lock --check
           uv run ruff check .
           uv run ruff format . --check
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,3 +34,9 @@ repos:
         types: [python]
         exclude: ^examples/|^truss/test.+/|model.py$
         pass_filenames: true
+      - id: uv-lock
+        name: uv lock
+        entry: uv lock
+        language: system
+        files: ^(pyproject\.toml|uv\.lock)$
+        pass_filenames: false

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.9, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -3292,7 +3292,7 @@ wheels = [
 
 [[package]]
 name = "truss"
-version = "0.10.2rc6"
+version = "0.10.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Small improvements:
- `uv` seems to put the current revision in the `uv.lock` - in order to keep things up to date, we have a pre-commit check that locks (very fast). CI will also enforce this.
- When we bump for releases, we need the release PR to also do this `uv lock` step

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
