### PR TITLE
Use `uv` for patches instead of `pip3`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "truss"
-version = "0.11.9rc2"
+version = "0.11.9rc6"
 description = "A seamless bridge from model development to model delivery"
 authors = [
     { name = "Pankaj Gupta", email = "no-reply@baseten.co" },

--- a/truss/templates/control/control/application.py
+++ b/truss/templates/control/control/application.py
@@ -84,10 +84,9 @@ def create_app(base_config: Dict):
         base_url=f"http://localhost:{app_state.inference_server_port}", limits=limits
     )
 
-    pip_path = getattr(app_state, "pip_path", None)
-
+    uv_path = getattr(app_state, "uv_path", None)
     patch_applier = ModelContainerPatchApplier(
-        Path(app_state.inference_server_home), app_logger, pip_path
+        Path(app_state.inference_server_home), app_logger, uv_path
     )
 
     oversee_inference_server = getattr(app_state, "oversee_inference_server", True)

--- a/truss/templates/control/control/helpers/truss_patch/model_container_patch_applier.py
+++ b/truss/templates/control/control/helpers/truss_patch/model_container_patch_applier.py
@@ -1,4 +1,6 @@
 import logging
+import os
+import shutil
 import subprocess
 from pathlib import Path
 from typing import Optional
@@ -30,7 +32,7 @@ class ModelContainerPatchApplier:
         self,
         inference_server_home: Path,
         app_logger: logging.Logger,
-        pip_path: Optional[str] = None,  # Only meant for testing
+        uv_path: Optional[str] = None,  # Only meant for testing
     ) -> None:
         self._inference_server_home = inference_server_home
         self._model_module_dir = (
@@ -41,9 +43,19 @@ class ModelContainerPatchApplier:
         ).resolve()
         self._data_dir = self._inference_server_home / self._truss_config.data_dir
         self._app_logger = app_logger
-        self._pip_path_cached = None
-        if pip_path is not None:
-            self._pip_path_cached = "pip"
+        self._uv_path_cached = None
+        if uv_path is not None:
+            self._uv_path_cached = uv_path
+
+        self._python_executable = self._get_python_executable()
+
+    def _get_python_executable(self) -> str:
+        # NB(nikhil): `uv` requires the full path to the python interpreter for patching
+        # python modules. We expect PYTHON_EXECUTABLE to exist in all development images, but
+        # we fallback to python3 as a default.
+        python_executable = os.environ.get("PYTHON_EXECUTABLE", "python3")
+        full_executable_path = shutil.which(python_executable)
+        return full_executable_path or python_executable
 
     def __call__(self, patch: Patch, inf_env: dict):
         self._app_logger.debug(f"Applying patch {patch.to_dict()}")
@@ -79,10 +91,10 @@ class ModelContainerPatchApplier:
         return TrussConfig.from_yaml(self._inference_server_home / "config.yaml")
 
     @property
-    def _pip_path(self) -> str:
-        if self._pip_path_cached is None:
-            self._pip_path_cached = _identify_pip_path()
-        return self._pip_path_cached
+    def _uv_path(self) -> str:
+        if self._uv_path_cached is None:
+            self._uv_path_cached = _identify_uv_path()
+        return self._uv_path_cached
 
     def _apply_python_requirement_patch(
         self, python_requirement_patch: PythonRequirementPatch
@@ -95,20 +107,25 @@ class ModelContainerPatchApplier:
         if action == Action.REMOVE:
             subprocess.run(
                 [
-                    self._pip_path,
+                    self._uv_path,
+                    "pip",
                     "uninstall",
-                    "-y",
                     python_requirement_patch.requirement,
+                    "--python",
+                    self._python_executable,
                 ],
                 check=True,
             )
         elif action in [Action.ADD, Action.UPDATE]:
             subprocess.run(
                 [
-                    self._pip_path,
+                    self._uv_path,
+                    "pip",
                     "install",
                     python_requirement_patch.requirement,
                     "--upgrade",
+                    "--python",
+                    self._python_executable,
                 ],
                 check=True,
             )
@@ -158,11 +175,9 @@ class ModelContainerPatchApplier:
             raise ValueError(f"Unknown patch action {action}")
 
 
-def _identify_pip_path() -> str:
-    if Path("/usr/local/bin/pip3").exists():
-        return "/usr/local/bin/pip3"
+def _identify_uv_path() -> str:
+    uv_path = shutil.which("uv")
+    if not uv_path:
+        raise RuntimeError("Unable to find `uv`, make sure it's installed.")
 
-    if Path("/usr/local/bin/pip").exists():
-        return "/usr/local/bin/pip"
-
-    raise RuntimeError("Unable to find pip, make sure it's installed.")
+    return uv_path

--- a/truss/tests/templates/control/control/test_server.py
+++ b/truss/tests/templates/control/control/test_server.py
@@ -53,7 +53,7 @@ def app(truss_container_fs, truss_original_hash, ports):
                 "control_server_port": ports["control_server_port"],
                 "inference_server_port": ports["inference_server_port"],
                 "oversee_inference_server": False,
-                "pip_path": "pip",
+                "uv_path": "uv",
             }
         )
         inference_server_controller = control_app.state.inference_server_controller

--- a/uv.lock
+++ b/uv.lock
@@ -3312,7 +3312,7 @@ wheels = [
 
 [[package]]
 name = "truss"
-version = "0.11.9rc2"
+version = "0.11.9rc6"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Cantina ran into an issue with patching python [packages](https://basetenlabs.slack.com/archives/C05CTDKQMCK/p1759324621955099), it's still unclear whether the core issue was:
- Temporary pypi timeouts, which surfaces as the error they saw (reproduced)
- Permissioning errors, even though they're root

While we investigate both options, this is a good improvement to use `uv` for upgrading/removing packages, instead of pip3 (deprecated from our workflow)

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
Truss watch now shows logs like:
```
Downloading pillow-avif-plugin (7.6MiB)
 Downloading pillow-avif-plugin
Prepared 1 package in 156ms
Uninstalled 1 package in 2ms
Installed 1 package in 5ms
 - pillow-avif-plugin==1.5.2
 + pillow-avif-plugin==1.5.1
```

Which indicates `uv` is managing the installation, not pip3
