### PR TITLE
Replace manual GraphQL string building with gql-query-builder

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "tenacity>=8.0.1",
     "watchfiles>=0.19.0,<0.20",
     "truss-transfer>=0.0.37,<0.0.40",
+    "gql-query-builder (>=0.1.7,<0.2.0)",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,9 @@ default-groups = [
     "dev-server",
 ]
 
+[tool.uv.extra-build-dependencies]
+gql-query-builder = ["pip"]
+
 # Simplified Hatchling configuration - let it auto-discover truss, manually include others
 [tool.hatch.build.targets.sdist]
 include = [

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -1,4 +1,3 @@
-import json
 import logging
 from enum import Enum
 from typing import Any, Dict, List, Mapping, Optional

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.9, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -964,6 +964,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/39/24/33db22342cf4a2ea2
 wheels = [
     { url = "https://files.pythonhosted.org/packages/86/f1/62a193f0227cf15a920390abe675f386dec35f7ae3ffe6da582d3ade42c7/googleapis_common_protos-1.70.0-py3-none-any.whl", hash = "sha256:b8bfcca8c25a2bb253e0e0b0adaf8c00773e5e6af6fd92397576680b807e0fd8", size = 294530, upload-time = "2025-04-14T10:17:01.271Z" },
 ]
+
+[[package]]
+name = "gql-query-builder"
+version = "0.1.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/62/bd/68d07678108ae2038dfd98ed4fdfcde833a2c015af27ef23c2a30020b406/gql-query-builder-0.1.7.tar.gz", hash = "sha256:99fd8e3f883b75fded271ab7957b7da6d6ec197679f0da7ff3d7d74c34b12842", size = 6711, upload-time = "2021-12-07T01:51:40.782Z" }
 
 [[package]]
 name = "grpcio"
@@ -3321,6 +3327,7 @@ dependencies = [
     { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "click", version = "8.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "google-cloud-storage" },
+    { name = "gql-query-builder" },
     { name = "httpx" },
     { name = "httpx-ws" },
     { name = "huggingface-hub" },
@@ -3393,6 +3400,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.34.85,<2" },
     { name = "click", specifier = ">=8.0.3,<9" },
     { name = "google-cloud-storage", specifier = ">=2.10.0" },
+    { name = "gql-query-builder", specifier = ">=0.1.7,<0.2.0" },
     { name = "httpx", specifier = ">=0.24.1" },
     { name = "httpx-ws", specifier = ">=0.7.1,<0.8" },
     { name = "huggingface-hub", specifier = ">=0.25.0" },


### PR DESCRIPTION
## :rocket: What

Swapped out the messy string concatenation for building GraphQL mutations with a proper query builder library. This follows GraphQL best practices by using structured query building instead of manual string formatting, making the code cleaner and less prone to syntax errors and injection.

## :computer: How

Added gql-query-builder as a dependency to handle GraphQL query construction. Refactored the `deploy_chain_atomic` method to use the query builder instead of manually building strings, which provides better parameter handling by properly filtering out null values and handling optional parameters.

## :microscope: Testing

Added a new test that validates complex GraphQL mutations with multiple dependencies. Updated existing tests to work with the cleaner query format, and all tests use regex to make sure the GraphQL structure is correct. Everything still works the same way from the outside.
