### PR TITLE
Add version field to TrainingJob

### DIFF
--- a/truss-train/truss_train/definitions.py
+++ b/truss-train/truss_train/definitions.py
@@ -204,6 +204,7 @@ class TrainingJob(custom_types.SafeModelNoExtra):
     image: Image
     compute: Compute = Compute()
     runtime: Runtime = Runtime()
+    version: int = 1
     interactive_session: Optional[InteractiveSession] = None
     name: Optional[str] = None
     workspace: Optional[Workspace] = None

--- a/truss-train/truss_train/deployment.py
+++ b/truss-train/truss_train/deployment.py
@@ -290,6 +290,7 @@ def prepare_push(
         interactive_session=training_job.interactive_session,
         workspace=training_job.workspace,
         weights=training_job.weights,
+        version=training_job.version,
         runtime_artifacts=[
             S3Artifact(s3_key=credentials["s3_key"], s3_bucket=credentials["s3_bucket"])
         ],


### PR DESCRIPTION
## Summary
- Adds `version: int = 1` field to `TrainingJob` definition
- Passes `version` through in `prepare_push`

## Test plan
- [ ] Verify existing training job tests pass
- [ ] Confirm version field defaults to 1 for backwards compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)