### PR TITLE
Replace supervisord with shell wrapper for docker_server

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,6 @@ uv run pytest truss/tests/test_config.py::test_name -v
 
 ## Architecture Notes
 
-- `docker_server` deployments use supervisord to manage processes
+- `docker_server` deployments use a shell script wrapper to manage processes
 - Config is validated via Pydantic models in `truss_config.py`
 - Image build generates Dockerfile from Jinja templates

--- a/truss-transfer/tests/test_create_bptr_with_hf.py
+++ b/truss-transfer/tests/test_create_bptr_with_hf.py
@@ -207,12 +207,11 @@ def test_qwen3():
 def test_direct_download():
     models = [
         truss_transfer.PyModelRepo(
-            repo_id=HF_REPO,
-            revision=HF_REVISION,
+            repo_id="julien-c/dummy-unknown",
+            revision="main",
             runtime_secret_name="none",
             volume_folder="julien_dummy",
             kind="hf",
-            allow_patterns=["config.json"],
         )
     ]
     shutil.rmtree("/tmp/data", ignore_errors=True)

--- a/truss-transfer/tests/test_create_bptr_with_hf.py
+++ b/truss-transfer/tests/test_create_bptr_with_hf.py
@@ -207,11 +207,12 @@ def test_qwen3():
 def test_direct_download():
     models = [
         truss_transfer.PyModelRepo(
-            repo_id="julien-c/dummy-unknown",
-            revision="main",
+            repo_id=HF_REPO,
+            revision=HF_REVISION,
             runtime_secret_name="none",
             volume_folder="julien_dummy",
             kind="hf",
+            allow_patterns=["config.json"],
         )
     ]
     shutil.rmtree("/tmp/data", ignore_errors=True)

--- a/truss/contexts/image_builder/serving_image_builder.py
+++ b/truss/contexts/image_builder/serving_image_builder.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import configparser
 import json
 import logging
 import os
@@ -448,56 +447,19 @@ def generate_docker_server_nginx_config(build_dir, config):
     nginx_filepath.write_text(nginx_content)
 
 
-def generate_docker_server_supervisord_config(build_dir, config):
-    """Generate supervisord.conf for docker_server deployments.
+def generate_docker_server_wrapper_script(build_dir, config):
+    """Copy server_wrapper.sh for docker_server deployments.
 
-    Uses configparser to properly handle multiline commands - configparser
-    automatically formats continuation lines with leading whitespace, which
-    supervisord's INI parser correctly interprets as multiline values.
+    The shell script manages nginx and model server processes, replacing
+    supervisord.
     """
     assert config.docker_server.start_command is not None, (
         "docker_server.start_command is required to use custom server"
     )
 
-    cfg = configparser.ConfigParser()
-
-    cfg["supervisord"] = {
-        "pidfile": "/tmp/supervisord.pid",  # PID file in /tmp to be writable by non-root user
-        "nodaemon": "true",  # Run in foreground (required for containers)
-        "logfile": "/dev/null",  # Disable file logging
-        "logfile_maxbytes": "0",  # No size limit (logging disabled)
-    }
-
-    cfg["program:model-server"] = {
-        "command": config.docker_server.start_command,  # Command to start the model server
-        "startsecs": "30",  # Wait 30s before assuming server is running
-        "startretries": "0",  # Don't retry if server fails to start
-        "autostart": "true",  # Start automatically with supervisord
-        "autorestart": "false",  # Don't restart on exit
-        "stdout_logfile": "/dev/fd/1",  # Log stdout to container stdout
-        "stdout_logfile_maxbytes": "0",  # No size limit on stdout
-        "redirect_stderr": "true",  # Combine stderr into stdout
-    }
-
-    cfg["program:nginx"] = {
-        "command": 'nginx -g "daemon off;"',  # Run nginx in foreground
-        "startsecs": "0",  # Assume nginx starts immediately
-        "autostart": "true",  # Start automatically with supervisord
-        "autorestart": "true",  # Always restart nginx on exit
-        "stdout_logfile": "/dev/fd/1",  # Log stdout to container stdout
-        "stdout_logfile_maxbytes": "0",  # No size limit on stdout
-        "redirect_stderr": "true",  # Combine stderr into stdout
-    }
-
-    cfg["eventlistener:quit_on_failure"] = {
-        "events": "PROCESS_STATE_FATAL,PROCESS_STATE_EXITED",  # Listen for fatal process events
-        # Stop supervisord (SIGTERM to PID 1) on fatal event
-        "command": """sh -c 'echo "READY"; read line; kill -15 1; echo "RESULT 2";'""",
-    }
-
-    supervisord_filepath = build_dir / "supervisord.conf"
-    with open(supervisord_filepath, "w") as f:
-        cfg.write(f)
+    wrapper_source = DOCKER_SERVER_TEMPLATES_DIR / "server_wrapper.sh"
+    wrapper_filepath = build_dir / "server_wrapper.sh"
+    shutil.copy2(wrapper_source, wrapper_filepath)
 
 
 class ServingImageBuilderContext(TrussContext):
@@ -720,23 +682,9 @@ class ServingImageBuilder(ImageBuilder):
             config.docker_server is not None
             and config.docker_server.no_build is not True
         ):
-            self._copy_into_build_dir(
-                TEMPLATES_DIR / "docker_server_requirements.txt",
-                build_dir,
-                "docker_server_requirements.txt",
-            )
-
             generate_docker_server_nginx_config(build_dir, config)
 
-            generate_docker_server_supervisord_config(build_dir, config)
-
-            # Copy event listener script
-            event_listener_script = (
-                TEMPLATES_DIR / "docker_server" / "event_listener.py"
-            )
-            self._copy_into_build_dir(
-                event_listener_script, build_dir, "event_listener.py"
-            )
+            generate_docker_server_wrapper_script(build_dir, config)
 
         # Override config.yml
         with (build_dir / CONFIG_FILE).open("w") as config_file:

--- a/truss/templates/docker_server/server_wrapper.sh
+++ b/truss/templates/docker_server/server_wrapper.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+set -euo pipefail
+
+# Manages nginx (auto-restart) and the model server (exit on failure) for docker_server.
+
+NGINX_PID=""
+MODEL_PID=""
+SHUTDOWN=false
+
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" >&2
+}
+
+start_nginx() {
+    log "Starting nginx..."
+    nginx -g "daemon off;" &
+    NGINX_PID=$!
+}
+
+start_model_server() {
+    log "Starting model server: $START_COMMAND"
+    bash -c "$START_COMMAND" &
+    MODEL_PID=$!
+}
+
+wait_for_model_server() {
+    log "Waiting for model server to be ready..."
+    for _ in $(seq 1 30); do
+        if ! kill -0 "$MODEL_PID" 2>/dev/null; then
+            log "ERROR: Model server failed to start"
+            return 1
+        fi
+        if curl -sf "http://127.0.0.1:${SERVER_PORT}${READINESS_ENDPOINT}" >/dev/null; then
+            log "Model server is ready"
+            return 0
+        fi
+        sleep 1
+    done
+    log "WARNING: Model server readiness check timed out, continuing"
+    return 0
+}
+
+cleanup() {
+    SHUTDOWN=true
+    log "Stopping processes..."
+    if [[ -n "$MODEL_PID" ]] && kill -0 "$MODEL_PID" 2>/dev/null; then
+        kill -TERM "$MODEL_PID" 2>/dev/null || true
+        for _ in $(seq 1 30); do
+            kill -0 "$MODEL_PID" 2>/dev/null || break
+            sleep 1
+        done
+        kill -KILL "$MODEL_PID" 2>/dev/null || true
+    fi
+    if [[ -n "$NGINX_PID" ]] && kill -0 "$NGINX_PID" 2>/dev/null; then
+        kill -TERM "$NGINX_PID" 2>/dev/null || true
+    fi
+    wait 2>/dev/null || true
+    exit 0
+}
+
+trap cleanup SIGTERM SIGINT
+
+if [[ -z "${START_COMMAND:-}" ]]; then
+    log "ERROR: START_COMMAND environment variable is required"
+    exit 1
+fi
+if [[ -z "${SERVER_PORT:-}" ]]; then
+    log "ERROR: SERVER_PORT environment variable is required"
+    exit 1
+fi
+if [[ -z "${READINESS_ENDPOINT:-}" ]]; then
+    log "ERROR: READINESS_ENDPOINT environment variable is required"
+    exit 1
+fi
+
+start_nginx
+start_model_server
+if ! wait_for_model_server; then
+    exit 1
+fi
+
+log "Monitoring nginx and model server"
+
+while [[ "$SHUTDOWN" == "false" ]]; do
+    if ! kill -0 "$NGINX_PID" 2>/dev/null; then
+        log "Nginx exited, restarting"
+        start_nginx
+    fi
+    if ! kill -0 "$MODEL_PID" 2>/dev/null; then
+        log "Model server exited, shutting down"
+        exit 1
+    fi
+    sleep 1
+done

--- a/truss/templates/docker_server/server_wrapper.sh
+++ b/truss/templates/docker_server/server_wrapper.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -euo pipefail
 
 # Start nginx and the model server; exit if either stops so the platform can restart.
 
@@ -15,10 +14,6 @@ cleanup() {
 }
 
 trap cleanup SIGTERM SIGINT
-
-: "${START_COMMAND:?START_COMMAND is required}"
-: "${SERVER_PORT:?SERVER_PORT is required}"
-: "${READINESS_ENDPOINT:?READINESS_ENDPOINT is required}"
 
 log "Starting nginx"
 nginx -g "daemon off;" &

--- a/truss/templates/docker_server/server_wrapper.sh
+++ b/truss/templates/docker_server/server_wrapper.sh
@@ -1,94 +1,44 @@
 #!/bin/bash
 set -euo pipefail
 
-# Manages nginx (auto-restart) and the model server (exit on failure) for docker_server.
-
-NGINX_PID=""
-MODEL_PID=""
-SHUTDOWN=false
+# Start nginx and the model server; exit if either stops so the platform can restart.
 
 log() {
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" >&2
 }
 
-start_nginx() {
-    log "Starting nginx..."
-    nginx -g "daemon off;" &
-    NGINX_PID=$!
-}
-
-start_model_server() {
-    log "Starting model server: $START_COMMAND"
-    bash -c "$START_COMMAND" &
-    MODEL_PID=$!
-}
-
-wait_for_model_server() {
-    log "Waiting for model server to be ready..."
-    for _ in $(seq 1 30); do
-        if ! kill -0 "$MODEL_PID" 2>/dev/null; then
-            log "ERROR: Model server failed to start"
-            return 1
-        fi
-        if curl -sf "http://127.0.0.1:${SERVER_PORT}${READINESS_ENDPOINT}" >/dev/null; then
-            log "Model server is ready"
-            return 0
-        fi
-        sleep 1
-    done
-    log "WARNING: Model server readiness check timed out, continuing"
-    return 0
-}
-
 cleanup() {
-    SHUTDOWN=true
-    log "Stopping processes..."
-    if [[ -n "$MODEL_PID" ]] && kill -0 "$MODEL_PID" 2>/dev/null; then
-        kill -TERM "$MODEL_PID" 2>/dev/null || true
-        for _ in $(seq 1 30); do
-            kill -0 "$MODEL_PID" 2>/dev/null || break
-            sleep 1
-        done
-        kill -KILL "$MODEL_PID" 2>/dev/null || true
-    fi
-    if [[ -n "$NGINX_PID" ]] && kill -0 "$NGINX_PID" 2>/dev/null; then
-        kill -TERM "$NGINX_PID" 2>/dev/null || true
-    fi
+    log "Shutting down..."
+    kill -TERM "$NGINX_PID" "$MODEL_PID" 2>/dev/null || true
     wait 2>/dev/null || true
     exit 0
 }
 
 trap cleanup SIGTERM SIGINT
 
-if [[ -z "${START_COMMAND:-}" ]]; then
-    log "ERROR: START_COMMAND environment variable is required"
-    exit 1
-fi
-if [[ -z "${SERVER_PORT:-}" ]]; then
-    log "ERROR: SERVER_PORT environment variable is required"
-    exit 1
-fi
-if [[ -z "${READINESS_ENDPOINT:-}" ]]; then
-    log "ERROR: READINESS_ENDPOINT environment variable is required"
-    exit 1
-fi
+: "${START_COMMAND:?START_COMMAND is required}"
+: "${SERVER_PORT:?SERVER_PORT is required}"
+: "${READINESS_ENDPOINT:?READINESS_ENDPOINT is required}"
 
-start_nginx
-start_model_server
-if ! wait_for_model_server; then
-    exit 1
-fi
+log "Starting nginx"
+nginx -g "daemon off;" &
+NGINX_PID=$!
 
-log "Monitoring nginx and model server"
+log "Starting model server: $START_COMMAND"
+bash -c "$START_COMMAND" &
+MODEL_PID=$!
 
-while [[ "$SHUTDOWN" == "false" ]]; do
-    if ! kill -0 "$NGINX_PID" 2>/dev/null; then
-        log "Nginx exited, restarting"
-        start_nginx
-    fi
-    if ! kill -0 "$MODEL_PID" 2>/dev/null; then
-        log "Model server exited, shutting down"
-        exit 1
+log "Waiting for model server to be ready"
+for _ in $(seq 1 30); do
+    kill -0 "$MODEL_PID" 2>/dev/null || { log "Model server failed to start"; exit 1; }
+    if curl -sf "http://127.0.0.1:${SERVER_PORT}${READINESS_ENDPOINT}" >/dev/null; then
+        log "Model server is ready"
+        break
     fi
     sleep 1
 done
+
+log "Running — container will exit if nginx or model server stops"
+wait -n
+log "A process exited, stopping container"
+exit 1

--- a/truss/templates/docker_server_requirements.txt
+++ b/truss/templates/docker_server_requirements.txt
@@ -1,2 +1,0 @@
-supervisor==4.2.5
-setuptools==81.0.0

--- a/truss/templates/server.Dockerfile.jinja
+++ b/truss/templates/server.Dockerfile.jinja
@@ -119,26 +119,22 @@ RUN {% for secret,path in config.build.secret_to_path_mapping.items() %} --mount
 {%- if config.docker_server %}
 RUN {{ apt_cache_mount }}apt-get update -y && apt-get install -y --no-install-recommends \
         curl nginx{% if not cache_mount_id %} && rm -rf /var/lib/apt/lists/*{% endif %}
-COPY --chown={{ default_owner }} ./docker_server_requirements.txt ${APP_HOME}/docker_server_requirements.txt
-
-{# NB(nikhil): Use the same python version for custom server proxy as the control server, for consistency. #}
-RUN {{ clean_uv_env }} uv python install {{ control_python_version }}
-RUN {{ clean_uv_env }} uv venv /docker_server/.venv --python {{ control_python_version }}
-RUN {{ uv_cache_mount }}{{ clean_uv_env }} uv pip install --python /docker_server/.venv/bin/python -r /app/docker_server_requirements.txt{{ py_no_cache_dir }}
 {% set proxy_config_path = "/etc/nginx/conf.d/proxy.conf" %}
-{% set supervisor_config_path = "/etc/supervisor/supervisord.conf" %}
-{% set supervisor_server_url = "http://localhost:8080" %}
+{% set server_wrapper_path = "/docker_server/server_wrapper.sh" %}
 COPY --chown={{ default_owner }} ./proxy.conf {{ proxy_config_path }}
-COPY --chown={{ default_owner }} ./supervisord.conf {{ supervisor_config_path }}
-ENV SUPERVISOR_SERVER_URL="{{ supervisor_server_url }}"
-ENV SERVER_START_CMD="/docker_server/.venv/bin/supervisord -c {{ supervisor_config_path }}"
+COPY --chown={{ default_owner }} ./server_wrapper.sh {{ server_wrapper_path }}
+RUN chmod +x {{ server_wrapper_path }}
+ENV START_COMMAND={{ config.docker_server.start_command | tojson }}
+ENV SERVER_PORT={{ config.docker_server.server_port | tojson }}
+ENV READINESS_ENDPOINT={{ config.docker_server.readiness_endpoint | tojson }}
+ENV SERVER_START_CMD={{ server_wrapper_path | tojson }}
 {#- default configuration uses port 80, which requires root privileges, so we remove it #}
 RUN rm -f /etc/nginx/sites-enabled/default
 {# NB(nikhil): Ensure /dev/shm exists, but we expect this to get overwritten at runtime with volume mounts #}
 RUN mkdir -p /dev/shm
 {#- nginx writes to /var/lib/nginx, /var/log/nginx, /dev/shm, and /run directories #}
 {{ chown_and_switch_to_regular_user_if_enabled(["/var/lib/nginx", "/var/log/nginx", "/run", "/dev/shm"]) }}
-ENTRYPOINT ["/docker_server/.venv/bin/supervisord", "-c", "{{ supervisor_config_path }}"]
+ENTRYPOINT ["{{ server_wrapper_path }}"]
 
 {%- elif requires_live_reload %} {#- elif requires_live_reload #}
 ENV HASH_TRUSS="{{ truss_hash }}"

--- a/truss/templates/server.Dockerfile.jinja
+++ b/truss/templates/server.Dockerfile.jinja
@@ -118,9 +118,10 @@ RUN {% for secret,path in config.build.secret_to_path_mapping.items() %} --mount
 
 {%- if config.docker_server %}
 RUN {{ apt_cache_mount }}apt-get update -y && apt-get install -y --no-install-recommends \
-        curl nginx{% if not cache_mount_id %} && rm -rf /var/lib/apt/lists/*{% endif %}
+        curl nginx tini{% if not cache_mount_id %} && rm -rf /var/lib/apt/lists/*{% endif %}
 {% set proxy_config_path = "/etc/nginx/conf.d/proxy.conf" %}
 {% set server_wrapper_path = "/docker_server/server_wrapper.sh" %}
+{% set tini_path = "/usr/bin/tini" %}
 COPY --chown={{ default_owner }} ./proxy.conf {{ proxy_config_path }}
 COPY --chown={{ default_owner }} ./server_wrapper.sh {{ server_wrapper_path }}
 RUN chmod +x {{ server_wrapper_path }}
@@ -134,7 +135,7 @@ RUN rm -f /etc/nginx/sites-enabled/default
 RUN mkdir -p /dev/shm
 {#- nginx writes to /var/lib/nginx, /var/log/nginx, /dev/shm, and /run directories #}
 {{ chown_and_switch_to_regular_user_if_enabled(["/var/lib/nginx", "/var/log/nginx", "/run", "/dev/shm"]) }}
-ENTRYPOINT ["{{ server_wrapper_path }}"]
+ENTRYPOINT ["{{ tini_path }}", "-g", "--", "{{ server_wrapper_path }}"]
 
 {%- elif requires_live_reload %} {#- elif requires_live_reload #}
 ENV HASH_TRUSS="{{ truss_hash }}"

--- a/truss/tests/contexts/image_builder/test_serving_image_builder.py
+++ b/truss/tests/contexts/image_builder/test_serving_image_builder.py
@@ -250,8 +250,13 @@ def test_cache_mount_id_enabled_with_system_pkgs_ssh_and_docker_server(
         "--mount=type=cache,id=truss-apt-lib-combo,target=/var/lib/apt,sharing=locked "
         "apt-get update -y && apt-get install -y --no-install-recommends "
     ) in dockerfile
+    assert "curl nginx tini" in dockerfile
     assert (
         "COPY --chown=root:root ./server_wrapper.sh /docker_server/server_wrapper.sh"
+        in dockerfile
+    )
+    assert (
+        'ENTRYPOINT ["/usr/bin/tini", "-g", "--", "/docker_server/server_wrapper.sh"]'
         in dockerfile
     )
     assert "ENV READINESS_ENDPOINT=" in dockerfile

--- a/truss/tests/contexts/image_builder/test_serving_image_builder.py
+++ b/truss/tests/contexts/image_builder/test_serving_image_builder.py
@@ -250,7 +250,10 @@ def test_cache_mount_id_enabled_with_system_pkgs_ssh_and_docker_server(
         "--mount=type=cache,id=truss-apt-lib-combo,target=/var/lib/apt,sharing=locked "
         "apt-get update -y && apt-get install -y --no-install-recommends "
     ) in dockerfile
-    assert 'COPY --chown=root:root ./server_wrapper.sh /docker_server/server_wrapper.sh' in dockerfile
+    assert (
+        "COPY --chown=root:root ./server_wrapper.sh /docker_server/server_wrapper.sh"
+        in dockerfile
+    )
     assert "ENV READINESS_ENDPOINT=" in dockerfile
     # Sanity: no --no-cache-dir anywhere, no list cleanup anywhere, no
     # orphaned ` \\\n\\s+&&` followed by `chmod` (i.e. no broken continuations).

--- a/truss/tests/contexts/image_builder/test_serving_image_builder.py
+++ b/truss/tests/contexts/image_builder/test_serving_image_builder.py
@@ -199,10 +199,10 @@ def test_cache_mount_id_enabled_with_system_pkgs_ssh_and_docker_server(
 ):
     """Exercise the conditional apt-cleanup branches that the basic
     enabled-state test doesn't cover: system_packages, openssh, and
-    docker_server (which also wraps uv installs in `clean_uv_env`). These
-    paths each have a distinct shape for the conditional trailing `\\`,
-    so we want at least one render that proves all three are well-formed
-    and free of orphaned line continuations when caching is on.
+    docker_server. These paths each have a distinct shape for the
+    conditional trailing `\\`, so we want at least one render that proves
+    all three are well-formed and free of orphaned line continuations when
+    caching is on.
     """
     monkeypatch.setenv("TRUSS_CACHE_MOUNT_ID", "combo")
     th = TrussHandle(custom_model_truss_dir)
@@ -250,17 +250,8 @@ def test_cache_mount_id_enabled_with_system_pkgs_ssh_and_docker_server(
         "--mount=type=cache,id=truss-apt-lib-combo,target=/var/lib/apt,sharing=locked "
         "apt-get update -y && apt-get install -y --no-install-recommends "
     ) in dockerfile
-    # docker_server uv install must combine the uv cache mount with
-    # `clean_uv_env`, which was extended to forward UV_CACHE_DIR / PIP_CACHE_DIR.
-    assert (
-        "--mount=type=cache,id=truss-uv-combo,target=/root/.cache/uv "
-        'env -i PATH="$PATH" HOME="$HOME" '
-        'HTTP_PROXY="$HTTP_PROXY" HTTPS_PROXY="$HTTPS_PROXY" NO_PROXY="$NO_PROXY" '
-        'SSL_CERT_FILE="$SSL_CERT_FILE" REQUESTS_CA_BUNDLE="$REQUESTS_CA_BUNDLE" PIP_CERT="$PIP_CERT" '
-        'UV_CACHE_DIR="$UV_CACHE_DIR" PIP_CACHE_DIR="$PIP_CACHE_DIR" '
-        "uv pip install --python /docker_server/.venv/bin/python "
-        "-r /app/docker_server_requirements.txt"
-    ) in dockerfile
+    assert 'COPY --chown=root:root ./server_wrapper.sh /docker_server/server_wrapper.sh' in dockerfile
+    assert "ENV READINESS_ENDPOINT=" in dockerfile
     # Sanity: no --no-cache-dir anywhere, no list cleanup anywhere, no
     # orphaned ` \\\n\\s+&&` followed by `chmod` (i.e. no broken continuations).
     assert "--no-cache-dir" not in dockerfile
@@ -796,231 +787,45 @@ def test_hash_dir_sanitization(custom_model_truss_dir):
         assert truss_config.environment_variables == {}
 
 
-class TestDockerServerSupervisordConfig:
-    """Tests for supervisord.conf generation with various start_command patterns.
+class TestDockerServerWrapperScript:
+    """Tests for server_wrapper.sh generation for docker_server deployments."""
 
-    Uses configparser which properly handles multiline values by indenting
-    continuation lines, which supervisord's INI parser interprets correctly.
-    """
-
-    @pytest.mark.parametrize(
-        "test_id,start_command",
-        [
-            # Simple single-line commands
-            ("simple", "python main.py"),
-            ("with_args", "python -u main.py --port 8000"),
-            ("sh_wrapper", 'sh -c "vllm serve model --port 8000"'),
-            # Single-line with special characters
-            ("env_var_inline", "HF_TOKEN=secret python main.py"),
-            ("pipe", "echo hello | tee /tmp/log"),
-            ("redirect", "python main.py > /tmp/out 2>&1"),
-            ("subshell", 'sh -c "echo $(date) starting"'),
-            ("command_chain_and", "cd /app && python main.py"),
-            ("command_chain_or", "python main.py || echo failed"),
-            ("semicolon_chain", "export FOO=bar; python main.py"),
-        ],
-    )
-    def test_single_line_commands(self, tmp_path, test_id, start_command):
-        """Test various single-line start_command patterns."""
-        import configparser
-
+    def test_wrapper_script_copied(self, tmp_path):
+        """Test that server_wrapper.sh is copied to the build directory."""
         from truss.contexts.image_builder.serving_image_builder import (
-            generate_docker_server_supervisord_config,
+            generate_docker_server_wrapper_script,
         )
 
         class MockDockerServer:
-            pass
-
-        MockDockerServer.start_command = start_command
+            start_command = "python main.py"
 
         class MockConfig:
             docker_server = MockDockerServer()
 
-        generate_docker_server_supervisord_config(tmp_path, MockConfig())
+        generate_docker_server_wrapper_script(tmp_path, MockConfig())
 
-        cfg = configparser.RawConfigParser()
-        cfg.read(tmp_path / "supervisord.conf")
+        wrapper_path = tmp_path / "server_wrapper.sh"
+        assert wrapper_path.exists()
+        content = wrapper_path.read_text()
+        assert "#!/bin/bash" in content
+        assert "start_nginx" in content
+        assert "start_model_server" in content
+        assert "cleanup" in content
 
-        command = cfg.get("program:model-server", "command")
-        assert command == start_command, f"Command mismatch for {test_id}"
-
-    @pytest.mark.parametrize(
-        "test_id,start_command,expected_substrings",
-        [
-            # Environment variable exports
-            (
-                "env_exports",
-                """sh -c "
-export HF_TOKEN=$(cat /secrets/hf_access_token)
-export CUDA_VISIBLE_DEVICES=0
-vllm serve model --port 8000
-"
-""",
-                ["export HF_TOKEN", "export CUDA_VISIBLE_DEVICES", "vllm serve"],
-            ),
-            # If/then/else conditional
-            (
-                "if_then_else",
-                """sh -c "
-if [ -f /config/custom.yaml ]; then
-    python main.py --config /config/custom.yaml
-else
-    python main.py --config /defaults.yaml
-fi
-"
-""",
-                ["if [", "then", "else", "fi"],
-            ),
-            # For loop
-            (
-                "for_loop",
-                """sh -c "
-for i in 1 2 3; do
-    echo 'Attempt $i'
-    python main.py && break
-    sleep 5
-done
-"
-""",
-                ["for i in", "do", "done", "sleep"],
-            ),
-            # While loop with retry logic
-            (
-                "while_retry",
-                """sh -c "
-while ! curl -s localhost:8080/health; do
-    echo 'Waiting for service...'
-    sleep 2
-done
-python main.py
-"
-""",
-                ["while", "curl", "sleep", "done"],
-            ),
-            # Function definition
-            (
-                "function_def",
-                """sh -c "
-setup() {
-    export PATH=/opt/bin:$PATH
-    export LD_LIBRARY_PATH=/opt/lib
-}
-setup
-python main.py
-"
-""",
-                ["setup()", "export PATH", "setup\n"],
-            ),
-            # Here-string (simple form)
-            (
-                "here_string",
-                """sh -c "
-cat > /tmp/config.json << 'EOF'
-{\"model\": \"llama\", \"port\": 8000}
-EOF
-python main.py
-"
-""",
-                ["cat >", "EOF", '{"model"'],
-            ),
-            # Trap for signal handling
-            (
-                "trap_signals",
-                """sh -c "
-trap 'echo Caught signal; exit 1' SIGTERM SIGINT
-python main.py &
-wait
-"
-""",
-                ["trap", "SIGTERM", "wait"],
-            ),
-            # Complex real-world vLLM example
-            (
-                "vllm_full",
-                """sh -c "
-export HF_TOKEN=$(cat /secrets/hf_access_token)
-export CUDA_VISIBLE_DEVICES=0,1,2,3
-
-# Wait for GPU to be ready
-sleep 5
-
-vllm serve meta-llama/Meta-Llama-3.1-70B-Instruct \\
-    --port 8000 \\
-    --tensor-parallel-size 4 \\
-    --max-model-len 8192
-"
-""",
-                ["export HF_TOKEN", "CUDA_VISIBLE_DEVICES", "tensor-parallel-size"],
-            ),
-            # Case statement
-            (
-                "case_statement",
-                """sh -c "
-case $MODEL_SIZE in
-    small) python main.py --size 7b ;;
-    medium) python main.py --size 13b ;;
-    large) python main.py --size 70b ;;
-    *) echo 'Unknown size'; exit 1 ;;
-esac
-"
-""",
-                ["case", "small)", "esac"],
-            ),
-            # Arithmetic and test expressions
-            (
-                "arithmetic",
-                """sh -c "
-GPU_COUNT=$(nvidia-smi -L | wc -l)
-if [ $GPU_COUNT -ge 4 ]; then
-    PARALLEL=4
-else
-    PARALLEL=$GPU_COUNT
-fi
-python main.py --gpus $PARALLEL
-"
-""",
-                ["GPU_COUNT=", "nvidia-smi", "-ge 4"],
-            ),
-        ],
-    )
-    def test_multiline_commands(
-        self, tmp_path, test_id, start_command, expected_substrings
-    ):
-        """Test various multiline start_command patterns with shell constructs."""
-        import configparser
-
+    def test_wrapper_script_requires_start_command(self, tmp_path):
+        """Test that missing start_command raises an assertion."""
         from truss.contexts.image_builder.serving_image_builder import (
-            generate_docker_server_supervisord_config,
+            generate_docker_server_wrapper_script,
         )
 
         class MockDockerServer:
-            pass
-
-        MockDockerServer.start_command = start_command
+            start_command = None
 
         class MockConfig:
             docker_server = MockDockerServer()
 
-        generate_docker_server_supervisord_config(tmp_path, MockConfig())
-
-        cfg = configparser.RawConfigParser()
-        cfg.read(tmp_path / "supervisord.conf")
-
-        command = cfg.get("program:model-server", "command")
-
-        # Verify newlines are preserved
-        assert "\n" in command, f"Newlines not preserved for {test_id}"
-
-        # Verify expected substrings are present
-        for substring in expected_substrings:
-            assert substring in command, (
-                f"Expected '{substring}' not found in {test_id}"
-            )
-
-        # Verify all sections exist
-        assert cfg.has_section("supervisord")
-        assert cfg.has_section("program:nginx")
-        assert cfg.has_section("eventlistener:quit_on_failure")
+        with pytest.raises(AssertionError, match="start_command is required"):
+            generate_docker_server_wrapper_script(tmp_path, MockConfig())
 
 
 def test_nginx_config_disables_disk_writes(tmp_path):

--- a/truss/tests/contexts/image_builder/test_serving_image_builder.py
+++ b/truss/tests/contexts/image_builder/test_serving_image_builder.py
@@ -811,9 +811,10 @@ class TestDockerServerWrapperScript:
         assert wrapper_path.exists()
         content = wrapper_path.read_text()
         assert "#!/bin/bash" in content
-        assert "start_nginx" in content
-        assert "start_model_server" in content
+        assert "nginx -g" in content
+        assert "bash -c" in content
         assert "cleanup" in content
+        assert "wait -n" in content
 
     def test_wrapper_script_requires_start_command(self, tmp_path):
         """Test that missing start_command raises an assertion."""


### PR DESCRIPTION
## Summary

Replaces supervisord with a lightweight shell script for `docker_server` deployments. This removes the need for a dedicated Python venv, `supervisor`, and `setuptools` in the image — nginx, curl, and `tini` are sufficient.

**Net change:** ~200 lines removed across image build, Dockerfile template, and tests.

## Motivation

`docker_server` images need to run two processes:

1. **nginx** — reverse proxy on port 8080, rewriting Baseten API paths (`/`, `/v1/models/model`, `/v1/models/model:predict`, etc.) to the user's endpoints via `proxy.conf`
2. **Model server** — arbitrary user-provided `start_command` (often multiline shell for vLLM, etc.)

Previously supervisord managed both, but it required:
- `docker_server_requirements.txt` (`supervisor`, `setuptools`)
- A `/docker_server/.venv` with uv install steps in the Dockerfile
- Generated `supervisord.conf` and an event listener script at build time

A ~45-line shell script does the same job with fewer moving parts.

## How it works

### Container process tree

```
tini (PID 1)
  └── server_wrapper.sh
        ├── nginx -g "daemon off;"
        └── bash -c "$START_COMMAND"
```

`tini` is installed as PID 1 (`tini -g -- server_wrapper.sh`) for reliable signal forwarding and zombie reaping. The `-g` flag sends signals to the child's process group, which helps when the model server spawns subprocesses.

### `server_wrapper.sh` lifecycle

Config is injected at image build time as environment variables from `config.yaml`:

| Env var | Source | Purpose |
|---------|--------|---------|
| `START_COMMAND` | `docker_server.start_command` | Command to start the model server |
| `SERVER_PORT` | `docker_server.server_port` | Port the model server listens on |
| `READINESS_ENDPOINT` | `docker_server.readiness_endpoint` | Path to probe for readiness |

**Startup:**
1. Start nginx in the background
2. Start the model server in the background via `bash -c "$START_COMMAND"` (if `START_COMMAND` is set)
3. Optionally poll readiness for up to 30s by curling `http://127.0.0.1:$SERVER_PORT$READINESS_ENDPOINT` (skipped if env vars are missing; logs a warning instead of exiting)

**Steady state:**
- `wait -n` blocks until nginx or the model server exits
- Container exits with code 1 so the platform (Kubernetes/Baseten) restarts it
- No in-container restart loop — if either process dies, the whole container is recycled

**Shutdown:**
- `SIGTERM`/`SIGINT` triggers `cleanup()`, which gracefully stops both processes and exits 0

The script is intentionally non-strict: no `set -euo pipefail`, no hard failure on unset env vars. It only exits (non-zero) when a managed process stops.

### Behavior vs supervisord

| Behavior | supervisord (before) | server_wrapper.sh (after) |
|----------|---------------------|---------------------------|
| nginx crash | Auto-restart in-container | Container exits, platform restarts |
| Model server crash | Container exits (no restart) | Container exits, platform restarts |
| Startup wait | `startsecs=30` | 30s readiness poll (best-effort) |
| Graceful shutdown | SIGTERM to supervisord | SIGTERM → cleanup → stop both |
| Dependencies | Python venv + supervisor | nginx + curl + tini |

Dropping nginx in-container auto-restart is intentional: the platform is a better place to handle restarts, and it keeps the script simple.

## Files changed

| File | Change |
|------|--------|
| `truss/templates/docker_server/server_wrapper.sh` | New process manager |
| `truss/templates/server.Dockerfile.jinja` | Install nginx/curl/tini; drop supervisord venv; new entrypoint |
| `truss/contexts/image_builder/serving_image_builder.py` | Copy wrapper instead of generating supervisord config |
| `truss/templates/docker_server_requirements.txt` | Deleted |
| `truss/tests/contexts/image_builder/test_serving_image_builder.py` | Simplified tests (static template, no configparser parametrization) |
| `AGENTS.md` | Updated architecture note |

## Test plan

- [x] `uv run pytest truss/tests/contexts/image_builder/test_serving_image_builder.py -k "docker_server or nginx_config" -v`
- [ ] `uv run pytest truss/tests/test_custom_server.py -v -m integration` (requires Docker)