### PR TITLE
fix(truss): move date-util into dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,6 @@ dependencies = [
     "tenacity>=8.0.1",
     "watchfiles>=0.19.0,<0.20",
     "truss-transfer==0.0.27",
-    "types-python-dateutil>=2.9.0.20250822",
 ]
 
 [project.urls]
@@ -79,6 +78,7 @@ dev = [
     "types-aiofiles>=24.1.0",
     "types-requests==2.31.0.2",
     "types-setuptools>=69.0.0.0,<70",
+    "types-python-dateutil>=2.9.0.20250822",
 ]
 dev-server = [
     "aiohttp>3.11.13",

--- a/uv.lock
+++ b/uv.lock
@@ -3342,7 +3342,6 @@ dependencies = [
     { name = "tenacity" },
     { name = "tomlkit" },
     { name = "truss-transfer" },
-    { name = "types-python-dateutil" },
     { name = "watchfiles" },
 ]
 
@@ -3364,6 +3363,7 @@ dev = [
     { name = "requests-mock" },
     { name = "ruff" },
     { name = "types-aiofiles" },
+    { name = "types-python-dateutil" },
     { name = "types-pyyaml" },
     { name = "types-requests" },
     { name = "types-setuptools" },
@@ -3414,7 +3414,6 @@ requires-dist = [
     { name = "tenacity", specifier = ">=8.0.1" },
     { name = "tomlkit", specifier = ">=0.13.2" },
     { name = "truss-transfer", specifier = "==0.0.27" },
-    { name = "types-python-dateutil", specifier = ">=2.9.0.20250822" },
     { name = "watchfiles", specifier = ">=0.19.0,<0.20" },
 ]
 
@@ -3436,6 +3435,7 @@ dev = [
     { name = "requests-mock", specifier = ">=1.11.0" },
     { name = "ruff", specifier = ">=0.9.0,<0.10" },
     { name = "types-aiofiles", specifier = ">=24.1.0" },
+    { name = "types-python-dateutil", specifier = ">=2.9.0.20250822" },
     { name = "types-pyyaml", specifier = ">=6.0.12.12,<7" },
     { name = "types-requests", specifier = "==2.31.0.2" },
     { name = "types-setuptools", specifier = ">=69.0.0.0,<70" },


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Ran uv sync after updating the `pyproject.toml` to update the `uv.lock`
<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
