### PR TITLE
add debug line

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "truss"
-version = "0.11.5"
+version = "0.11.6rc104"
 description = "A seamless bridge from model development to model delivery"
 authors = [
     { name = "Pankaj Gupta", email = "no-reply@baseten.co" },

--- a/truss/templates/server/truss_server.py
+++ b/truss/templates/server/truss_server.py
@@ -182,6 +182,12 @@ class BasetenEndpoints:
         """
         Executes a predictive endpoint
         """
+        request_id = request.headers.get("x-baseten-request-id")
+
+        logging.debug(
+            f"[DEBUG] Request received - {request.method} /{method.__name__} "
+            f", Request ID: {request_id}"
+        )
         self.check_healthy()
         trace_ctx = otel_propagate.extract(request.headers) or None
         # This is the top-level span in the truss-server, so we set the context here.
@@ -464,6 +470,7 @@ class TrussServer:
             if self._config["runtime"].get("enable_debug_logs", False)
             else "INFO"
         )
+
         extra_kwargs = {}
         # We don't pass these if not set, to not override the default.
         if (

--- a/truss/templates/server/truss_server.py
+++ b/truss/templates/server/truss_server.py
@@ -470,7 +470,6 @@ class TrussServer:
             if self._config["runtime"].get("enable_debug_logs", False)
             else "INFO"
         )
-
         extra_kwargs = {}
         # We don't pass these if not set, to not override the default.
         if (


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What

**Problem:** Requests sometimes are stuck and it's unclear if the request made it onto the model pod or not. Adding a debug log line at the beginning (ie: before we hit the semaphore), can help rule out any problems downstream. If we don't hit this log line we can be fairly confident the truss server was not reached.

To use this, enable debug logs in your truss config:

```
runtime:
  enable_debug_logs: true
```

As a follow-up, we should add more of these.

## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing

Pushed an rc (`truss==0.11.6.rc104`), saw this:

![test___Model___Baseten](https://github.com/user-attachments/assets/3cf59ba3-b594-44fa-9482-3a223388da3f)


