### PR TITLE
docs: update truss push examples to use explicit --publish/--watch flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,10 @@ To set up the Baseten remote, you'll need a [Baseten API key](https://app.basete
 With your Baseten API key ready to paste when prompted, you can deploy your model:
 
 ```sh
-truss push
+truss push --publish
 ```
+
+For development with hot reload support, use `truss push --watch` instead.
 
 You can monitor your model deployment from [your model dashboard on Baseten](https://app.baseten.co/models/).
 

--- a/docs/examples/01-getting-started-bert.mdx
+++ b/docs/examples/01-getting-started-bert.mdx
@@ -119,10 +119,12 @@ external_package_dirs: []
 Deploy the model with the following command:
 
 ```bash
-$ truss push
+$ truss push --publish
 ```
 
-And then you can performance inference with:
+For development with hot reload, use `truss push --watch` instead.
+
+And then you can perform inference with:
 ```
 $ truss predict -d '"Truss is awesome!"'
 ```

--- a/docs/examples/02-llm.mdx
+++ b/docs/examples/02-llm.mdx
@@ -117,8 +117,11 @@ system_packages: []
 
 Deploy the model like you would other Trusses, with:
 ```bash
-$ truss push
+$ truss push --publish
 ```
+
+For development with hot reload, use `truss push --watch` instead.
+
 You can then invoke the model with:
 ```bash
 $ truss predict -d '{"inputs": "What is a large language model?"}'

--- a/docs/examples/04-image-generation.mdx
+++ b/docs/examples/04-image-generation.mdx
@@ -250,8 +250,11 @@ model_cache:
 
 Deploy the model like you would other Trusses, with:
 ```bash
-$ truss push
+$ truss push --publish
 ```
+
+For development with hot reload, use `truss push --watch` instead.
+
 You can then invoke the model with:
 ```bash
 $ truss predict -d '{"prompt": "A tree in a field under the night sky", "use_refiner": true}'

--- a/docs/examples/06-high-performance-cached-weights.mdx
+++ b/docs/examples/06-high-performance-cached-weights.mdx
@@ -114,9 +114,12 @@ secrets: {}
 
 Deploy the model like you would other Trusses, with:
 ```bash
-$ truss push
+$ truss push --publish
 ```
- <Note>
+
+For development with hot reload, use `truss push --watch` instead.
+
+<Note>
  The build step will take  longer than with the normal
  Llama Truss, since bundling the model weights is now happening during the build.
  The deploy step & scale-ups will happen much faster with this approach.

--- a/docs/examples/09-private-huggingface.mdx
+++ b/docs/examples/09-private-huggingface.mdx
@@ -88,8 +88,10 @@ system_packages: []
 # Deploying the model
 
 ```bash
-$ truss push
+$ truss push --publish
 ```
+
+For development with hot reload, use `truss push --watch` instead.
 
 After the model finishes deploying, you can invoke it with:
 ```bash

--- a/docs/examples/10-using-system-packages.mdx
+++ b/docs/examples/10-using-system-packages.mdx
@@ -85,8 +85,11 @@ system_packages:
 ```
 # Deploy the model
 ```bash
-$ truss push
+$ truss push --publish
 ```
+
+For development with hot reload, use `truss push --watch` instead.
+
 You can then invoke the model with:
 ```
 $ truss predict -d '{"url": "https://templates.invoicehome.com/invoice-template-us-neat-750px.png", "prompt": "What is the invoice number?"}'

--- a/docs/examples/performance/cached-weights.mdx
+++ b/docs/examples/performance/cached-weights.mdx
@@ -139,8 +139,10 @@ You'll need a [Baseten API key](https://app.baseten.co/settings/account/api_keys
 We have successfully packaged Llama 2 as a Truss. Let's deploy!
 
 ```sh
-truss push
+truss push --publish
 ```
+
+For development with hot reload, use `truss push --watch` instead.
 
 ### Step 5: Invoke the model
 

--- a/docs/examples/private-model.mdx
+++ b/docs/examples/private-model.mdx
@@ -155,8 +155,10 @@ You'll need a [Baseten API key](https://app.baseten.co/settings/account/api_keys
 We have successfully packaged a gated model as a Truss. Let's deploy!
 
 ```sh
-truss push
+truss push --publish
 ```
+
+For development with hot reload, use `truss push --watch` instead.
 
 Wait for the model to finish deployment before invoking.
 

--- a/docs/examples/streaming.mdx
+++ b/docs/examples/streaming.mdx
@@ -223,8 +223,10 @@ You'll need a [Baseten API key](https://app.baseten.co/settings/account/api_keys
 We have successfully packaged Falcon as a Truss. Let's deploy! Run:
 
 ```sh
-truss push
+truss push --publish
 ```
+
+For development with hot reload, use `truss push --watch` instead.
 
 ### Step 5: Invoke the model
 

--- a/docs/examples/system-packages.mdx
+++ b/docs/examples/system-packages.mdx
@@ -132,8 +132,10 @@ You'll need a [Baseten API key](https://app.baseten.co/settings/account/api_keys
 We have successfully packaged LayoutLM Document QA as a Truss. Let's deploy!
 
 ```sh
-truss push
+truss push --publish
 ```
+
+For development with hot reload, use `truss push --watch` instead.
 
 You can invoke the model with:
 


### PR DESCRIPTION
## Summary
- Update documentation examples to use explicit `--publish` flag for production deployments
- Add note about `--watch` flag for development deployments with hot reload

## Context
Following the merge of PR #1969, `truss push` now:
- Defaults to **published deployment** when no flag is specified
- Accepts `--watch` flag for development deployments with hot reload support

This PR updates the truss repository documentation to reflect the new CLI behavior.

## Test plan
- [x] Verified documentation examples are accurate
- [x] Verified notes correctly describe default behavior