### PR TITLE
Default enable_baseten_workdir to True

### DIFF
--- a/truss-train/truss_train/definitions.py
+++ b/truss-train/truss_train/definitions.py
@@ -209,7 +209,7 @@ class TrainingJob(custom_types.SafeModelNoExtra):
     workspace: Optional[Workspace] = None
     weights: List[truss_config.WeightsSource] = []
     """MDN weight sources to mount in the training container. Weights are mirrored and cached for fast startup."""
-    enable_baseten_workdir: bool = False
+    enable_baseten_workdir: bool = True
 
     @model_validator(mode="after")
     def _validate_weights_auth_only_custom_secret(self) -> "TrainingJob":


### PR DESCRIPTION
## Summary
- Changes the default value of `enable_baseten_workdir` from `False` to `True` in `TrainingJob`
- This is a breaking change — will be released with a minor version upgrade. Power users have been given a heads up.

## Test plan
- [ ] Verify existing training jobs that explicitly set `enable_baseten_workdir` are unaffected
- [ ] Verify new training jobs default to having the baseten workdir enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)