### PR TITLE
Make truss FastAPI-starlette compatible with a lifespan function

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "truss"
-version = "0.13.2"
+version = "0.13.2rc500"
 description = "A seamless bridge from model development to model delivery"
 authors = [
     { name = "Pankaj Gupta", email = "no-reply@baseten.co" },

--- a/uv.lock
+++ b/uv.lock
@@ -3393,7 +3393,7 @@ wheels = [
 
 [[package]]
 name = "truss"
-version = "0.13.2"
+version = "0.13.2rc500"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## :rocket: What
Define and use a single lifespan() function that yields after startup.

## :computer: How
Define function, call where needed.

## :microscope: Testing
Unit tests passing.

[Integration tests](https://github.com/basetenlabs/truss/actions/runs/21770706665)