### PR TITLE
feat: implement truss deployment logs command with tail option

### DIFF
--- a/truss/cli/logs/model_log_watcher.py
+++ b/truss/cli/logs/model_log_watcher.py
@@ -1,19 +1,43 @@
-from typing import Any, List, Optional
+import signal
+import time
+from typing import Any, Iterator, List, Optional
 
 from truss.cli.logs.base_watcher import LogWatcher
+from truss.cli.logs.utils import ParsedLog
+from truss.cli.utils.output import console
 from truss.remote.baseten.api import BasetenApi
 from truss.remote.baseten.utils.status import MODEL_RUNNING_STATES
+
+POLL_INTERVAL_SEC = 2
+CLOCK_SKEW_BUFFER_MS = 60000
 
 
 class ModelDeploymentLogWatcher(LogWatcher):
     _model_id: str
     _deployment_id: str
     _current_status: Optional[str] = None
+    _tail_only: bool = False
 
-    def __init__(self, api: BasetenApi, model_id: str, deployment_id: str):
+    def __init__(
+        self,
+        api: BasetenApi,
+        model_id: str,
+        deployment_id: str,
+        tail_only: bool = False,
+        start_epoch_millis: Optional[int] = None,
+    ):
         super().__init__(api)
         self._model_id = model_id
         self._deployment_id = deployment_id
+        self._tail_only = tail_only
+        self._start_epoch_millis = start_epoch_millis
+        # Register SIGINT handler to show helpful message on Ctrl+C
+        signal.signal(signal.SIGINT, self._handle_sigint)
+
+    def _handle_sigint(self, signum: int, frame: Any) -> None:
+        msg = f"\n\nExiting deployment logs. To continue viewing logs, run `truss deployment logs --tail --deployment-id {self._deployment_id}`"
+        console.print(msg, style="yellow")
+        raise KeyboardInterrupt()
 
     def before_polling(self) -> None:
         self._current_status = self._get_current_status()
@@ -36,3 +60,43 @@ class ModelDeploymentLogWatcher(LogWatcher):
 
     def after_polling(self) -> None:
         pass
+
+    def watch(self) -> Iterator[ParsedLog]:
+        """Override the base watch method to support tail-only mode."""
+        self.before_polling()
+
+        if self._tail_only:
+            # For tail-only mode, start from specified time or current time
+            if self._start_epoch_millis is not None:
+                self._last_poll_time = self._start_epoch_millis
+                # First, show historical logs from the specified start time
+                with console.status("Fetching historical logs", spinner="aesthetic"):
+                    for log in self._poll():
+                        yield log
+            else:
+                self._last_poll_time = int(time.time() * 1000)
+
+            # Then continue tailing if deployment is running
+            with console.status("Tailing deployment logs", spinner="aesthetic"):
+                while self.should_poll_again():
+                    for log in self._poll():
+                        yield log
+                    time.sleep(POLL_INTERVAL_SEC)
+                    self.post_poll()
+        else:
+            # Use the original behavior for backward compatibility
+            with console.status("Polling logs", spinner="aesthetic"):
+                while True:
+                    for log in self._poll():
+                        yield log
+                    if self._log_hashes:
+                        break
+                    time.sleep(POLL_INTERVAL_SEC)
+
+                while self.should_poll_again():
+                    for log in self._poll():
+                        yield log
+                    time.sleep(POLL_INTERVAL_SEC)
+                    self.post_poll()
+
+        self.after_polling()

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -474,6 +474,25 @@ class BasetenApi:
         resp = self._post_graphql_query(query_string)
         return resp["data"]
 
+    def get_deployment_by_id(self, deployment_id: str):
+        """
+        Get deployment information by deployment ID.
+        Uses get_model_version_by_id to get the model_id from the deployment_id.
+        """
+        # First get the model version info to extract the model_id
+        model_version_data = self.get_model_version_by_id(deployment_id)
+        model_version = model_version_data["model_version"]
+
+        # Extract the oracle (model) ID from the model version
+        oracle_id = model_version["oracle"]["id"]
+
+        # Return the deployment info in the expected format
+        return {
+            "model_id": oracle_id,
+            "deployment_id": deployment_id,
+            "model_version": model_version,
+        }
+
     def patch_draft_truss_two_step(self, model_name, patch_request):
         patch = base64_encoded_json_str(patch_request.to_dict())
         query_string = f"""


### PR DESCRIPTION
- Add new 'truss deployment logs' command with simplified interface
- Support --tail flag for real-time log streaming
- Add time-based filtering with --start-time and --end-time options
- Support both ISO format and relative time formats (e.g., '1h', '30m')
- Implement pagination for large log datasets
- Add graceful SIGINT handling with helpful exit message
- Enhance ModelDeploymentLogWatcher with tail-only mode
- Add get_deployment_by_id API method for deployment lookup

<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
