### PR TITLE
feat(trainers): Add checkpointing — save/load state

### DIFF
--- a/trainers/server/src/trainers_server/dp_worker/api/controller.py
+++ b/trainers/server/src/trainers_server/dp_worker/api/controller.py
@@ -18,6 +18,7 @@ from torch.optim import AdamW
 from swift.arguments import RolloutArguments
 from swift.infer_engine import RequestConfig
 from swift.infer_engine.protocol import RolloutInferRequest
+from swift.model.model_meta import get_matched_model_meta
 from swift.model.register import get_model_processor
 from swift.pipelines.infer.rollout import rollout_main
 from swift.rlhf_trainers.utils import FlattenedTensorBucket
@@ -133,6 +134,10 @@ class RLController:
             raise ValueError("training.gpus must contain at least one GPU id.")
         if not self.config.inference.gpus:
             raise ValueError("inference.gpus must contain at least one GPU id.")
+
+        model_meta = get_matched_model_meta(config.model_id)
+        self._swift_model_type: Optional[str] = model_meta.model_type if model_meta else None
+        logger.info("Resolved swift model_type=%s for model_id=%s", self._swift_model_type, config.model_id)
 
         training_device = self._training_device()
         load_checkpoint_dir = os.environ.get("BT_LOAD_CHECKPOINT_DIR")
@@ -583,15 +588,16 @@ class RLController:
         with self._lock:
             t0 = time.perf_counter()
             logger.info("load_state: loading model weights from %s ...", ckpt_dir)
-            self.model.train()
             model, processor = get_model_processor(
                 str(ckpt_dir),
                 torch_dtype=_parse_torch_dtype("bfloat16"),
                 device_map={"": self._training_device()},
                 use_hf=True,
                 task_type="causal_lm",
+                model_type=self._swift_model_type,
             )
             self.model = model
+            self.model.train()
             self.processor = processor
             self.optimizer = AdamW(self.model.parameters(), lr=0.0, weight_decay=0.0)
             self.optimizer.zero_grad(set_to_none=True)
@@ -605,15 +611,16 @@ class RLController:
         with self._lock:
             t0 = time.perf_counter()
             logger.info("load_state_with_optimizer: loading from %s ...", ckpt_dir)
-            self.model.train()
             model, processor = get_model_processor(
                 str(ckpt_dir),
                 torch_dtype=_parse_torch_dtype("bfloat16"),
                 device_map={"": self._training_device()},
                 use_hf=True,
                 task_type="causal_lm",
+                model_type=self._swift_model_type,
             )
             self.model = model
+            self.model.train()
             self.processor = processor
             self.optimizer = AdamW(self.model.parameters(), lr=0.0, weight_decay=0.0)
             self.optimizer.zero_grad(set_to_none=True)

--- a/trainers/server/src/trainers_server/dp_worker/api/controller.py
+++ b/trainers/server/src/trainers_server/dp_worker/api/controller.py
@@ -582,7 +582,10 @@ class RLController:
         with self._lock:
             t0 = time.perf_counter()
             logger.info("load_state: loading model weights from %s ...", ckpt_dir)
-            self.model = type(self.model).from_pretrained(
+            model_cls = type(self.model)
+            del self.model
+            torch.cuda.empty_cache()
+            self.model = model_cls.from_pretrained(
                 str(ckpt_dir),
                 torch_dtype=torch.bfloat16,
                 device_map={"": self._training_device()},
@@ -600,7 +603,10 @@ class RLController:
         with self._lock:
             t0 = time.perf_counter()
             logger.info("load_state_with_optimizer: loading from %s ...", ckpt_dir)
-            self.model = type(self.model).from_pretrained(
+            model_cls = type(self.model)
+            del self.model
+            torch.cuda.empty_cache()
+            self.model = model_cls.from_pretrained(
                 str(ckpt_dir),
                 torch_dtype=torch.bfloat16,
                 device_map={"": self._training_device()},

--- a/trainers/server/src/trainers_server/dp_worker/api/controller.py
+++ b/trainers/server/src/trainers_server/dp_worker/api/controller.py
@@ -138,20 +138,33 @@ class RLController:
         load_checkpoint_dir = os.environ.get("BT_LOAD_CHECKPOINT_DIR")
 
         if model is None or processor is None:
-            model_source = load_checkpoint_dir if load_checkpoint_dir else config.model_id
             logger.info(
                 "Loading model and processor from %s (dtype=bfloat16, training_device=%s) ...",
-                model_source,
+                config.model_id,
                 training_device,
             )
             t0 = time.perf_counter()
             model, processor = get_model_processor(
-                model_source,
+                config.model_id,
                 torch_dtype=_parse_torch_dtype("bfloat16"),
                 device_map={"": training_device},
                 use_hf=True,
             )
             logger.info("Model and processor loaded in %.1fs", time.perf_counter() - t0)
+
+            if load_checkpoint_dir:
+                logger.info("Overwriting weights from checkpoint %s ...", load_checkpoint_dir)
+                t0 = time.perf_counter()
+                model_cls = type(model)
+                del model
+                torch.cuda.empty_cache()
+                model = model_cls.from_pretrained(
+                    load_checkpoint_dir,
+                    torch_dtype=torch.bfloat16,
+                    device_map={"": training_device},
+                )
+                logger.info("Checkpoint weights loaded in %.1fs", time.perf_counter() - t0)
+
         self.model = model
         self.processor = processor
 
@@ -583,6 +596,7 @@ class RLController:
             t0 = time.perf_counter()
             logger.info("load_state: loading model weights from %s ...", ckpt_dir)
             model_cls = type(self.model)
+            del self.optimizer
             del self.model
             torch.cuda.empty_cache()
             self.model = model_cls.from_pretrained(
@@ -604,6 +618,7 @@ class RLController:
             t0 = time.perf_counter()
             logger.info("load_state_with_optimizer: loading from %s ...", ckpt_dir)
             model_cls = type(self.model)
+            del self.optimizer
             del self.model
             torch.cuda.empty_cache()
             self.model = model_cls.from_pretrained(

--- a/trainers/server/src/trainers_server/dp_worker/api/controller.py
+++ b/trainers/server/src/trainers_server/dp_worker/api/controller.py
@@ -28,6 +28,8 @@ from trainers_server.shared.models import (
     Datum,
     ForwardBackwardDetails,
     ForwardBackwardResult,
+    LoadStateDetails,
+    LoadStateResult,
     OptimStepDetails,
     OptimStepResult,
     SampleDetails,
@@ -133,15 +135,18 @@ class RLController:
             raise ValueError("inference.gpus must contain at least one GPU id.")
 
         training_device = self._training_device()
+        load_checkpoint_dir = os.environ.get("BT_LOAD_CHECKPOINT_DIR")
+
         if model is None or processor is None:
+            model_source = load_checkpoint_dir if load_checkpoint_dir else config.model_id
             logger.info(
-                "Loading model and processor for %s (dtype=bfloat16, training_device=%s) ...",
-                config.model_id,
+                "Loading model and processor from %s (dtype=bfloat16, training_device=%s) ...",
+                model_source,
                 training_device,
             )
             t0 = time.perf_counter()
             model, processor = get_model_processor(
-                config.model_id,
+                model_source,
                 torch_dtype=_parse_torch_dtype("bfloat16"),
                 device_map={"": training_device},
                 use_hf=True,
@@ -163,6 +168,18 @@ class RLController:
         logger.info("Initializing AdamW optimizer (params set per optim_step via AdamParams) ...")
         self.optimizer = AdamW(self.model.parameters(), lr=0.0, weight_decay=0.0)
         self.optimizer.zero_grad(set_to_none=True)
+
+        if load_checkpoint_dir:
+            trainer_state_path = Path(load_checkpoint_dir) / "trainer_state.pt"
+            if trainer_state_path.exists():
+                logger.info("Restoring trainer state from %s ...", trainer_state_path)
+                trainer_state = torch.load(trainer_state_path, map_location="cpu", weights_only=False)
+                self.step = trainer_state.get("step", 0)
+                self.last_loss = trainer_state.get("last_loss")
+                self.optimizer.load_state_dict(trainer_state["optimizer"])
+                logger.info("Trainer state restored — step=%d", self.step)
+            else:
+                logger.info("No trainer_state.pt found in %s, starting from step 0.", load_checkpoint_dir)
 
         logger.info("Launching rollout server on inference GPUs=%s ...", config.inference.gpus)
         self._launch_rollout_server()
@@ -519,12 +536,17 @@ class RLController:
             logger.info("sample: done in %.2fs — %d sequence(s)", time.perf_counter() - t0, len(sequences))
             return SampleResult(sequences=sequences)
 
-    def save_state(self, path: str) -> SaveStateResult:
+    def save_state(self, path: Optional[str] = None) -> SaveStateResult:
+        resolved_path = path or os.environ.get("BT_CHECKPOINT_DIR")
+        if not resolved_path:
+            raise ValueError(
+                "save_state requires a path. Pass path= or set the BT_CHECKPOINT_DIR env var."
+            )
         with self._lock:
             self._ensure_training_mode("save_state")
             t0 = time.perf_counter()
-            logger.info("save_state: saving to %s ...", path)
-            ckpt_dir = Path(path)
+            logger.info("save_state: saving to %s ...", resolved_path)
+            ckpt_dir = Path(resolved_path)
             ckpt_dir.mkdir(parents=True, exist_ok=True)
 
             logger.info("save_state: saving model ...")
@@ -543,6 +565,70 @@ class RLController:
             torch.save(trainer_state, ckpt_dir / "trainer_state.pt")
             logger.info("save_state: done in %.2fs", time.perf_counter() - t0)
             return SaveStateResult(mode=self.mode)
+
+    def _resolve_load_path(self, path: Optional[str], caller: str) -> Path:
+        resolved = path or os.environ.get("BT_LOAD_CHECKPOINT_DIR")
+        if not resolved:
+            raise ValueError(
+                f"{caller} requires a path. Pass path= or set the BT_LOAD_CHECKPOINT_DIR env var."
+            )
+        ckpt_dir = Path(resolved)
+        if not ckpt_dir.exists():
+            raise ValueError(f"{caller}: checkpoint directory not found: {ckpt_dir}")
+        return ckpt_dir
+
+    def load_state(self, details: LoadStateDetails) -> LoadStateResult:
+        ckpt_dir = self._resolve_load_path(details.path, "load_state")
+        with self._lock:
+            t0 = time.perf_counter()
+            logger.info("load_state: loading model weights from %s ...", ckpt_dir)
+            self.model.train()
+            model, processor = get_model_processor(
+                str(ckpt_dir),
+                torch_dtype=_parse_torch_dtype("bfloat16"),
+                device_map={"": self._training_device()},
+                use_hf=True,
+            )
+            self.model = model
+            self.processor = processor
+            self.optimizer = AdamW(self.model.parameters(), lr=0.0, weight_decay=0.0)
+            self.optimizer.zero_grad(set_to_none=True)
+            self.mode = "training"
+            self._communicator_ready = False
+            logger.info("load_state: done in %.2fs — weights loaded, optimizer reset", time.perf_counter() - t0)
+            return LoadStateResult(mode=self.mode, step=self.step)
+
+    def load_state_with_optimizer(self, details: LoadStateDetails) -> LoadStateResult:
+        ckpt_dir = self._resolve_load_path(details.path, "load_state_with_optimizer")
+        with self._lock:
+            t0 = time.perf_counter()
+            logger.info("load_state_with_optimizer: loading from %s ...", ckpt_dir)
+            self.model.train()
+            model, processor = get_model_processor(
+                str(ckpt_dir),
+                torch_dtype=_parse_torch_dtype("bfloat16"),
+                device_map={"": self._training_device()},
+                use_hf=True,
+            )
+            self.model = model
+            self.processor = processor
+            self.optimizer = AdamW(self.model.parameters(), lr=0.0, weight_decay=0.0)
+            self.optimizer.zero_grad(set_to_none=True)
+
+            trainer_state_path = ckpt_dir / "trainer_state.pt"
+            if trainer_state_path.exists():
+                trainer_state = torch.load(trainer_state_path, map_location="cpu", weights_only=False)
+                self.step = trainer_state.get("step", 0)
+                self.last_loss = trainer_state.get("last_loss")
+                self.optimizer.load_state_dict(trainer_state["optimizer"])
+                logger.info("load_state_with_optimizer: restored step=%d", self.step)
+            else:
+                logger.warning("load_state_with_optimizer: no trainer_state.pt found, optimizer state not restored")
+
+            self.mode = "training"
+            self._communicator_ready = False
+            logger.info("load_state_with_optimizer: done in %.2fs", time.perf_counter() - t0)
+            return LoadStateResult(mode=self.mode, step=self.step)
 
     def close(self) -> None:
         with self._lock:

--- a/trainers/server/src/trainers_server/dp_worker/api/controller.py
+++ b/trainers/server/src/trainers_server/dp_worker/api/controller.py
@@ -18,7 +18,6 @@ from torch.optim import AdamW
 from swift.arguments import RolloutArguments
 from swift.infer_engine import RequestConfig
 from swift.infer_engine.protocol import RolloutInferRequest
-from swift.model.model_meta import get_matched_model_meta
 from swift.model.register import get_model_processor
 from swift.pipelines.infer.rollout import rollout_main
 from swift.rlhf_trainers.utils import FlattenedTensorBucket
@@ -135,10 +134,6 @@ class RLController:
         if not self.config.inference.gpus:
             raise ValueError("inference.gpus must contain at least one GPU id.")
 
-        model_meta = get_matched_model_meta(config.model_id)
-        self._swift_model_type: Optional[str] = model_meta.model_type if model_meta else None
-        logger.info("Resolved swift model_type=%s for model_id=%s", self._swift_model_type, config.model_id)
-
         training_device = self._training_device()
         load_checkpoint_dir = os.environ.get("BT_LOAD_CHECKPOINT_DIR")
 
@@ -155,7 +150,6 @@ class RLController:
                 torch_dtype=_parse_torch_dtype("bfloat16"),
                 device_map={"": training_device},
                 use_hf=True,
-                task_type="causal_lm",
             )
             logger.info("Model and processor loaded in %.1fs", time.perf_counter() - t0)
         self.model = model
@@ -588,17 +582,12 @@ class RLController:
         with self._lock:
             t0 = time.perf_counter()
             logger.info("load_state: loading model weights from %s ...", ckpt_dir)
-            model, processor = get_model_processor(
+            self.model = type(self.model).from_pretrained(
                 str(ckpt_dir),
-                torch_dtype=_parse_torch_dtype("bfloat16"),
+                torch_dtype=torch.bfloat16,
                 device_map={"": self._training_device()},
-                use_hf=True,
-                task_type="causal_lm",
-                model_type=self._swift_model_type,
             )
-            self.model = model
             self.model.train()
-            self.processor = processor
             self.optimizer = AdamW(self.model.parameters(), lr=0.0, weight_decay=0.0)
             self.optimizer.zero_grad(set_to_none=True)
             self.mode = "training"
@@ -611,17 +600,12 @@ class RLController:
         with self._lock:
             t0 = time.perf_counter()
             logger.info("load_state_with_optimizer: loading from %s ...", ckpt_dir)
-            model, processor = get_model_processor(
+            self.model = type(self.model).from_pretrained(
                 str(ckpt_dir),
-                torch_dtype=_parse_torch_dtype("bfloat16"),
+                torch_dtype=torch.bfloat16,
                 device_map={"": self._training_device()},
-                use_hf=True,
-                task_type="causal_lm",
-                model_type=self._swift_model_type,
             )
-            self.model = model
             self.model.train()
-            self.processor = processor
             self.optimizer = AdamW(self.model.parameters(), lr=0.0, weight_decay=0.0)
             self.optimizer.zero_grad(set_to_none=True)
 

--- a/trainers/server/src/trainers_server/dp_worker/api/controller.py
+++ b/trainers/server/src/trainers_server/dp_worker/api/controller.py
@@ -150,6 +150,7 @@ class RLController:
                 torch_dtype=_parse_torch_dtype("bfloat16"),
                 device_map={"": training_device},
                 use_hf=True,
+                task_type="causal_lm",
             )
             logger.info("Model and processor loaded in %.1fs", time.perf_counter() - t0)
         self.model = model
@@ -588,6 +589,7 @@ class RLController:
                 torch_dtype=_parse_torch_dtype("bfloat16"),
                 device_map={"": self._training_device()},
                 use_hf=True,
+                task_type="causal_lm",
             )
             self.model = model
             self.processor = processor
@@ -609,6 +611,7 @@ class RLController:
                 torch_dtype=_parse_torch_dtype("bfloat16"),
                 device_map={"": self._training_device()},
                 use_hf=True,
+                task_type="causal_lm",
             )
             self.model = model
             self.processor = processor

--- a/trainers/server/src/trainers_server/dp_worker/api/server.py
+++ b/trainers/server/src/trainers_server/dp_worker/api/server.py
@@ -6,6 +6,8 @@ from fastapi.responses import Response
 from trainers_server.shared.models import (
     ForwardBackwardDetails,
     ForwardBackwardResult,
+    LoadStateDetails,
+    LoadStateResult,
     OptimStepDetails,
     OptimStepResult,
     SampleDetails,
@@ -64,8 +66,16 @@ def create_app(config: Optional[RLControllerConfig] = None, *, controller: Optio
         return _run_or_raise(controller.sample, details)
 
     @app.post("/save_state", response_model=SaveStateResult)
-    async def save_state(details: SaveStateDetails) -> SaveStateResult:
+    async def save_state(details: SaveStateDetails = SaveStateDetails()) -> SaveStateResult:
         return _run_or_raise(controller.save_state, details.path)
+
+    @app.post("/load_state", response_model=LoadStateResult)
+    async def load_state(details: LoadStateDetails = LoadStateDetails()) -> LoadStateResult:
+        return _run_or_raise(controller.load_state, details)
+
+    @app.post("/load_state_with_optimizer", response_model=LoadStateResult)
+    async def load_state_with_optimizer(details: LoadStateDetails = LoadStateDetails()) -> LoadStateResult:
+        return _run_or_raise(controller.load_state_with_optimizer, details)
 
     @app.get("/status", response_model=StatusResult)
     async def get_status() -> StatusResult:

--- a/trainers/server/src/trainers_server/shared/models.py
+++ b/trainers/server/src/trainers_server/shared/models.py
@@ -178,7 +178,7 @@ class ForwardBackwardDetails(BaseModel):
 
 
 class OptimStepDetails(BaseModel):
-    adam_params: AdamParams
+    adam_params: AdamParams = Field(default_factory=AdamParams)
 
 
 class SampleDetails(BaseModel):
@@ -193,8 +193,17 @@ class SaveWeightsAndGetSamplingClientDetails(BaseModel):
 
 
 class SaveStateDetails(BaseModel):
-    path: str
+    path: str | None = None
     ttl_seconds: int | None = None
+
+
+class LoadStateDetails(BaseModel):
+    path: str | None = None
+
+
+class LoadStateResult(BaseModel):
+    mode: str = ""
+    step: int = 0
 
 
 # ── Operation variants ───────────────────────────────────────────────

--- a/trainers/tests/conftest.py
+++ b/trainers/tests/conftest.py
@@ -1,0 +1,25 @@
+"""Stub out heavy ML dependencies so server modules can be imported without the
+full worker installation (ms-swift, vllm, megatron, CUDA torch).
+"""
+
+import sys
+from unittest.mock import MagicMock
+
+_HEAVY_MODULES = [
+    "swift",
+    "swift.arguments",
+    "swift.infer_engine",
+    "swift.infer_engine.protocol",
+    "swift.model.register",
+    "swift.pipelines.infer.rollout",
+    "swift.rlhf_trainers",
+    "swift.rlhf_trainers.utils",
+    "swift.rlhf_trainers.vllm_client",
+    "swift.template",
+    "swift.template.register",
+    "vllm",
+]
+
+for _mod in _HEAVY_MODULES:
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()

--- a/trainers/tests/e2e.py
+++ b/trainers/tests/e2e.py
@@ -3,14 +3,16 @@
 
 Usage:
     python e2e.py --namespace org-xxx --test smoke
+    python e2e.py --namespace org-xxx --test checkpointing
     python e2e.py --namespace org-xxx --test math_rl
     python e2e.py --namespace org-xxx --test multiturn_rl
     python e2e.py --namespace org-xxx --test math_rl --job-id q86dgg3  # skip deploy
 
 Tests:
-    smoke        — health, forward_backward, optim_step, save_weights, sample
-    math_rl      — GRPO on arithmetic problems (single-turn RL)
-    multiturn_rl — number guessing game (multi-turn RL)
+    smoke         — health, forward_backward, optim_step, save_weights, sample
+    checkpointing — save_state, load_state_with_optimizer, load_state, resume training
+    math_rl       — GRPO on arithmetic problems (single-turn RL)
+    multiturn_rl  — number guessing game (multi-turn RL)
 """
 
 import argparse
@@ -296,8 +298,74 @@ for step in range(STEPS):
 print("=== Multi-turn RL acceptance test PASSED ===")
 '''
 
+CHECKPOINTING_SCRIPT = r'''
+import sys, time, httpx
+TIMEOUT = 300.0
+base_url = sys.argv[1]
+client = httpx.Client(timeout=TIMEOUT)
+
+print("[0] Waiting for worker...")
+for attempt in range(60):
+    try:
+        if client.get(f"{base_url}/health").status_code == 200: break
+    except (httpx.ConnectError, httpx.ConnectTimeout): pass
+    print(f"  waiting ({attempt + 1}/60)..."); time.sleep(5)
+else:
+    print("  FAILED: worker not healthy after 5 min"); sys.exit(1)
+print("  Worker ready\n")
+
+CKPT_PATH = "/tmp/ckpt-e2e"
+adam = {"learning_rate": 5e-6, "beta1": 0.9, "beta2": 0.95, "eps": 1e-12, "weight_decay": 0.0, "grad_clip_norm": 0.0}
+data = [{"model_input": {"chunks": [{"type": "encoded_text", "tokens": list(range(10))}]},
+         "loss_fn_inputs": {"reward": {"data": [1.0], "dtype": "float32", "shape": [1]}}}]
+
+print("[1/6] forward_backward + optim_step (reach step 1)")
+resp = client.post(f"{base_url}/forward_backward", json={"data": data, "loss_fn": "cross_entropy"})
+assert resp.status_code == 200, f"FAILED: {resp.status_code} {resp.text}"
+loss_before = resp.json()["metrics"]["loss"]
+resp = client.post(f"{base_url}/optim_step", json={"adam_params": adam})
+assert resp.status_code == 200, f"FAILED: {resp.status_code} {resp.text}"
+step_before_save = int(resp.json()["metrics"]["step"])
+print(f"  loss={loss_before:.4f}, step={step_before_save}")
+
+print("[2/6] save_state")
+resp = client.post(f"{base_url}/save_state", json={"path": CKPT_PATH})
+assert resp.status_code == 200, f"FAILED: {resp.status_code} {resp.text}"
+print(f"  mode={resp.json().get('mode', '?')} — checkpoint written to {CKPT_PATH}")
+
+print("[3/6] forward_backward + optim_step (advance past checkpoint)")
+resp = client.post(f"{base_url}/forward_backward", json={"data": data, "loss_fn": "cross_entropy"})
+assert resp.status_code == 200, f"FAILED: {resp.status_code} {resp.text}"
+resp = client.post(f"{base_url}/optim_step", json={"adam_params": adam})
+assert resp.status_code == 200, f"FAILED: {resp.status_code} {resp.text}"
+step_after_extra = int(resp.json()["metrics"]["step"])
+assert step_after_extra > step_before_save, f"Expected step to advance beyond {step_before_save}, got {step_after_extra}"
+print(f"  step={step_after_extra} (advanced past checkpoint)")
+
+print("[4/6] load_state_with_optimizer — restore weights + optimizer + step")
+resp = client.post(f"{base_url}/load_state_with_optimizer", json={"path": CKPT_PATH})
+assert resp.status_code == 200, f"FAILED: {resp.status_code} {resp.text}"
+restored_step = resp.json()["step"]
+assert restored_step == step_before_save, \
+    f"Expected step restored to {step_before_save}, got {restored_step}"
+print(f"  step={restored_step} (correctly restored to checkpoint)")
+
+print("[5/6] load_state — weights only, optimizer reset")
+resp = client.post(f"{base_url}/load_state", json={"path": CKPT_PATH})
+assert resp.status_code == 200, f"FAILED: {resp.status_code} {resp.text}"
+print(f"  mode={resp.json().get('mode', '?')}")
+
+print("[6/6] forward_backward still works after load")
+resp = client.post(f"{base_url}/forward_backward", json={"data": data, "loss_fn": "cross_entropy"})
+assert resp.status_code == 200, f"FAILED: {resp.status_code} {resp.text}"
+print(f"  loss={resp.json()['metrics']['loss']:.4f}")
+
+print("\nAll checks passed!")
+'''
+
 TESTS = {
     "smoke": {"script": SMOKE_SCRIPT, "image": "python:3.12-slim", "pip": "httpx"},
+    "checkpointing": {"script": CHECKPOINTING_SCRIPT, "image": "python:3.12-slim", "pip": "httpx"},
     "math_rl": {"script": MATH_RL_SCRIPT, "image": "python:3.12-slim", "pip": "httpx transformers"},
     "multiturn_rl": {"script": MULTITURN_RL_SCRIPT, "image": "python:3.12-slim", "pip": "httpx transformers"},
 }

--- a/trainers/tests/test_checkpointing.py
+++ b/trainers/tests/test_checkpointing.py
@@ -25,10 +25,24 @@ from trainers_server.shared.models import LoadStateDetails, SaveStateDetails
 # Helpers
 # ---------------------------------------------------------------------------
 
+class _FakeModel(nn.Linear):
+    """Minimal fake model that mimics a HuggingFace model's save/load API."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(4, 4)
+        self.save_pretrained = MagicMock()
+
+    @classmethod
+    def from_pretrained(cls, path, **kwargs):
+        m = cls()
+        m.save_pretrained = MagicMock()
+        return m
+
+
 def _make_controller(step: int = 5, last_loss: float = 0.25) -> RLController:
     """Build a minimal RLController, bypassing heavy __init__.
 
-    Uses a tiny nn.Linear so save/load can operate on real tensors without
+    Uses a tiny _FakeModel so save/load can operate on real tensors without
     needing a GPU or a real HuggingFace model.
     """
     ctrl = object.__new__(RLController)
@@ -41,7 +55,7 @@ def _make_controller(step: int = 5, last_loss: float = 0.25) -> RLController:
     ctrl.vllm_client = None
     ctrl._communicator_ready = False
 
-    ctrl.model = nn.Linear(4, 4)
+    ctrl.model = _FakeModel()
     ctrl.model.train()
     ctrl.model.save_pretrained = MagicMock()
 
@@ -118,11 +132,7 @@ class TestLoadState:
         ctrl.step = 99
 
         new_ctrl = _make_controller(step=99)
-        with patch(
-            "trainers_server.dp_worker.api.controller.get_model_processor",
-            return_value=(nn.Linear(4, 4), MagicMock()),
-        ):
-            result = new_ctrl.load_state(LoadStateDetails(path=str(tmp_path)))
+        result = new_ctrl.load_state(LoadStateDetails(path=str(tmp_path)))
 
         assert result.mode == "training"
         # step is preserved from the controller (load_state doesn't restore step)
@@ -141,11 +151,7 @@ class TestLoadState:
 
         monkeypatch.setenv("BT_LOAD_CHECKPOINT_DIR", str(tmp_path))
         new_ctrl = _make_controller()
-        with patch(
-            "trainers_server.dp_worker.api.controller.get_model_processor",
-            return_value=(nn.Linear(4, 4), MagicMock()),
-        ):
-            result = new_ctrl.load_state(LoadStateDetails())  # no path
+        result = new_ctrl.load_state(LoadStateDetails())  # no path
 
         assert result.mode == "training"
 
@@ -169,11 +175,7 @@ class TestLoadStateWithOptimizer:
         self._save_checkpoint(tmp_path, ctrl)
 
         new_ctrl = _make_controller(step=0, last_loss=None)
-        with patch(
-            "trainers_server.dp_worker.api.controller.get_model_processor",
-            return_value=(nn.Linear(4, 4), MagicMock()),
-        ):
-            result = new_ctrl.load_state_with_optimizer(LoadStateDetails(path=str(tmp_path)))
+        result = new_ctrl.load_state_with_optimizer(LoadStateDetails(path=str(tmp_path)))
 
         assert result.step == 11
         assert new_ctrl.step == 11
@@ -188,12 +190,8 @@ class TestLoadStateWithOptimizer:
         (tmp_path / "dummy_weight.bin").touch()  # make dir non-empty
 
         new_ctrl = _make_controller(step=0)
-        with patch(
-            "trainers_server.dp_worker.api.controller.get_model_processor",
-            return_value=(nn.Linear(4, 4), MagicMock()),
-        ):
-            # Should not raise even without trainer_state.pt
-            result = new_ctrl.load_state_with_optimizer(LoadStateDetails(path=str(tmp_path)))
+        # Should not raise even without trainer_state.pt
+        result = new_ctrl.load_state_with_optimizer(LoadStateDetails(path=str(tmp_path)))
 
         assert result.mode == "training"
         assert new_ctrl.step == 0  # unchanged — no trainer_state.pt to restore from
@@ -217,13 +215,7 @@ class TestCheckpointRoundtrip:
         original.save_state(str(ckpt1))
 
         restored = _make_controller(step=0)
-        replacement_model = nn.Linear(4, 4)
-        replacement_model.save_pretrained = MagicMock()
-        with patch(
-            "trainers_server.dp_worker.api.controller.get_model_processor",
-            return_value=(replacement_model, MagicMock()),
-        ):
-            restored.load_state_with_optimizer(LoadStateDetails(path=str(ckpt1)))
+        restored.load_state_with_optimizer(LoadStateDetails(path=str(ckpt1)))
 
         assert restored.step == 42
         assert restored.last_loss == pytest.approx(0.123)

--- a/trainers/tests/test_checkpointing.py
+++ b/trainers/tests/test_checkpointing.py
@@ -1,0 +1,308 @@
+"""Tests for trainer checkpointing — save_state / load_state / load_state_with_optimizer.
+
+Controller tests use a minimal fake model (nn.Linear) and bypass the heavy __init__
+(no real model loading, no rollout server) to keep tests fast and self-contained.
+
+FastAPI endpoint tests verify routing via TestClient with a mock controller.
+"""
+
+import os
+import threading
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+import torch.nn as nn
+from fastapi.testclient import TestClient
+
+from trainers_server.dp_worker.api.controller import RLController
+from trainers_server.dp_worker.api.server import create_app
+from trainers_server.shared.models import LoadStateDetails, SaveStateDetails
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_controller(step: int = 5, last_loss: float = 0.25) -> RLController:
+    """Build a minimal RLController, bypassing heavy __init__.
+
+    Uses a tiny nn.Linear so save/load can operate on real tensors without
+    needing a GPU or a real HuggingFace model.
+    """
+    ctrl = object.__new__(RLController)
+    ctrl._lock = threading.RLock()
+    ctrl.mode = "training"
+    ctrl.step = step
+    ctrl.last_loss = last_loss
+    ctrl._closed = False
+    ctrl._rollout_process = None
+    ctrl.vllm_client = None
+    ctrl._communicator_ready = False
+
+    ctrl.model = nn.Linear(4, 4)
+    ctrl.model.train()
+    ctrl.model.save_pretrained = MagicMock()
+
+    ctrl.processor = MagicMock()
+    ctrl.processor.save_pretrained = MagicMock()
+
+    ctrl.optimizer = torch.optim.AdamW(ctrl.model.parameters(), lr=1e-3)
+    ctrl.optimizer.zero_grad(set_to_none=True)
+
+    ctrl.config = MagicMock()
+    ctrl.config.model_id = "test-model"
+    ctrl.config.training.gpus = [0]
+    ctrl.config.model_dump.return_value = {"model_id": "test-model"}
+
+    return ctrl
+
+
+# ---------------------------------------------------------------------------
+# save_state
+# ---------------------------------------------------------------------------
+
+class TestSaveState:
+    def test_saves_model_and_trainer_state(self, tmp_path):
+        ctrl = _make_controller(step=7, last_loss=0.11)
+        ctrl.save_state(str(tmp_path))
+
+        # processor.save_pretrained called with the checkpoint dir
+        ctrl.processor.save_pretrained.assert_called_once_with(str(tmp_path))
+
+        # trainer_state.pt written with correct values
+        state = torch.load(tmp_path / "trainer_state.pt", map_location="cpu", weights_only=False)
+        assert state["step"] == 7
+        assert state["last_loss"] == pytest.approx(0.11)
+        assert "optimizer" in state
+
+    def test_creates_directory_if_missing(self, tmp_path):
+        ctrl = _make_controller()
+        nested = tmp_path / "a" / "b" / "c"
+        ctrl.save_state(str(nested))
+        assert nested.is_dir()
+
+    def test_falls_back_to_env_var(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("BT_CHECKPOINT_DIR", str(tmp_path))
+        ctrl = _make_controller(step=3)
+        ctrl.save_state()  # no path argument
+        state = torch.load(tmp_path / "trainer_state.pt", map_location="cpu", weights_only=False)
+        assert state["step"] == 3
+
+    def test_raises_when_no_path_and_no_env_var(self, monkeypatch):
+        monkeypatch.delenv("BT_CHECKPOINT_DIR", raising=False)
+        ctrl = _make_controller()
+        with pytest.raises(ValueError, match="BT_CHECKPOINT_DIR"):
+            ctrl.save_state()
+
+    def test_returns_save_state_result(self, tmp_path):
+        ctrl = _make_controller()
+        result = ctrl.save_state(str(tmp_path))
+        assert result.mode == "training"
+
+
+# ---------------------------------------------------------------------------
+# load_state
+# ---------------------------------------------------------------------------
+
+class TestLoadState:
+    def _save_checkpoint(self, tmp_path, ctrl):
+        ctrl.save_state(str(tmp_path))
+
+    def test_loads_weights_and_resets_optimizer(self, tmp_path):
+        ctrl = _make_controller(step=4)
+        self._save_checkpoint(tmp_path, ctrl)
+
+        # Advance step and do a fake gradient update so optimizer has state
+        ctrl.step = 99
+
+        new_ctrl = _make_controller(step=99)
+        with patch(
+            "trainers_server.dp_worker.api.controller.get_model_processor",
+            return_value=(nn.Linear(4, 4), MagicMock()),
+        ):
+            result = new_ctrl.load_state(LoadStateDetails(path=str(tmp_path)))
+
+        assert result.mode == "training"
+        # step is preserved from the controller (load_state doesn't restore step)
+        assert new_ctrl.mode == "training"
+        assert not new_ctrl._communicator_ready
+
+    def test_raises_when_path_missing(self, tmp_path):
+        ctrl = _make_controller()
+        missing = tmp_path / "does_not_exist"
+        with pytest.raises(ValueError, match="not found"):
+            ctrl.load_state(LoadStateDetails(path=str(missing)))
+
+    def test_falls_back_to_env_var(self, tmp_path, monkeypatch):
+        ctrl = _make_controller(step=2)
+        self._save_checkpoint(tmp_path, ctrl)
+
+        monkeypatch.setenv("BT_LOAD_CHECKPOINT_DIR", str(tmp_path))
+        new_ctrl = _make_controller()
+        with patch(
+            "trainers_server.dp_worker.api.controller.get_model_processor",
+            return_value=(nn.Linear(4, 4), MagicMock()),
+        ):
+            result = new_ctrl.load_state(LoadStateDetails())  # no path
+
+        assert result.mode == "training"
+
+    def test_raises_when_no_path_and_no_env_var(self, monkeypatch):
+        monkeypatch.delenv("BT_LOAD_CHECKPOINT_DIR", raising=False)
+        ctrl = _make_controller()
+        with pytest.raises(ValueError, match="BT_LOAD_CHECKPOINT_DIR"):
+            ctrl.load_state(LoadStateDetails())
+
+
+# ---------------------------------------------------------------------------
+# load_state_with_optimizer
+# ---------------------------------------------------------------------------
+
+class TestLoadStateWithOptimizer:
+    def _save_checkpoint(self, tmp_path, ctrl):
+        ctrl.save_state(str(tmp_path))
+
+    def test_restores_step_and_optimizer(self, tmp_path):
+        ctrl = _make_controller(step=11, last_loss=0.77)
+        self._save_checkpoint(tmp_path, ctrl)
+
+        new_ctrl = _make_controller(step=0, last_loss=None)
+        with patch(
+            "trainers_server.dp_worker.api.controller.get_model_processor",
+            return_value=(nn.Linear(4, 4), MagicMock()),
+        ):
+            result = new_ctrl.load_state_with_optimizer(LoadStateDetails(path=str(tmp_path)))
+
+        assert result.step == 11
+        assert new_ctrl.step == 11
+        assert new_ctrl.last_loss == pytest.approx(0.77)
+        assert result.mode == "training"
+        assert not new_ctrl._communicator_ready
+
+    def test_succeeds_without_trainer_state_pt(self, tmp_path):
+        """If no trainer_state.pt exists, loads weights but doesn't restore step."""
+        ctrl = _make_controller(step=5)
+        # Only save model weights, not the full checkpoint
+        (tmp_path / "dummy_weight.bin").touch()  # make dir non-empty
+
+        new_ctrl = _make_controller(step=0)
+        with patch(
+            "trainers_server.dp_worker.api.controller.get_model_processor",
+            return_value=(nn.Linear(4, 4), MagicMock()),
+        ):
+            # Should not raise even without trainer_state.pt
+            result = new_ctrl.load_state_with_optimizer(LoadStateDetails(path=str(tmp_path)))
+
+        assert result.mode == "training"
+        assert new_ctrl.step == 0  # unchanged — no trainer_state.pt to restore from
+
+    def test_raises_when_path_missing(self, tmp_path):
+        ctrl = _make_controller()
+        with pytest.raises(ValueError, match="not found"):
+            ctrl.load_state_with_optimizer(LoadStateDetails(path=str(tmp_path / "missing")))
+
+
+# ---------------------------------------------------------------------------
+# Roundtrip: save → load_state_with_optimizer → save again
+# ---------------------------------------------------------------------------
+
+class TestCheckpointRoundtrip:
+    def test_roundtrip_preserves_step_and_loss(self, tmp_path):
+        ckpt1 = tmp_path / "ckpt1"
+        ckpt2 = tmp_path / "ckpt2"
+
+        original = _make_controller(step=42, last_loss=0.123)
+        original.save_state(str(ckpt1))
+
+        restored = _make_controller(step=0)
+        replacement_model = nn.Linear(4, 4)
+        replacement_model.save_pretrained = MagicMock()
+        with patch(
+            "trainers_server.dp_worker.api.controller.get_model_processor",
+            return_value=(replacement_model, MagicMock()),
+        ):
+            restored.load_state_with_optimizer(LoadStateDetails(path=str(ckpt1)))
+
+        assert restored.step == 42
+        assert restored.last_loss == pytest.approx(0.123)
+
+        # Save again from the restored state
+        restored.save_state(str(ckpt2))
+        state2 = torch.load(ckpt2 / "trainer_state.pt", map_location="cpu", weights_only=False)
+        assert state2["step"] == 42
+
+
+# ---------------------------------------------------------------------------
+# FastAPI endpoint tests (routing + response shape)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def api_client():
+    """TestClient backed by a mock controller — no model loading."""
+    ctrl = MagicMock(spec=RLController)
+
+    from trainers_server.shared.models import LoadStateResult, SaveStateResult
+    ctrl.save_state.return_value = SaveStateResult(mode="training")
+    ctrl.load_state.return_value = LoadStateResult(mode="training", step=7)
+    ctrl.load_state_with_optimizer.return_value = LoadStateResult(mode="training", step=7)
+
+    app = create_app(controller=ctrl)
+    return TestClient(app), ctrl
+
+
+class TestEndpoints:
+    def test_save_state_no_body(self, api_client):
+        client, ctrl = api_client
+        resp = client.post("/save_state")
+        assert resp.status_code == 200
+        ctrl.save_state.assert_called_once_with(None)
+
+    def test_save_state_with_path(self, api_client):
+        client, ctrl = api_client
+        resp = client.post("/save_state", json={"path": "/ckpt/step-1"})
+        assert resp.status_code == 200
+        ctrl.save_state.assert_called_once_with("/ckpt/step-1")
+
+    def test_load_state_no_body(self, api_client):
+        client, ctrl = api_client
+        resp = client.post("/load_state")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["mode"] == "training"
+        assert data["step"] == 7
+
+    def test_load_state_with_path(self, api_client):
+        client, ctrl = api_client
+        resp = client.post("/load_state", json={"path": "/ckpt/step-1"})
+        assert resp.status_code == 200
+        from trainers_server.shared.models import LoadStateDetails
+        ctrl.load_state.assert_called_once_with(LoadStateDetails(path="/ckpt/step-1"))
+
+    def test_load_state_with_optimizer_no_body(self, api_client):
+        client, ctrl = api_client
+        resp = client.post("/load_state_with_optimizer")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["mode"] == "training"
+        assert data["step"] == 7
+
+    def test_load_state_with_optimizer_with_path(self, api_client):
+        client, ctrl = api_client
+        resp = client.post("/load_state_with_optimizer", json={"path": "/ckpt/step-2"})
+        assert resp.status_code == 200
+        from trainers_server.shared.models import LoadStateDetails
+        ctrl.load_state_with_optimizer.assert_called_once_with(LoadStateDetails(path="/ckpt/step-2"))
+
+    def test_save_state_value_error_returns_400(self, api_client):
+        client, ctrl = api_client
+        ctrl.save_state.side_effect = ValueError("no path provided")
+        resp = client.post("/save_state")
+        assert resp.status_code == 400
+
+    def test_load_state_value_error_returns_400(self, api_client):
+        client, ctrl = api_client
+        ctrl.load_state.side_effect = ValueError("checkpoint not found")
+        resp = client.post("/load_state")
+        assert resp.status_code == 400


### PR DESCRIPTION
## Summary

- `save_state` path is now optional — falls back to `BT_CHECKPOINT_DIR` env var; saves model weights, processor, and `trainer_state.pt` (step count, last loss, optimizer state)
- New `load_state` endpoint — reloads weights from a checkpoint directory, resets optimizer
- New `load_state_with_optimizer` endpoint — restores weights + optimizer state + step count from `trainer_state.pt`
- Startup: if `BT_LOAD_CHECKPOINT_DIR` is set, loads model from that directory instead of HuggingFace
- Fix `OptimStepDetails.adam_params` missing default (was causing Pydantic crash at startup in e2e)
- Wire `/load_state` and `/load_state_with_optimizer` into the FastAPI server

## Test plan

- [ ] `save_state` with no path uses `BT_CHECKPOINT_DIR`
- [ ] `save_state` writes `trainer_state.pt` with correct step/optimizer state
- [ ] `load_state` reloads weights and resets optimizer
- [ ] `load_state_with_optimizer` restores step count and optimizer state
- [ ] Startup with `BT_LOAD_CHECKPOINT_DIR` loads from checkpoint instead of HF
- [ ] e2e smoke test passes (optim_step no longer crashes on startup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes [TRN-590](https://linear.app/baseten/issue/TRN-590/checkpointing-endpoints-in-trainer)