### PR TITLE
Add --output json, --dry-run to push/predict and CONTEXT.md

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,90 @@
+# Truss CLI Agent Context
+
+## Authentication
+
+Set `BASETEN_API_KEY` as an environment variable. Never use interactive login.
+
+```bash
+export BASETEN_API_KEY="your-api-key"
+```
+
+## Essential Commands
+
+### Deploy a model
+
+```bash
+# Published deployment (production-ready, autoscaling)
+truss push --remote baseten --model-name "my-model" --non-interactive
+
+# Development deployment (fast iteration, live reload)
+truss push --remote baseten --model-name "my-model" --watch --non-interactive
+```
+
+### Iterate on a development deployment
+
+```bash
+# Re-attach to existing development deployment
+truss watch --remote baseten --model-name "my-model" --non-interactive
+```
+
+### Call a model
+
+```bash
+# Falls back to model name from config.yaml in the truss directory
+truss predict --remote baseten -d '{"prompt": "hello"}'
+
+# By model ID (targets development deployment by default)
+truss predict --remote baseten --model "model-id" -d '{"prompt": "hello"}'
+
+# By deployment ID (targets specific deployment)
+truss predict --remote baseten --model-deployment "deploy-id" -d '{"prompt": "hello"}'
+
+# Target the published (production) deployment
+truss predict --remote baseten --published -d '{"prompt": "hello"}'
+```
+
+### Deploy a chain
+
+```bash
+truss chains push my_chain.py --name "my-chain" --remote baseten --non-interactive
+```
+
+## Rules for Agents
+
+- Always use `--non-interactive` to disable prompts (available on `push`, `watch`, `chains push`, and most commands via `common_options`)
+- Always use `--remote baseten` (or whatever remote is configured)
+- For `predict`, pass JSON with `-d` or `-f path/to/file.json`
+- `truss push` without `--watch` creates a published deployment (production)
+- `truss push --watch` creates a development deployment and starts watching for code changes
+- `truss watch` re-attaches to an existing development deployment (fails if none exists)
+- `--promote` deploys directly to the production environment
+- `--environment staging` deploys to a named environment
+- `config.yaml` is the source of truth for model resources, dependencies, and settings
+- Model names are set in `config.yaml` under `model_name:` or overridden with `--model-name`
+
+## Configuration (config.yaml)
+
+Key fields:
+
+```yaml
+model_name: my-model
+resources:
+  accelerator: L4        # GPU type (L4, A10G, A100, H100, etc.)
+  instance_type: "L4:4x16"  # Or specify exact instance
+requirements:
+  - torch
+  - transformers
+secrets:
+  hf_access_token: null  # Set in Baseten workspace
+environment_variables: {}
+```
+
+## Common Mistakes to Avoid
+
+- Do NOT use `truss login` in automated contexts — use `BASETEN_API_KEY` env var
+- Do NOT omit `--non-interactive` — the CLI may prompt for input and hang
+- Do NOT confuse `truss push --watch` (creates new dev deployment) with `truss watch` (re-attaches to existing)
+- Do NOT use `--promote` with `--watch` — they are mutually exclusive
+- Do NOT use `--environment` with `--watch` — they are mutually exclusive
+- Do NOT use `--wait` with `--tail` — they are mutually exclusive
+- Do NOT use `--promote` with `--environment` — they are mutually exclusive

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -27,7 +27,8 @@ from truss.cli.resolvers.model_team_resolver import (
     resolve_model_team_name,
 )
 from truss.cli.utils import common, self_upgrade
-from truss.cli.utils.output import console, error_console
+from truss.cli.utils.common import is_json_output
+from truss.cli.utils.output import console, error_console, json_output
 from truss.remote.baseten.core import (
     ACTIVE_STATUS,
     DEPLOYING_STATUSES,
@@ -394,6 +395,7 @@ def _extract_request_data(data: Optional[str], file: Optional[Path]):
 )
 @click.option("--model", type=str, required=False, help="ID of model to call")
 @common.log_level_option
+@common._output_format_option
 def predict(
     target_directory: str,
     remote: str,
@@ -451,7 +453,10 @@ def predict(
         for chunk in result:
             click.echo(chunk, nl=False)
         return
-    console.print_json(data=result)
+    if is_json_output() or not sys.stdout.isatty():
+        json_output(result)
+    else:
+        console.print_json(data=result)
 
 
 @truss_cli.command()
@@ -640,6 +645,13 @@ def run_python(script, target_directory):
         "to apply live patches. Cannot be used with --promote, --environment, or --tail."
     ),
 )
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Validate and resolve the deployment without actually pushing. Shows what would happen.",
+)
+@common._output_format_option
 @common.common_options()
 def push(
     target_directory: str,
@@ -662,6 +674,7 @@ def push(
     provided_team_name: Optional[str] = None,
     labels: Optional[str] = None,
     watch_after_push: bool = False,
+    dry_run: bool = False,
 ) -> None:
     """
     Pushes a truss to a TrussRemote.
@@ -669,9 +682,12 @@ def push(
     TARGET_DIRECTORY: A Truss directory. If none, use current directory.
 
     """
+    json_mode = is_json_output()
+    # In JSON mode, use stderr for human messages to keep stdout clean
+    out = error_console if json_mode else console
 
     if publish:
-        console.print(
+        out.print(
             "[DEPRECATED] The --publish flag is deprecated. Published deployments are now the default.",
             style="yellow",
         )
@@ -692,16 +708,24 @@ def push(
             )
         if tail:
             raise click.UsageError("Cannot use --watch with --tail.")
+        if dry_run:
+            raise click.UsageError("Cannot use --watch with --dry-run.")
         # Development deployment for watch mode
         publish = False
         wait = True
     else:
         # Default is now published deployment
         publish = True
-        console.print(
-            "Deploying as a published deployment. Use --watch for a development deployment.",
-            style="green",
-        )
+        if not json_mode:
+            out.print(
+                "Deploying as a published deployment. Use --watch for a development deployment.",
+                style="green",
+            )
+
+    if dry_run and wait:
+        raise click.UsageError("Cannot use --dry-run with --wait.")
+    if dry_run and tail:
+        raise click.UsageError("Cannot use --dry-run with --tail.")
 
     if wait and tail:
         raise click.UsageError(
@@ -711,7 +735,7 @@ def push(
     tr = _get_truss_from_directory(target_directory=target_directory, config=config)
 
     if tr.spec.config.resources.instance_type:
-        console.print(
+        out.print(
             "Field 'instance_type' specified - ignoring 'cpu', 'memory', 'accelerator', and 'use_gpu' fields.",
             style="yellow",
         )
@@ -768,7 +792,7 @@ def push(
 
     if preserve_env_instance_type is not None and not environment:
         preserve_env_warning = "'preserve-env-instance-type' flag specified without the 'environment' parameter. Ignoring the value of `preserve-env-instance-type`"
-        console.print(preserve_env_warning, style="yellow")
+        out.print(preserve_env_warning, style="yellow")
     if preserve_env_instance_type is None:
         # If the flag is not specified, we set it to True by default. We handle the default here instead of in click.options
         # to only print the warning above when the flag was specified by the user.
@@ -777,15 +801,15 @@ def push(
     if environment:
         if preserve_env_instance_type:
             preserve_env_info = f"'preserve-env-instance-type' used. Resources from the config will be ignored and the current instance type of the '{environment}' environment will be used."
-            console.print(preserve_env_info)
+            out.print(preserve_env_info)
         else:
             preserve_env_info = f"'no-preserve-env-instance-type' used. Instance type will be derived from the config and updated in the '{environment}' environment."
-            console.print(preserve_env_info)
+            out.print(preserve_env_info)
 
     # Log a warning if using --trusted.
     if trusted is not None:
         trusted_deprecation_notice = "[DEPRECATED] '--trusted' option is deprecated and no longer needed. All models are trusted by default."
-        console.print(trusted_deprecation_notice, style="yellow")
+        out.print(trusted_deprecation_notice, style="yellow")
 
     # Parse labels from CLI option
     labels_dict: Optional[dict] = None
@@ -802,18 +826,18 @@ def push(
     if uses_trt_llm_builder(tr):
         if not publish:
             live_reload_disabled_text = "Development mode is currently not supported for trusses using TRT-LLM build flow. Remove --watch to deploy as a published model."
-            console.print(live_reload_disabled_text, style="red")
+            out.print(live_reload_disabled_text, style="red")
             sys.exit(1)
 
         if memory_updated_for_trt_llm_builder(tr):
-            console.print(
+            out.print(
                 f"Automatically increasing memory for trt-llm builder to {TRTLLM_MIN_MEMORY_REQUEST_GI}Gi."
             )
         message_oai, raised_message_oai = has_no_tags_trt_llm_builder(tr)
         if message_oai:
-            console.print(message_oai, style="yellow")
+            out.print(message_oai, style="yellow")
             if raised_message_oai:
-                console.print(message_oai, style="red")
+                out.print(message_oai, style="red")
                 sys.exit(1)
 
         trt_llm_build_config = tr.spec.config.trt_llm.build
@@ -827,7 +851,49 @@ def push(
                 "GPU memory required at build time may be significantly more than that required at inference time due to FP8 quantization, which can result in OOM failures during the engine build phase."
                 "'num_builder_gpus' can be used to specify the number of GPUs to use at build time."
             )
-            console.print(fp8_and_num_builder_gpus_text, style="yellow")
+            out.print(fp8_and_num_builder_gpus_text, style="yellow")
+
+    if dry_run:
+        resources = tr.spec.config.resources
+        resource_info = {}
+        if resources.instance_type:
+            resource_info["instance_type"] = resources.instance_type
+        else:
+            if resources.accelerator:
+                resource_info["accelerator"] = str(resources.accelerator)
+            if resources.cpu:
+                resource_info["cpu"] = str(resources.cpu)
+            if resources.memory:
+                resource_info["memory"] = str(resources.memory)
+
+        summary = {
+            "dry_run": True,
+            "model_name": model_name,
+            "is_draft": not publish,
+            "environment": environment,
+            "team": provided_team_name,
+            "config_valid": True,
+            "resources": resource_info,
+        }
+
+        if json_mode:
+            json_output(summary)
+        else:
+            console.print("[bold]Dry run summary:[/bold]")
+            console.print(f"  Model name: {model_name}")
+            console.print(
+                f"  Deployment type: {'development' if not publish else 'published'}"
+            )
+            console.print(f"  Environment: {environment or 'None'}")
+            console.print(f"  Team: {provided_team_name or 'None'}")
+            console.print("  Config valid: Yes")
+            if resource_info:
+                for k, v in resource_info.items():
+                    console.print(f"  {k}: {v}")
+            console.print(
+                "\n[yellow]Did not deploy because --dry-run flag was provided.[/yellow]"
+            )
+        return
 
     source = Path(target_directory)
     working_dir = source.parent if source.is_file() else source.resolve()
@@ -850,10 +916,25 @@ def push(
         labels=labels_dict,
     )
 
-    click.echo(f"✨ Model {model_name} was successfully pushed ✨")
+    if json_mode:
+        result_data: dict = {
+            "model_name": model_name,
+            "is_draft": service.is_draft,
+            "logs_url": service.logs_url,
+            "predict_url": service.predict_url,
+        }
+        if isinstance(service, BasetenService):
+            result_data["model_id"] = service.model_id
+            result_data["model_version_id"] = service.model_version_id
+        if not wait:
+            json_output(result_data)
+            return
+        # If --wait, continue to wait loop below, then emit JSON with status
+    else:
+        click.echo(f"✨ Model {model_name} was successfully pushed ✨")
 
-    if service.is_draft:
-        draft_model_text = """
+        if service.is_draft:
+            draft_model_text = """
 |---------------------------------------------------------------------------------------|
 | Your model is deploying as a development model. Development models allow you to       |
 | iterate quickly during the deployment process.                                        |
@@ -864,53 +945,84 @@ def push(
 |---------------------------------------------------------------------------------------|
 """
 
-        click.echo(draft_model_text)
+            click.echo(draft_model_text)
 
-    if environment:
-        promotion_text = (
-            f"Your Truss has been deployed into the {environment} environment. After it successfully "
-            f"deploys, it will become the next {environment} deployment of your model."
+        if environment:
+            promotion_text = (
+                f"Your Truss has been deployed into the {environment} environment. After it successfully "
+                f"deploys, it will become the next {environment} deployment of your model."
+            )
+            console.print(promotion_text, style="green")
+
+        console.print(
+            f"🪵  View logs for your deployment at {common.format_link(service.logs_url)}"
         )
-        console.print(promotion_text, style="green")
-
-    console.print(
-        f"🪵  View logs for your deployment at {common.format_link(service.logs_url)}"
-    )
     if wait:
         start_time = time.time()
-        with console.status("[bold green]Deploying...") as status:
+        final_status = None
+        deployment_status = None
+        if json_mode:
+            # Suppress spinners for JSON output; just poll silently
             for deployment_status in service.poll_deployment_status():
                 if (
                     timeout_seconds is not None
                     and time.time() - start_time > timeout_seconds
                 ):
-                    console.print("Deployment timed out.", style="red")
+                    result_data["status"] = "TIMED_OUT"
+                    json_output(result_data)
                     sys.exit(1)
 
-                status.update(
-                    f"[bold green]Deploying...Current Status: {deployment_status}"
-                )
-
                 if deployment_status == ACTIVE_STATUS:
-                    console.print("Deployment succeeded.", style="bold green")
+                    final_status = deployment_status
                     break
 
-                # For --watch (dev deployments), enter watch mode early
-                # once past BUILDING, so user can iterate on code
                 if watch_after_push and deployment_status in ("LOADING_MODEL"):
-                    console.print(
-                        f"Deployment status: {deployment_status}. "
-                        "Entering watch mode early for faster iteration...",
-                        style="bold blue",
-                    )
+                    final_status = deployment_status
                     break
 
                 if deployment_status not in DEPLOYING_STATUSES:
-                    console.print(
-                        f"Deployment failed with status {deployment_status}.",
-                        style="red",
-                    )
+                    result_data["status"] = deployment_status
+                    json_output(result_data)
                     sys.exit(1)
+
+            result_data["status"] = final_status or deployment_status
+            json_output(result_data)
+            if not watch_after_push:
+                return
+        else:
+            with console.status("[bold green]Deploying...") as status:
+                for deployment_status in service.poll_deployment_status():
+                    if (
+                        timeout_seconds is not None
+                        and time.time() - start_time > timeout_seconds
+                    ):
+                        console.print("Deployment timed out.", style="red")
+                        sys.exit(1)
+
+                    status.update(
+                        f"[bold green]Deploying...Current Status: {deployment_status}"
+                    )
+
+                    if deployment_status == ACTIVE_STATUS:
+                        console.print("Deployment succeeded.", style="bold green")
+                        break
+
+                    # For --watch (dev deployments), enter watch mode early
+                    # once past BUILDING, so user can iterate on code
+                    if watch_after_push and deployment_status in ("LOADING_MODEL"):
+                        console.print(
+                            f"Deployment status: {deployment_status}. "
+                            "Entering watch mode early for faster iteration...",
+                            style="bold blue",
+                        )
+                        break
+
+                    if deployment_status not in DEPLOYING_STATUSES:
+                        console.print(
+                            f"Deployment failed with status {deployment_status}.",
+                            style="red",
+                        )
+                        sys.exit(1)
 
         # If --watch was used, start watching after deploy success
         if watch_after_push:

--- a/truss/cli/utils/common.py
+++ b/truss/cli/utils/common.py
@@ -7,7 +7,7 @@ import threading
 import time
 import warnings
 from functools import wraps
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, cast
 
 import pydantic
 import requests as requests_lib
@@ -122,6 +122,18 @@ def _non_interactive_option(f: Callable[..., object]) -> Callable[..., object]:
     )(f)
 
 
+def _output_format_option(f: Callable[..., object]) -> Callable[..., object]:
+    return click.option(
+        "--output",
+        "output_format",
+        type=click.Choice(["text", "json"], case_sensitive=False),
+        default="text",
+        help="Output format. Use 'json' for machine-readable output.",
+        expose_value=False,
+        callback=_store_param_callback,
+    )(f)
+
+
 def _error_handling(f: Callable[..., object]) -> Callable[..., object]:
     @wraps(f)
     def wrapper(*args: object, **kwargs: object) -> None:
@@ -191,6 +203,15 @@ def format_link(url: str, display_text: Optional[str] = None) -> str:
 
 def is_human_log_level(ctx: click.Context) -> bool:
     return get_required_option(ctx, "log") != _HUMANFRIENDLY_LOG_LEVEL
+
+
+def get_output_format(ctx: click.Context) -> str:
+    return cast(str, get_required_option(ctx, "output_format"))
+
+
+def is_json_output() -> bool:
+    ctx = click.get_current_context()
+    return get_output_format(ctx) == "json"
 
 
 def _normalize_iso_timestamp(iso_timestamp: str) -> str:

--- a/truss/cli/utils/output.py
+++ b/truss/cli/utils/output.py
@@ -1,3 +1,6 @@
+import json
+import sys
+
 import rich
 import rich.live
 import rich.logging
@@ -15,3 +18,8 @@ rich.spinner.SPINNERS["failed"] = {"interval": 500, "frames": ["😤 ", " 😤"]
 
 console = Console()
 error_console = Console(stderr=True, style="bold red")
+
+
+def json_output(data: object) -> None:
+    """Write structured JSON to stdout for machine consumption."""
+    print(json.dumps(data), file=sys.stdout, flush=True)

--- a/truss/tests/cli/test_cli.py
+++ b/truss/tests/cli/test_cli.py
@@ -1,3 +1,4 @@
+import json
 import threading
 from unittest.mock import MagicMock, Mock, patch
 
@@ -1060,3 +1061,256 @@ def test_watch_model_name_flag_overrides_config(
     # The flag value should be used, not the config value
     first_call_args = mock_resolve.call_args_list[0]
     assert first_call_args[0][1] == "flag-name"
+
+
+def test_push_output_json(
+    custom_model_truss_dir_with_pre_and_post,
+    remote,
+    mock_baseten_requests,
+    mock_upload_truss,
+    mock_create_truss_service,
+):
+    """Test that --output json emits structured JSON on push."""
+    runner = CliRunner()
+    with patch("truss.cli.cli.RemoteFactory.create", return_value=remote):
+        remote.api.get_teams = Mock(return_value={})
+        with patch("truss.cli.cli.resolve_model_team_name", return_value=(None, None)):
+            result = runner.invoke(
+                truss_cli,
+                [
+                    "push",
+                    str(custom_model_truss_dir_with_pre_and_post),
+                    "--remote",
+                    "baseten",
+                    "--model-name",
+                    "test-model",
+                    "--output",
+                    "json",
+                ],
+            )
+    assert result.exit_code == 0
+    lines = [line for line in result.output.strip().split("\n") if line.strip()]
+    output = json.loads(lines[-1])
+    assert "model_id" in output
+    assert "model_version_id" in output
+    assert output["model_name"] == "test-model"
+
+
+def test_push_output_json_suppresses_human_text(
+    custom_model_truss_dir_with_pre_and_post,
+    remote,
+    mock_baseten_requests,
+    mock_upload_truss,
+    mock_create_truss_service,
+):
+    """Test that --output json suppresses Rich/click human-readable output."""
+    runner = CliRunner()
+    with patch("truss.cli.cli.RemoteFactory.create", return_value=remote):
+        remote.api.get_teams = Mock(return_value={})
+        with patch("truss.cli.cli.resolve_model_team_name", return_value=(None, None)):
+            result = runner.invoke(
+                truss_cli,
+                [
+                    "push",
+                    str(custom_model_truss_dir_with_pre_and_post),
+                    "--remote",
+                    "baseten",
+                    "--model-name",
+                    "test-model",
+                    "--output",
+                    "json",
+                ],
+            )
+    assert result.exit_code == 0
+    # Should NOT contain human-friendly text
+    assert "Deploying as a published deployment" not in result.output
+    assert "\u2728" not in result.output
+    # Should be valid JSON
+    lines = [line for line in result.output.strip().split("\n") if line.strip()]
+    output = json.loads(lines[-1])
+    assert isinstance(output, dict)
+
+
+def test_push_output_text_default(
+    custom_model_truss_dir_with_pre_and_post,
+    remote,
+    mock_baseten_requests,
+    mock_upload_truss,
+    mock_create_truss_service,
+):
+    """Test that default output (text) still shows human-friendly messages."""
+    runner = CliRunner()
+    with patch("truss.cli.cli.RemoteFactory.create", return_value=remote):
+        remote.api.get_teams = Mock(return_value={})
+        with patch("truss.cli.cli.resolve_model_team_name", return_value=(None, None)):
+            result = runner.invoke(
+                truss_cli,
+                [
+                    "push",
+                    str(custom_model_truss_dir_with_pre_and_post),
+                    "--remote",
+                    "baseten",
+                    "--model-name",
+                    "test-model",
+                ],
+            )
+    assert result.exit_code == 0
+    assert "\u2728" in result.output or "Model" in result.output
+
+
+# --dry-run tests
+
+
+def test_push_dry_run_does_not_deploy(
+    custom_model_truss_dir_with_pre_and_post,
+    remote,
+    mock_baseten_requests,
+    mock_upload_truss,
+    mock_create_truss_service,
+):
+    """Test that --dry-run does NOT call remote_provider.push()."""
+    runner = CliRunner()
+    with patch("truss.cli.cli.RemoteFactory.create", return_value=remote):
+        remote.api.get_teams = Mock(return_value={})
+        with patch("truss.cli.cli.resolve_model_team_name", return_value=(None, None)):
+            result = runner.invoke(
+                truss_cli,
+                [
+                    "push",
+                    str(custom_model_truss_dir_with_pre_and_post),
+                    "--remote",
+                    "baseten",
+                    "--model-name",
+                    "test-model",
+                    "--dry-run",
+                ],
+            )
+    assert result.exit_code == 0
+    assert "dry run" in result.output.lower() or "Did not deploy" in result.output
+    mock_create_truss_service.assert_not_called()
+
+
+def test_push_dry_run_shows_model_info(
+    custom_model_truss_dir_with_pre_and_post,
+    remote,
+    mock_baseten_requests,
+    mock_upload_truss,
+    mock_create_truss_service,
+):
+    """Test that --dry-run shows model name and deployment type."""
+    runner = CliRunner()
+    with patch("truss.cli.cli.RemoteFactory.create", return_value=remote):
+        remote.api.get_teams = Mock(return_value={})
+        with patch("truss.cli.cli.resolve_model_team_name", return_value=(None, None)):
+            result = runner.invoke(
+                truss_cli,
+                [
+                    "push",
+                    str(custom_model_truss_dir_with_pre_and_post),
+                    "--remote",
+                    "baseten",
+                    "--model-name",
+                    "my-model",
+                    "--dry-run",
+                ],
+            )
+    assert result.exit_code == 0
+    assert "my-model" in result.output
+    assert "published" in result.output
+
+
+def test_push_dry_run_json_output(
+    custom_model_truss_dir_with_pre_and_post,
+    remote,
+    mock_baseten_requests,
+    mock_upload_truss,
+    mock_create_truss_service,
+):
+    """Test that --dry-run with --output json emits valid JSON."""
+    runner = CliRunner()
+    with patch("truss.cli.cli.RemoteFactory.create", return_value=remote):
+        remote.api.get_teams = Mock(return_value={})
+        with patch("truss.cli.cli.resolve_model_team_name", return_value=(None, None)):
+            result = runner.invoke(
+                truss_cli,
+                [
+                    "push",
+                    str(custom_model_truss_dir_with_pre_and_post),
+                    "--remote",
+                    "baseten",
+                    "--model-name",
+                    "test-model",
+                    "--dry-run",
+                    "--output",
+                    "json",
+                ],
+            )
+    assert result.exit_code == 0
+    lines = [line for line in result.output.strip().split("\n") if line.strip()]
+    output = json.loads(lines[-1])
+    assert output["dry_run"] is True
+    assert output["model_name"] == "test-model"
+    assert output["is_draft"] is False
+
+
+def test_push_dry_run_with_watch_fails():
+    """Test that --dry-run with --watch fails."""
+    mock_truss = Mock()
+    mock_truss.spec.config.runtime.transport.kind = "http"
+    mock_truss.spec.config.resources.instance_type = None
+    runner = CliRunner()
+    with patch("truss.cli.cli._get_truss_from_directory", return_value=mock_truss):
+        result = runner.invoke(
+            truss_cli,
+            [
+                "push",
+                "test_truss",
+                "--remote",
+                "r",
+                "--model-name",
+                "n",
+                "--dry-run",
+                "--watch",
+            ],
+        )
+    assert result.exit_code == 2
+
+
+def test_push_dry_run_with_wait_fails():
+    """Test that --dry-run with --wait fails."""
+    mock_truss = Mock()
+    mock_truss.spec.config.runtime.transport.kind = "http"
+    mock_truss.spec.config.resources.instance_type = None
+    runner = CliRunner()
+    with patch("truss.cli.cli._get_truss_from_directory", return_value=mock_truss):
+        result = runner.invoke(
+            truss_cli,
+            [
+                "push",
+                "test_truss",
+                "--remote",
+                "r",
+                "--model-name",
+                "n",
+                "--dry-run",
+                "--wait",
+            ],
+        )
+    assert result.exit_code == 2
+
+
+# CONTEXT.md tests
+
+
+def test_context_md_exists_and_has_required_sections():
+    """Verify CONTEXT.md ships with agent-facing guidance."""
+    import pathlib
+
+    context_path = pathlib.Path(__file__).parent.parent.parent.parent / "CONTEXT.md"
+    assert context_path.exists(), "CONTEXT.md must exist at repo root"
+    content = context_path.read_text()
+    assert "BASETEN_API_KEY" in content
+    assert "--non-interactive" in content
+    assert "truss push" in content
+    assert "truss predict" in content
+    assert "config.yaml" in content


### PR DESCRIPTION
## Summary

- **`--output json`** on `push` and `predict` for machine-readable output (model_id, version_id, URLs)
- **`--dry-run`** on `push` validates config and resolves model/team/env without deploying
- **`CONTEXT.md`** at repo root with agent-facing CLI guidance (auth, commands, config reference, common mistakes)
- Warnings routed to stderr in JSON mode so stdout stays parseable
- `--output` flag scoped to push/predict only — not leaked to all commands via `common_options()`

## Changes

| File | What |
|------|------|
| `truss/cli/cli.py` | `--output json` on push/predict, `--dry-run` on push, stderr routing for warnings |
| `truss/cli/utils/common.py` | `_output_format_option`, `get_output_format()`, `is_json_output()` helpers |
| `truss/cli/utils/output.py` | `json_output()` helper for structured JSON to stdout |
| `truss/tests/cli/test_cli.py` | 9 new tests (JSON output, dry-run, CONTEXT.md validation) |
| `CONTEXT.md` | Agent-facing CLI context file |

## Test plan

- [x] 41/41 unit tests pass (32 existing + 9 new)
- [x] `ruff check` and `ruff format` pass
- [x] Live tested `truss push --dry-run --output json` against Baseten API
- [x] Verified `--output` flag does NOT appear on unrelated commands (`truss init --help`)
- [x] Verified warnings go to stderr in JSON mode (`2>/dev/null` yields clean JSON)