### PR TITLE
feat(train): add truss train capacity command

### DIFF
--- a/truss/cli/train/core.py
+++ b/truss/cli/train/core.py
@@ -670,6 +670,10 @@ def display_training_capacity(remote_provider: BasetenRemote) -> None:
     table.add_column("Limit", justify="right")
     table.add_column("Usage", justify="right")
 
+    if not gpu_capacities:
+        console.print("No Training GPU capacity limits.")
+        return
+
     for item in gpu_capacities:
         table.add_row(
             item.get("gpu_type", ""),

--- a/truss/cli/train/core.py
+++ b/truss/cli/train/core.py
@@ -652,3 +652,30 @@ def view_cache_summary_by_project(
 
     project = fetch_project_by_name_or_id(remote_provider, project_identifier)
     view_cache_summary(remote_provider, project["id"], sort_by, order, output_format)
+
+
+def display_training_capacity(remote_provider: BasetenRemote) -> None:
+    """Fetch and display GPU capacity limits and usage for the organization."""
+    gpu_capacities = remote_provider.api.get_training_capacity()
+
+    table = rich.table.Table(
+        show_header=True,
+        header_style="bold magenta",
+        title="Training GPU Capacity",
+        box=rich.table.box.ROUNDED,
+        border_style="blue",
+    )
+    table.add_column("GPU Type", style="cyan")
+    table.add_column("Baseline", justify="right")
+    table.add_column("Limit", justify="right")
+    table.add_column("Usage", justify="right")
+
+    for item in gpu_capacities:
+        table.add_row(
+            item.get("gpu_type", ""),
+            str(item.get("baseline", 0)),
+            str(item.get("limit", 0)),
+            str(item.get("usage_count", 0)),
+        )
+
+    console.print(table)

--- a/truss/cli/train_commands.py
+++ b/truss/cli/train_commands.py
@@ -1082,3 +1082,16 @@ def _patch_sessions(
         sys.exit(1)
 
     return messages
+
+
+@train.command(name="capacity")
+@common.common_options()
+@click.option("--remote", type=str, required=False, help="Name of the remote to use")
+def capacity(remote: Optional[str]):
+    """Show GPU capacity limits and current usage for the organization."""
+    if not remote:
+        remote = remote_cli.inquire_remote_name()
+    remote_provider: BasetenRemote = cast(
+        BasetenRemote, RemoteFactory.create(remote=remote)
+    )
+    train_cli.display_training_capacity(remote_provider)

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -857,6 +857,10 @@ class BasetenApi:
         )
         return resp_json["training_job"]
 
+    def get_training_capacity(self) -> list[dict]:
+        resp_json = self._rest_api_client.get("v1/training/capacity")
+        return resp_json.get("gpu_capacities", [])
+
     def list_training_job_checkpoints(self, project_id: str, job_id: str):
         resp_json = self._rest_api_client.get(
             f"v1/training_projects/{project_id}/jobs/{job_id}/checkpoints"

--- a/truss/tests/cli/train/test_train_cli_core.py
+++ b/truss/tests/cli/train/test_train_cli_core.py
@@ -457,16 +457,11 @@ def test_display_training_capacity(capsys):
     display_training_capacity(mock_remote)
 
     lines = capsys.readouterr().out.splitlines()
-    h100_cells = [
-        c.strip()
-        for c in next(line for line in lines if "H100" in line).split("│")
-        if c.strip()
-    ]
-    a10g_cells = [
-        c.strip()
-        for c in next(line for line in lines if "A10G" in line).split("│")
-        if c.strip()
-    ]
+    rows = {
+        cells[0]: cells
+        for line in lines
+        if (cells := [c.strip() for c in line.split("│") if c.strip()])
+    }
 
-    assert h100_cells == ["H100", "16", "64", "32"]
-    assert a10g_cells == ["A10G", "0", "8", "0"]
+    assert rows["H100"] == ["H100", "16", "64", "32"]
+    assert rows["A10G"] == ["A10G", "0", "8", "0"]

--- a/truss/tests/cli/train/test_train_cli_core.py
+++ b/truss/tests/cli/train/test_train_cli_core.py
@@ -4,7 +4,7 @@ from truss.cli.train.cache import (
     calculate_directory_sizes,
     create_file_summary_with_directory_sizes,
 )
-from truss.cli.train.core import view_training_job_metrics
+from truss.cli.train.core import display_training_capacity, view_training_job_metrics
 from truss.remote.baseten.custom_types import FileSummary
 
 
@@ -442,3 +442,31 @@ def test_calculate_directory_sizes_max_depth():
     assert result_depth_2["/root/level1"] == 100  # file1.txt only
     assert result_depth_2["/root/level1/level2"] == 200  # file2.txt only
     assert result_depth_2["/root/level1/level2/level3"] == 300  # file3.txt only
+
+
+def test_display_training_capacity(capsys):
+    """Table is printed with GPU type, baseline, limit, and usage for each entry."""
+    mock_api = Mock()
+    mock_api.get_training_capacity.return_value = [
+        {"gpu_type": "H100", "baseline": 16, "limit": 64, "usage_count": 32},
+        {"gpu_type": "A10G", "baseline": 0, "limit": 8, "usage_count": 0},
+    ]
+    mock_remote = Mock()
+    mock_remote.api = mock_api
+
+    display_training_capacity(mock_remote)
+
+    lines = capsys.readouterr().out.splitlines()
+    h100_cells = [
+        c.strip()
+        for c in next(line for line in lines if "H100" in line).split("│")
+        if c.strip()
+    ]
+    a10g_cells = [
+        c.strip()
+        for c in next(line for line in lines if "A10G" in line).split("│")
+        if c.strip()
+    ]
+
+    assert h100_cells == ["H100", "16", "64", "32"]
+    assert a10g_cells == ["A10G", "0", "8", "0"]

--- a/truss/tests/cli/train/test_train_cli_core.py
+++ b/truss/tests/cli/train/test_train_cli_core.py
@@ -465,3 +465,15 @@ def test_display_training_capacity(capsys):
 
     assert rows["H100"] == ["H100", "16", "64", "32"]
     assert rows["A10G"] == ["A10G", "0", "8", "0"]
+
+
+def test_display_training_capacity_empty(capsys):
+    """Empty state message is printed when there are no GPU capacities."""
+    mock_api = Mock()
+    mock_api.get_training_capacity.return_value = []
+    mock_remote = Mock()
+    mock_remote.api = mock_api
+
+    display_training_capacity(mock_remote)
+
+    assert "No Training GPU capacity limits." in capsys.readouterr().out


### PR DESCRIPTION
## :rocket: What

  Adds a truss train capacity CLI command that displays a table of the organization's GPU capacity limits and current usage, including baseline allocation, peak limit, and active usage per GPU type.

## :computer: How

  - Added get_training_capacity() method on BasetenApi that calls GET /v1/training/capacity
  - Added display_training_capacity() in truss/cli/train/core.py that renders a Rich table with GPU Type, Baseline, Limit, and Usage columns. Baseline of 0 is displayed as "0".
  - Added truss train capacity Click command in train_commands.py

## :microscope: Testing

  Added test_display_training_capacity in truss/tests/cli/train/test_train_cli_core.py:
  - Mocks the API response with two GPU types (one with a baseline, one with baseline=0) and verifies all columns render correctly in the output

 ## :ship: Release requirements

  - Pre-release: Requires the companion baseten PR to be deployed
  - Post-release: None
  - External communication: None
