### PR TITLE
Better sanitization of control server errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "truss"
-version = "0.11.9"
+version = "0.11.10rc4"
 description = "A seamless bridge from model development to model delivery"
 authors = [
     { name = "Pankaj Gupta", email = "no-reply@baseten.co" },

--- a/truss/templates/control/control/application.py
+++ b/truss/templates/control/control/application.py
@@ -38,14 +38,17 @@ class SanitizedExceptionMiddleware(BaseHTTPMiddleware):
         try:
             return await call_next(request)
         except Exception as exc:
-            sanitized_traceback = self._create_sanitized_traceback(exc)
-            request.app.state.logger.error(sanitized_traceback)
-
+            # NB(nikhil): Intentionally bypass error logging for ModelLoadFailed, since health checks
+            # are noisy. The underlying model logs for why the load failed will still be visible.
             if isinstance(exc, ModelLoadFailed):
                 return JSONResponse(
                     {"error": str(exc)}, status_code=http.HTTPStatus.BAD_GATEWAY.value
                 )
-            elif isinstance(exc, PatchApplicatonError):
+
+            sanitized_traceback = self._create_sanitized_traceback(exc)
+            request.app.state.logger.error(sanitized_traceback)
+
+            if isinstance(exc, PatchApplicatonError):
                 error_type = _camel_to_snake_case(type(exc).__name__)
                 return JSONResponse({"error": {"type": error_type, "msg": str(exc)}})
             else:

--- a/uv.lock
+++ b/uv.lock
@@ -3312,7 +3312,7 @@ wheels = [
 
 [[package]]
 name = "truss"
-version = "0.11.9"
+version = "0.11.10rc4"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Small quality of life improvement, I recently realized that we explicitly ping draft [models](https://github.com/basetenlabs/baseten/blob/22457beaa4c178796d4cf1e13c3ecf8e96292e10/operator/core/utils/models_utils.py?plain=1#L59-L64) (both MCM / operator) which leads to very noisy logs in case the model failed to load.

<img width="1184" height="343" alt="image" src="https://github.com/user-attachments/assets/a598d8d8-b0ee-4e1c-832c-44fca9f6c668" />

In these cases, I think having an additional error log from the control server is not very helpful, since the underlying error from the Model should be the primary focus. 

The other sanitation we get from this [PR](https://github.com/basetenlabs/truss/pull/1954) is still valuable, for other types of errors. 

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
