### PR TITLE
feat(trainers): Configure dp_worker from environment variables

### DIFF
--- a/trainers/server/src/trainers_server/dp_worker/api/models.py
+++ b/trainers/server/src/trainers_server/dp_worker/api/models.py
@@ -2,6 +2,7 @@ from typing import Dict, List, Literal, Optional
 
 from pydantic import BaseModel, Field
 
+
 class StatusResult(BaseModel):
     mode: Literal["training", "inference"]
     step: int
@@ -27,5 +28,6 @@ class TrainingServerConfig(BaseModel):
 
 class RLControllerConfig(BaseModel):
     model_id: str = "Qwen/Qwen3-0.6B"
+    lora_rank: int = 0  # 0 = full fine-tuning, >0 = LoRA
     inference: InferenceServerConfig = Field(default_factory=InferenceServerConfig)
     training: TrainingServerConfig = Field(default_factory=TrainingServerConfig)

--- a/trainers/server/src/trainers_server/dp_worker/main.py
+++ b/trainers/server/src/trainers_server/dp_worker/main.py
@@ -2,32 +2,87 @@
 
 import argparse
 import logging
+import os
 
 import uvicorn
 
-from trainers_server.dp_worker.api.models import RLControllerConfig
+from trainers_server.dp_worker.api.models import (
+    InferenceServerConfig,
+    RLControllerConfig,
+    TrainingServerConfig,
+)
 from trainers_server.dp_worker.api.server import create_app
 
 logger = logging.getLogger(__name__)
 
 
+def _config_from_env() -> RLControllerConfig | None:
+    """Build RLControllerConfig from environment variables.
+
+    Returns None if BT_MODEL_ID is not set (fall back to --config JSON).
+
+    Environment variables:
+        BT_MODEL_ID             HuggingFace model ID (required to activate env-var mode)
+        BT_LORA_RANK            LoRA rank; 0 = full fine-tuning (default: 0)
+        BT_MAX_LENGTH           Max token sequence length for training (default: 2048)
+        BT_TRAINING_GPUS        Comma-separated GPU IDs for training, e.g. "0,1" (default: "0")
+        BT_TENSOR_PARALLEL_SIZE Tensor parallel size for training (default: 1)
+    """
+    model_id = os.environ.get("BT_MODEL_ID")
+    if model_id is None:
+        return None
+
+    training_gpus_raw = os.environ.get("BT_TRAINING_GPUS", "0")
+    training_gpus = [int(g.strip()) for g in training_gpus_raw.split(",") if g.strip()]
+
+    return RLControllerConfig(
+        model_id=model_id,
+        lora_rank=int(os.environ.get("BT_LORA_RANK", "0")),
+        training=TrainingServerConfig(
+            max_length=int(os.environ.get("BT_MAX_LENGTH", "2048")),
+            gpus=training_gpus,
+            tensor_parallel_size=int(os.environ.get("BT_TENSOR_PARALLEL_SIZE", "1")),
+        ),
+        inference=InferenceServerConfig(),
+    )
+
+
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="dp_worker: RL training worker server")
-    parser.add_argument("--config", required=True, help="Path to JSON config file")
-    parser.add_argument("--port", type=int, default=8000, help="Port to listen on (default: 8000)")
-    parser.add_argument("--host", default="0.0.0.0", help="Host to bind to (default: 0.0.0.0)")
+    parser.add_argument(
+        "--config",
+        default=None,
+        help="Path to JSON config file. Not required if BT_MODEL_ID env var is set.",
+    )
+    parser.add_argument(
+        "--port", type=int, default=8000, help="Port to listen on (default: 8000)"
+    )
+    parser.add_argument(
+        "--host", default="0.0.0.0", help="Host to bind to (default: 0.0.0.0)"
+    )
     return parser.parse_args(argv)
 
 
 def main():
-    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s"
+    )
     args = parse_args()
 
-    with open(args.config) as f:
-        config_json = f.read()
-
-    config = RLControllerConfig.model_validate_json(config_json)
-    logger.info("loaded config: model_id=%s", config.model_id)
+    config = _config_from_env()
+    if config is not None:
+        logger.info("loaded config from environment: model_id=%s", config.model_id)
+    elif args.config is not None:
+        with open(args.config) as f:
+            config_json = f.read()
+        config = RLControllerConfig.model_validate_json(config_json)
+        logger.info(
+            "loaded config from file %s: model_id=%s", args.config, config.model_id
+        )
+    else:
+        raise SystemExit(
+            "error: must supply either BT_MODEL_ID env var or --config <path>"
+        )
 
     app = create_app(config)
     uvicorn.run(app, host=args.host, port=args.port)


### PR DESCRIPTION
## Summary

- Adds env var config mode to `dp_worker/main.py`: if `BT_MODEL_ID` is set, the server builds its config entirely from env vars — no `--config` file needed
- Supported vars: `BT_MODEL_ID`, `BT_LORA_RANK`, `BT_MAX_LENGTH`, `BT_TRAINING_GPUS` (comma-separated), `BT_TENSOR_PARALLEL_SIZE`
- `--config <json>` is kept as a local dev fallback; if neither is provided, the server exits with a clear error
- Adds `lora_rank: int = 0` field to `RLControllerConfig` (0 = full fine-tuning, >0 = LoRA adapter — used by upcoming PR 2)

## Why

Plumbing team needs to launch trainer pods via Kubernetes without mounting a config file. Env vars are the standard interface for pod configuration.

## Test plan

- [ ] Start server with `BT_MODEL_ID=Qwen/Qwen3-0.6B` and no `--config` flag — verify it starts
- [ ] Start server with `--config config.json` and no env vars — verify it still works
- [ ] Start server with neither — verify it exits with a clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes [TRN-582](https://linear.app/baseten/issue/TRN-582/trainer-config-via-env-vars)