### PR TITLE
Add --output json to truss push

### DIFF
--- a/truss-chains/truss_chains/deployment/deployment_client.py
+++ b/truss-chains/truss_chains/deployment/deployment_client.py
@@ -326,6 +326,9 @@ class DockerChainletService(b10_service.TrussService):
     def predict_url(self) -> str:
         return f"{self._service_url}/v1/models/model:predict"
 
+    def poll_deployment(self, sleep_secs: int = 1) -> Iterator[dict]:
+        raise NotImplementedError()
+
     def poll_deployment_status(self, sleep_secs: int = 1) -> Iterator[str]:
         raise NotImplementedError()
 

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -26,7 +26,7 @@ from truss.cli.resolvers.model_team_resolver import (
     resolve_model_team_name,
 )
 from truss.cli.utils import common, self_upgrade
-from truss.cli.utils.output import console, error_console
+from truss.cli.utils.output import console, error_console, json_command
 from truss.remote.baseten.core import (
     ACTIVE_STATUS,
     DEPLOYING_STATUSES,
@@ -673,7 +673,18 @@ def run_python(script, target_directory):
     default=False,
     help="Keep the development model warm by preventing scale-to-zero while watching. Requires --watch.",
 )
+@click.option(
+    "--output",
+    "output_format",
+    type=click.Choice(["text", "json"]),
+    default="text",
+    help=(
+        "Output format. 'json' emits structured JSON to stdout and "
+        "all other output (progress, logs) to stderr."
+    ),
+)
 @common.common_options()
+@json_command
 def push(
     target_directory: str,
     config: Optional[str],
@@ -698,6 +709,7 @@ def push(
     watch_hot_reload: bool = False,
     no_cache: bool = False,
     watch_no_sleep: bool = False,
+    output_format: str = "text",
 ) -> None:
     """
     Pushes a truss to a TrussRemote.
@@ -775,6 +787,8 @@ def push(
         include_git_info = user_config.settings.include_git_info
 
     remote_provider = RemoteFactory.create(remote=remote)
+    if output_format == "json" and isinstance(remote_provider, BasetenRemote):
+        remote_provider.api.suppress_error_print = True
 
     # model_name from CLI flag (explicit), or fall back to config
     cli_model_name = model_name  # what the user inputted for `--model-name`
@@ -893,7 +907,7 @@ def push(
         labels=labels_dict,
     )
 
-    click.echo(f"✨ Model {model_name} was successfully pushed ✨")
+    console.print(f"✨ Model {model_name} was successfully pushed ✨")
 
     if service.is_draft:
         draft_model_text = """
@@ -907,7 +921,7 @@ def push(
 |---------------------------------------------------------------------------------------|
 """
 
-        click.echo(draft_model_text)
+        console.print(draft_model_text)
 
     if environment:
         promotion_text = (
@@ -919,16 +933,18 @@ def push(
     console.print(
         f"🪵  View logs for your deployment at {common.format_link(service.logs_url)}"
     )
+    last_deployment = None
     if wait:
         start_time = time.time()
         with console.status("[bold green]Deploying...") as status:
-            for deployment_status in service.poll_deployment_status():
+            for deployment in service.poll_deployment():
+                last_deployment = deployment
+                deployment_status = deployment["status"]
                 if (
                     timeout_seconds is not None
                     and time.time() - start_time > timeout_seconds
                 ):
-                    console.print("Deployment timed out.", style="red")
-                    sys.exit(1)
+                    raise TimeoutError("Deployment timed out.")
 
                 status.update(
                     f"[bold green]Deploying...Current Status: {deployment_status}"
@@ -949,11 +965,11 @@ def push(
                     break
 
                 if deployment_status not in DEPLOYING_STATUSES:
-                    console.print(
-                        f"Deployment failed with status {deployment_status}.",
-                        style="red",
+                    exc = RuntimeError(
+                        f"Deployment failed with status {deployment_status}."
                     )
-                    sys.exit(1)
+                    setattr(exc, "json_data", {"deployment": deployment})
+                    raise exc
 
         # If --watch was used, start watching after deploy success
         if watch_after_push:
@@ -988,6 +1004,18 @@ def push(
         )
         for log in log_watcher.watch():
             cli_log_utils.output_log(log)
+
+    if output_format == "json" and isinstance(service, BasetenService):
+        result: dict = {
+            "model_id": service.model_id,
+            "model_version_id": service.model_version_id,
+            "predict_url": service.predict_url,
+            "logs_url": service.logs_url,
+            "is_draft": service.is_draft,
+        }
+        if last_deployment is not None:
+            result["deployment"] = last_deployment
+        print(json.dumps(result, indent=2), file=sys.stdout)
 
 
 @truss_cli.command()

--- a/truss/cli/utils/output.py
+++ b/truss/cli/utils/output.py
@@ -1,3 +1,10 @@
+import contextlib
+import functools
+import json
+import sys
+from typing import Any, Dict
+
+import requests
 import rich
 import rich.live
 import rich.logging
@@ -5,6 +12,8 @@ import rich.spinner
 import rich.table
 import rich.traceback
 from rich.console import Console
+
+from truss.remote.baseten.error import ApiError
 
 rich.spinner.SPINNERS["deploying"] = {"interval": 500, "frames": ["👾 ", " 👾"]}
 rich.spinner.SPINNERS["building"] = {"interval": 500, "frames": ["🛠️ ", " 🛠️"]}
@@ -15,3 +24,70 @@ rich.spinner.SPINNERS["failed"] = {"interval": 500, "frames": ["😤 ", " 😤"]
 
 console = Console()
 error_console = Console(stderr=True, style="bold red")
+
+
+def json_command(fn):
+    """Decorator for CLI commands that support --output json.
+
+    When output_format="json", redirects console to stderr and catches
+    exceptions to emit structured JSON errors to stdout.
+    In text mode, behaves as a passthrough.
+    """
+
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        output_format = kwargs.get("output_format", "text")
+        if output_format != "json":
+            return fn(*args, **kwargs)
+
+        with console_to_stderr():
+            try:
+                return fn(*args, **kwargs)
+            except Exception as exc:
+                print(json.dumps(_format_json_error(exc)), file=sys.stdout)
+                print(f"Error: {exc}", file=sys.stderr)
+                sys.exit(1)
+
+    return wrapper
+
+
+@contextlib.contextmanager
+def console_to_stderr():
+    """Redirect all Rich consoles to stderr.
+
+    Redirects both the module-level console and Rich's global console
+    (used by RichHandler for logging and by progress bars).
+    Used in JSON output mode so stdout is reserved for structured JSON.
+    """
+    global_console = rich.get_console()
+    original = console.stderr
+    original_global = global_console.stderr
+    console.stderr = True
+    global_console.stderr = True
+    try:
+        yield
+    finally:
+        console.stderr = original
+        global_console.stderr = original_global
+
+
+def _format_json_error(exc: Exception) -> Dict[str, Any]:
+    """Format an exception as a JSON-serializable error dict."""
+    error: Dict[str, Any] = {"message": str(exc)}
+
+    if isinstance(exc, requests.HTTPError) and exc.response is not None:
+        error["status_code"] = exc.response.status_code
+        try:
+            error["response_body"] = exc.response.json()
+        except ValueError:
+            error["response_body"] = exc.response.text
+    elif isinstance(exc, ApiError):
+        error["message"] = exc.message
+        if exc.graphql_error_code:
+            error["error_code"] = exc.graphql_error_code
+
+    # Include any additional data attached to the exception.
+    if hasattr(exc, "json_data") and exc.json_data:
+        error.update(exc.json_data)
+
+    return {"error": error}

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -149,6 +149,14 @@ class BasetenApi:
     def auth_token(self) -> ApiKey:
         return self._auth_token
 
+    @property
+    def suppress_error_print(self) -> bool:
+        return self._rest_api_client.suppress_error_print
+
+    @suppress_error_print.setter
+    def suppress_error_print(self, value: bool) -> None:
+        self._rest_api_client.suppress_error_print = value
+
     def _post_graphql_query(self, query: str, variables: Optional[dict] = None) -> dict:
         headers = self._auth_token.header()
         payload: Dict[str, Any] = {"query": query}

--- a/truss/remote/baseten/rest_client.py
+++ b/truss/remote/baseten/rest_client.py
@@ -10,12 +10,13 @@ class RestAPIClient:
     def __init__(self, base_url: str, headers: Dict[str, str]):
         self.base_url = base_url
         self.headers = headers
+        self.suppress_error_print = False
 
     def _handle_error(self, resp: requests.Response):
         if 400 <= resp.status_code < 500:
             try:
                 data = resp.json()
-                if "message" in data:
+                if "message" in data and not self.suppress_error_print:
                     print(f"Client error: {data['message']}")
             except ValueError:
                 pass

--- a/truss/remote/baseten/service.py
+++ b/truss/remote/baseten/service.py
@@ -163,15 +163,17 @@ class BasetenService(TrussService):
     def _fetch_deployment(self) -> Any:
         return self._api.get_deployment(self.model_id, self.model_version_id)
 
-    def poll_deployment_status(self, sleep_secs: int = 1) -> Iterator[str]:
-        """
-        Wait for the service to be deployed.
-        """
+    def poll_deployment(self, sleep_secs: int = 1) -> Iterator[Dict[str, Any]]:
+        """Poll for deployment, yielding the full deployment dict."""
         while True:
             time.sleep(sleep_secs)
             try:
-                deployment = self._fetch_deployment()
-                yield deployment["status"]
+                yield self._fetch_deployment()
             except requests.exceptions.RequestException:
                 logger.warning("Network error, unable to reach Baseten. Retrying...")
                 continue
+
+    def poll_deployment_status(self, sleep_secs: int = 1) -> Iterator[str]:
+        """Poll for deployment status, yielding only the status string."""
+        for deployment in self.poll_deployment(sleep_secs):
+            yield deployment["status"]

--- a/truss/remote/truss_remote.py
+++ b/truss/remote/truss_remote.py
@@ -176,6 +176,13 @@ class TrussService(ABC):
         pass
 
     @abstractmethod
+    def poll_deployment(self, sleep_secs: int = 1) -> Iterator[Dict[str, Any]]:
+        """
+        Poll for a deployment, yielding the full deployment dict.
+        """
+        pass
+
+    @abstractmethod
     def poll_deployment_status(self, sleep_secs: int = 1) -> Iterator[str]:
         """
         Poll for a deployment status.

--- a/truss/tests/cli/test_cli.py
+++ b/truss/tests/cli/test_cli.py
@@ -1,3 +1,4 @@
+import json
 import threading
 from unittest.mock import MagicMock, Mock, patch
 
@@ -8,6 +9,7 @@ from click.testing import CliRunner
 from truss.cli.cli import truss_cli
 from truss.cli.utils import common
 from truss.remote.baseten.custom_types import OidcInfo, OidcTeamInfo
+from truss.remote.baseten.service import BasetenService
 from truss.remote.truss_remote import RemoteUser
 
 
@@ -786,7 +788,7 @@ def test_push_watch_creates_development_deployment(
     mock_service = MagicMock()
     mock_service.is_draft = True
     mock_service.logs_url = "https://example.com/logs"
-    mock_service.poll_deployment_status.return_value = iter(["MODEL_READY"])
+    mock_service.poll_deployment.return_value = iter([{"status": "MODEL_READY"}])
     remote.push = Mock(return_value=mock_service)
 
     with patch("truss.cli.cli.RemoteFactory.create", return_value=remote):
@@ -986,7 +988,7 @@ def test_push_watch_no_sleep_starts_keepalive(
     mock_service = MagicMock()
     mock_service.is_draft = True
     mock_service.logs_url = "https://example.com/logs"
-    mock_service.poll_deployment_status.return_value = iter(["LOADING_MODEL"])
+    mock_service.poll_deployment.return_value = iter([{"status": "LOADING_MODEL"}])
     remote.push = Mock(return_value=mock_service)
 
     mock_resolve = Mock(
@@ -1078,8 +1080,8 @@ def test_push_watch_enters_watch_mode_on_deploying_status(
     mock_service.is_draft = True
     mock_service.logs_url = "https://example.com/logs"
     # Simulate: BUILDING -> LOADING_MODEL — never reaches ACTIVE
-    mock_service.poll_deployment_status.return_value = iter(
-        ["BUILDING", "LOADING_MODEL"]
+    mock_service.poll_deployment.return_value = iter(
+        [{"status": "BUILDING"}, {"status": "LOADING_MODEL"}]
     )
     remote.push = Mock(return_value=mock_service)
 
@@ -1126,8 +1128,8 @@ def test_push_watch_still_exits_on_deploy_failed(
     mock_service = MagicMock()
     mock_service.is_draft = True
     mock_service.logs_url = "https://example.com/logs"
-    mock_service.poll_deployment_status.return_value = iter(
-        ["BUILDING", "DEPLOY_FAILED"]
+    mock_service.poll_deployment.return_value = iter(
+        [{"status": "BUILDING"}, {"status": "DEPLOY_FAILED"}]
     )
     remote.push = Mock(return_value=mock_service)
 
@@ -1221,3 +1223,91 @@ def test_watch_model_name_flag_overrides_config(
     # The flag value should be used, not the config value
     first_call_args = mock_resolve.call_args_list[0]
     assert first_call_args[0][1] == "flag-name"
+
+
+def _make_mock_service(**overrides):
+    mock_service = MagicMock(spec=BasetenService)
+    mock_service.is_draft = False
+    mock_service.model_id = "model_id"
+    mock_service.model_version_id = "version_id"
+    mock_service.predict_url = (
+        "https://model.api.baseten.co/deployment/version_id/predict"
+    )
+    mock_service.logs_url = "https://app.baseten.co/models/model_id/logs/version_id"
+    for k, v in overrides.items():
+        setattr(mock_service, k, v)
+    return mock_service
+
+
+def _invoke_push_json(runner, truss_dir, remote, extra_args=None):
+    args = [
+        "push",
+        str(truss_dir),
+        "--remote",
+        "baseten",
+        "--model-name",
+        "model_name",
+        "--output",
+        "json",
+    ]
+    if extra_args:
+        args.extend(extra_args)
+
+    with patch("truss.cli.cli.RemoteFactory.create", return_value=remote):
+        remote.api.get_teams = Mock(return_value={})
+        with patch("truss.cli.cli.resolve_model_team_name", return_value=(None, None)):
+            return runner.invoke(truss_cli, args)
+
+
+def test_push_json_output_success(custom_model_truss_dir_with_pre_and_post, remote):
+    runner = CliRunner()
+    remote.push = Mock(return_value=_make_mock_service())
+    result = _invoke_push_json(runner, custom_model_truss_dir_with_pre_and_post, remote)
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["model_id"] == "model_id"
+    assert data["model_version_id"] == "version_id"
+    assert "predict_url" in data
+    assert "logs_url" in data
+    assert data["is_draft"] is False
+    assert "deployment" not in data
+
+
+def test_push_json_output_wait_success(
+    custom_model_truss_dir_with_pre_and_post, remote
+):
+    runner = CliRunner()
+    deployment_response = {"status": "ACTIVE", "id": "deploy_id", "replicas": 1}
+    mock_service = _make_mock_service()
+    mock_service.poll_deployment.return_value = iter([deployment_response])
+    remote.push = Mock(return_value=mock_service)
+    result = _invoke_push_json(
+        runner, custom_model_truss_dir_with_pre_and_post, remote, ["--wait"]
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["model_id"] == "model_id"
+    assert data["deployment"] == deployment_response
+
+
+def test_push_json_output_wait_deploy_failed(
+    custom_model_truss_dir_with_pre_and_post, remote
+):
+    runner = CliRunner()
+    failed_deployment = {"status": "DEPLOY_FAILED", "id": "deploy_id", "error": "OOM"}
+    mock_service = _make_mock_service()
+    mock_service.poll_deployment.return_value = iter(
+        [{"status": "BUILDING"}, failed_deployment]
+    )
+    remote.push = Mock(return_value=mock_service)
+    result = _invoke_push_json(
+        runner, custom_model_truss_dir_with_pre_and_post, remote, ["--wait"]
+    )
+
+    assert result.exit_code == 1
+    data = json.loads(result.stdout)
+    assert "error" in data
+    assert "DEPLOY_FAILED" in data["error"]["message"]
+    assert data["error"]["deployment"] == failed_deployment

--- a/truss/tests/remote/test_truss_remote.py
+++ b/truss/tests/remote/test_truss_remote.py
@@ -36,9 +36,13 @@ class TrussTestService(TrussService):
     def predict_url(self) -> str:
         return f"{self._service_url}/v1/models/model:predict"
 
-    def poll_deployment_status(self, sleep_secs: int = 1) -> Iterator[str]:
+    def poll_deployment(self, sleep_secs: int = 1) -> Iterator[dict]:
         for status in ["DEPLOYING", "ACTIVE"]:
-            yield status
+            yield {"status": status}
+
+    def poll_deployment_status(self, sleep_secs: int = 1) -> Iterator[str]:
+        for deployment in self.poll_deployment(sleep_secs):
+            yield deployment["status"]
 
 
 def mock_successful_response():


### PR DESCRIPTION
## :rocket: What

- Adds `--output json` flag to `truss push`
- Structured JSON result on stdout, all other output (progress, logs, spinners) to stderr
- JSON error output on failure with status codes, response bodies, deployment state

Fixes #2353 

## :computer: How

- `json_command` decorator in `output.py`: redirects Rich consoles to stderr, catches exceptions and formats as JSON
- `console_to_stderr` context manager mutates both the module-level and Rich global console
- Replaced `sys.exit(1)` in wait loop with raised exceptions carrying `json_data`
- Added `poll_deployment` method yielding full deployment dict; `poll_deployment_status` delegates to it
- `suppress_error_print` on `RestAPIClient`/`BasetenApi` to prevent bare `print()` from corrupting JSON stdout

## :microscope: Testing

- Unit tests for JSON success, wait+success, and wait+deploy-failed paths
- Manual e2e: successful deploy, failed deploy (bad base image), timeout
- Verified stdout is clean JSON and stderr gets all human-readable output