### PR TITLE
Experiment: More declarative runtime var approach

### DIFF
--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -733,6 +733,13 @@ class TrussConfig(custom_types.ConfigModel):
         exclude_unset = bool(info.context and "verbose" in info.context)
         return trt_llm.model_dump(exclude_unset=exclude_unset)
 
+    # NB(nikhil): sanitize_runtime_fields will remove all runtime specific fields from the config so
+    # we can more optimally detect whether a new image build is needed.
+    def sanitize_runtime_fields(self) -> None:
+        self.docker_server = None
+        self.training_checkpoints = None
+        self.environment_variables = {}
+
 
 def _map_to_supported_python_version(python_version: str) -> str:
     """Map python version to truss supported python version.

--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -599,19 +599,25 @@ class TrussConfig(custom_types.ConfigModel):
     requirements_file: Optional[str] = None
     requirements: list[str] = pydantic.Field(default_factory=list)
     system_packages: list[str] = pydantic.Field(default_factory=list)
-    environment_variables: Annotated[dict[str, str], pydantic.Field(default_factory=dict, runtime_only=True)]
+    environment_variables: Annotated[
+        dict[str, str], pydantic.Field(default_factory=dict, runtime_only=True)
+    ]
     secrets: MutableMapping[str, Optional[str]] = pydantic.Field(default_factory=dict)
 
     resources: Resources = pydantic.Field(default_factory=Resources)
     runtime: Runtime = pydantic.Field(default_factory=Runtime)
     build: Build = pydantic.Field(default_factory=Build)
     build_commands: list[str] = pydantic.Field(default_factory=list)
-    docker_server: Annotated[Optional[DockerServer], pydantic.Field(runtime_only=True)] = None
+    docker_server: Annotated[
+        Optional[DockerServer], pydantic.Field(runtime_only=True)
+    ] = None
     model_cache: ModelCache = pydantic.Field(default_factory=lambda: ModelCache([]))
     trt_llm: Optional[trt_llm_config.TRTLLMConfiguration] = None
 
     # deploying from checkpoint
-    training_checkpoints: Annotated[Optional[CheckpointList], pydantic.Field(runtime_only=True)] = None
+    training_checkpoints: Annotated[
+        Optional[CheckpointList], pydantic.Field(runtime_only=True)
+    ] = None
 
     # Internal / Legacy.
     input_type: str = "Any"
@@ -738,7 +744,9 @@ class TrussConfig(custom_types.ConfigModel):
     def sanitize_runtime_fields(self) -> None:
         """Remove all runtime-specific fields from the config."""
         for field_name, field_info in self.__class__.model_fields.items():
-            if field_info.json_schema_extra and field_info.json_schema_extra.get('runtime_only'):
+            if field_info.json_schema_extra and field_info.json_schema_extra.get(
+                "runtime_only"
+            ):
                 current_value = getattr(self, field_name)
                 if isinstance(current_value, dict):
                     setattr(self, field_name, {})

--- a/truss/cli/train/deploy_checkpoints/__init__.py
+++ b/truss/cli/train/deploy_checkpoints/__init__.py
@@ -1,3 +1,3 @@
-from .deploy_checkpoints import create_build_time_config, prepare_checkpoint_deploy
+from .deploy_checkpoints import prepare_checkpoint_deploy
 
-__all__ = ["create_build_time_config", "prepare_checkpoint_deploy"]
+__all__ = ["prepare_checkpoint_deploy"]

--- a/truss/cli/train/deploy_checkpoints/deploy_checkpoints.py
+++ b/truss/cli/train/deploy_checkpoints/deploy_checkpoints.py
@@ -36,24 +36,6 @@ CHECKPOINT_PATTERN = re.compile(r".*checkpoint-\d+(?:-\d+)?$")
 ALLOWED_DEPLOYMENT_NAMES = re.compile(r"^[0-9a-zA-Z_\-\.]*$")
 
 
-def create_build_time_config(context_path_str: Path) -> None:
-    """Create a build time config for the truss, excludes run-time only attributes."""
-    truss_config_obj = truss_config.TrussConfig.from_yaml(
-        context_path_str / "config.yaml"
-    )
-
-    # we will set the start command at runtime, so we don't need to include it in the build hash
-    if truss_config_obj.docker_server:
-        truss_config_obj.docker_server.start_command = ""
-    # we will set the checkpoints at runtime, so we don't need to include them in the build hash
-    truss_config_obj.training_checkpoints = None
-    # we will set the environment variables at runtime, so we don't need to include them in the build hash
-    truss_config_obj.environment_variables = {}
-
-    # write the truss config back to a file (used for build hash calculation)
-    truss_config_obj.write_to_yaml_file(context_path_str / "config_build_time.yaml")
-
-
 def prepare_checkpoint_deploy(
     remote_provider: BasetenRemote,
     checkpoint_deploy_config: DeployCheckpointsConfig,
@@ -69,7 +51,6 @@ def prepare_checkpoint_deploy(
     truss_directory = Path(tempfile.mkdtemp())
     truss_config_path = truss_directory / "config.yaml"
     rendered_truss.write_to_yaml_file(truss_config_path)
-    create_build_time_config(truss_directory)
     console.print(rendered_truss, style="green")
     console.print(f"Writing truss config to {truss_config_path}", style="yellow")
     return PrepareCheckpointResult(

--- a/truss/contexts/image_builder/serving_image_builder.py
+++ b/truss/contexts/image_builder/serving_image_builder.py
@@ -721,16 +721,13 @@ class ServingImageBuilder(ImageBuilder):
         if build_hash_path.exists():
             shutil.rmtree(build_hash_path)
         shutil.copytree(build_dir, build_hash_path)
-        # remove the config.yaml file from the build_hash directory
-        # we will use only config_build_time.yaml to compute the hash
+
+        # Sanitize the TrussConfig in the hash directory, remove all runtime attributes.
         config_file_path = build_hash_path / "config.yaml"
         if config_file_path.exists():
-            config_file_path.unlink()
-        # similarly, remove the build-time config from the context directory
-        # else it will clobber prior hashes
-        config_build_time_file_path = build_dir / "config_build_time.yaml"
-        if config_build_time_file_path.exists():
-            config_build_time_file_path.unlink()
+            truss_config = TrussConfig.from_yaml(config_file_path)
+            truss_config.sanitize_runtime_fields()
+            truss_config.write_to_yaml_file(config_file_path)
 
     def _render_dockerfile(
         self,

--- a/truss/tests/contexts/image_builder/test_serving_image_builder.py
+++ b/truss/tests/contexts/image_builder/test_serving_image_builder.py
@@ -533,3 +533,15 @@ def _assert_copied(src_path: str, dest_path: str):
             assert filecmp.cmp(src_file, dest_file, shallow=False), (
                 f"{src_file} and {dest_file} are not the same"
             )
+
+
+def test_hash_dir_sanitization(custom_model_truss_dir):
+    th = TrussHandle(custom_model_truss_dir)
+    th.add_environment_variable("foo", "bar")
+    image_builder = ServingImageBuilderContext.run(th.spec.truss_dir)
+
+    with TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir)
+        image_builder.prepare_image_build_dir(tmp_path)
+        truss_config = TrussConfig.from_yaml(tmp_path / "build_hash" / "config.yaml")
+        assert truss_config.environment_variables == {}

--- a/truss/tests/test_config.py
+++ b/truss/tests/test_config.py
@@ -18,8 +18,10 @@ from truss.base.truss_config import (
     BaseImage,
     Build,
     CacheInternal,
+    CheckpointList,
     DockerAuthSettings,
     DockerAuthType,
+    DockerServer,
     HTTPOptions,
     ModelCache,
     ModelRepo,
@@ -977,3 +979,26 @@ def test_supported_versions_are_sorted():
     assert semvers == semvers_sorted, (
         f"{constants.SUPPORTED_PYTHON_VERSIONS} must be sorted ascendingly"
     )
+
+
+def test_sanitize_runtime_fields():
+    config = TrussConfig(
+        python_version="py39",
+        docker_server=DockerServer(
+            start_command="./foo",
+            server_port=10,
+            predict_endpoint="/predict",
+            readiness_endpoint="/ready",
+            liveness_endpoint="/live",
+        ),
+        training_checkpoints=CheckpointList(
+            download_folder="/tmp", checkpoints=[], artifact_references=[]
+        ),
+        environment_variables={"FOO": "BAR"},
+    )
+
+    config.sanitize_runtime_fields()
+    assert config.python_version == "py39"
+    assert config.docker_server is None
+    assert config.training_checkpoints is None
+    assert config.environment_variables == {}

--- a/truss/tests/test_config.py
+++ b/truss/tests/test_config.py
@@ -1000,10 +1000,12 @@ def test_sanitize_runtime_fields():
     # Get runtime field names dynamically from field metadata
     runtime_fields = []
     for field_name, field_info in TrussConfig.model_fields.items():
-        if field_info.json_schema_extra and field_info.json_schema_extra.get('runtime_only'):
+        if field_info.json_schema_extra and field_info.json_schema_extra.get(
+            "runtime_only"
+        ):
             runtime_fields.append(field_name)
-    
-    config.sanitize_runtime_fields()    
+
+    config.sanitize_runtime_fields()
     assert config.python_version == "py39"
     # Verify all runtime fields are sanitized
     for field_name in runtime_fields:

--- a/truss/truss_handle/truss_handle.py
+++ b/truss/truss_handle/truss_handle.py
@@ -309,12 +309,9 @@ class TrussHandle:
                 envs["PATCH_PING_URL_TRUSS"] = patch_ping_url
             if disable_json_logging:
                 envs["DISABLE_JSON_LOGGING"] = "true"
-            if self.spec.config.docker_server and self.spec.config.training_checkpoints:
-                envs["BT_DOCKER_SERVER_START_CMD"] = (
-                    self.spec.config.docker_server.start_command
-                )
 
-            # Add environment variables from config
+            # For traditional model deploys, env variables are provided in the k8s spec,
+            # so we have to manually add them here.
             envs.update(self.spec.config.environment_variables)
 
             if container_name_prefix:


### PR DESCRIPTION
## :rocket: What
Use a more declarative way to enumerate runtime variables.

This will prevent us from re-listing such variables in sanitization, tests etc.

## :computer: How
Use Pydantic annotation. This is not my idea, it was suggested by Claude.

## :microscope: Testing
Updated unit test. Verified that it runs successfully locally.