### PR TITLE
Initial changes for non-root user

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truss"
-version = "0.9.120rc50"
+version = "0.9.120rc508"
 description = "A seamless bridge from model development to model delivery"
 license = "MIT"
 readme = "README.md"

--- a/truss/contexts/image_builder/serving_image_builder.py
+++ b/truss/contexts/image_builder/serving_image_builder.py
@@ -82,6 +82,7 @@ from truss.util.path import (
     load_trussignore_patterns,
 )
 
+APP_USER_ID = "60000"
 BUILD_SERVER_DIR_NAME = "server"
 BUILD_CONTROL_SERVER_DIR_NAME = "control"
 BUILD_SERVER_EXTENSIONS_PATH = "extensions"
@@ -400,7 +401,9 @@ def generate_docker_server_supervisord_config(build_dir, config):
         start_command = "%(ENV_BT_DOCKER_SERVER_START_CMD)s"
     else:
         start_command = config.docker_server.start_command
-    supervisord_contents = supervisord_template.render(start_command=start_command)
+    supervisord_contents = supervisord_template.render(
+        start_command=start_command, app_user_id=APP_USER_ID
+    )
     supervisord_filepath = build_dir / "supervisord.conf"
     supervisord_filepath.write_text(supervisord_contents)
 

--- a/truss/templates/base.Dockerfile.jinja
+++ b/truss/templates/base.Dockerfile.jinja
@@ -8,6 +8,30 @@ FROM {{ base_image_name_and_tag }} AS truss_server
 {%- set python_executable = config.base_image.python_executable_path or 'python3' %}
 ENV PYTHON_EXECUTABLE="{{ python_executable }}"
 
+# Non-root user for the app.
+ENV APP_USERNAME app
+# We choose a high number for user ID to avoid conflicts with existing users.
+ENV APP_USER_UID 60000
+# Directories owned by the non-root user.
+# Directory containing inference server code.
+ENV APP_HOME /app
+# Directory containing control server code.
+ENV CONTROL_SERVER_DIR /control
+# The non-root user's home directory.
+ENV HOME /home/app
+# Create a non-root user to run model containers.
+RUN useradd -u ${APP_USER_UID} -ms /bin/bash ${APP_USERNAME} \
+    && mkdir ${APP_HOME} \
+    && mkdir ${CONTROL_SERVER_DIR} \
+    && chmod -R a=rwx ${APP_HOME} ${HOME} ${CONTROL_SERVER_DIR}
+ENV PATH=${PATH}:${HOME}/.local/bin
+# CAUTION: COPY directives use the root user, so we need to chown the directories to the non-root user.
+# If we have COPY directives after this, we need to run chown again. (or use COPY --chown ...)
+RUN chown -R ${APP_USERNAME}:${APP_USERNAME} ${HOME} ${APP_HOME} ${CONTROL_SERVER_DIR}
+# Now switch to the non-root user early, we will switch back to root where needed.
+USER ${APP_USERNAME}
+ENV PATH="${HOME}/.local/bin:$PATH"
+
 {%- set UV_VERSION = "0.7.19" %}
 {#
 NB(nikhil): We use a semi-complex uv installation command across the board:
@@ -35,11 +59,13 @@ RUN {{ python_exec_path }} -c "import sys; \
 
 {% block install_uv %}
 {# Install `uv` and `curl` if not already present in the image. #}
+USER root
+# FIXME: not using && because of a server-side issue with apt update
+RUN apt update -y; apt install -y curl
+USER ${APP_USERNAME}
 RUN if ! command -v uv >/dev/null 2>&1; then \
-    command -v curl >/dev/null 2>&1 || (apt update && apt install -y curl) && \
     curl -LsSf --retry 5 --retry-delay 5 https://astral.sh/uv/{{ UV_VERSION }}/install.sh | sh; \
 fi
-ENV PATH="/root/.local/bin:$PATH"
 {% endblock %}
 
 {% block base_image_patch %}

--- a/truss/templates/docker_server/supervisord.conf.jinja
+++ b/truss/templates/docker_server/supervisord.conf.jinja
@@ -5,6 +5,7 @@ logfile_maxbytes=0           ; No size limit on logfile (since logging is disabl
 
 [program:model-server]
 command={{start_command}}    ; Command to start the model server (provided by Jinja variable)
+user={{app_user_id}}         ; Run the server as the non-root user
 startsecs=30                 ; Wait 30 seconds before assuming the server is running
 autostart=true               ; Automatically start the program when supervisord starts
 autorestart=true             ; Always restart the program if it exits, no matter what the exit code

--- a/truss/templates/server.Dockerfile.jinja
+++ b/truss/templates/server.Dockerfile.jinja
@@ -14,6 +14,7 @@ ENV PYTHONUNBUFFERED="True"
 ENV DEBIAN_FRONTEND="noninteractive"
 
 {# Install common dependencies #}
+USER root
 RUN apt update && \
     apt install -y bash \
                 build-essential \
@@ -24,6 +25,7 @@ RUN apt update && \
     && apt-get autoremove -y \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
+USER ${APP_USERNAME}
 
 COPY ./{{ base_server_requirements_filename }} {{ base_server_requirements_filename }}
 RUN {{ sys_pip_install_command }} -r {{ base_server_requirements_filename }} --no-cache-dir
@@ -35,7 +37,9 @@ RUN {{ sys_pip_install_command }} -r {{ base_server_requirements_filename }} --n
     {# This is specific to the user-provided base image scenario. #}
 RUN readlink {{ config.base_image.python_executable_path }} &>/dev/null \
     && echo "WARNING: Overwriting existing link at /usr/local/bin/python"
+USER root
 RUN ln -sf {{ config.base_image.python_executable_path }} /usr/local/bin/python
+USER ${APP_USERNAME}
     {%- endif %} {#- endif requires_live_reload #}
 {% endif %} {#- endif config.base_image #}
 
@@ -75,11 +79,13 @@ COPY ./{{ config.data_dir }} /app/data
 
 {%- if model_cache_v2 %}
 # v0.0.9, keep synced with server_requirements.txt
+USER root
 RUN curl -sSL --fail --retry 5 --retry-delay 2 -o /usr/local/bin/truss-transfer-cli https://github.com/basetenlabs/truss/releases/download/v0.9.115rc18/truss-transfer-cli-v0.9.115rc18-linux-x86_64-unknown-linux-musl
 RUN chmod +x /usr/local/bin/truss-transfer-cli
 RUN mkdir /bptr
 RUN echo "hash {{model_cache_hash}}"
 COPY ./bptr-manifest /bptr/static-bptr-manifest.json
+USER ${APP_USERNAME}
 {%- endif %} {#- endif model_cache_v2 #}
 
 {%- if not config.docker_server %}
@@ -107,12 +113,15 @@ COPY ./{{ config.model_module_dir }} /app/model
 {% endblock %} {#- endblock app_copy #}
 
 {% block run %}
+USER root
     {%- if config.docker_server %}
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         curl nginx && rm -rf /var/lib/apt/lists/*
+USER ${APP_USERNAME}
 COPY ./docker_server_requirements.txt /app/docker_server_requirements.txt
 
 {# NB(nikhil): Use the same python version for custom server proxy as the control server, for consistency. #}
+USER root
 RUN uv python install {{ control_python_version }}
 RUN uv venv /docker_server/.venv --python {{ control_python_version }}
 RUN uv pip install --python /docker_server/.venv/bin/python -r /app/docker_server_requirements.txt --no-cache-dir
@@ -127,12 +136,20 @@ ENV SUPERVISOR_SERVER_URL="{{ supervisor_server_url }}"
 ENV SERVER_START_CMD="/docker_server/.venv/bin/supervisord -c {{ supervisor_config_path }}"
 ENTRYPOINT ["/docker_server/.venv/bin/supervisord", "-c", "{{ supervisor_config_path }}"]
     {%- elif requires_live_reload %} {#- elif requires_live_reload #}
+# Run chown again to ensure all files are owned by the non-root user:
+# Docker's COPY directives from earlier would have used the root user.
+RUN chown -R ${APP_USERNAME}:${APP_USERNAME} ${HOME} ${APP_HOME} ${CONTROL_SERVER_DIR}
+USER ${APP_USERNAME}
 ENV HASH_TRUSS="{{ truss_hash }}"
 ENV CONTROL_SERVER_PORT="8080"
 ENV INFERENCE_SERVER_PORT="8090"
 ENV SERVER_START_CMD="/control/.env/bin/python /control/control/server.py"
 ENTRYPOINT ["/control/.env/bin/python", "/control/control/server.py"]
     {%- else %} {#- else (default inference server) #}
+# Run chown again to ensure all files are owned by the non-root user:
+# Docker's COPY directives from earlier would have used the root user.
+RUN chown -R ${APP_USERNAME}:${APP_USERNAME} ${HOME} ${APP_HOME} ${CONTROL_SERVER_DIR}
+USER ${APP_USERNAME}
 ENV INFERENCE_SERVER_PORT="8080"
 ENV SERVER_START_CMD="{{ python_executable }} /app/main.py"
 ENTRYPOINT ["{{ python_executable }}", "/app/main.py"]


### PR DESCRIPTION
## :rocket: What
Use non-root user (60000) for truss

## :computer: How
1. Switch to non-root early during container building.
2. Iteratively add root blocks where needed.
3. Add a final chown because COPY statements use root by default.

Separately,
1. use non-root user in supervisord config.
2. Set user in knative configuration (server-side).

## :microscope: Testing
Tested on local dev-container:
- inference server (model push)
- custom docker server
- training checkpoints
