### PR TITLE
make nginx a sidecar for docker server deployments

### DIFF
--- a/truss/contexts/image_builder/serving_image_builder.py
+++ b/truss/contexts/image_builder/serving_image_builder.py
@@ -64,6 +64,7 @@ from truss.base.truss_config import (
     K8S_RESERVED_ENVIRONMENT_VARIABLES,
     DockerServer,
     RequirementsFileType,
+    TransportKind,
     TrussConfig,
 )
 from truss.base.truss_spec import TrussSpec
@@ -104,6 +105,16 @@ CLOUD_BUCKET_CACHE = MODEL_CACHE_PATH
 
 HF_SOURCE_DIR = Path("./root/.cache/huggingface/hub/")
 HF_CACHE_DIR = Path("/root/.cache/huggingface/hub/")
+
+
+def _should_use_docker_server_sidecar(config: TrussConfig) -> bool:
+    if not os.getenv("BT_USE_DOCKER_SERVER_SIDECAR", False):
+        return False
+    if config.docker_server is None:
+        return False
+    if config.runtime.transport.kind == TransportKind.GRPC:
+        return False
+    return True
 
 
 class RemoteCache(ABC):
@@ -652,23 +663,23 @@ class ServingImageBuilder(ImageBuilder):
             config.docker_server is not None
             and config.docker_server.no_build is not True
         ):
-            self._copy_into_build_dir(
-                TEMPLATES_DIR / "docker_server_requirements.txt",
-                build_dir,
-                "docker_server_requirements.txt",
-            )
+            if not _should_use_docker_server_sidecar(config):
+                self._copy_into_build_dir(
+                    TEMPLATES_DIR / "docker_server_requirements.txt",
+                    build_dir,
+                    "docker_server_requirements.txt",
+                )
 
-            generate_docker_server_nginx_config(build_dir, config)
+                generate_docker_server_nginx_config(build_dir, config)
 
-            generate_docker_server_supervisord_config(build_dir, config)
+                generate_docker_server_supervisord_config(build_dir, config)
 
-            # Copy event listener script
-            event_listener_script = (
-                TEMPLATES_DIR / "docker_server" / "event_listener.py"
-            )
-            self._copy_into_build_dir(
-                event_listener_script, build_dir, "event_listener.py"
-            )
+                event_listener_script = (
+                    TEMPLATES_DIR / "docker_server" / "event_listener.py"
+                )
+                self._copy_into_build_dir(
+                    event_listener_script, build_dir, "event_listener.py"
+                )
 
         # Override config.yml
         with (build_dir / CONFIG_FILE).open("w") as config_file:
@@ -962,6 +973,7 @@ class ServingImageBuilder(ImageBuilder):
             use_local_src=config.use_local_src,
             passthrough_environment_variables=passthrough_environment_variables,
             run_as_user_id=run_as_user_id,
+            docker_server_uses_sidecar=_should_use_docker_server_sidecar(config),
             **FILENAME_CONSTANTS_MAP,
         )
         # Consolidate repeated empty lines to single empty lines.

--- a/truss/templates/server.Dockerfile.jinja
+++ b/truss/templates/server.Dockerfile.jinja
@@ -115,6 +115,13 @@ RUN {% for secret,path in config.build.secret_to_path_mapping.items() %} --mount
 {%- endif %} {#- endif build_commands #}
 
 {%- if config.docker_server %}
+{%- if docker_server_uses_sidecar %}
+ENV DOCKER_SERVER_USES_SIDECAR="true"
+ENV SERVER_START_CMD={{ config.docker_server.start_command | tojson }}
+{{ chown_and_switch_to_regular_user_if_enabled() }}
+ENTRYPOINT ["sh", "-c"]
+CMD [{{ config.docker_server.start_command | tojson }}]
+{%- else %}
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
         curl nginx && rm -rf /var/lib/apt/lists/*
 COPY --chown={{ default_owner }} ./docker_server_requirements.txt ${APP_HOME}/docker_server_requirements.txt
@@ -137,6 +144,7 @@ RUN mkdir -p /dev/shm
 {#- nginx writes to /var/lib/nginx, /var/log/nginx, /dev/shm, and /run directories #}
 {{ chown_and_switch_to_regular_user_if_enabled(["/var/lib/nginx", "/var/log/nginx", "/run", "/dev/shm"]) }}
 ENTRYPOINT ["/docker_server/.venv/bin/supervisord", "-c", "{{ supervisor_config_path }}"]
+{%- endif %} {#- endif docker_server_uses_sidecar #}
 
 {%- elif requires_live_reload %} {#- elif requires_live_reload #}
 ENV HASH_TRUSS="{{ truss_hash }}"

--- a/truss/tests/contexts/image_builder/test_serving_image_builder.py
+++ b/truss/tests/contexts/image_builder/test_serving_image_builder.py
@@ -10,7 +10,7 @@ import pytest
 import yaml
 
 from truss.base.constants import TRTLLM_PREDICT_CONCURRENCY, TRTLLM_TRUSS_DIR
-from truss.base.truss_config import ModelCache, ModelRepo, TrussConfig
+from truss.base.truss_config import DockerServer, ModelCache, ModelRepo, TrussConfig
 from truss.contexts.image_builder.serving_image_builder import (
     HF_ACCESS_TOKEN_FILE_NAME,
     ServingImageBuilderContext,
@@ -18,6 +18,7 @@ from truss.contexts.image_builder.serving_image_builder import (
     get_files_to_model_cache_v1,
 )
 from truss.tests.test_testing_utilities_for_other_tests import ensure_kill_all
+from truss.truss_handle.build import init_directory
 from truss.truss_handle.truss_handle import TrussHandle
 
 BASE_DIR = Path(__file__).parent
@@ -822,3 +823,86 @@ def test_nginx_config_disables_disk_writes(tmp_path):
     assert "fastcgi_temp_path /dev/shm/nginx_fastcgi_temp;" in nginx_config
     assert "uwsgi_temp_path /dev/shm/nginx_uwsgi_temp;" in nginx_config
     assert "scgi_temp_path /dev/shm/nginx_scgi_temp;" in nginx_config
+
+
+class TestDockerServerSidecarBuild:
+    def _make_docker_server_truss(self, tmp_path):
+        truss_dir = tmp_path / "docker_server_truss"
+        th = TrussHandle(init_directory(truss_dir))
+        th.update_python_version("py311")
+        th.set_base_image("python:3.11-slim", "/usr/local/bin/python3")
+        config = th.spec.config
+        config.docker_server = DockerServer(
+            start_command="python main.py --port 8000",
+            server_port=8000,
+            predict_endpoint="/predict",
+            readiness_endpoint="/health",
+            liveness_endpoint="/health",
+        )
+        with (truss_dir / "config.yaml").open("w") as f:
+            yaml.dump(config.to_dict(verbose=True), f)
+        return truss_dir
+
+    def test_sidecar_dockerfile_omits_nginx_and_supervisord(self, tmp_path):
+        truss_dir = self._make_docker_server_truss(tmp_path)
+        with patch.dict(os.environ, {"BT_USE_DOCKER_SERVER_SIDECAR": "true"}):
+            builder = ServingImageBuilderContext.run(truss_dir)
+            build_dir = tmp_path / "build"
+            builder.prepare_image_build_dir(build_dir)
+
+        dockerfile = (build_dir / "Dockerfile").read_text()
+        assert "DOCKER_SERVER_USES_SIDECAR" in dockerfile
+        assert "SERVER_START_CMD" in dockerfile
+        assert 'ENTRYPOINT ["sh", "-c"]' in dockerfile
+        assert "nginx" not in dockerfile.lower()
+        assert "supervisord" not in dockerfile.lower()
+        assert not (build_dir / "proxy.conf").exists()
+        assert not (build_dir / "supervisord.conf").exists()
+        assert not (build_dir / "docker_server_requirements.txt").exists()
+
+    def test_legacy_dockerfile_includes_nginx_and_supervisord(self, tmp_path):
+        truss_dir = self._make_docker_server_truss(tmp_path)
+        builder = ServingImageBuilderContext.run(truss_dir)
+        build_dir = tmp_path / "build"
+        builder.prepare_image_build_dir(build_dir)
+
+        dockerfile = (build_dir / "Dockerfile").read_text()
+        assert "DOCKER_SERVER_USES_SIDECAR" not in dockerfile
+        assert "supervisord" in dockerfile
+        assert "nginx" in dockerfile
+        assert (build_dir / "proxy.conf").exists()
+        assert (build_dir / "supervisord.conf").exists()
+        assert (build_dir / "docker_server_requirements.txt").exists()
+
+    def _make_grpc_docker_server_truss(self, tmp_path):
+        truss_dir = tmp_path / "grpc_docker_server_truss"
+        th = TrussHandle(init_directory(truss_dir))
+        th.update_python_version("py311")
+        th.set_base_image("python:3.11-slim", "/usr/local/bin/python3")
+        config = th.spec.config
+        config.docker_server = DockerServer(
+            start_command="python main.py --port 8000",
+            server_port=8000,
+            predict_endpoint="/predict",
+            readiness_endpoint="/health",
+            liveness_endpoint="/health",
+        )
+        config.runtime.transport = {"kind": "grpc"}
+        with (truss_dir / "config.yaml").open("w") as f:
+            yaml.dump(config.to_dict(verbose=True), f)
+        return truss_dir
+
+    def test_grpc_docker_server_falls_back_to_legacy_in_image_path(self, tmp_path):
+        truss_dir = self._make_grpc_docker_server_truss(tmp_path)
+        with patch.dict(os.environ, {"BT_USE_DOCKER_SERVER_SIDECAR": "true"}):
+            builder = ServingImageBuilderContext.run(truss_dir)
+            build_dir = tmp_path / "build"
+            builder.prepare_image_build_dir(build_dir)
+
+        dockerfile = (build_dir / "Dockerfile").read_text()
+        assert "DOCKER_SERVER_USES_SIDECAR" not in dockerfile
+        assert "supervisord" in dockerfile
+        assert "nginx" in dockerfile
+        assert (build_dir / "proxy.conf").exists()
+        assert (build_dir / "supervisord.conf").exists()
+        assert (build_dir / "docker_server_requirements.txt").exists()


### PR DESCRIPTION
## What

Adds a `docker_server` build that omits nginx and supervisord. Triggered by `BT_USE_DOCKER_SERVER_SIDECAR=true`. Customer's `start_command` runs as PID 1. Pairs with an external nginx sidecar provided by the deploying platform.

## How

`server.Dockerfile.jinja` splits `{% if config.docker_server %}` into two paths:
- **Sidecar path** (env var set): no nginx install, no supervisord venv, no `proxy.conf`. Sets `DOCKER_SERVER_USES_SIDECAR=true` and `SERVER_START_CMD`; entrypoint is `sh -c`; `CMD` is the customer's `start_command`.
- **Legacy path** (env var absent): unchanged.

Both the dockerfile branch and the build-dir scaffolding gate on `_should_use_docker_server_sidecar(config)`, mirroring the `BT_USE_NON_ROOT_USER` pattern.

The gate excludes `runtime.transport.kind == GRPC`; gRPC `docker_server` builds keep the legacy in-image path. Lifting this is a separate follow-up.

## Testing

`uv run pytest truss/tests/contexts/image_builder/test_serving_image_builder.py::TestDockerServerSidecarBuild` covers sidecar path, legacy fallback, and gRPC fallback when env var set.

## Release requirements

- Pre-release: none. Env var is not set by default; no-op until the platform enables it.
- Post-release: none.
- External communication: none.