### PR TITLE
[bugfix] truss train init - Only clone "training" directory for examples

### DIFF
--- a/truss/cli/train/core.py
+++ b/truss/cli/train/core.py
@@ -458,6 +458,7 @@ def _get_all_train_init_example_options(
 def _get_train_init_example_info(
     repo_id: str = "ml-cookbook",
     examples_subdir: str = "examples",
+    training_subdir: str = "training",
     example_name: Optional[str] = None,
     token: Optional[str] = None,
 ) -> list[Dict[str, str]]:
@@ -471,6 +472,7 @@ def _get_train_init_example_info(
 
     url = f"https://api.github.com/repos/basetenlabs/{repo_id}/contents/{examples_subdir}/{example_name}"
 
+    console.print(f"Attempting to retrieve example info from: {url}")
     try:
         response = requests.get(url, headers=headers)
         response.raise_for_status()
@@ -478,6 +480,8 @@ def _get_train_init_example_info(
         items = response.json()
         if not isinstance(items, list):
             items = [items]
+        # return only training subdirectory info for example
+        items = [item for item in items if item["name"] == training_subdir]
         return items
 
     except requests.exceptions.HTTPError as e:


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Bug description:
When initializing an example from the [examples repo](https://github.com/basetenlabs/ml-cookbook/tree/main/examples), for examples with directories other than `training`, the first subdir only got cloned. 
Example:
```
(venv) [23/09/25 4:11:48] ➜  playground truss train init --examples oss-gpt-20b-fft
Creating directory /Users/rcano/baseten/playground/oss-gpt-20b-fft
📄 Downloading Dockerfile
📄 Downloading requirements.txt
✨ Training directory for oss-gpt-20b-fft initialized at /Users/rcano/baseten/playground/oss-gpt-20b-fft
(venv) [23/09/25 4:11:58] ➜  playground cd oss-gpt-20b-fft
(venv) [23/09/25 4:12:08] ➜  oss-gpt-20b-fft ls
Dockerfile       requirements.txt
```

<!--
  How was the change described above implemented?
-->
## :computer: How
Since all [examples](https://github.com/basetenlabs/ml-cookbook/tree/main/examples) have a `training` directory containing everything necessary to launch training, only clone the contents of `training` for each example. 
Examples may have other directories like `docker`, `inference` etc. `truss train init` is not meant to clone any of these.

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
Unit testing with 
```
cd truss/tests/cli/train
pytest test_train_init.py
```

Cloning an example with `docker` and `training`, previously failing
<img width="976" height="193" alt="image" src="https://github.com/user-attachments/assets/43819855-15c5-46a7-aaf3-f383206b35ba" />

Other examples-
<img width="1125" height="339" alt="image" src="https://github.com/user-attachments/assets/4be2eb74-a15a-45e4-afd7-8d3b21b51d59" />


