### PR TITLE
feat(truss): Multinode metrics

### DIFF
--- a/truss/cli/train/metrics_watcher.py
+++ b/truss/cli/train/metrics_watcher.py
@@ -168,10 +168,27 @@ class MetricsWatcher(TrainingPollerMixin):
         per_node_metrics = metrics_data.get("per_node_metrics", [])
 
         if not per_node_metrics:
-            raise ValueError(
-                "Expected 'per_node_metrics' in training job metrics response. "
-                "The API has been updated to always provide per-node metrics."
+            # Job is likely just starting up - show waiting message
+            from rich.text import Text
+
+            waiting_table = Table(title="Training Job Status")
+            waiting_table.add_column("Status")
+            waiting_table.add_column("Message")
+
+            waiting_table.add_row(
+                "Status",
+                Text("⏳ Waiting for metrics to become available...", style="yellow"),
             )
+            waiting_table.add_row(
+                "Note",
+                Text(
+                    "Metrics will appear once the training job starts running.",
+                    style="dim",
+                ),
+            )
+
+            tables.append(waiting_table)
+            return tables
 
         # Process each node's metrics
         for node_metrics in per_node_metrics:

--- a/truss/tests/cli/train/test_train_cli_core.py
+++ b/truss/tests/cli/train/test_train_cli_core.py
@@ -51,6 +51,38 @@ def test_view_training_job_metrics(time_sleep, capfd):
                 "0": [{"timestamp": "", "value": 4321}],
                 "1": [{"timestamp": "", "value": 2222}],
             },
+            "per_node_metrics": [
+                {
+                    "node_id": "node-0",
+                    "metrics": {
+                        "cpu_usage": [{"timestamp": "", "value": 3.2}],
+                        "cpu_memory_usage_bytes": [{"timestamp": "", "value": 1234}],
+                        "gpu_utilization": {
+                            "0": [{"timestamp": "", "value": 0.2}],
+                            "1": [{"timestamp": "", "value": 0.3}],
+                        },
+                        "gpu_memory_usage_bytes": {
+                            "0": [{"timestamp": "", "value": 4321}],
+                            "1": [{"timestamp": "", "value": 2222}],
+                        },
+                    },
+                },
+                {
+                    "node_id": "node-1",
+                    "metrics": {
+                        "cpu_usage": [{"timestamp": "", "value": 2.8}],
+                        "cpu_memory_usage_bytes": [{"timestamp": "", "value": 1000}],
+                        "gpu_utilization": {
+                            "0": [{"timestamp": "", "value": 0.15}],
+                            "1": [{"timestamp": "", "value": 0.25}],
+                        },
+                        "gpu_memory_usage_bytes": {
+                            "0": [{"timestamp": "", "value": 4000}],
+                            "1": [{"timestamp": "", "value": 2000}],
+                        },
+                    },
+                },
+            ],
         },
         {
             "training_job": {
@@ -68,6 +100,38 @@ def test_view_training_job_metrics(time_sleep, capfd):
                 "0": [{"timestamp": "", "value": 4321}],
                 "1": [{"timestamp": "", "value": 2222}],
             },
+            "per_node_metrics": [
+                {
+                    "node_id": "node-0",
+                    "metrics": {
+                        "cpu_usage": [{"timestamp": "", "value": 3.2}],
+                        "cpu_memory_usage_bytes": [{"timestamp": "", "value": 1234}],
+                        "gpu_utilization": {
+                            "0": [{"timestamp": "", "value": 0.2}],
+                            "1": [{"timestamp": "", "value": 0.3}],
+                        },
+                        "gpu_memory_usage_bytes": {
+                            "0": [{"timestamp": "", "value": 4321}],
+                            "1": [{"timestamp": "", "value": 2222}],
+                        },
+                    },
+                },
+                {
+                    "node_id": "node-1",
+                    "metrics": {
+                        "cpu_usage": [{"timestamp": "", "value": 2.8}],
+                        "cpu_memory_usage_bytes": [{"timestamp": "", "value": 1000}],
+                        "gpu_utilization": {
+                            "0": [{"timestamp": "", "value": 0.15}],
+                            "1": [{"timestamp": "", "value": 0.25}],
+                        },
+                        "gpu_memory_usage_bytes": {
+                            "0": [{"timestamp": "", "value": 4000}],
+                            "1": [{"timestamp": "", "value": 2000}],
+                        },
+                    },
+                },
+            ],
         },
         {
             "training_job": {
@@ -85,6 +149,38 @@ def test_view_training_job_metrics(time_sleep, capfd):
                 "0": [{"timestamp": "", "value": 4321}],
                 "1": [{"timestamp": "", "value": 2222}],
             },
+            "per_node_metrics": [
+                {
+                    "node_id": "node-0",
+                    "metrics": {
+                        "cpu_usage": [{"timestamp": "", "value": 3.2}],
+                        "cpu_memory_usage_bytes": [{"timestamp": "", "value": 1234}],
+                        "gpu_utilization": {
+                            "0": [{"timestamp": "", "value": 0.2}],
+                            "1": [{"timestamp": "", "value": 0.3}],
+                        },
+                        "gpu_memory_usage_bytes": {
+                            "0": [{"timestamp": "", "value": 4321}],
+                            "1": [{"timestamp": "", "value": 2222}],
+                        },
+                    },
+                },
+                {
+                    "node_id": "node-1",
+                    "metrics": {
+                        "cpu_usage": [{"timestamp": "", "value": 2.8}],
+                        "cpu_memory_usage_bytes": [{"timestamp": "", "value": 1000}],
+                        "gpu_utilization": {
+                            "0": [{"timestamp": "", "value": 0.15}],
+                            "1": [{"timestamp": "", "value": 0.25}],
+                        },
+                        "gpu_memory_usage_bytes": {
+                            "0": [{"timestamp": "", "value": 4000}],
+                            "1": [{"timestamp": "", "value": 2002}],
+                        },
+                    },
+                },
+            ],
         },
     ]
 


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
`truss train metrics --job-id <job id>` 

* standardize use of `usage` (raw) vs `utilization` (percentage) 
* standardize capitalization
* Multinode metrics for training 
<img width="1204" height="535" alt="image" src="https://github.com/user-attachments/assets/1fdfafef-b6d8-4162-ba5a-f39e7f8cb6bd" />

<!--
  How was the change described above implemented?
-->
## :computer: How
* use layouts instead of columns 
* Iterate through the per node metrics
<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
