### PR TITLE
feat(trainers): Wire SDK load_state and create_training_client_from_state

### DIFF
--- a/trainers/server/pyproject.toml
+++ b/trainers/server/pyproject.toml
@@ -45,4 +45,5 @@ explicit = true
 [dependency-groups]
 dev = [
     "pytest>=9.0.3",
+    "tinker>=0.13.1,<0.14",
 ]

--- a/trainers/server/uv.lock
+++ b/trainers/server/uv.lock
@@ -1510,6 +1510,19 @@ wheels = [
 ]
 
 [[package]]
+name = "h2"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hpack" },
+    { name = "hyperframe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
+]
+
+[[package]]
 name = "hf-transfer"
 version = "0.1.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1571,6 +1584,15 @@ wheels = [
 ]
 
 [[package]]
+name = "hpack"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/48/71de9ed269fdae9c8057e5a4c0aa7402e8bb16f2c6e90b3aa53327b113f8/hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca", size = 51276, upload-time = "2025-01-22T21:44:58.347Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496", size = 34357, upload-time = "2025-01-22T21:44:56.92Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1618,6 +1640,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
+[package.optional-dependencies]
+http2 = [
+    { name = "h2" },
+]
+
 [[package]]
 name = "httpx-sse"
 version = "0.4.3"
@@ -1644,6 +1671,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7c/b7/8cb61d2eece5fb05a83271da168186721c450eb74e3c31f7ef3169fa475b/huggingface_hub-0.36.2.tar.gz", hash = "sha256:1934304d2fb224f8afa3b87007d58501acfda9215b334eed53072dd5e815ff7a", size = 649782, upload-time = "2026-02-06T09:24:13.098Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a8/af/48ac8483240de756d2438c380746e7130d1c6f75802ef22f3c6d49982787/huggingface_hub-0.36.2-py3-none-any.whl", hash = "sha256:48f0c8eac16145dfce371e9d2d7772854a4f591bcb56c9cf548accf531d54270", size = 566395, upload-time = "2026-02-06T09:24:11.133Z" },
+]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
 ]
 
 [[package]]
@@ -4807,6 +4843,27 @@ wheels = [
 ]
 
 [[package]]
+name = "tinker"
+version = "0.13.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "click" },
+    { name = "distro" },
+    { name = "httpx", extra = ["http2"] },
+    { name = "numpy" },
+    { name = "pydantic" },
+    { name = "rich" },
+    { name = "sniffio" },
+    { name = "transformers" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e8/14/9abd320e01ec113dc383c407ea02261bfa97b9c43edbb299ce7ecaea3b61/tinker-0.13.1.tar.gz", hash = "sha256:d856cf99c37a46238a9d92cee719444ce657f5de9b45c4a8f233d3b6b1a482e1", size = 178940, upload-time = "2026-02-13T22:13:54.661Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/81/73689ad28b86167fa34a221d640900319376fd7bc917ceca8f505c1e426a/tinker-0.13.1-py3-none-any.whl", hash = "sha256:02e4bccf55c21a2dc9b9d389fa14bdd9363d0542c61bda69112d3387c37d40de", size = 173889, upload-time = "2026-02-13T22:13:53.519Z" },
+]
+
+[[package]]
 name = "tokenizers"
 version = "0.22.2"
 source = { registry = "https://pypi.org/simple" }
@@ -5007,6 +5064,7 @@ worker = [
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "tinker" },
 ]
 
 [package.metadata]
@@ -5024,7 +5082,10 @@ requires-dist = [
 provides-extras = ["worker"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=9.0.3" }]
+dev = [
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "tinker", specifier = ">=0.13.1,<0.14" },
+]
 
 [[package]]
 name = "transformers"

--- a/trainers/tests/conftest.py
+++ b/trainers/tests/conftest.py
@@ -1,11 +1,13 @@
-"""Stub out heavy ML dependencies so server modules can be imported without the
-full worker installation (ms-swift, vllm, megatron, CUDA torch).
+"""Stub out heavy ML and deploy dependencies so test modules can be imported
+without the full worker (ms-swift, vllm, megatron, CUDA torch) or deploy
+stack (truss internals that require watchfiles, boto3, etc.).
 """
 
 import sys
 from unittest.mock import MagicMock
 
 _HEAVY_MODULES = [
+    # ML worker dependencies
     "swift",
     "swift.arguments",
     "swift.infer_engine",
@@ -19,6 +21,13 @@ _HEAVY_MODULES = [
     "swift.template.register",
     "swift.tuners",
     "vllm",
+    # Deploy-stack dependencies pulled in by trainers.client (only needed for
+    # deploy=True; safe to stub for all SDK unit/integration tests)
+    "truss_train",
+    "truss_train.definitions",
+    "truss_train.public_api",
+    "truss.base",
+    "truss.base.truss_config",
 ]
 
 for _mod in _HEAVY_MODULES:

--- a/trainers/tests/test_integration.py
+++ b/trainers/tests/test_integration.py
@@ -10,16 +10,25 @@ No external services needed — fully self-contained.
 """
 
 import json
-from http.server import HTTPServer, BaseHTTPRequestHandler
 import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
 
 import pytest
 
-from trainers import ServiceClient, TrainingClient, AdamParams, ModelInput, SamplingParams, Datum, TensorData
+from trainers import (
+    AdamParams,
+    Datum,
+    ModelInput,
+    SamplingParams,
+    ServiceClient,
+    TensorData,
+)
 
 
 class MockWorkerHandler(BaseHTTPRequestHandler):
     """Simulates a dp_worker with mock responses."""
+
+    last_request: dict = {}  # class-level, stores most recent POST body per path
 
     def do_GET(self):
         if self.path == "/health":
@@ -32,6 +41,8 @@ class MockWorkerHandler(BaseHTTPRequestHandler):
     def do_POST(self):
         content_length = int(self.headers.get("Content-Length", 0))
         body = self.rfile.read(content_length) if content_length else b""
+        if body:
+            MockWorkerHandler.last_request[self.path] = json.loads(body)
 
         responses = {
             "/forward_backward": {
@@ -40,20 +51,23 @@ class MockWorkerHandler(BaseHTTPRequestHandler):
                 "metrics": {"loss": 0.42},
             },
             "/optim_step": {
-                "metrics": {"step": 1.0, "learning_rate": 5e-6, "lr": 5e-6},
+                "metrics": {"step": 1.0, "learning_rate": 5e-6, "lr": 5e-6}
             },
-            "/to_inference": {
-                "path": "",
-                "type": "save_weights",
-            },
+            "/to_inference": {"path": "", "type": "save_weights"},
             "/sample": {
                 "sequences": [
-                    {"tokens": [1, 2, 3], "stop_reason": "stop", "logprobs": [-0.1, -0.2, -0.3]},
-                ],
+                    {
+                        "tokens": [1, 2, 3],
+                        "stop_reason": "stop",
+                        "logprobs": [-0.1, -0.2, -0.3],
+                    }
+                ]
             },
-            "/save_state": {
-                "path": "step-1",
-                "type": "save_weights",
+            "/save_state": {"path": "step-1", "type": "save_weights"},
+            "/load_state": {"path": "/ckpt/step-1", "type": "load_weights"},
+            "/load_state_with_optimizer": {
+                "path": "/ckpt/step-1",
+                "type": "load_weights",
             },
         }
 
@@ -100,8 +114,10 @@ def test_forward_backward(client):
     batch = [
         Datum(
             model_input=ModelInput.from_ints(list(range(10))),
-            loss_fn_inputs={"reward": TensorData(data=[1.0], dtype="float32", shape=[1])},
-        ),
+            loss_fn_inputs={
+                "reward": TensorData(data=[1.0], dtype="float32", shape=[1])
+            },
+        )
     ]
     future = client.forward_backward(data=batch, loss_fn="cross_entropy")
     result = future.result(timeout=5.0)
@@ -148,15 +164,14 @@ def test_pipelining(client):
     batch = [
         Datum(
             model_input=ModelInput.from_ints(list(range(8))),
-            loss_fn_inputs={"reward": TensorData(data=[1.0], dtype="float32", shape=[1])},
-        ),
+            loss_fn_inputs={
+                "reward": TensorData(data=[1.0], dtype="float32", shape=[1])
+            },
+        )
     ]
 
     # Dispatch 3 forward_backward ops without waiting.
-    futures = [
-        client.forward_backward(data=batch)
-        for _ in range(3)
-    ]
+    futures = [client.forward_backward(data=batch) for _ in range(3)]
 
     # Now collect all results.
     for f in futures:
@@ -169,11 +184,15 @@ def test_training_loop(client):
     batch = [
         Datum(
             model_input=ModelInput.from_ints(list(range(10))),
-            loss_fn_inputs={"reward": TensorData(data=[1.0], dtype="float32", shape=[1])},
+            loss_fn_inputs={
+                "reward": TensorData(data=[1.0], dtype="float32", shape=[1])
+            },
         ),
         Datum(
             model_input=ModelInput.from_ints(list(range(10, 20))),
-            loss_fn_inputs={"reward": TensorData(data=[0.5], dtype="float32", shape=[1])},
+            loss_fn_inputs={
+                "reward": TensorData(data=[0.5], dtype="float32", shape=[1])
+            },
         ),
     ]
 
@@ -196,3 +215,51 @@ def test_training_loop(client):
         sampling_params=SamplingParams(max_tokens=32),
     ).result(timeout=5.0)
     assert len(result.sequences) == 1
+
+
+# --- load_state / load_state_with_optimizer ---
+
+
+def test_load_state(client):
+    result = client.load_state("/ckpt/step-1").result(timeout=5.0)
+    assert result.type == "load_weights"
+    assert MockWorkerHandler.last_request["/load_state"]["path"] == "/ckpt/step-1"
+
+
+def test_load_state_with_optimizer(client):
+    result = client.load_state_with_optimizer("/ckpt/step-1").result(timeout=5.0)
+    assert result.type == "load_weights"
+    assert (
+        MockWorkerHandler.last_request["/load_state_with_optimizer"]["path"]
+        == "/ckpt/step-1"
+    )
+
+
+# --- ServiceClient factory methods ---
+
+
+def test_create_training_client_from_state(mock_worker):
+    service = ServiceClient(base_url=mock_worker)
+    c = service.create_training_client_from_state("/ckpt/step-1")
+    try:
+        c.health()  # verifies the returned client points at a live server
+    finally:
+        c.close()
+
+
+def test_create_training_client_from_state_with_optimizer(mock_worker):
+    service = ServiceClient(base_url=mock_worker)
+    c = service.create_training_client_from_state_with_optimizer("/ckpt/step-1")
+    try:
+        c.health()
+    finally:
+        c.close()
+
+
+def test_create_training_client_from_state_accepts_explicit_base_url(mock_worker):
+    service = ServiceClient(base_url="http://unused:9999")
+    c = service.create_training_client_from_state("/ckpt/step-1", base_url=mock_worker)
+    try:
+        c.health()  # would fail if it used the unused URL
+    finally:
+        c.close()

--- a/trainers/trainers/service_client.py
+++ b/trainers/trainers/service_client.py
@@ -26,10 +26,7 @@ class ServiceClient:
     """
 
     def __init__(
-        self,
-        base_url: str | None = None,
-        *,
-        api_key: str | None = None,
+        self, base_url: str | None = None, *, api_key: str | None = None
     ) -> None:
         self._base_url = base_url or os.environ.get("TRAINERS_BASE_URL", "")
         self._api_key = api_key or os.environ.get("TRAINERS_API_KEY")
@@ -62,27 +59,41 @@ class ServiceClient:
         )
 
     def create_training_client_from_state(
-        self,
-        path: str,
+        self, path: str, *, base_url: str | None = None, timeout: float = 600.0
     ) -> TrainingClient:
-        """Resume training from a saved checkpoint (weights only)."""
-        raise NotImplementedError(
-            "create_training_client_from_state() is not yet implemented"
-        )
+        """Return a TrainingClient for a trainer pod started from a checkpoint.
+
+        The checkpoint is loaded at pod startup via BT_LOAD_CHECKPOINT_DIR (set
+        by the plumbing layer). The path argument is accepted for API compatibility
+        but is not used by the SDK — the pod has already loaded the checkpoint
+        before this method is called.
+
+        Args:
+            path: Checkpoint path (used by the plumbing layer to configure the pod).
+            base_url: URL of the running trainer pod. Defaults to self._base_url.
+            timeout: HTTP timeout for training operations.
+        """
+        url = base_url or self._base_url
+        return TrainingClient(url, api_key=self._api_key, timeout=timeout)
 
     def create_training_client_from_state_with_optimizer(
-        self,
-        path: str,
+        self, path: str, *, base_url: str | None = None, timeout: float = 600.0
     ) -> TrainingClient:
-        """Resume training from a saved checkpoint (weights + optimizer state)."""
-        raise NotImplementedError(
-            "create_training_client_from_state_with_optimizer() is not yet implemented"
-        )
+        """Return a TrainingClient for a trainer pod started from a checkpoint.
+
+        Like create_training_client_from_state but the pod also restores optimizer
+        state (trainer_state.pt), so training resumes from the exact same step.
+
+        Args:
+            path: Checkpoint path (used by the plumbing layer to configure the pod).
+            base_url: URL of the running trainer pod. Defaults to self._base_url.
+            timeout: HTTP timeout for training operations.
+        """
+        url = base_url or self._base_url
+        return TrainingClient(url, api_key=self._api_key, timeout=timeout)
 
     def create_sampling_client(
-        self,
-        base_model: str | None = None,
-        model_path: str | None = None,
+        self, base_model: str | None = None, model_path: str | None = None
     ) -> SamplingClient:
         """Create a sampling client for text generation.
 
@@ -94,6 +105,4 @@ class ServiceClient:
 
     def get_server_capabilities(self) -> dict:
         """Query the backend for supported features."""
-        raise NotImplementedError(
-            "get_server_capabilities() is not yet implemented"
-        )
+        raise NotImplementedError("get_server_capabilities() is not yet implemented")

--- a/trainers/trainers/training_client.py
+++ b/trainers/trainers/training_client.py
@@ -3,10 +3,9 @@
 from __future__ import annotations
 
 import concurrent.futures
+from functools import lru_cache
 from types import TracebackType
 from typing import Callable, Generic, TypeVar
-
-from functools import lru_cache
 
 import httpx
 from pydantic import BaseModel, Field
@@ -25,6 +24,7 @@ from trainers.models import (
 
 class SampledSequence(BaseModel):
     """A single generated sequence with token IDs and optional logprobs."""
+
     tokens: list[int] = Field(default_factory=list)
     logprobs: list[float] | None = None
     stop_reason: str = "length"
@@ -32,7 +32,9 @@ class SampledSequence(BaseModel):
 
 class SampleResult(BaseModel):
     """Token-level sampling result."""
+
     sequences: list[SampledSequence] = Field(default_factory=list)
+
 
 T = TypeVar("T")
 
@@ -51,6 +53,7 @@ class OperationFuture(Generic[T]):
 
     def __await__(self):
         import asyncio
+
         return asyncio.to_thread(self.result).__await__()
 
 
@@ -58,6 +61,7 @@ class OperationFuture(Generic[T]):
 def _load_tokenizer(model_name: str):
     """Load and cache a HuggingFace tokenizer."""
     from transformers import AutoTokenizer
+
     return AutoTokenizer.from_pretrained(model_name)
 
 
@@ -138,9 +142,7 @@ class TrainingClient:
         return self._submit(_call)
 
     def save_weights_and_get_sampling_client(
-        self,
-        name: str | None = None,
-        ttl_seconds: int | None = None,
+        self, name: str | None = None, ttl_seconds: int | None = None
     ) -> OperationFuture[SaveWeightsResponse]:
         body = {"path": name, "ttl_seconds": ttl_seconds}
 
@@ -159,7 +161,9 @@ class TrainingClient:
         body = {
             "prompt": prompt.model_dump(mode="json"),
             "num_samples": num_samples,
-            "sampling_params": (sampling_params or SamplingParams()).model_dump(mode="json"),
+            "sampling_params": (sampling_params or SamplingParams()).model_dump(
+                mode="json"
+            ),
         }
 
         def _call() -> SampleResult:
@@ -168,7 +172,9 @@ class TrainingClient:
 
         return self._submit(_call)
 
-    def save_state(self, name: str, ttl_seconds: int | None = None) -> OperationFuture[SaveWeightsResponse]:
+    def save_state(
+        self, name: str, ttl_seconds: int | None = None
+    ) -> OperationFuture[SaveWeightsResponse]:
         body = {"path": name, "ttl_seconds": ttl_seconds}
 
         def _call() -> SaveWeightsResponse:
@@ -210,25 +216,35 @@ class TrainingClient:
         raise NotImplementedError("forward() is not yet implemented")
 
     def forward_backward_custom(
-        self,
-        data: list[Datum],
-        loss_fn: str,
+        self, data: list[Datum], loss_fn: str
     ) -> OperationFuture[ForwardBackwardOutput]:
         """Forward-backward with a custom PyTorch loss function."""
         raise NotImplementedError("forward_backward_custom() is not yet implemented")
 
     def save_weights_for_sampler(
-        self,
-        name: str,
-        ttl_seconds: int | None = None,
+        self, name: str, ttl_seconds: int | None = None
     ) -> OperationFuture[SaveWeightsResponse]:
         """Save current weights for use by a SamplingClient."""
         raise NotImplementedError("save_weights_for_sampler() is not yet implemented")
 
     def load_state(self, path: str) -> OperationFuture[LoadWeightsResponse]:
-        """Load model weights from a checkpoint path."""
-        raise NotImplementedError("load_state() is not yet implemented")
+        """Load model weights from a checkpoint path (optimizer resets)."""
+        body = {"path": path}
 
-    def load_state_with_optimizer(self, path: str) -> OperationFuture[LoadWeightsResponse]:
+        def _call() -> LoadWeightsResponse:
+            resp = self._post("/load_state", json=body)
+            return LoadWeightsResponse.model_validate(resp.json())
+
+        return self._submit(_call)
+
+    def load_state_with_optimizer(
+        self, path: str
+    ) -> OperationFuture[LoadWeightsResponse]:
         """Load model weights and optimizer state from a checkpoint path."""
-        raise NotImplementedError("load_state_with_optimizer() is not yet implemented")
+        body = {"path": path}
+
+        def _call() -> LoadWeightsResponse:
+            resp = self._post("/load_state_with_optimizer", json=body)
+            return LoadWeightsResponse.model_validate(resp.json())
+
+        return self._submit(_call)


### PR DESCRIPTION
## Summary

- Implements `TrainingClient.load_state` and `load_state_with_optimizer` (previously raised `NotImplementedError`) — both POST to the corresponding dp_worker endpoints and parse `LoadWeightsResponse`
- Implements `ServiceClient.create_training_client_from_state` and `create_training_client_from_state_with_optimizer` — return a `TrainingClient` pointed at the running pod; accept an optional `base_url` override for the case where the URL differs from `self._base_url`
- Extends the integration test mock server with `/load_state` and `/load_state_with_optimizer` endpoints + POST-body capture; adds 5 new tests covering the new paths and the `base_url` override behavior
- Adds `tinker` as a dev dependency to the server venv so test imports resolve; stubs out `truss.base` and `truss_train` in `conftest.py` to avoid pulling in the full deploy stack

## Test plan

- [ ] `uv run pytest trainers/tests/ -v` from `trainers/server/` — all 41 tests pass
- [ ] `test_load_state` / `test_load_state_with_optimizer` assert correct endpoint and forwarded path
- [ ] `test_create_training_client_from_state_accepts_explicit_base_url` verifies `base_url` override works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes [TRN-584](https://linear.app/baseten/issue/TRN-584/wire-sdk-load-stubs)