### PR TITLE
properly disable ws pings

### DIFF
--- a/truss/templates/server/truss_server.py
+++ b/truss/templates/server/truss_server.py
@@ -472,7 +472,7 @@ class TrussServer:
         ):
             extra_kwargs["ws_ping_interval"] = ws_ping_interval_seconds
         else:
-            extra_kwargs["ws_ping_interval"] = ws_ping_interval_seconds
+            extra_kwargs["ws_ping_interval"] = None
 
         if (
             ws_ping_timeout_seconds := self._config["runtime"]


### PR DESCRIPTION
We must explicitly set the ws ping fields to None in order to override the default of 20 seconds.