### PR TITLE
Allow `--tail` with `push --wait`, `push --watch`, and `watch`

### DIFF
--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -98,8 +98,14 @@ def _start_tail(
     log_watcher = ModelDeploymentLogWatcher(remote.api, model_id, version_id)
 
     def _tail_logs():
-        for log in log_watcher.watch(show_spinner=not in_background):
-            cli_log_utils.output_log(log)
+        try:
+            for log in log_watcher.watch(show_spinner=not in_background):
+                cli_log_utils.output_log(log)
+        except Exception as exc:
+            error_console.print(
+                f"[red]Log tailing stopped due to an error:[/red] {exc}"
+            )
+            raise
 
     if in_background:
         thread = threading.Thread(target=_tail_logs, daemon=True)

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -2,6 +2,7 @@ import inspect
 import json
 import os
 import sys
+import threading
 import time
 from pathlib import Path
 from typing import Optional, cast
@@ -89,6 +90,22 @@ def _get_truss_from_directory(
 
     truss_dir = code_gen.gen_truss_model_from_source(Path(target_directory))
     return load(truss_dir, config_path=config_path)
+
+
+def _start_tail(
+    remote: BasetenRemote, model_id: str, version_id: str, in_background: bool
+) -> None:
+    log_watcher = ModelDeploymentLogWatcher(remote.api, model_id, version_id)
+
+    def _tail_logs():
+        for log in log_watcher.watch(show_spinner=not in_background):
+            cli_log_utils.output_log(log)
+
+    if in_background:
+        thread = threading.Thread(target=_tail_logs, daemon=True)
+        thread.start()
+    else:
+        _tail_logs()
 
 
 def _start_watch_mode(
@@ -643,7 +660,7 @@ def run_python(script, target_directory):
     help=(
         "Deploy as a development model and watch for changes. "
         "Waits for deployment to complete, then starts watching for code changes "
-        "to apply live patches. Cannot be used with --promote, --environment, or --tail."
+        "to apply live patches. Cannot be used with --promote or --environment."
     ),
 )
 @click.option(
@@ -731,8 +748,6 @@ def push(
             raise click.UsageError(
                 "Cannot use --watch with --environment. Watch mode runs a development deployment."
             )
-        if tail:
-            raise click.UsageError("Cannot use --watch with --tail.")
         # Development deployment for watch mode
         publish = False
         wait = True
@@ -744,11 +759,6 @@ def push(
         console.print(
             "Deploying as a published deployment. Use --watch for a development deployment.",
             style="green",
-        )
-
-    if wait and tail:
-        raise click.UsageError(
-            "Cannot use --wait with --tail. Use --tail by itself to wait for deployment and tail logs."
         )
 
     tr = _get_truss_from_directory(target_directory=target_directory, config=config)
@@ -919,6 +929,17 @@ def push(
     console.print(
         f"🪵  View logs for your deployment at {common.format_link(service.logs_url)}"
     )
+
+    if tail and isinstance(service, BasetenService):
+        # When combined with --wait/--watch, tail runs in background so the
+        # wait polling loop below can proceed on the main thread.
+        _start_tail(
+            cast(BasetenRemote, remote_provider),
+            service.model_id,
+            service.model_version_id,
+            in_background=wait,
+        )
+
     if wait:
         start_time = time.time()
         with console.status("[bold green]Deploying...") as status:
@@ -980,14 +1001,6 @@ def push(
                 error_console=error_console,
                 hot_reload=watch_hot_reload,
             )
-
-    elif tail and isinstance(service, BasetenService):
-        bt_remote = cast(BasetenRemote, remote_provider)
-        log_watcher = ModelDeploymentLogWatcher(
-            bt_remote.api, service.model_id, service.model_version_id
-        )
-        for log in log_watcher.watch():
-            cli_log_utils.output_log(log)
 
 
 @truss_cli.command()
@@ -1063,6 +1076,7 @@ def model_logs(
     required=False,
     help="Temporarily override the name of the model",
 )
+@click.option("--tail", is_flag=True, help="Tail logs while watching.")
 @common.common_options()
 def watch(
     target_directory: str,
@@ -1072,6 +1086,7 @@ def watch(
     no_sleep: bool = False,
     hot_reload: bool = False,
     model_name: Optional[str] = None,
+    tail: bool = False,
 ) -> None:
     """
     Seamless remote development with truss
@@ -1135,6 +1150,9 @@ def watch(
 
     if no_sleep:
         common.start_keepalive(model_hostname, api_key)
+
+    if tail:
+        _start_tail(remote_provider, model_id, dev_version_id, in_background=True)
 
     # Re-resolve the model to get the latest version and truss hash and latest push before watching
     resolved_model, versions = resolve_model_for_watch(

--- a/truss/cli/logs/base_watcher.py
+++ b/truss/cli/logs/base_watcher.py
@@ -1,3 +1,4 @@
+import contextlib
 import hashlib
 import time
 from abc import ABC, abstractmethod
@@ -64,9 +65,13 @@ class LogWatcher(ABC):
 
         self._last_poll_time_ms = now_ms
 
-    def watch(self) -> Iterator[ParsedLog]:
+    def watch(self, show_spinner: bool = True) -> Iterator[ParsedLog]:
         self.before_polling()
-        with console.status("Polling logs", spinner="aesthetic"):
+        with (
+            console.status("Polling logs", spinner="aesthetic")
+            if show_spinner
+            else contextlib.nullcontext()
+        ):
             while True:
                 for log in self.poll():
                     yield log

--- a/truss/tests/cli/test_cli.py
+++ b/truss/tests/cli/test_cli.py
@@ -8,6 +8,7 @@ from click.testing import CliRunner
 from truss.cli.cli import truss_cli
 from truss.cli.utils import common
 from truss.remote.baseten.custom_types import OidcInfo, OidcTeamInfo
+from truss.remote.baseten.service import BasetenService
 from truss.remote.truss_remote import RemoteUser
 
 
@@ -877,35 +878,58 @@ def test_push_watch_with_environment_fails():
     )
 
 
-def test_push_watch_with_tail_fails():
-    """Test that --watch with --tail fails."""
-    mock_truss = Mock()
-    mock_truss.spec.config.runtime.transport.kind = "http"
-    mock_truss.spec.config.resources.instance_type = None
-    mock_truss.spec.config.build = None
-    mock_truss.spec.config.trt_llm = None
-
+def test_push_watch_with_tail_starts_background_tail(
+    custom_model_truss_dir_with_pre_and_post,
+    remote,
+    mock_baseten_requests,
+    mock_upload_truss,
+    mock_create_truss_service,
+):
+    """Test that --watch with --tail starts tail in background."""
     runner = CliRunner()
 
-    with patch("truss.cli.cli._get_truss_from_directory", return_value=mock_truss):
-        result = runner.invoke(
-            truss_cli,
-            [
-                "push",
-                "test_truss",
-                "--remote",
-                "remote1",
-                "--model-name",
-                "name",
-                "--watch",
-                "--tail",
-            ],
-        )
+    mock_service = MagicMock(spec=BasetenService)
+    mock_service.is_draft = True
+    mock_service.logs_url = "https://example.com/logs"
+    mock_service.model_id = "model_id"
+    mock_service.model_version_id = "version_id"
+    mock_service.poll_deployment_status.return_value = iter(["LOADING_MODEL"])
+    remote.push = Mock(return_value=mock_service)
 
-    assert result.exit_code == 2
-    assert "Cannot use --watch with --tail" in result.output or (
-        result.exception
-        and "Cannot use --watch with --tail" in str(result.exception.__context__)
+    mock_resolve = Mock(
+        return_value=(
+            {
+                "id": "model_id",
+                "name": "model_name",
+                "hostname": "https://model.api.baseten.co",
+            },
+            [{"id": "version_id", "is_draft": True}],
+        )
+    )
+
+    with patch("truss.cli.cli.RemoteFactory.create", return_value=remote):
+        remote.api.get_teams = Mock(return_value={})
+        with patch("truss.cli.cli.resolve_model_team_name", return_value=(None, None)):
+            with patch("truss.cli.cli.resolve_model_for_watch", mock_resolve):
+                with patch("truss.cli.cli._start_watch_mode"):
+                    with patch("truss.cli.cli._start_tail") as mock_start_tail:
+                        result = runner.invoke(
+                            truss_cli,
+                            [
+                                "push",
+                                str(custom_model_truss_dir_with_pre_and_post),
+                                "--remote",
+                                "baseten",
+                                "--model-name",
+                                "model_name",
+                                "--watch",
+                                "--tail",
+                            ],
+                        )
+
+    assert result.exit_code == 0, result.output
+    mock_start_tail.assert_called_once_with(
+        remote, "model_id", "version_id", in_background=True
     )
 
 
@@ -1031,35 +1055,45 @@ def test_push_watch_no_sleep_starts_keepalive(
     mock_start_watch.assert_called_once()
 
 
-def test_push_wait_with_tail_fails():
-    """Test that --wait with --tail fails."""
-    mock_truss = Mock()
-    mock_truss.spec.config.runtime.transport.kind = "http"
-    mock_truss.spec.config.resources.instance_type = None
-    mock_truss.spec.config.build = None
-    mock_truss.spec.config.trt_llm = None
-
+def test_push_wait_with_tail_starts_background_tail(
+    custom_model_truss_dir_with_pre_and_post,
+    remote,
+    mock_baseten_requests,
+    mock_upload_truss,
+    mock_create_truss_service,
+):
+    """Test that --wait with --tail starts tail in background."""
     runner = CliRunner()
 
-    with patch("truss.cli.cli._get_truss_from_directory", return_value=mock_truss):
-        result = runner.invoke(
-            truss_cli,
-            [
-                "push",
-                "test_truss",
-                "--remote",
-                "remote1",
-                "--model-name",
-                "name",
-                "--wait",
-                "--tail",
-            ],
-        )
+    mock_service = MagicMock(spec=BasetenService)
+    mock_service.is_draft = False
+    mock_service.logs_url = "https://example.com/logs"
+    mock_service.model_id = "model_id"
+    mock_service.model_version_id = "version_id"
+    mock_service.poll_deployment_status.return_value = iter(["ACTIVE"])
+    remote.push = Mock(return_value=mock_service)
 
-    assert result.exit_code == 2
-    assert "Cannot use --wait with --tail" in result.output or (
-        result.exception
-        and "Cannot use --wait with --tail" in str(result.exception.__context__)
+    with patch("truss.cli.cli.RemoteFactory.create", return_value=remote):
+        remote.api.get_teams = Mock(return_value={})
+        with patch("truss.cli.cli.resolve_model_team_name", return_value=(None, None)):
+            with patch("truss.cli.cli._start_tail") as mock_start_tail:
+                result = runner.invoke(
+                    truss_cli,
+                    [
+                        "push",
+                        str(custom_model_truss_dir_with_pre_and_post),
+                        "--remote",
+                        "baseten",
+                        "--model-name",
+                        "model_name",
+                        "--wait",
+                        "--tail",
+                    ],
+                )
+
+    assert result.exit_code == 0, result.output
+    mock_start_tail.assert_called_once_with(
+        remote, "model_id", "version_id", in_background=True
     )
 
 

--- a/truss/tests/cli/test_cli.py
+++ b/truss/tests/cli/test_cli.py
@@ -922,7 +922,7 @@ def test_push_watch_with_tail_starts_background_tail(
     mock_service.logs_url = "https://example.com/logs"
     mock_service.model_id = "model_id"
     mock_service.model_version_id = "version_id"
-    mock_service.poll_deployment_status.return_value = iter(["LOADING_MODEL"])
+    mock_service.poll_deployment.return_value = iter([{"status": "LOADING_MODEL"}])
     remote.push = Mock(return_value=mock_service)
 
     mock_resolve = Mock(
@@ -1099,7 +1099,7 @@ def test_push_wait_with_tail_starts_background_tail(
     mock_service.logs_url = "https://example.com/logs"
     mock_service.model_id = "model_id"
     mock_service.model_version_id = "version_id"
-    mock_service.poll_deployment_status.return_value = iter(["ACTIVE"])
+    mock_service.poll_deployment.return_value = iter([{"status": "ACTIVE"}])
     remote.push = Mock(return_value=mock_service)
 
     with patch("truss.cli.cli.RemoteFactory.create", return_value=remote):

--- a/truss/tests/cli/test_cli.py
+++ b/truss/tests/cli/test_cli.py
@@ -431,6 +431,34 @@ def test_watch_without_no_sleep_does_not_start_thread():
     mock_start_keepalive.assert_not_called()
 
 
+def test_watch_with_tail_starts_background_tail():
+    """Test that watch --tail starts tail in background."""
+    resolved_model, versions, dev_version, mock_tr, remote_provider = (
+        _make_watch_mocks()
+    )
+    runner = CliRunner()
+
+    with _patch_watch_common(
+        remote_provider, mock_tr, resolved_model, versions, dev_version
+    ):
+        with patch("truss.cli.utils.common.requests_lib") as mock_requests:
+            mock_requests.post.return_value = Mock(status_code=202)
+            mock_requests.RequestException = requests.RequestException
+            with patch("truss.cli.cli._start_tail") as mock_start_tail:
+                with patch.object(
+                    remote_provider, "sync_truss_to_dev_version_with_model"
+                ):
+                    result = runner.invoke(
+                        truss_cli,
+                        ["watch", "/tmp/fake", "--remote", "baseten", "--tail"],
+                    )
+
+    assert result.exit_code == 0, result.output
+    mock_start_tail.assert_called_once_with(
+        remote_provider, "model_id", "dev_version_id", in_background=True
+    )
+
+
 def test_keepalive_loop_continues_before_max_duration():
     """Keepalive loop should keep running before 24 hours."""
     stop_event = threading.Event()


### PR DESCRIPTION
## :rocket: What

Users were unable to `--tail` while they were waiting or watching deployments, now they can. Got rid of constraints about using `--tail` with `push --wait` and `push --watch`, and added new `--tail` option to `watch`.

Fixes #2351

## :computer: How

Made tail a background thread while waiting/watching and confirmed in code the thread safety of console use and spinner use. Also disabled tail spinner in this case (don't want double spinners)

## :microscope: Testing

* Replaced existing tail+wait/watch-not-allowed tests with proper ons
* Manual testing of all permutations