### PR TITLE
allow users to truss init an existing directory

### DIFF
--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -196,10 +196,12 @@ def init(target_directory, backend, name, python_config) -> None:
     TARGET_DIRECTORY: A Truss is created in this directory
     """
     if os.path.isdir(target_directory):
-        raise click.ClickException(
-            f"Error: Directory '{target_directory}' already exists "
-            "and cannot be overwritten."
-        )
+        if not click.confirm(
+            f"Directory '{target_directory}' already exists. "
+            "Are you okay with overwriting it?"
+        ):
+            click.echo("Init aborted.")
+            return
     tr_path = Path(target_directory)
     build_config = Build(model_server=ModelServer[backend])
     if name:

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -198,7 +198,8 @@ def init(target_directory, backend, name, python_config) -> None:
     if os.path.isdir(target_directory):
         if not click.confirm(
             f"Directory '{target_directory}' already exists. "
-            "Are you okay with overwriting it?"
+            "Files in the directory may be overwritten. "
+            "Are you sure you want to continue?"
         ):
             click.echo("Init aborted.")
             return


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
allow users to truss init an existing directory but adds a warning that files may be overwritten and asks user to confirm before continuing 

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
manually tested
<img width="892" height="216" alt="Screenshot 2025-12-16 at 3 18 23 PM" src="https://github.com/user-attachments/assets/fdba87f1-a48c-4e3d-8781-4f07d5393244" />
