### PR TITLE
Bring back docker server for buildless deploys

### DIFF
--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -736,7 +736,6 @@ class TrussConfig(custom_types.ConfigModel):
     # NB(nikhil): clear_runtime_fields will remove all runtime specific fields from the config so
     # we can more optimally detect whether a new image build is needed.
     def clear_runtime_fields(self) -> None:
-        self.docker_server = None
         self.training_checkpoints = None
         self.environment_variables = {}
 

--- a/truss/tests/test_config.py
+++ b/truss/tests/test_config.py
@@ -21,7 +21,6 @@ from truss.base.truss_config import (
     CheckpointList,
     DockerAuthSettings,
     DockerAuthType,
-    DockerServer,
     HTTPOptions,
     ModelCache,
     ModelRepo,
@@ -984,13 +983,6 @@ def test_supported_versions_are_sorted():
 def test_clear_runtime_fields():
     config = TrussConfig(
         python_version="py39",
-        docker_server=DockerServer(
-            start_command="./foo",
-            server_port=10,
-            predict_endpoint="/predict",
-            readiness_endpoint="/ready",
-            liveness_endpoint="/live",
-        ),
         training_checkpoints=CheckpointList(
             download_folder="/tmp", checkpoints=[], artifact_references=[]
         ),
@@ -999,6 +991,5 @@ def test_clear_runtime_fields():
 
     config.clear_runtime_fields()
     assert config.python_version == "py39"
-    assert config.docker_server is None
     assert config.training_checkpoints is None
     assert config.environment_variables == {}


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
There's a slight bug in 0.10.5, but all gated behind a feature flag that is not rolled out yet - if the only changes in a config are in the `docker_server` section, we'll pull from the previous image and not respect the new values. This PR fixes that (by forcing a rebuild)

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
