### PR TITLE
Allow run of precommit from GHA Web interface

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,6 +1,7 @@
 name: PR - pre-commit
 
 on:
+  workflow_dispatch: # Allows running from actions tab
   pull_request:
 
 concurrency:


### PR DESCRIPTION
## :rocket: What
Allow run of precommit from GHA Web interface.

This allows us to push the branch, trigger this workflow and fix broken tests prior to opening the PR.

## :computer: How
Add `workflow_dispatch:` to the relevant workflow file.

## :microscope: Testing
To be tested.