### PR TITLE
feat(truss): use project instead of project_id across the CLI 

### DIFF
--- a/truss/cli/train/core.py
+++ b/truss/cli/train/core.py
@@ -156,7 +156,7 @@ def display_training_projects(projects: list[dict], remote_url: str) -> None:
         latest_job = project.get("latest_job") or {}
         if latest_job_id := latest_job.get("id", ""):
             latest_job_link = cli_common.format_link(
-                status_page_url(remote_url, latest_job_id), "link"
+                status_page_url(remote_url, project["id"], latest_job_id), "link"
             )
         else:
             latest_job_link = ""
@@ -305,8 +305,11 @@ def display_training_job(
     table.add_row("Created", cli_common.format_localized_time(job["created_at"]))
     table.add_row("Last Modified", cli_common.format_localized_time(job["updated_at"]))
     table.add_row(
-        "Status Page",
-        cli_common.format_link(status_page_url(remote_url, job["id"]), "link"),
+        "Job Page",
+        cli_common.format_link(
+            status_page_url(remote_url, job["training_project"]["id"], job["id"]),
+            "link",
+        ),
     )
 
     # Add error message if present
@@ -417,8 +420,8 @@ def download_checkpoint_artifacts(
     return urls_file
 
 
-def status_page_url(remote_url: str, training_job_id: str) -> str:
-    return f"{remote_url}/training/jobs/{training_job_id}"
+def status_page_url(remote_url: str, project_id: str, training_job_id: str) -> str:
+    return f"{remote_url}/training/{project_id}/logs/{training_job_id}"
 
 
 def _get_all_train_init_example_options(

--- a/truss/cli/train_commands.py
+++ b/truss/cli/train_commands.py
@@ -41,6 +41,7 @@ truss_cli.add_command(train)
 
 def _print_training_job_success_message(
     job_id: str,
+    project_id: str,
     project_name: str,
     job_object: Optional[TrainingJob],
     remote_provider: BasetenRemote,
@@ -64,7 +65,7 @@ def _print_training_job_success_message(
         f"🔍 View metrics for your job via "
         f"[cyan]'truss train metrics --job-id {job_id}'[/cyan]\n"
         f"{cache_summary_snippet}"
-        f"🌐 Status page: {common.format_link(core.status_page_url(remote_provider.remote_url, job_id))}"
+        f"🌐 View job in the UI: {common.format_link(core.status_page_url(remote_provider.remote_url, project_id, job_id))}"
     )
 
 
@@ -82,7 +83,11 @@ def _handle_post_create_logic(
     else:
         # recreate currently doesn't pass back a job object.
         _print_training_job_success_message(
-            job_id, project_name, job_resp.get("job_object"), remote_provider
+            job_id,
+            project_id,
+            project_name,
+            job_resp.get("job_object"),
+            remote_provider,
         )
 
     if tail:


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
* Allow customers to specify projects by project name 
* https://www.loom.com/share/de1bf6a4a65b4ce49b5951f326381230?sid=9f1bb183-063d-407d-baf4-d7cc0df9411b
<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
