### PR TITLE
add messages for anthropic sdk compatibility

### DIFF
--- a/truss/templates/server/model_wrapper.py
+++ b/truss/templates/server/model_wrapper.py
@@ -59,6 +59,7 @@ class MethodName(str, enum.Enum):
     CHAT_COMPLETIONS = enum.auto()
     COMPLETIONS = enum.auto()
     IS_HEALTHY = enum.auto()
+    MESSAGES = enum.auto()
     POSTPROCESS = enum.auto()
     PREDICT = enum.auto()
     PREPROCESS = enum.auto()
@@ -244,6 +245,7 @@ class ModelDescriptor:
     is_healthy: Optional[MethodDescriptor]
     completions: Optional[MethodDescriptor]
     chat_completions: Optional[MethodDescriptor]
+    messages: Optional[MethodDescriptor]
     websocket: Optional[MethodDescriptor]
 
     @cached_property
@@ -291,6 +293,7 @@ class ModelDescriptor:
         setup = cls._safe_extract_descriptor(model_cls, MethodName.SETUP_ENVIRONMENT)
         completions = cls._safe_extract_descriptor(model_cls, MethodName.COMPLETIONS)
         chats = cls._safe_extract_descriptor(model_cls, MethodName.CHAT_COMPLETIONS)
+        messages = cls._safe_extract_descriptor(model_cls, MethodName.MESSAGES)
         is_healthy = cls._safe_extract_descriptor(model_cls, MethodName.IS_HEALTHY)
         if is_healthy and is_healthy.arg_config != ArgConfig.NONE:
             raise errors.ModelDefinitionError(
@@ -359,6 +362,7 @@ class ModelDescriptor:
             is_healthy=is_healthy,
             completions=completions,
             chat_completions=chats,
+            messages=messages,
             websocket=websocket,
         )
 
@@ -922,6 +926,14 @@ class ModelWrapper:
     ) -> OutputType:
         descriptor = self._get_descriptor_or_raise(
             self.model_descriptor.chat_completions, MethodName.CHAT_COMPLETIONS
+        )
+        return await self._execute_model_endpoint(inputs, request, descriptor)
+
+    async def messages(
+        self, inputs: InputType, request: starlette.requests.Request
+    ) -> OutputType:
+        descriptor = self._get_descriptor_or_raise(
+            self.model_descriptor.messages, MethodName.MESSAGES
         )
         return await self._execute_model_endpoint(inputs, request, descriptor)
 

--- a/truss/templates/server/truss_server.py
+++ b/truss/templates/server/truss_server.py
@@ -231,6 +231,13 @@ class BasetenEndpoints:
             method=self._model.completions, request=request, body_raw=body_raw
         )
 
+    async def messages(
+        self, request: Request, body_raw: bytes = Depends(parse_body)
+    ) -> Response:
+        return await self._execute_request(
+            method=self._model.messages, request=request, body_raw=body_raw
+        )
+
     async def websocket(self, ws: WebSocket) -> None:
         self.check_healthy()
         trace_ctx = otel_propagate.extract(ws.headers) or None
@@ -425,6 +432,12 @@ class TrussServer:
                 FastAPIRoute(
                     r"/v1/completions",
                     self._endpoints.completions,
+                    methods=["POST"],
+                    tags=["V1"],
+                ),
+                FastAPIRoute(
+                    r"/v1/messages",
+                    self._endpoints.messages,
                     methods=["POST"],
                     tags=["V1"],
                 ),

--- a/truss/tests/test_data/test_openai/model/model.py
+++ b/truss/tests/test_data/test_openai/model/model.py
@@ -13,3 +13,6 @@ class Model:
 
     def predict(self, input: Dict) -> str:
         return "predict"
+
+    def messages(self, input: Dict) -> str:
+        return "messages"

--- a/truss/truss_handle/truss_handle.py
+++ b/truss/truss_handle/truss_handle.py
@@ -106,6 +106,7 @@ class DockerURLs:
         self.predict_url = f"{base_url}/v1/models/model:predict"
         self.completions_url = f"{base_url}/v1/completions"
         self.chat_completions_url = f"{base_url}/v1/chat/completions"
+        self.messages_url = f"{base_url}/v1/messages"
 
         self.schema_url = f"{base_url}/v1/models/model/schema"
         self.metrics_url = f"{base_url}/metrics"


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Adds /v1/messages
<!--
  How was the change described above implemented?
-->
## :computer: How
<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
tested by pip installing truss from src, running openai_test with curl to curl -X POST http://localhost:8080/v1/messages \
  -H "Content-Type: application/json" \
  -d '{"key1": "value1", "key2": "value2"}'
