### PR TITLE
feat(truss): support named training jobs

### DIFF
--- a/truss-train/truss_train/definitions.py
+++ b/truss-train/truss_train/definitions.py
@@ -127,6 +127,7 @@ class TrainingJob(custom_types.SafeModelNoExtra):
     image: Image
     compute: Compute = Compute()
     runtime: Runtime = Runtime()
+    name: Optional[str] = None
 
     def model_dump(self, *args, **kwargs):
         data = super().model_dump(*args, **kwargs)

--- a/truss/cli/train_commands.py
+++ b/truss/cli/train_commands.py
@@ -73,8 +73,11 @@ def _prepare_click_context(f: click.Command, params: dict) -> click.Context:
 @click.argument("config", type=Path, required=True)
 @click.option("--remote", type=str, required=False, help="Remote to use")
 @click.option("--tail", is_flag=True, help="Tail for status + logs after push.")
+@click.option("--job-name", type=str, required=False, help="Name of the training job.")
 @common.common_options()
-def push_training_job(config: Path, remote: Optional[str], tail: bool):
+def push_training_job(
+    config: Path, remote: Optional[str], tail: bool, job_name: Optional[str]
+):
     """Run a training job"""
     from truss_train import deployment
 
@@ -85,7 +88,9 @@ def push_training_job(config: Path, remote: Optional[str], tail: bool):
         remote_provider: BasetenRemote = cast(
             BasetenRemote, RemoteFactory.create(remote=remote)
         )
-        job_resp = deployment.create_training_job_from_file(remote_provider, config)
+        job_resp = deployment.create_training_job_from_file(
+            remote_provider, config, job_name
+        )
 
     # Note: This post create logic needs to happen outside the context
     # of the above context manager, as only one console session can be active


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What

Add a field that let's a user specify a job name for a training job. They can also pass it in via the CLI. If both CLI and job name inside the Truss exist. The one passed in via the CLI will take precedence and a log like this will appear.
`⚠ Warning: name 'AGHILANWORLD' provided in config file will be ignored. Using job name 'UmeshWORLD' provided via --job-name flag.
`

This is how a sample config.py looks

```
training_job = definitions.TrainingJob(
    name="my-new-name" # new
    compute=definitions.Compute(
        cpu_count=0,
        memory="0Mi",
    ),
    image=definitions.Image(base_image="python:3-slim-bullseye"),
)

first_project = definitions.TrainingProject(name="spin", job=training_job)
```

CLI Usage
```
truss train push config.py --job-name="JAKEWORLD"
```
https://www.loom.com/share/bc7ca069198146f78ebe7c7e82e72e66?sid=6c0173aa-9b93-4d9c-b506-243739817344

Auto-incrementing logic for the names is handled already by Django in a prior change

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing

Manually verified 3 cases, job name via CLI,. job name via config, CLI taking precedence when both passed in and log appearing.
