### PR TITLE
💥 Default `--no-sleep` to true for `watch` and `push --watch`

### DIFF
--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -668,13 +668,15 @@ def run_python(script, target_directory):
 )
 @click.option(
     "--watch-no-sleep",
-    is_flag=True,
+    type=bool,
     required=False,
-    default=False,
+    default=True,
     help="Keep the development model warm by preventing scale-to-zero while watching. Requires --watch.",
 )
 @common.common_options()
+@click.pass_context
 def push(
+    ctx: click.Context,
     target_directory: str,
     config: Optional[str],
     remote: str,
@@ -697,7 +699,7 @@ def push(
     watch_after_push: bool = False,
     watch_hot_reload: bool = False,
     no_cache: bool = False,
-    watch_no_sleep: bool = False,
+    watch_no_sleep: bool = True,
 ) -> None:
     """
     Pushes a truss to a TrussRemote.
@@ -710,11 +712,6 @@ def push(
         console.print(
             "[DEPRECATED] The --publish flag is deprecated. Published deployments are now the default.",
             style="yellow",
-        )
-
-    if watch_no_sleep and not watch_after_push:
-        raise click.UsageError(
-            "Cannot use --watch-no-sleep without --watch. --watch-no-sleep prevents scale-to-zero during watch mode."
         )
 
     # Handle --watch flag: deploys as development and then watches
@@ -739,6 +736,11 @@ def push(
     else:
         if watch_hot_reload:
             raise click.UsageError("--watch-hot-reload requires --watch.")
+        if (
+            ctx.get_parameter_source("watch_no_sleep")
+            != click.core.ParameterSource.DEFAULT  # type: ignore[attr-defined]
+        ):
+            raise click.UsageError("--watch-no-sleep requires --watch.")
         # Default is now published deployment
         publish = True
         console.print(
@@ -1043,8 +1045,8 @@ def model_logs(
 )
 @click.option(
     "--no-sleep",
-    is_flag=True,
-    default=False,
+    type=bool,
+    default=True,
     help="Keep the development model warm by preventing scale-to-zero while watching.",
 )
 @click.option(
@@ -1069,7 +1071,7 @@ def watch(
     config: Optional[str],
     remote: str,
     provided_team_name: Optional[str] = None,
-    no_sleep: bool = False,
+    no_sleep: bool = True,
     hot_reload: bool = False,
     model_name: Optional[str] = None,
 ) -> None:

--- a/truss/tests/cli/test_cli.py
+++ b/truss/tests/cli/test_cli.py
@@ -267,11 +267,11 @@ def test_watch_sends_wake_request():
         # Need to patch requests_lib in common.py now since wake is called from there
         with patch("truss.cli.utils.common.requests_lib") as mock_requests:
             mock_requests.post.return_value = Mock(status_code=202)
+            mock_requests.get.return_value = Mock(status_code=200)
             mock_requests.RequestException = requests.RequestException
             with patch.object(remote_provider, "sync_truss_to_dev_version_with_model"):
                 _result = runner.invoke(
-                    truss_cli,
-                    ["watch", "/tmp/fake", "--remote", "baseten"],  # No --no-sleep
+                    truss_cli, ["watch", "/tmp/fake", "--remote", "baseten"]
                 )
 
     mock_requests.post.assert_called_once_with(
@@ -282,7 +282,7 @@ def test_watch_sends_wake_request():
 
 
 def test_watch_no_sleep_starts_keepalive_thread():
-    """--no-sleep should start a daemon keepalive thread after model is ready."""
+    """No-sleep is default, so keepalive thread should start without explicit flag."""
     resolved_model, versions, dev_version, mock_tr, remote_provider = (
         _make_watch_mocks()
     )
@@ -302,8 +302,7 @@ def test_watch_no_sleep_starts_keepalive_thread():
                     remote_provider, "sync_truss_to_dev_version_with_model"
                 ):
                     _result = runner.invoke(
-                        truss_cli,
-                        ["watch", "/tmp/fake", "--remote", "baseten", "--no-sleep"],
+                        truss_cli, ["watch", "/tmp/fake", "--remote", "baseten"]
                     )
 
     mock_thread_cls.assert_called_once()
@@ -374,8 +373,7 @@ def test_watch_no_sleep_waits_for_active_status():
                     remote_provider, "sync_truss_to_dev_version_with_model"
                 ):
                     result = runner.invoke(
-                        truss_cli,
-                        ["watch", "/tmp/fake", "--remote", "baseten", "--no-sleep"],
+                        truss_cli, ["watch", "/tmp/fake", "--remote", "baseten"]
                     )
 
     assert result.exit_code == 0
@@ -397,7 +395,7 @@ def test_watch_no_sleep_exits_on_failed_deployment():
             mock_requests.post.return_value = Mock(status_code=202)
             mock_requests.RequestException = requests.RequestException
             result = runner.invoke(
-                truss_cli, ["watch", "/tmp/fake", "--remote", "baseten", "--no-sleep"]
+                truss_cli, ["watch", "/tmp/fake", "--remote", "baseten"]
             )
 
     assert result.exit_code != 0
@@ -405,7 +403,7 @@ def test_watch_no_sleep_exits_on_failed_deployment():
 
 
 def test_watch_without_no_sleep_does_not_start_thread():
-    """Without --no-sleep, no keepalive thread should be started."""
+    """With --no-sleep=false, no keepalive thread should be started."""
     resolved_model, versions, dev_version, mock_tr, remote_provider = (
         _make_watch_mocks()
     )
@@ -424,7 +422,14 @@ def test_watch_without_no_sleep_does_not_start_thread():
                     remote_provider, "sync_truss_to_dev_version_with_model"
                 ):
                     _result = runner.invoke(
-                        truss_cli, ["watch", "/tmp/fake", "--remote", "baseten"]
+                        truss_cli,
+                        [
+                            "watch",
+                            "/tmp/fake",
+                            "--remote",
+                            "baseten",
+                            "--no-sleep=false",
+                        ],
                     )
 
     mock_start_keepalive.assert_not_called()
@@ -961,15 +966,14 @@ def test_push_watch_no_sleep_without_watch_fails():
                 "remote1",
                 "--model-name",
                 "name",
-                "--watch-no-sleep",
+                "--watch-no-sleep=false",
             ],
         )
 
     assert result.exit_code != 0
-    assert "Cannot use --watch-no-sleep without --watch" in result.output or (
+    assert "--watch-no-sleep requires --watch" in result.output or (
         result.exception
-        and "Cannot use --watch-no-sleep without --watch"
-        in str(result.exception.__context__)
+        and "--watch-no-sleep requires --watch" in str(result.exception.__context__)
     )
 
 
@@ -980,7 +984,7 @@ def test_push_watch_no_sleep_starts_keepalive(
     mock_upload_truss,
     mock_create_truss_service,
 ):
-    """Test that --watch --no-sleep starts the keepalive thread before entering watch mode."""
+    """Test that --watch starts the keepalive thread by default before entering watch mode."""
     runner = CliRunner()
 
     mock_service = MagicMock()
@@ -1020,7 +1024,6 @@ def test_push_watch_no_sleep_starts_keepalive(
                                 "--model-name",
                                 "model_name",
                                 "--watch",
-                                "--watch-no-sleep",
                             ],
                         )
 

--- a/truss/tests/cli/test_cli.py
+++ b/truss/tests/cli/test_cli.py
@@ -267,12 +267,14 @@ def test_watch_sends_wake_request():
         # Need to patch requests_lib in common.py now since wake is called from there
         with patch("truss.cli.utils.common.requests_lib") as mock_requests:
             mock_requests.post.return_value = Mock(status_code=202)
-            mock_requests.get.return_value = Mock(status_code=200)
             mock_requests.RequestException = requests.RequestException
-            with patch.object(remote_provider, "sync_truss_to_dev_version_with_model"):
-                _result = runner.invoke(
-                    truss_cli, ["watch", "/tmp/fake", "--remote", "baseten"]
-                )
+            with patch("truss.cli.utils.common.start_keepalive"):
+                with patch.object(
+                    remote_provider, "sync_truss_to_dev_version_with_model"
+                ):
+                    _result = runner.invoke(
+                        truss_cli, ["watch", "/tmp/fake", "--remote", "baseten"]
+                    )
 
     mock_requests.post.assert_called_once_with(
         "https://model-abc123.api.baseten.co/development/wake",
@@ -1088,7 +1090,11 @@ def test_push_watch_enters_watch_mode_on_deploying_status(
 
     mock_resolve = Mock(
         return_value=(
-            {"id": "model_id", "name": "model_name"},
+            {
+                "id": "model_id",
+                "name": "model_name",
+                "hostname": "https://model.api.baseten.co",
+            },
             [{"id": "version_id", "is_draft": True}],
         )
     )
@@ -1099,18 +1105,19 @@ def test_push_watch_enters_watch_mode_on_deploying_status(
         with patch("truss.cli.cli.resolve_model_team_name", return_value=(None, None)):
             with patch("truss.cli.cli.resolve_model_for_watch", mock_resolve):
                 with patch("truss.cli.cli._start_watch_mode", mock_start_watch):
-                    result = runner.invoke(
-                        truss_cli,
-                        [
-                            "push",
-                            str(custom_model_truss_dir_with_pre_and_post),
-                            "--remote",
-                            "baseten",
-                            "--model-name",
-                            "model_name",
-                            "--watch",
-                        ],
-                    )
+                    with patch("truss.cli.cli.common.start_keepalive"):
+                        result = runner.invoke(
+                            truss_cli,
+                            [
+                                "push",
+                                str(custom_model_truss_dir_with_pre_and_post),
+                                "--remote",
+                                "baseten",
+                                "--model-name",
+                                "model_name",
+                                "--watch",
+                            ],
+                        )
 
     assert result.exit_code == 0
     mock_start_watch.assert_called_once()
@@ -1206,20 +1213,21 @@ def test_watch_model_name_flag_overrides_config(
             with patch("truss.cli.utils.common.requests_lib") as mock_requests:
                 mock_requests.post.return_value = Mock(status_code=202)
                 mock_requests.RequestException = __import__("requests").RequestException
-                with patch.object(
-                    remote_provider, "sync_truss_to_dev_version_with_model"
-                ):
-                    runner.invoke(
-                        truss_cli,
-                        [
-                            "watch",
-                            "/tmp/fake",
-                            "--remote",
-                            "baseten",
-                            "--model-name",
-                            "flag-name",
-                        ],
-                    )
+                with patch("truss.cli.utils.common.start_keepalive"):
+                    with patch.object(
+                        remote_provider, "sync_truss_to_dev_version_with_model"
+                    ):
+                        runner.invoke(
+                            truss_cli,
+                            [
+                                "watch",
+                                "/tmp/fake",
+                                "--remote",
+                                "baseten",
+                                "--model-name",
+                                "flag-name",
+                            ],
+                        )
 
     # The flag value should be used, not the config value
     first_call_args = mock_resolve.call_args_list[0]


### PR DESCRIPTION
## :rocket: What

When watching for local disk changes, `--no-sleep` was recently made an opt-in keepalive in #2211 and #2308. It has since become clear this should be the default to prevent scale down while watching.

The log of `💤 --no-sleep enabled: keeping development model warm` now appears for every watch by default, which is a good thing.

💥 BACKWARDS INCOMPATIBLE CHANGE - `--no-sleep` as a sans-value flag does not work anymore, it is implied, and users must `--no-sleep=false` to disable. This was a recent addition, so impact should be minimal.

💥 BEHAVIOR CHANGE - By default `push --watch` and `watch` will no longer scale down while watch is running, which means while watch is running, replica stays online and therefore users will continue to get charged. This only affects users that were using watch beyond scale down time, where before watch would just stop working. This is common-sense behavior that watching something live keeps it alive. Impact for most users should be minimal, but release notes need to clarify since it prevents replica tear down. The log line informs the user too.

Fixes #2355

## :computer: How

Made `--no-sleep` a bool option instead of a flag, and defaulted it to true

## :microscope: Testing

Updated existing tests to flip their default expectations and confirmed coverage