### PR TITLE
feat(training): support TRAINING_JOB_PENDING queue status in CLI

### DIFF
--- a/truss/cli/train/core.py
+++ b/truss/cli/train/core.py
@@ -28,6 +28,7 @@ from truss_train import loader
 from truss_train.definitions import DeployCheckpointsConfig
 
 ACTIVE_JOB_STATUSES = [
+    "TRAINING_JOB_PENDING",
     "TRAINING_JOB_RUNNING",
     "TRAINING_JOB_CREATED",
     "TRAINING_JOB_DEPLOYING",

--- a/truss/cli/train/poller.py
+++ b/truss/cli/train/poller.py
@@ -10,7 +10,12 @@ POLL_INTERVAL_SEC = 2
 # NB(nikhil): When a job ends, we poll for this many seconds after to capture
 # any trailing logs that contain information about errors.
 JOB_TERMINATION_GRACE_PERIOD_SEC = 10
-JOB_STARTING_STATES = ["TRAINING_JOB_CREATED", "TRAINING_JOB_QUEUED"]
+JOB_PENDING_STATES = ["TRAINING_JOB_PENDING"]
+JOB_STARTING_STATES = [
+    "TRAINING_JOB_PENDING",
+    "TRAINING_JOB_CREATED",
+    "TRAINING_JOB_QUEUED",
+]
 JOB_LOGGING_STATES = ["TRAINING_JOB_DEPLOYING", "TRAINING_JOB_RUNNING"]
 STATES_WITH_ERROR_MESSAGES = ["TRAINING_JOB_DEPLOY_FAILED"]
 
@@ -37,17 +42,16 @@ class TrainingPollerMixin:
 
     def before_polling(self) -> None:
         self._update_from_current_status()
-        status_str = "Waiting for job to deploy, currently {current_status}..."
-        with console.status(
-            status_str.format(current_status=self._current_status.status),
-            spinner="dots",
-        ) as status:
+        with console.status(self._starting_status_message(), spinner="dots") as status:
             while self._current_status.status in JOB_STARTING_STATES:
                 time.sleep(POLL_INTERVAL_SEC)
                 self._update_from_current_status()
-                status.update(
-                    status_str.format(current_status=self._current_status.status)
-                )
+                status.update(self._starting_status_message())
+
+    def _starting_status_message(self) -> str:
+        if self._current_status.status in JOB_PENDING_STATES:
+            return "Waiting for GPU capacity (job is queued)..."
+        return f"Waiting for job to deploy, currently {self._current_status.status}..."
 
     def post_poll(self) -> None:
         self._update_from_current_status()

--- a/truss/cli/train_commands.py
+++ b/truss/cli/train_commands.py
@@ -87,7 +87,13 @@ def _handle_post_create_logic(
     project_id, job_id = job_resp["training_project"]["id"], job_resp["id"]
     project_name = job_resp["training_project"]["name"]
 
-    if job_resp.get("current_status", None) == "TRAINING_JOB_QUEUED":
+    if job_resp.get("current_status") == "TRAINING_JOB_PENDING":
+        console.print(
+            f"🟡 Training job is pending — waiting for GPU capacity. "
+            f"Check status: 'truss train view --job-id={job_id}'.",
+            style="yellow",
+        )
+    elif job_resp.get("current_status") == "TRAINING_JOB_QUEUED":
         console.print(
             f"🟢 Training job is queued. You can check the status of your job by running 'truss train view --job-id={job_id}'.",
             style="green",

--- a/truss/tests/cli/train/test_poller.py
+++ b/truss/tests/cli/train/test_poller.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from truss.cli.train.core import ACTIVE_JOB_STATUSES
-from truss.cli.train.poller import JOB_PENDING_STATES, JOB_STARTING_STATES, TrainingPollerMixin
+from truss.cli.train.poller import JOB_STARTING_STATES, TrainingPollerMixin
 
 
 def _make_poller(statuses: list[str]) -> TrainingPollerMixin:

--- a/truss/tests/cli/train/test_poller.py
+++ b/truss/tests/cli/train/test_poller.py
@@ -3,11 +3,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from truss.cli.train.core import ACTIVE_JOB_STATUSES
-from truss.cli.train.poller import (
-    JOB_PENDING_STATES,
-    JOB_STARTING_STATES,
-    TrainingPollerMixin,
-)
+from truss.cli.train.poller import JOB_PENDING_STATES, JOB_STARTING_STATES, TrainingPollerMixin
 
 
 def _make_poller(statuses: list[str]) -> TrainingPollerMixin:
@@ -23,10 +19,6 @@ def _make_poller(statuses: list[str]) -> TrainingPollerMixin:
 
 def test_pending_in_job_starting_states():
     assert "TRAINING_JOB_PENDING" in JOB_STARTING_STATES
-
-
-def test_pending_in_job_pending_states():
-    assert "TRAINING_JOB_PENDING" in JOB_PENDING_STATES
 
 
 def test_starting_status_message_pending():

--- a/truss/tests/cli/train/test_poller.py
+++ b/truss/tests/cli/train/test_poller.py
@@ -1,0 +1,83 @@
+from unittest.mock import Mock, patch
+
+import pytest
+
+from truss.cli.train.core import ACTIVE_JOB_STATUSES
+from truss.cli.train.poller import (
+    JOB_PENDING_STATES,
+    JOB_STARTING_STATES,
+    TrainingPollerMixin,
+)
+
+
+def _make_poller(statuses: list[str]) -> TrainingPollerMixin:
+    """Create a TrainingPollerMixin with a mocked API returning the given statuses in sequence."""
+    mock_api = Mock()
+    mock_api.get_training_job.side_effect = [
+        {"training_job": {"current_status": s, "error_message": None}} for s in statuses
+    ]
+    poller = TrainingPollerMixin.__new__(TrainingPollerMixin)
+    TrainingPollerMixin.__init__(poller, mock_api, "proj1", "job1")
+    return poller
+
+
+def test_pending_in_job_starting_states():
+    assert "TRAINING_JOB_PENDING" in JOB_STARTING_STATES
+
+
+def test_pending_in_job_pending_states():
+    assert "TRAINING_JOB_PENDING" in JOB_PENDING_STATES
+
+
+def test_starting_status_message_pending():
+    poller = _make_poller(["TRAINING_JOB_PENDING"])
+    poller._update_from_current_status()
+    assert "GPU capacity" in poller._starting_status_message()
+    assert "queued" in poller._starting_status_message()
+
+
+def test_starting_status_message_created():
+    poller = _make_poller(["TRAINING_JOB_CREATED"])
+    poller._update_from_current_status()
+    assert "deploy" in poller._starting_status_message()
+    assert "TRAINING_JOB_CREATED" in poller._starting_status_message()
+
+
+@patch("truss.cli.train.poller.time.sleep")
+def test_before_polling_waits_through_pending(mock_sleep):
+    """before_polling should spin through PENDING and CREATED before exiting."""
+    statuses = [
+        "TRAINING_JOB_PENDING",
+        "TRAINING_JOB_PENDING",
+        "TRAINING_JOB_CREATED",
+        "TRAINING_JOB_DEPLOYING",
+    ]
+    poller = _make_poller(statuses)
+    poller.before_polling()
+    # Should have exited once status left JOB_STARTING_STATES
+    assert poller._current_status.status == "TRAINING_JOB_DEPLOYING"
+
+
+def test_pending_in_active_job_statuses():
+    assert "TRAINING_JOB_PENDING" in ACTIVE_JOB_STATUSES
+
+
+@pytest.mark.parametrize(
+    "status,expected_fragment",
+    [("TRAINING_JOB_PENDING", "pending"), ("TRAINING_JOB_QUEUED", "queued")],
+)
+def test_handle_post_create_logic_queue_messages(status, expected_fragment, capsys):
+    """_handle_post_create_logic should print queue/pending message for non-deployed statuses."""
+    from truss.cli.train_commands import _handle_post_create_logic
+
+    mock_remote = Mock()
+    mock_remote.remote_url = "https://app.baseten.co"
+    job_resp = {
+        "id": "job123",
+        "current_status": status,
+        "training_project": {"id": "proj456", "name": "my-project"},
+    }
+    # tail=False so we don't try to stream logs
+    _handle_post_create_logic(job_resp, mock_remote, tail=False)
+    captured = capsys.readouterr()
+    assert expected_fragment in captured.out.lower()


### PR DESCRIPTION
## :rocket: What

Add client-side support for the new `TRAINING_JOB_PENDING` status introduced by the per-org training job queue on the backend ([basetenlabs/baseten#18696](https://github.com/basetenlabs/baseten/pull/18696)).

When an org is at GPU capacity and has `max_queue_length > 0`, new jobs enter `PENDING` state instead of being rejected. This PR ensures the CLI handles that state gracefully.

## :computer: How

- **`truss/cli/train/poller.py`**: Added `JOB_PENDING_STATES = ["TRAINING_JOB_PENDING"]` and added `TRAINING_JOB_PENDING` to `JOB_STARTING_STATES` so `--tail` waits correctly through the queue. Added `_starting_status_message()` to show `"Waiting for GPU capacity (job is queued)..."` while pending (vs the generic deploy message for other starting states).
- **`truss/cli/train/core.py`**: Added `TRAINING_JOB_PENDING` to `ACTIVE_JOB_STATUSES` so pending jobs appear in `truss train view` and can be found/stopped via `truss train stop`.
- **`truss/cli/train_commands.py`**: Added PENDING branch in `_handle_post_create_logic` with a distinct yellow message, separate from the green QUEUED message.

## :microscope: Testing

- Added `truss/tests/cli/train/test_poller.py` with 8 tests covering:
  - `TRAINING_JOB_PENDING` membership in `JOB_STARTING_STATES` and `JOB_PENDING_STATES`
  - Correct spinner messages for PENDING vs CREATED states
  - `before_polling()` correctly waits through PENDING → CREATED → DEPLOYING
  - `TRAINING_JOB_PENDING` in `ACTIVE_JOB_STATUSES`
  - `_handle_post_create_logic` prints the right message for both PENDING and QUEUED statuses
- All 8 tests pass; ruff clean