### PR TITLE
Remove unnecessary deploy checkpoint method

### DIFF
--- a/truss/cli/train/deploy_checkpoints/deploy_checkpoints.py
+++ b/truss/cli/train/deploy_checkpoints/deploy_checkpoints.py
@@ -296,18 +296,6 @@ def _get_checkpoint_ids_to_deploy(
     return checkpoint_ids
 
 
-def _select_single_checkpoint(checkpoint_id_options: List[str]) -> List[str]:
-    """Select a single checkpoint using interactive prompt."""
-    checkpoint_id = inquirer.select(
-        message="Select the checkpoints to deploy:", choices=checkpoint_id_options
-    ).execute()
-
-    if not checkpoint_id:
-        raise click.UsageError("A checkpoint must be selected.")
-
-    return [checkpoint_id]
-
-
 def _select_multiple_checkpoints(checkpoint_id_options: List[str]) -> List[str]:
     """Select multiple checkpoints using interactive checkbox."""
     checkpoint_ids = inquirer.checkbox(


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What

As part of PR #1890 , I accidentally kept a method that is unused when rebasing. Since this method is completely unused, this PR is to remove it. 

Proof of blunder:
<img width="600" alt="image" src="https://github.com/user-attachments/assets/825eee84-2002-4ec8-ad0a-848efb8a47c3" />


Not used anywhere else and not mentioned in unit test files either.
<img width="600" alt="image" src="https://github.com/user-attachments/assets/5f234cd4-4218-46de-a9ce-5f0e45a4e513" />


<!--
  How was the change described above implemented?
-->
## :computer: How
Delete

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
Unit tests
