### PR TITLE
fix(truss): named checkpoint to no longer have a project name

### DIFF
--- a/truss-train/truss_train/definitions.py
+++ b/truss-train/truss_train/definitions.py
@@ -3,7 +3,7 @@ from abc import ABC
 from typing import Dict, List, Literal, Optional, Union
 
 import pydantic
-from pydantic import field_validator, model_validator
+from pydantic import ValidationError, field_validator, model_validator
 
 from truss.base import constants, custom_types, truss_config
 
@@ -68,7 +68,7 @@ class _BasetenLatestCheckpoint(_CheckpointBase):
 
 class _BasetenNamedCheckpoint(_CheckpointBase):
     checkpoint_name: str
-    job_id: Optional[str]
+    job_id: str
     typ: Literal["baseten_named_checkpoint"] = "baseten_named_checkpoint"
 
 
@@ -78,7 +78,7 @@ class BasetenCheckpoint:
         project_name: Optional[str] = None, job_id: Optional[str] = None
     ) -> _BasetenLatestCheckpoint:
         if not job_id and not project_name:
-            raise ValueError("job_id or project_name is required")
+            raise ValidationError("job_id or project_name is required")
         return _BasetenLatestCheckpoint(project_name=project_name, job_id=job_id)
 
     @classmethod

--- a/truss-train/truss_train/definitions.py
+++ b/truss-train/truss_train/definitions.py
@@ -69,7 +69,6 @@ class _BasetenLatestCheckpoint(_CheckpointBase):
 class _BasetenNamedCheckpoint(_CheckpointBase):
     checkpoint_name: str
     job_id: Optional[str]
-    project_name: Optional[str]
     typ: Literal["baseten_named_checkpoint"] = "baseten_named_checkpoint"
 
 
@@ -78,18 +77,15 @@ class BasetenCheckpoint:
     def from_latest_checkpoint(
         project_name: Optional[str] = None, job_id: Optional[str] = None
     ) -> _BasetenLatestCheckpoint:
+        if not job_id and not project_name:
+            raise ValueError("job_id or project_name is required")
         return _BasetenLatestCheckpoint(project_name=project_name, job_id=job_id)
 
     @classmethod
     def from_named_checkpoint(
-        cls,
-        checkpoint_name: str,
-        project_name: Optional[str] = None,
-        job_id: Optional[str] = None,
+        cls, checkpoint_name: str, job_id: Optional[str] = None
     ) -> _BasetenNamedCheckpoint:
-        return _BasetenNamedCheckpoint(
-            checkpoint_name=checkpoint_name, project_name=project_name, job_id=job_id
-        )
+        return _BasetenNamedCheckpoint(checkpoint_name=checkpoint_name, job_id=job_id)
 
 
 class LoadCheckpointConfig(custom_types.SafeModelNoExtra):

--- a/truss-train/truss_train/definitions.py
+++ b/truss-train/truss_train/definitions.py
@@ -83,7 +83,7 @@ class BasetenCheckpoint:
 
     @classmethod
     def from_named_checkpoint(
-        cls, checkpoint_name: str, job_id: Optional[str] = None
+        cls, checkpoint_name: str, job_id: str
     ) -> _BasetenNamedCheckpoint:
         return _BasetenNamedCheckpoint(checkpoint_name=checkpoint_name, job_id=job_id)
 

--- a/truss-train/truss_train/restore_from_checkpoint.py
+++ b/truss-train/truss_train/restore_from_checkpoint.py
@@ -18,9 +18,7 @@ load_most_recent_checkpoint = BasetenCheckpoint.from_latest_checkpoint(
 )
 
 load_from_named_checkpoint = BasetenCheckpoint.from_named_checkpoint(
-    checkpoint_name="checkpoint-24",
-    project_name="first-project",  # Optional
-    job_id="lqz4pw4",  # Optional
+    checkpoint_name="checkpoint-24", job_id="lqz4pw4"
 )
 
 load_checkpoint_config = LoadCheckpointConfig(


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What

Remove the project name from the named checkpoint, this field was always Optional in the backend so the backend will continue with life as normal as long as job id is provided

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
