### PR TITLE
Bump version of control server

### DIFF
--- a/truss/templates/control/requirements.txt
+++ b/truss/templates/control/requirements.txt
@@ -6,7 +6,7 @@ loguru>=0.7.2
 python-json-logger>=2.0.2
 tenacity>=8.1.0
  # To avoid divergence, this should follow the latest release.
-truss==0.11.1rc15
+truss==0.11.2
 uvicorn>=0.24.0
 uvloop>=0.19.0
 websockets>=10.0


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Bumps the version of truss to be used in control server. Similar to base images, we have a chicken/egg problem, where we can either:
- Release a version with our changes without updating the file, then release a new version that updates `requirements.txt`
- Make a code change to point to a future version, and then ensure we release soon after

I'm opting to do (2) until we figure out a better way to sequence updates to the control server

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
