### PR TITLE
truss init CLI to accept a positional project name argument

### DIFF
--- a/truss/cli/train_commands.py
+++ b/truss/cli/train_commands.py
@@ -510,24 +510,42 @@ def download_checkpoint_artifacts(job_id: Optional[str], remote: Optional[str]) 
 
 
 @train.command(name="init")
+@click.argument("project_name", type=str, required=False, default="hello-world")
 @click.option("--list-examples", is_flag=True, help="List all available examples.")
-@click.option("--target-directory", type=str, required=False)
-@click.option("--examples", type=str, required=False)
+@click.option(
+    "--target-directory",
+    type=str,
+    required=False,
+    help="Directory to download examples into (only used with --examples).",
+)
+@click.option(
+    "--examples",
+    type=str,
+    required=False,
+    help="Comma-separated list of examples to download from ml-cookbook.",
+)
 @common.common_options()
 def init_training_job(
+    project_name: str,
     list_examples: Optional[bool],
     target_directory: Optional[str],
     examples: Optional[str],
 ) -> None:
+    """
+    Initialize a new training project.
+
+    PROJECT_NAME: Name of the directory to create for the training project.
+    Defaults to 'hello-world' if not specified.
+    """
     try:
         if list_examples:
             all_examples = train_cli._get_all_train_init_example_options()
             console.print("Available training examples:", style="bold")
             for example in all_examples:
                 console.print(f"- {example}")
+            console.print("\nTo download examples, run:", style="bold")
             console.print(
-                "To launch, run `truss train init --examples <example1,example2>`",
-                style="bold",
+                "  truss train init --examples <example1,example2>", style="cyan"
             )
             return
 
@@ -535,17 +553,31 @@ def init_training_job(
 
         # No examples selected, initialize empty training project structure
         if not selected_options:
-            if target_directory is None:
-                target_directory = "truss-train-init"
-            console.print(f"Initializing empty training project at {target_directory}")
-            os.makedirs(target_directory)
-            copy_tree_path(Path(TRAINING_TEMPLATE_DIR), Path(target_directory))
+            target_path = Path(project_name)
+
+            if target_path.exists():
+                error_console.print(
+                    f"Error: Directory '{project_name}' already exists. "
+                    "Please choose a different name or remove the existing directory."
+                )
+                sys.exit(1)
+
+            console.print(f"Initializing training project at '{project_name}'...")
+            os.makedirs(project_name)
+            copy_tree_path(Path(TRAINING_TEMPLATE_DIR), target_path)
             console.print(
-                f"✨ Empty training project initialized at {target_directory}",
+                f"\n✨ Training project initialized at '{project_name}/'",
                 style="bold green",
             )
+            console.print("\nNext steps:", style="bold")
+            console.print(f"  cd {project_name}", style="cyan")
+            console.print(
+                "  # Edit config.py to configure your training job", style="dim"
+            )
+            console.print("  truss train push config.py", style="cyan")
             return
 
+        # Examples mode: download examples to target directory or current directory
         if target_directory is None:
             target_directory = os.getcwd()
         for example_to_download in selected_options:
@@ -557,7 +589,8 @@ def init_training_job(
             if not download_info:
                 all_examples = train_cli._get_all_train_init_example_options()
                 error_console.print(
-                    f"Example {example_to_download} not found in the ml-cookbook repository. Examples have to be one or more comma separated values from: {', '.join(all_examples)}"
+                    f"Example '{example_to_download}' not found in the ml-cookbook repository. "
+                    f"Examples must be one or more comma-separated values from: {', '.join(all_examples)}"
                 )
                 continue
             success = train_cli.download_git_directory(
@@ -565,12 +598,12 @@ def init_training_job(
             )
             if success:
                 console.print(
-                    f"✨ Training directory for {example_to_download} initialized at {local_dir}",
+                    f"✨ Training directory for '{example_to_download}' initialized at '{local_dir}'",
                     style="bold green",
                 )
             else:
                 error_console.print(
-                    f"Failed to initialize training artifacts to {local_dir}"
+                    f"Failed to initialize training artifacts to '{local_dir}'"
                 )
 
     except Exception as e:

--- a/truss/templates/train/config.py
+++ b/truss/templates/train/config.py
@@ -1,46 +1,49 @@
 # Import necessary classes from the Baseten Training SDK
 from truss_train import definitions
-from truss.base import truss_config
 
-PROJECT_NAME = "My-Baseten-Training-Project"
-NUM_NODES = 1
-NUM_GPUS_PER_NODE = 1
+# Project name - change this to identify your training project
+PROJECT_NAME = "MNIST Training Example"
 
-# 1. Define a base image for your training job. You can also use
-# private images via AWS IAM or GCP Service Account authentication.
-BASE_IMAGE = "pytorch/pytorch:2.7.0-cuda12.8-cudnn9-runtime"
+# Base image with PyTorch pre-installed
+BASE_IMAGE = "pytorch/pytorch:2.6.0-cuda12.4-cudnn9-runtime"
 
-# 2. Define the Runtime Environment for the Training Job
-# This includes start commands and environment variables.
-# Secrets from the baseten workspace like API keys are referenced using
-# `SecretReference`.
+# Runtime configuration
 training_runtime = definitions.Runtime(
-    start_commands=[  # Example: list of commands to run your training script
-        "/bin/sh -c 'chmod +x ./run.sh && ./run.sh'"
+    start_commands=[
+        "/bin/sh -c 'chmod +x ./run.sh && ./run.sh'",
     ],
     environment_variables={
+        # Add your secrets here (configure in Baseten workspace first):
         # "HF_TOKEN": definitions.SecretReference(name="hf_access_token"),
-        "HELLO": "WORLD"
+        # "WANDB_API_KEY": definitions.SecretReference(name="wandb_api_key"),
     },
-    cache_config=definitions.CacheConfig(
-        enabled=False  # Set to True to enable caching between runs
-    ),
+    # Enable checkpointing to save model weights to Baseten
     checkpointing_config=definitions.CheckpointingConfig(
-        enabled=False  # Set to True to enable saving checkpoints on Baseten
+        enabled=True,
+    ),
+    # Enable caching for datasets and other reusable files
+    cache_config=definitions.CacheConfig(
+        enabled=True,
     ),
 )
 
+# Compute configuration - CPU only for this example
+# For GPU training, uncomment and modify the accelerator section
 training_compute = definitions.Compute(
-    node_count=NUM_NODES,
-    accelerator=truss_config.AcceleratorSpec(
-        accelerator=truss_config.Accelerator.H100, count=NUM_GPUS_PER_NODE
-    ),
+    cpu_count=4,
+    memory="16Gi",
+    # accelerator=truss_config.AcceleratorSpec(
+    #     accelerator=truss_config.Accelerator.H100,
+    #     count=1,
+    # ),
 )
 
+# Combine into a training job
 training_job = definitions.TrainingJob(
     image=definitions.Image(base_image=BASE_IMAGE),
     compute=training_compute,
     runtime=training_runtime,
 )
 
+# Define the training project
 training_project = definitions.TrainingProject(name=PROJECT_NAME, job=training_job)

--- a/truss/templates/train/requirements.txt
+++ b/truss/templates/train/requirements.txt
@@ -1,0 +1,2 @@
+torch
+torchvision

--- a/truss/templates/train/run.sh
+++ b/truss/templates/train/run.sh
@@ -1,11 +1,6 @@
 #!/bin/bash
-
-# Exit immediately if a command exits with a non-zero status
 set -eux
 
-echo "Initializing model training environment..."
-# TODO: Call your training logic below
-echo "Placeholder: insert your model training logic below."
-# e.g., python train_model.py --config config.yaml --epochs 10
+pip install -r requirements.txt
 
-echo "Training process completed (placeholder)."
+python train.py

--- a/truss/templates/train/train.py
+++ b/truss/templates/train/train.py
@@ -1,0 +1,106 @@
+"""
+MNIST Training Example
+
+A simple CNN classifier for the MNIST handwritten digits dataset.
+This example demonstrates:
+- Using BT_RW_CACHE_DIR for caching downloaded data
+- Using BT_CHECKPOINT_DIR for saving model checkpoints
+- Basic PyTorch training loop
+"""
+
+import os
+
+import torch
+import torch.nn as nn
+import torch.optim as optim
+import torchvision
+import torchvision.transforms as transforms
+from torch.utils.data import DataLoader
+
+# Device setup
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+print(f"Using device: {device}")
+
+# Data directory - use cache so data persists between runs
+data_dir = os.path.join(os.environ["BT_RW_CACHE_DIR"], "mnist")
+
+# Data loaders
+transform = transforms.ToTensor()
+train_loader = DataLoader(
+    torchvision.datasets.MNIST(
+        data_dir, train=True, download=True, transform=transform
+    ),
+    batch_size=512,
+    shuffle=True,
+)
+test_loader = DataLoader(
+    torchvision.datasets.MNIST(
+        data_dir, train=False, download=True, transform=transform
+    ),
+    batch_size=512,
+    shuffle=False,
+)
+
+
+# Simple CNN model
+class MNISTClassifier(nn.Module):
+    def __init__(self):
+        super(MNISTClassifier, self).__init__()
+        self.conv1 = nn.Conv2d(1, 16, 3, 1)
+        self.conv2 = nn.Conv2d(16, 32, 3, 1)
+        self.pool = nn.MaxPool2d(2)
+        self.flatten = nn.Flatten()
+        self.fc1 = nn.Linear(4608, 128)
+        self.fc2 = nn.Linear(128, 10)
+        self.relu = nn.ReLU()
+
+    def forward(self, x):
+        x = self.relu(self.conv1(x))
+        x = self.relu(self.conv2(x))
+        x = self.pool(x)
+        x = self.flatten(x)
+        x = self.relu(self.fc1(x))
+        x = self.fc2(x)
+        return x
+
+
+model = MNISTClassifier().to(device)
+
+# Training setup
+optimizer = optim.Adam(model.parameters(), lr=0.0001)
+criterion = nn.CrossEntropyLoss()
+
+# Checkpoint directory - Baseten will save these for you
+checkpoint_dir = os.environ["BT_CHECKPOINT_DIR"]
+os.makedirs(checkpoint_dir, exist_ok=True)
+
+# Training loop
+print("Starting MNIST training...")
+for epoch in range(5):
+    # Train
+    model.train()
+    for batch_idx, (data, target) in enumerate(train_loader):
+        data, target = data.to(device), target.to(device)
+        optimizer.zero_grad()
+        loss = criterion(model(data), target)
+        loss.backward()
+        optimizer.step()
+        if batch_idx % 200 == 0:
+            print(f"Epoch: {epoch + 1}, Batch: {batch_idx}, Loss: {loss.item():.4f}")
+
+    # Evaluate
+    model.eval()
+    correct = sum(
+        model(data.to(device)).argmax(1).eq(target.to(device)).sum().item()
+        for data, target in test_loader
+    )
+    accuracy = 100.0 * correct / len(test_loader.dataset)
+    print(f"Epoch {epoch + 1}: Accuracy: {accuracy:.2f}%")
+
+    # Save checkpoint
+    torch.save(
+        model.state_dict(), os.path.join(checkpoint_dir, f"epoch_{epoch + 1}.pth")
+    )
+
+print("Training completed!")
+torch.save(model.state_dict(), os.path.join(checkpoint_dir, "final.pth"))


### PR DESCRIPTION
:rocket: What                                                              
                                                                           
truss init CLI to accept a positional project name argument following conventions established by tools like `npm init`, `cargo new`, and `django-admin startproject`. 
                                                                                                         
Before:                                                                    
- `truss train init` created a directory named truss-train-init              
- `truss train init my-project` did nothing useful (argument was ignored)    
                                                                           
After:                                                                     
- `truss train init` creates a `hello-world`/ directory with a working MNIST   
example                                                                    
- truss train init my-project creates a my-project/ directory              
- Provides clear "Next steps" guidance after initialization                
- Errors gracefully if the directory already exists                        
                                                                           
:computer: How                                                             
                                                                           
1. CLI argument parsing (truss/cli/train_commands.py):                     
  - Added `PROJECT_NAME` as a positional argument with default `hello-world`   
  - Kept` --target-directory` option for `--examples` mode

2. Updated default template (truss/templates/train/):                      
  - Added train.py with PyTorch MNIST classifier training code             
      
                                                                           
:microscope: Testing                                                       
                                                                           
- All CLI tests pass                                     
- Manual testing verified:                                                 
  - truss train init creates hello-world/ with all 4 files                 
  - truss train init my-project creates my-project/ correctly              
