### PR TITLE
Remote SSH support for model containers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "truss"
-version = "0.15.12"
+version = "0.15.13rc1"
 description = "A seamless bridge from model development to model delivery"
 authors = [
     { name = "Pankaj Gupta", email = "no-reply@baseten.co" },

--- a/truss-train/truss_train/definitions.py
+++ b/truss-train/truss_train/definitions.py
@@ -116,6 +116,7 @@ class InteractiveSessionTrigger(str, enum.Enum):
 class InteractiveSessionProvider(str, enum.Enum):
     VS_CODE = "vs_code"
     CURSOR = "cursor"
+    SSH = "ssh"
 
 
 class InteractiveSessionAuthProvider(str, enum.Enum):

--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -590,6 +590,15 @@ Transport = Annotated[
 ]
 
 
+class RemoteSSH(custom_types.ConfigModel):
+    """Configuration for SSH access to running model instances."""
+
+    enabled: bool = pydantic.Field(
+        default=False,
+        description="If true, enables SSH access to running model instances.",
+    )
+
+
 class Runtime(custom_types.ConfigModel):
     """Runtime settings for your model instance."""
 
@@ -619,6 +628,10 @@ class Runtime(custom_types.ConfigModel):
     health_checks: HealthChecks = pydantic.Field(
         default_factory=HealthChecks,
         description="Custom health check configuration for your deployments.",
+    )
+    remote_ssh: RemoteSSH = pydantic.Field(
+        default_factory=RemoteSSH,
+        description="Configuration for SSH access to running model instances.",
     )
     truss_server_version_override: Optional[str] = pydantic.Field(
         None,
@@ -1201,6 +1214,20 @@ class TrussConfig(custom_types.ConfigModel):
 
     class Config:
         protected_namespaces = ()  # Silence warnings about fields starting with `model_`.
+
+    @pydantic.model_validator(mode="after")
+    def _validate_remote_ssh(self) -> "TrussConfig":
+        if (
+            self.runtime.remote_ssh.enabled
+            and self.docker_server is not None
+            and self.docker_server.run_as_user_id is not None
+        ):
+            raise ValueError(
+                "remote_ssh.enabled is not compatible with "
+                "docker_server.run_as_user_id. SSH requires the default "
+                "'app' user (uid 60000)."
+            )
+        return self
 
     @property
     def canonical_python_version(self) -> str:

--- a/truss/cli/train/proxy_command.py
+++ b/truss/cli/train/proxy_command.py
@@ -1,0 +1,444 @@
+#!/usr/bin/env python3
+"""SSH helper for Baseten training jobs.
+
+This script is installed to ~/.ssh/baseten/proxy-command.py by `truss train ssh setup`.
+It is fully self-contained (only Python stdlib imports, no truss dependency).
+
+It has two modes, both invoked by SSH automatically:
+
+  1. Sign mode (Match exec): Signs an SSH certificate and caches the JWT.
+     Invoked as: proxy-command.py --sign <hostname>
+
+  2. Proxy mode (ProxyCommand): Connects to the SSH proxy using the cached JWT.
+     Invoked as: proxy-command.py <hostname>
+
+Hostname format: training-job-<job_id>-<node>.<remote>.ssh.baseten.co
+Example: training-job-5wo5n3y-0.dev.ssh.baseten.co
+"""
+
+import configparser
+import json
+import os
+import selectors
+import socket
+import ssl
+import struct
+import sys
+import threading
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+# Stamped by `truss train ssh setup` with the truss version at install time.
+# Sent to the signing API so the server can reject outdated clients.
+CLIENT_VERSION = "{{CLIENT_VERSION}}"
+
+BASETEN_SSH_DIR = Path.home() / ".ssh" / "baseten"
+TRUSSRC_PATH = Path.home() / ".trussrc"
+JWT_CACHE_DIR = BASETEN_SSH_DIR / ".jwt-cache"
+
+HOSTNAME_SUFFIX = ".ssh.baseten.co"
+HOSTNAME_PREFIX = "training-job-"
+
+BASETEN_REST_API_URL = "https://api.baseten.co"
+
+STATUS_OK = 0x00
+
+
+def error(msg):
+    print(f"baseten-ssh: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def find_key_path():
+    """Find the SSH private key (ed25519 or RSA fallback)."""
+    for name in ("id_ed25519", "id_rsa"):
+        path = BASETEN_SSH_DIR / name
+        if path.exists():
+            return path
+    return None
+
+
+def parse_hostname(hostname):
+    """Parse hostname into (job_id, replica, remote, api_prefix).
+
+    Supported formats:
+      training-job-<job_id>-<node>.ssh.baseten.co                       — default remote, default API
+      training-job-<job_id>-<node>.<remote>.ssh.baseten.co              — explicit remote, default API
+      training-job-<job_id>-<node>.<remote>.<api_prefix>.ssh.baseten.co — explicit remote, custom API
+    """
+    if not hostname.endswith(HOSTNAME_SUFFIX):
+        error(f"Invalid hostname: {hostname} (expected *.ssh.baseten.co)")
+
+    prefix = hostname[: -len(HOSTNAME_SUFFIX)]
+    dot_idx = prefix.find(".")
+    if dot_idx == -1:
+        job_replica = prefix
+        remote = None
+        api_prefix = None
+    else:
+        job_replica = prefix[:dot_idx]
+        rest = prefix[dot_idx + 1 :]
+        parts = rest.split(".", 1)
+        remote = parts[0]
+        api_prefix = parts[1] if len(parts) > 1 else None
+
+    if not job_replica.startswith(HOSTNAME_PREFIX):
+        error(
+            f"Invalid hostname: {hostname} "
+            f"(expected training-job-<job_id>-<node>.ssh.baseten.co)"
+        )
+
+    job_replica = job_replica[len(HOSTNAME_PREFIX) :]
+
+    dash_idx = job_replica.rfind("-")
+    if dash_idx == -1:
+        error(f"Invalid hostname: {hostname} (cannot parse job_id and node)")
+
+    job_id = job_replica[:dash_idx]
+    replica_str = job_replica[dash_idx + 1 :]
+
+    if not replica_str:
+        error(f"Invalid hostname: {hostname} (empty replica)")
+
+    if not replica_str.isdigit():
+        error(f"Invalid hostname: {hostname} (replica must be a number)")
+
+    replica = replica_str
+
+    if not job_id:
+        error(f"Invalid hostname: {hostname} (empty job_id)")
+
+    return job_id, replica, remote, api_prefix
+
+
+def _read_trussrc():
+    """Read and return the parsed ~/.trussrc config."""
+    if not TRUSSRC_PATH.exists():
+        error("~/.trussrc not found. Run 'truss login' first.")
+
+    config = configparser.ConfigParser()
+    config.read(TRUSSRC_PATH)
+    return config
+
+
+def resolve_remote(remote, config):
+    """Resolve the remote name. If None, default to the only remote in ~/.trussrc."""
+    if remote is None:
+        sections = config.sections()
+        if len(sections) == 1:
+            remote = sections[0]
+        elif len(sections) == 0:
+            error("No remotes configured in ~/.trussrc. Run 'truss login' first.")
+        else:
+            error(
+                f"Multiple remotes in ~/.trussrc: {', '.join(sections)}. "
+                f"Specify one in the hostname: ssh training-job-<job_id>-<node>.<remote>.ssh.baseten.co"
+            )
+    return remote
+
+
+def load_trussrc(remote, config=None):
+    """Read ~/.trussrc and return (api_key, remote_url) for the given remote."""
+    if config is None:
+        config = _read_trussrc()
+
+    if not config.has_section(remote):
+        error(
+            f"Remote '{remote}' not found in ~/.trussrc. Available: {', '.join(config.sections())}"
+        )
+
+    api_key = config.get(remote, "api_key", fallback=None)
+    remote_url = config.get(remote, "remote_url", fallback=None)
+
+    if not api_key:
+        error(f"No api_key for remote '{remote}' in ~/.trussrc")
+    if not remote_url:
+        error(f"No remote_url for remote '{remote}' in ~/.trussrc")
+
+    return api_key, remote_url
+
+
+def resolve_rest_api_url(api_prefix=None):
+    """Determine the REST API URL.
+
+    If api_prefix is set (from hostname), use https://api.<prefix>.baseten.co.
+    Otherwise use the default production URL.
+    """
+    if api_prefix:
+        return f"https://api.{api_prefix}.baseten.co"
+    return BASETEN_REST_API_URL
+
+
+def api_request(url, api_key, method="GET", body=None, extra_headers=None):
+    """Make an API request, return parsed JSON or raise on error."""
+    headers = {
+        "Authorization": f"Api-Key {api_key}",
+        "Content-Type": "application/json",
+    }
+    if extra_headers:
+        headers.update(extra_headers)
+    headers["X-Client-Version"] = CLIENT_VERSION
+
+    data = json.dumps(body).encode() if body else None
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        try:
+            err_body = json.loads(e.read())
+            # API errors can come in different formats
+            if isinstance(err_body, dict):
+                msg = (
+                    err_body.get("error")
+                    or err_body.get("detail")
+                    or err_body.get("message")
+                    or str(err_body)
+                )
+            elif isinstance(err_body, list) and err_body:
+                msg = err_body[0] if isinstance(err_body[0], str) else str(err_body[0])
+            else:
+                msg = str(err_body)
+        except Exception:
+            msg = e.reason
+        error(f"API error ({e.code}): {msg}")
+    except urllib.error.URLError as e:
+        error(f"Cannot reach API: {e.reason}")
+
+
+def resolve_project_id(rest_url, api_key, job_id):
+    """Look up project_id for a job via the search API."""
+    resp = api_request(
+        f"{rest_url}/v1/training_jobs/search",
+        api_key,
+        method="POST",
+        body={"job_id": job_id},
+    )
+
+    jobs = resp if isinstance(resp, list) else resp.get("training_jobs", [])
+    if not jobs:
+        error(f"Job '{job_id}' not found. Is the job ID correct?")
+
+    return jobs[0]["training_project"]["id"]
+
+
+def sign_certificate(
+    rest_url, api_key, project_id, job_id, public_key, replica, key_path
+):
+    """Call the SSH signing endpoint. Returns (ssh_cert, jwt, proxy_address)."""
+    resp = api_request(
+        f"{rest_url}/v1/training_projects/{project_id}/jobs/{job_id}/ssh/sign",
+        api_key,
+        method="POST",
+        body={"public_key": public_key, "replica_id": replica},
+    )
+
+    # Write cert next to the key (e.g. id_ed25519-cert.pub)
+    cert_path = key_path.parent / (key_path.name + "-cert.pub")
+    cert_path.write_text(resp["ssh_certificate"])
+
+    return resp["jwt"], resp["proxy_address"]
+
+
+# --- JWT cache: shared between sign mode and proxy mode ---
+
+
+def _jwt_cache_path(job_id, replica):
+    return JWT_CACHE_DIR / f"{job_id}-{replica}.json"
+
+
+def save_jwt_cache(job_id, replica, jwt_token, proxy_address):
+    """Save JWT and proxy address for the proxy command to read."""
+    JWT_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    path = _jwt_cache_path(job_id, replica)
+    path.write_text(json.dumps({"jwt": jwt_token, "proxy_address": proxy_address}))
+
+
+def load_jwt_cache(job_id, replica):
+    """Load cached JWT and proxy address. Returns (jwt, proxy_address) or None."""
+    path = _jwt_cache_path(job_id, replica)
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text())
+        return data["jwt"], data["proxy_address"]
+    except (json.JSONDecodeError, KeyError):
+        return None
+
+
+# --- Sign mode (Match exec) ---
+
+
+def main_sign():
+    """Sign mode: called by Match exec before SSH loads identity files.
+
+    Signs the certificate, writes it to disk, and caches the JWT for
+    the ProxyCommand to use. Always exits 0 so the Match block applies.
+    """
+    if len(sys.argv) < 3:
+        error("Usage: proxy-command.py --sign <hostname>")
+
+    hostname = sys.argv[2]
+
+    key_path = find_key_path()
+    if not key_path:
+        print(
+            "baseten-ssh: SSH keypair not found. Run 'truss train ssh setup' first.",
+            file=sys.stderr,
+        )
+        sys.exit(0)  # Exit 0 so Match still applies; ProxyCommand will show error too
+
+    job_id, replica, remote, api_prefix = parse_hostname(hostname)
+    config = _read_trussrc()
+    remote = resolve_remote(remote, config)
+    api_key, _ = load_trussrc(remote, config)
+    rest_url = resolve_rest_api_url(api_prefix)
+
+    project_id = resolve_project_id(rest_url, api_key, job_id)
+    public_key = key_path.with_suffix(".pub").read_text().strip()
+    jwt_token, proxy_address = sign_certificate(
+        rest_url, api_key, project_id, job_id, public_key, replica, key_path
+    )
+
+    save_jwt_cache(job_id, replica, jwt_token, proxy_address)
+
+
+# --- Proxy mode (ProxyCommand) ---
+
+
+def connect_proxy(proxy_address, jwt_token):
+    """TLS connect to proxy, send JWT, return connected socket."""
+    host, port_str = proxy_address.rsplit(":", 1)
+    port = int(port_str)
+
+    ctx = ssl.create_default_context()
+    raw_sock = socket.create_connection((host, port), timeout=10)
+    tls_sock = ctx.wrap_socket(raw_sock, server_hostname=host)
+
+    # Send length-prefixed JWT
+    jwt_bytes = jwt_token.encode()
+    tls_sock.sendall(struct.pack("!I", len(jwt_bytes)))
+    tls_sock.sendall(jwt_bytes)
+
+    # Read status byte
+    status = tls_sock.recv(1)
+    if not status or status[0] != STATUS_OK:
+        tls_sock.close()
+        error("SSH proxy rejected the connection. Is the job and SSH server running?")
+
+    return tls_sock
+
+
+def relay_selectors(tls_sock):
+    """Bidirectional relay using selectors (macOS/Linux)."""
+    stdin_fd = sys.stdin.buffer.fileno()
+    stdout_fd = sys.stdout.buffer.fileno()
+
+    sel = selectors.DefaultSelector()
+    sel.register(stdin_fd, selectors.EVENT_READ, "stdin")
+    sel.register(tls_sock, selectors.EVENT_READ, "socket")
+
+    try:
+        while True:
+            events = sel.select()
+            for key, _ in events:
+                if key.data == "stdin":
+                    data = os.read(stdin_fd, 65536)
+                    if not data:
+                        return
+                    tls_sock.sendall(data)
+                elif key.data == "socket":
+                    data = tls_sock.recv(65536)
+                    if not data:
+                        return
+                    os.write(stdout_fd, data)
+    except (BrokenPipeError, ConnectionResetError, OSError):
+        pass
+    finally:
+        sel.close()
+
+
+def relay_threads(tls_sock):
+    """Bidirectional relay using threads (Windows)."""
+    done = threading.Event()
+
+    def stdin_to_socket():
+        try:
+            while not done.is_set():
+                data = os.read(sys.stdin.buffer.fileno(), 65536)
+                if not data:
+                    break
+                tls_sock.sendall(data)
+        except (BrokenPipeError, ConnectionResetError, OSError):
+            pass
+        finally:
+            done.set()
+
+    def socket_to_stdout():
+        try:
+            while not done.is_set():
+                data = tls_sock.recv(65536)
+                if not data:
+                    break
+                os.write(sys.stdout.buffer.fileno(), data)
+        except (BrokenPipeError, ConnectionResetError, OSError):
+            pass
+        finally:
+            done.set()
+
+    t1 = threading.Thread(target=stdin_to_socket, daemon=True)
+    t2 = threading.Thread(target=socket_to_stdout, daemon=True)
+    t1.start()
+    t2.start()
+    done.wait()
+
+
+def main_proxy():
+    """Proxy mode: called by ProxyCommand after sign mode has run."""
+    if len(sys.argv) < 2:
+        error("Usage: proxy-command.py <hostname>")
+
+    hostname = sys.argv[1]
+
+    key_path = find_key_path()
+    if not key_path:
+        error("SSH keypair not found. Run 'truss train ssh setup' first.")
+
+    job_id, replica, remote, api_prefix = parse_hostname(hostname)
+
+    # Try to use cached JWT from sign mode
+    cached = load_jwt_cache(job_id, replica)
+    if cached:
+        jwt_token, proxy_address = cached
+    else:
+        # Fallback: sign here if Match exec didn't run (e.g. old SSH config)
+        config = _read_trussrc()
+        remote = resolve_remote(remote, config)
+        api_key, _ = load_trussrc(remote, config)
+        rest_url = resolve_rest_api_url(api_prefix)
+        project_id = resolve_project_id(rest_url, api_key, job_id)
+        public_key = key_path.with_suffix(".pub").read_text().strip()
+        jwt_token, proxy_address = sign_certificate(
+            rest_url, api_key, project_id, job_id, public_key, replica, key_path
+        )
+
+    # Connect to proxy
+    tls_sock = connect_proxy(proxy_address, jwt_token)
+
+    # Relay stdin/stdout
+    try:
+        if sys.platform == "win32":
+            relay_threads(tls_sock)
+        else:
+            relay_selectors(tls_sock)
+    finally:
+        tls_sock.close()
+
+
+if __name__ == "__main__":
+    if len(sys.argv) >= 2 and sys.argv[1] == "--sign":
+        main_sign()
+    else:
+        main_proxy()

--- a/truss/cli/train/proxy_command.py
+++ b/truss/cli/train/proxy_command.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-"""SSH helper for Baseten training jobs.
+"""SSH helper for Baseten workloads (training jobs and inference models).
 
-This script is installed to ~/.ssh/baseten/proxy-command.py by `truss train ssh setup`.
+This script is installed to ~/.ssh/baseten/proxy-command.py by `truss ssh setup`.
 It is fully self-contained (only Python stdlib imports, no truss dependency).
 
 It has two modes, both invoked by SSH automatically:
@@ -12,11 +12,14 @@ It has two modes, both invoked by SSH automatically:
   2. Proxy mode (ProxyCommand): Connects to the SSH proxy using the cached JWT.
      Invoked as: proxy-command.py <hostname>
 
-Hostname format: training-job-<job_id>-<node>.<remote>.ssh.baseten.co
-Example: training-job-5wo5n3y-0.dev.ssh.baseten.co
+Hostname formats:
+  training-job-<job_id>-<node>.<remote>.ssh.baseten.co        (training)
+  model-<model_id>.<remote>.ssh.baseten.co                    (inference, default env)
+  model-<model_id>-<env_name>.<remote>.ssh.baseten.co         (inference, specific env)
 """
 
 import configparser
+import dataclasses
 import json
 import os
 import selectors
@@ -28,6 +31,7 @@ import threading
 import urllib.error
 import urllib.request
 from pathlib import Path
+from typing import Optional
 
 # Stamped by `truss train ssh setup` with the truss version at install time.
 # Sent to the signing API so the server can reject outdated clients.
@@ -40,7 +44,11 @@ TRUSSRC_PATH = Path(os.environ.get("USER_TRUSSRC_PATH", Path.home() / ".trussrc"
 JWT_CACHE_DIR = BASETEN_SSH_DIR / ".jwt-cache"
 
 HOSTNAME_SUFFIX = ".ssh.baseten.co"
-HOSTNAME_PREFIX = "training-job-"
+HOSTNAME_PREFIX_TRAINING = "training-job-"
+HOSTNAME_PREFIX_MODEL = "model-"
+
+WORKLOAD_TRAINING = "training"
+WORKLOAD_MODEL = "model"
 
 BASETEN_REST_API_URL = os.environ.get("BASETEN_BASE_URL", "https://api.baseten.co")
 
@@ -61,13 +69,25 @@ def find_key_path():
     return None
 
 
+@dataclasses.dataclass
+class ParsedHostname:
+    """Result of parsing an SSH hostname."""
+
+    workload_type: str
+    id: str
+    replica: Optional[str]
+    environment: Optional[str]
+    remote: Optional[str]
+    api_prefix: Optional[str]
+
+
 def parse_hostname(hostname):
-    """Parse hostname into (job_id, replica, remote, api_prefix).
+    """Parse hostname into a ParsedHostname.
 
     Supported formats:
-      training-job-<job_id>-<node>.ssh.baseten.co                       — default remote, default API
-      training-job-<job_id>-<node>.<remote>.ssh.baseten.co              — explicit remote, default API
-      training-job-<job_id>-<node>.<remote>.<api_prefix>.ssh.baseten.co — explicit remote, custom API
+      training-job-<job_id>-<node>[.<remote>[.<api_prefix>]].ssh.baseten.co
+      model-<model_id>[.<remote>[.<api_prefix>]].ssh.baseten.co
+      model-<model_id>-<env_name>[.<remote>[.<api_prefix>]].ssh.baseten.co
     """
     if not hostname.endswith(HOSTNAME_SUFFIX):
         error(f"Invalid hostname: {hostname} (expected *.ssh.baseten.co)")
@@ -75,43 +95,85 @@ def parse_hostname(hostname):
     prefix = hostname[: -len(HOSTNAME_SUFFIX)]
     dot_idx = prefix.find(".")
     if dot_idx == -1:
-        job_replica = prefix
+        workload_part = prefix
         remote = None
         api_prefix = None
     else:
-        job_replica = prefix[:dot_idx]
+        workload_part = prefix[:dot_idx]
         rest = prefix[dot_idx + 1 :]
         parts = rest.split(".", 1)
         remote = parts[0]
         api_prefix = parts[1] if len(parts) > 1 else None
 
-    if not job_replica.startswith(HOSTNAME_PREFIX):
+    if workload_part.startswith(HOSTNAME_PREFIX_TRAINING):
+        return _parse_training_hostname(hostname, workload_part, remote, api_prefix)
+    elif workload_part.startswith(HOSTNAME_PREFIX_MODEL):
+        return _parse_model_hostname(hostname, workload_part, remote, api_prefix)
+    else:
         error(
             f"Invalid hostname: {hostname} "
-            f"(expected training-job-<job_id>-<node>.ssh.baseten.co)"
+            f"(expected training-job-<job_id>-<node> or model-<model_id>)"
         )
 
-    job_replica = job_replica[len(HOSTNAME_PREFIX) :]
 
-    dash_idx = job_replica.rfind("-")
+def _parse_training_hostname(hostname, workload_part, remote, api_prefix):
+    remainder = workload_part[len(HOSTNAME_PREFIX_TRAINING) :]
+
+    dash_idx = remainder.rfind("-")
     if dash_idx == -1:
         error(f"Invalid hostname: {hostname} (cannot parse job_id and node)")
 
-    job_id = job_replica[:dash_idx]
-    replica_str = job_replica[dash_idx + 1 :]
+    job_id = remainder[:dash_idx]
+    replica_str = remainder[dash_idx + 1 :]
 
     if not replica_str:
         error(f"Invalid hostname: {hostname} (empty replica)")
-
     if not replica_str.isdigit():
         error(f"Invalid hostname: {hostname} (replica must be a number)")
-
-    replica = replica_str
-
     if not job_id:
         error(f"Invalid hostname: {hostname} (empty job_id)")
 
-    return job_id, replica, remote, api_prefix
+    return ParsedHostname(
+        workload_type=WORKLOAD_TRAINING,
+        id=job_id,
+        replica=replica_str,
+        environment=None,
+        remote=remote,
+        api_prefix=api_prefix,
+    )
+
+
+def _parse_model_hostname(hostname, workload_part, remote, api_prefix):
+    remainder = workload_part[len(HOSTNAME_PREFIX_MODEL) :]
+    if not remainder:
+        error(f"Invalid hostname: {hostname} (empty model_id)")
+
+    # Model IDs are [a-z0-9]+ (no hyphens). If there's a hyphen, everything
+    # after the first one is the environment name.
+    dash_idx = remainder.find("-")
+    if dash_idx == -1:
+        model_id = remainder
+        environment = None
+    else:
+        model_id = remainder[:dash_idx]
+        environment = remainder[dash_idx + 1 :]
+        if not environment:
+            error(f"Invalid hostname: {hostname} (empty environment name)")
+
+    if not model_id:
+        error(f"Invalid hostname: {hostname} (empty model_id)")
+
+    # Replica comes from env var, not hostname
+    replica = os.environ.get("BASETEN_REPLICA") or None
+
+    return ParsedHostname(
+        workload_type=WORKLOAD_MODEL,
+        id=model_id,
+        replica=replica,
+        environment=environment,
+        remote=remote,
+        api_prefix=api_prefix,
+    )
 
 
 def _read_trussrc():
@@ -226,10 +288,10 @@ def resolve_project_id(rest_url, api_key, job_id):
     return jobs[0]["training_project"]["id"]
 
 
-def sign_certificate(
+def sign_training_certificate(
     rest_url, api_key, project_id, job_id, public_key, replica, key_path
 ):
-    """Call the SSH signing endpoint. Returns (ssh_cert, jwt, proxy_address)."""
+    """Call the training SSH signing endpoint. Returns (jwt, proxy_address)."""
     resp = api_request(
         f"{rest_url}/v1/training_projects/{project_id}/jobs/{job_id}/ssh/sign",
         api_key,
@@ -237,30 +299,55 @@ def sign_certificate(
         body={"public_key": public_key, "replica_id": replica},
     )
 
-    # Write cert next to the key (e.g. id_ed25519-cert.pub)
     cert_path = key_path.parent / (key_path.name + "-cert.pub")
     cert_path.write_text(resp["ssh_certificate"])
+    return resp["jwt"], resp["proxy_address"]
 
+
+def sign_model_certificate(rest_url, api_key, parsed, public_key, key_path):
+    """Call the inference SSH signing endpoint. Returns (jwt, proxy_address)."""
+    body = {"public_key": public_key}
+    if parsed.replica:
+        body["replica_id"] = parsed.replica
+
+    if parsed.environment:
+        url = f"{rest_url}/v1/models/{parsed.id}/environments/{parsed.environment}/ssh/sign"
+    else:
+        url = f"{rest_url}/v1/models/{parsed.id}/ssh/sign"
+
+    resp = api_request(url, api_key, method="POST", body=body)
+
+    cert_path = key_path.parent / (key_path.name + "-cert.pub")
+    cert_path.write_text(resp["ssh_certificate"])
     return resp["jwt"], resp["proxy_address"]
 
 
 # --- JWT cache: shared between sign mode and proxy mode ---
 
 
-def _jwt_cache_path(job_id, replica):
-    return JWT_CACHE_DIR / f"{job_id}-{replica}.json"
+def _jwt_cache_path(parsed):
+    if parsed.workload_type == WORKLOAD_TRAINING:
+        name = f"{parsed.id}-{parsed.replica}"
+    else:
+        parts = [parsed.id]
+        if parsed.environment:
+            parts.append(parsed.environment)
+        if parsed.replica:
+            parts.append(parsed.replica)
+        name = "-".join(parts)
+    return JWT_CACHE_DIR / f"{name}.json"
 
 
-def save_jwt_cache(job_id, replica, jwt_token, proxy_address):
+def save_jwt_cache(parsed, jwt_token, proxy_address):
     """Save JWT and proxy address for the proxy command to read."""
     JWT_CACHE_DIR.mkdir(parents=True, exist_ok=True)
-    path = _jwt_cache_path(job_id, replica)
+    path = _jwt_cache_path(parsed)
     path.write_text(json.dumps({"jwt": jwt_token, "proxy_address": proxy_address}))
 
 
-def load_jwt_cache(job_id, replica):
+def load_jwt_cache(parsed):
     """Load cached JWT and proxy address. Returns (jwt, proxy_address) or None."""
-    path = _jwt_cache_path(job_id, replica)
+    path = _jwt_cache_path(parsed)
     if not path.exists():
         return None
     try:
@@ -271,6 +358,25 @@ def load_jwt_cache(job_id, replica):
 
 
 # --- Sign mode (Match exec) ---
+
+
+def _sign_for_parsed(parsed, rest_url, api_key, key_path):
+    """Sign a certificate for the given parsed hostname. Returns (jwt, proxy_address)."""
+    public_key = key_path.with_suffix(".pub").read_text().strip()
+
+    if parsed.workload_type == WORKLOAD_TRAINING:
+        project_id = resolve_project_id(rest_url, api_key, parsed.id)
+        return sign_training_certificate(
+            rest_url,
+            api_key,
+            project_id,
+            parsed.id,
+            public_key,
+            parsed.replica,
+            key_path,
+        )
+    else:
+        return sign_model_certificate(rest_url, api_key, parsed, public_key, key_path)
 
 
 def main_sign():
@@ -292,19 +398,14 @@ def main_sign():
         )
         sys.exit(0)  # Exit 0 so Match still applies; ProxyCommand will show error too
 
-    job_id, replica, remote, api_prefix = parse_hostname(hostname)
+    parsed = parse_hostname(hostname)
     config = _read_trussrc()
-    remote = resolve_remote(remote, config)
+    remote = resolve_remote(parsed.remote, config)
     api_key, _ = load_trussrc(remote, config)
-    rest_url = resolve_rest_api_url(api_prefix)
+    rest_url = resolve_rest_api_url(parsed.api_prefix)
 
-    project_id = resolve_project_id(rest_url, api_key, job_id)
-    public_key = key_path.with_suffix(".pub").read_text().strip()
-    jwt_token, proxy_address = sign_certificate(
-        rest_url, api_key, project_id, job_id, public_key, replica, key_path
-    )
-
-    save_jwt_cache(job_id, replica, jwt_token, proxy_address)
+    jwt_token, proxy_address = _sign_for_parsed(parsed, rest_url, api_key, key_path)
+    save_jwt_cache(parsed, jwt_token, proxy_address)
 
 
 # --- Proxy mode (ProxyCommand) ---
@@ -332,7 +433,9 @@ def connect_proxy(proxy_address, jwt_token):
     status = tls_sock.recv(1)
     if not status or status[0] != STATUS_OK:
         tls_sock.close()
-        error("SSH proxy rejected the connection. Is the job and SSH server running?")
+        error(
+            "SSH proxy rejected the connection. Is the workload and SSH server running?"
+        )
 
     return tls_sock
 
@@ -412,23 +515,19 @@ def main_proxy():
     if not key_path:
         error("SSH keypair not found. Run 'truss train ssh setup' first.")
 
-    job_id, replica, remote, api_prefix = parse_hostname(hostname)
+    parsed = parse_hostname(hostname)
 
     # Try to use cached JWT from sign mode
-    cached = load_jwt_cache(job_id, replica)
+    cached = load_jwt_cache(parsed)
     if cached:
         jwt_token, proxy_address = cached
     else:
         # Fallback: sign here if Match exec didn't run (e.g. old SSH config)
         config = _read_trussrc()
-        remote = resolve_remote(remote, config)
+        remote = resolve_remote(parsed.remote, config)
         api_key, _ = load_trussrc(remote, config)
-        rest_url = resolve_rest_api_url(api_prefix)
-        project_id = resolve_project_id(rest_url, api_key, job_id)
-        public_key = key_path.with_suffix(".pub").read_text().strip()
-        jwt_token, proxy_address = sign_certificate(
-            rest_url, api_key, project_id, job_id, public_key, replica, key_path
-        )
+        rest_url = resolve_rest_api_url(parsed.api_prefix)
+        jwt_token, proxy_address = _sign_for_parsed(parsed, rest_url, api_key, key_path)
 
     # Connect to proxy
     tls_sock = connect_proxy(proxy_address, jwt_token)

--- a/truss/cli/train/proxy_command.py
+++ b/truss/cli/train/proxy_command.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """SSH helper for Baseten workloads (training jobs and inference models).
 
-This script is installed to ~/.ssh/baseten/proxy-command.py by `truss ssh setup`.
+This script is installed to ~/.ssh/baseten/proxy-command.py by `truss train ssh setup`.
 It is fully self-contained (only Python stdlib imports, no truss dependency).
 
 It has two modes, both invoked by SSH automatically:

--- a/truss/cli/train/proxy_command.py
+++ b/truss/cli/train/proxy_command.py
@@ -33,14 +33,16 @@ from pathlib import Path
 # Sent to the signing API so the server can reject outdated clients.
 CLIENT_VERSION = "{{CLIENT_VERSION}}"
 
-BASETEN_SSH_DIR = Path.home() / ".ssh" / "baseten"
-TRUSSRC_PATH = Path.home() / ".trussrc"
+BASETEN_SSH_DIR = Path(
+    os.environ.get("BASETEN_SSH_DIR", Path.home() / ".ssh" / "baseten")
+)
+TRUSSRC_PATH = Path(os.environ.get("USER_TRUSSRC_PATH", Path.home() / ".trussrc"))
 JWT_CACHE_DIR = BASETEN_SSH_DIR / ".jwt-cache"
 
 HOSTNAME_SUFFIX = ".ssh.baseten.co"
 HOSTNAME_PREFIX = "training-job-"
 
-BASETEN_REST_API_URL = "https://api.baseten.co"
+BASETEN_REST_API_URL = os.environ.get("BASETEN_BASE_URL", "https://api.baseten.co")
 
 STATUS_OK = 0x00
 
@@ -313,9 +315,13 @@ def connect_proxy(proxy_address, jwt_token):
     host, port_str = proxy_address.rsplit(":", 1)
     port = int(port_str)
 
-    ctx = ssl.create_default_context()
     raw_sock = socket.create_connection((host, port), timeout=10)
-    tls_sock = ctx.wrap_socket(raw_sock, server_hostname=host)
+
+    if os.environ.get("BASETEN_SSH_PROXY_INSECURE", "").lower() in ("1", "true"):
+        tls_sock = raw_sock
+    else:
+        ctx = ssl.create_default_context()
+        tls_sock = ctx.wrap_socket(raw_sock, server_hostname=host)
 
     # Send length-prefixed JWT
     jwt_bytes = jwt_token.encode()

--- a/truss/cli/train/ssh.py
+++ b/truss/cli/train/ssh.py
@@ -21,9 +21,17 @@ MARKER_END = "# --- end baseten-ssh ---"
 
 SSH_CONFIG_BLOCK_UNIX = """\
 {marker_start}
-Match host *.ssh.baseten.co exec "{python} {proxy_script} --sign %n"
+Match host training-job-*.ssh.baseten.co exec "{python} {proxy_script} --sign %n"
     ProxyCommand sh -c 'test -x "{python}" || {{ echo "baseten-ssh: Python not found at {python}. Please try re-running: truss train ssh setup" >&2; exit 127; }}; exec "{python}" "{proxy_script}" "$1"' -- %n
     User baseten
+    IdentityFile {key_path}
+    CertificateFile {cert_path}
+    StrictHostKeyChecking no
+    UserKnownHostsFile /dev/null
+
+Match host model-*.ssh.baseten.co exec "{python} {proxy_script} --sign %n"
+    ProxyCommand sh -c 'test -x "{python}" || {{ echo "baseten-ssh: Python not found at {python}. Please try re-running: truss train ssh setup" >&2; exit 127; }}; exec "{python}" "{proxy_script}" "$1"' -- %n
+    User app
     IdentityFile {key_path}
     CertificateFile {cert_path}
     StrictHostKeyChecking no
@@ -33,9 +41,17 @@ Match host *.ssh.baseten.co exec "{python} {proxy_script} --sign %n"
 
 SSH_CONFIG_BLOCK_WINDOWS = """\
 {marker_start}
-Match host *.ssh.baseten.co exec "{python} {proxy_script} --sign %n"
+Match host training-job-*.ssh.baseten.co exec "{python} {proxy_script} --sign %n"
     ProxyCommand cmd /c "if exist "{python}" ("{python}" "{proxy_script}" "%n") else (echo baseten-ssh: Python not found at {python}. Run: truss train ssh setup 1>&2)"
     User baseten
+    IdentityFile {key_path}
+    CertificateFile {cert_path}
+    StrictHostKeyChecking no
+    UserKnownHostsFile /dev/null
+
+Match host model-*.ssh.baseten.co exec "{python} {proxy_script} --sign %n"
+    ProxyCommand cmd /c "if exist "{python}" ("{python}" "{proxy_script}" "%n") else (echo baseten-ssh: Python not found at {python}. Run: truss train ssh setup 1>&2)"
+    User app
     IdentityFile {key_path}
     CertificateFile {cert_path}
     StrictHostKeyChecking no

--- a/truss/cli/train/ssh.py
+++ b/truss/cli/train/ssh.py
@@ -1,0 +1,214 @@
+"""SSH setup logic for `truss train ssh` commands."""
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+import truss
+
+BASETEN_SSH_DIR = Path.home() / ".ssh" / "baseten"
+SSH_CONFIG_PATH = Path.home() / ".ssh" / "config"
+
+MARKER_START = "# --- baseten-ssh ---"
+MARKER_END = "# --- end baseten-ssh ---"
+
+SSH_CONFIG_BLOCK_UNIX = """\
+{marker_start}
+Match host *.ssh.baseten.co exec "{python} {proxy_script} --sign %n"
+    ProxyCommand sh -c 'test -x "{python}" || {{ echo "baseten-ssh: Python not found at {python}. Please try re-running: truss train ssh setup" >&2; exit 127; }}; exec "{python}" "{proxy_script}" "$1"' -- %n
+    User baseten
+    IdentityFile {key_path}
+    CertificateFile {cert_path}
+    StrictHostKeyChecking no
+    UserKnownHostsFile /dev/null
+{marker_end}
+"""
+
+SSH_CONFIG_BLOCK_WINDOWS = """\
+{marker_start}
+Match host *.ssh.baseten.co exec "{python} {proxy_script} --sign %n"
+    ProxyCommand cmd /c "if exist "{python}" ("{python}" "{proxy_script}" "%n") else (echo baseten-ssh: Python not found at {python}. Run: truss train ssh setup 1>&2)"
+    User baseten
+    IdentityFile {key_path}
+    CertificateFile {cert_path}
+    StrictHostKeyChecking no
+    UserKnownHostsFile /dev/null
+{marker_end}
+"""
+
+PROXY_COMMAND_SOURCE = Path(__file__).parent / "proxy_command.py"
+
+
+def _resolve_python() -> str:
+    """Find a stable Python 3.10+ interpreter for the ProxyCommand.
+
+    System python3 on macOS can be as old as 3.9 with broken TLS 1.3
+    support. We prefer a system-wide install over a venv Python since
+    venvs can be deleted/recreated, breaking the hardcoded path.
+    """
+    min_version = (3, 10)
+
+    def _is_venv(path: str) -> bool:
+        return "/.venv/" in path or "/venv/" in path
+
+    def _check_version(path: str) -> bool:
+        try:
+            result = subprocess.run(
+                [
+                    path,
+                    "-c",
+                    "import sys; print(sys.version_info.major, sys.version_info.minor)",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if result.returncode == 0:
+                major, minor = result.stdout.strip().split()
+                return (int(major), int(minor)) >= min_version
+        except Exception:
+            pass
+        return False
+
+    # First: look for a system-wide Python 3.10+ (survives venv changes)
+    # Include "python" for Windows where "python3" doesn't exist,
+    # and "py" for the Windows Python Launcher.
+    candidates = [
+        "python3.13",
+        "python3.12",
+        "python3.11",
+        "python3.10",
+        "python3",
+        "python",
+    ]
+    if sys.platform == "win32":
+        candidates.append("py")
+
+    for name in candidates:
+        path = shutil.which(name)
+        if path and not _is_venv(path) and _check_version(path):
+            return path
+
+    raise RuntimeError(
+        "Could not find Python 3.10+ on your system. "
+        "Re-run with an explicit path: truss train ssh setup --python /path/to/python3"
+    )
+
+
+def ensure_ssh_keypair(key_dir: Path = BASETEN_SSH_DIR) -> Path:
+    """Generate SSH keypair if it doesn't exist. Returns private key path.
+
+    Prefers ed25519, falls back to RSA if ssh-keygen doesn't support it.
+    """
+    key_dir.mkdir(parents=True, exist_ok=True)
+    os.chmod(key_dir, 0o700)
+
+    for name in ("id_ed25519", "id_rsa"):
+        if (key_dir / name).exists():
+            return key_dir / name
+
+    key_path = key_dir / "id_ed25519"
+    result = subprocess.run(
+        [
+            "ssh-keygen",
+            "-t",
+            "ed25519",
+            "-f",
+            str(key_path),
+            "-N",
+            "",
+            "-C",
+            "baseten-training",
+            "-q",
+        ],
+        capture_output=True,
+    )
+    if result.returncode == 0:
+        return key_path
+
+    key_path = key_dir / "id_rsa"
+    subprocess.run(
+        [
+            "ssh-keygen",
+            "-t",
+            "rsa",
+            "-b",
+            "4096",
+            "-f",
+            str(key_path),
+            "-N",
+            "",
+            "-C",
+            "baseten-training",
+            "-q",
+        ],
+        check=True,
+    )
+    return key_path
+
+
+def install_proxy_command_script(key_dir: Path = BASETEN_SSH_DIR) -> Path:
+    """Install the proxy-command.py script to key_dir with the current truss version stamped in."""
+    key_dir.mkdir(parents=True, exist_ok=True)
+
+    source_content = PROXY_COMMAND_SOURCE.read_text()
+    stamped_content = source_content.replace("{{CLIENT_VERSION}}", truss.__version__)
+
+    dest = key_dir / "proxy-command.py"
+    dest.write_text(stamped_content)
+    os.chmod(dest, 0o700)
+    return dest
+
+
+def setup_ssh_config(
+    key_dir: Path = BASETEN_SSH_DIR,
+    key_path: Optional[Path] = None,
+    python_override: Optional[str] = None,
+) -> None:
+    """Add or replace the baseten-ssh block in ~/.ssh/config."""
+    SSH_CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+    proxy_script = key_dir / "proxy-command.py"
+    if key_path is None:
+        key_path = key_dir / "id_ed25519"
+    cert_path = key_path.parent / (key_path.name + "-cert.pub")
+
+    template = (
+        SSH_CONFIG_BLOCK_WINDOWS if sys.platform == "win32" else SSH_CONFIG_BLOCK_UNIX
+    )
+    block = template.format(
+        marker_start=MARKER_START,
+        marker_end=MARKER_END,
+        python=python_override or _resolve_python(),
+        proxy_script=proxy_script,
+        key_path=key_path,
+        cert_path=cert_path,
+    )
+
+    if SSH_CONFIG_PATH.exists():
+        existing = SSH_CONFIG_PATH.read_text()
+    else:
+        existing = ""
+
+    # Replace existing block or append
+    start_idx = existing.find(MARKER_START)
+    end_idx = existing.find(MARKER_END)
+
+    if start_idx != -1 and end_idx != -1:
+        new_content = (
+            existing[:start_idx] + block + existing[end_idx + len(MARKER_END) + 1 :]
+        )
+    else:
+        separator = "\n" if existing and not existing.endswith("\n") else ""
+        new_content = existing + separator + block
+
+    SSH_CONFIG_PATH.write_text(new_content)
+    os.chmod(SSH_CONFIG_PATH, 0o644)
+
+
+def is_setup_complete(key_dir: Path = BASETEN_SSH_DIR) -> bool:
+    """Check if SSH setup has been completed."""
+    return (key_dir / "proxy-command.py").exists() and (key_dir / "id_ed25519").exists()

--- a/truss/cli/train/ssh.py
+++ b/truss/cli/train/ssh.py
@@ -9,8 +9,12 @@ from typing import Optional
 
 import truss
 
-BASETEN_SSH_DIR = Path.home() / ".ssh" / "baseten"
-SSH_CONFIG_PATH = Path.home() / ".ssh" / "config"
+BASETEN_SSH_DIR = Path(
+    os.environ.get("BASETEN_SSH_DIR", Path.home() / ".ssh" / "baseten")
+)
+SSH_CONFIG_PATH = Path(
+    os.environ.get("BASETEN_SSH_CONFIG_PATH", Path.home() / ".ssh" / "config")
+)
 
 MARKER_START = "# --- baseten-ssh ---"
 MARKER_END = "# --- end baseten-ssh ---"

--- a/truss/cli/train_commands.py
+++ b/truss/cli/train_commands.py
@@ -1082,3 +1082,49 @@ def _patch_sessions(
         sys.exit(1)
 
     return messages
+
+
+@train.group(name="ssh")
+def ssh():
+    """SSH access to training jobs."""
+
+
+@ssh.command(name="setup")
+@click.option(
+    "--python",
+    "python_path",
+    type=str,
+    required=False,
+    help="Path to Python 3.10+ interpreter for the ProxyCommand. Auto-detected if omitted.",
+)
+@common.common_options()
+def ssh_setup(python_path: Optional[str]):
+    """One-time setup: configure SSH access for Baseten training jobs.
+
+    Generates an SSH keypair, installs a ProxyCommand script, and adds a
+    wildcard Host entry to ~/.ssh/config. After running this once, connect
+    to any running training job with:
+
+        ssh <job-id>-<replica>.<remote>.ssh.baseten.co
+
+    Example: ssh 5wo5n3y-0.dev.ssh.baseten.co
+    """
+    from truss.cli.train.ssh import (
+        ensure_ssh_keypair,
+        install_proxy_command_script,
+        setup_ssh_config,
+    )
+
+    key_path = ensure_ssh_keypair()
+    console.print(f"SSH keypair: {key_path}", style="dim")
+
+    proxy_script = install_proxy_command_script()
+    console.print(f"Proxy script: {proxy_script}", style="dim")
+
+    setup_ssh_config(key_path=key_path, python_override=python_path)
+    console.print("SSH config updated: ~/.ssh/config", style="dim")
+
+    console.print(
+        "\n[green]SSH access configured.[/green] Connect to any running training job with:\n\n"
+        "  ssh [bold]training-job-<job-id>-<node>.ssh.baseten.co[/bold]"
+    )

--- a/truss/config.schema.json
+++ b/truss/config.schema.json
@@ -653,6 +653,20 @@
       "title": "ModelServer",
       "type": "string"
     },
+    "RemoteSSH": {
+      "additionalProperties": true,
+      "description": "Configuration for SSH access to running model instances.",
+      "properties": {
+        "enabled": {
+          "default": false,
+          "description": "If true, enables SSH access to running model instances.",
+          "title": "Enabled",
+          "type": "boolean"
+        }
+      },
+      "title": "RemoteSSH",
+      "type": "object"
+    },
     "Resources": {
       "additionalProperties": true,
       "description": "Compute resources that your model needs, including CPU, memory, and GPU resources.",
@@ -787,6 +801,9 @@
         },
         "health_checks": {
           "$ref": "#/$defs/HealthChecks"
+        },
+        "remote_ssh": {
+          "$ref": "#/$defs/RemoteSSH"
         },
         "truss_server_version_override": {
           "anyOf": [

--- a/truss/contexts/image_builder/serving_image_builder.py
+++ b/truss/contexts/image_builder/serving_image_builder.py
@@ -787,6 +787,14 @@ class ServingImageBuilder(ImageBuilder):
         )
         (build_dir / SYSTEM_PACKAGES_TXT_FILENAME).write_text(spec.system_packages_txt)
 
+        remote_ssh = getattr(getattr(config, "runtime", None), "remote_ssh", None)
+        if remote_ssh is not None and remote_ssh.enabled:
+            self._copy_into_build_dir(
+                TEMPLATES_DIR / "baseten-ssh-server.sh",
+                build_dir,
+                "baseten-ssh-server.sh",
+            )
+
         # Copy constraints file to bound versions for user-overridden packages.
         self._copy_into_build_dir(
             SERVER_CODE_DIR / CONSTRAINTS_TXT_FILENAME,
@@ -898,6 +906,8 @@ class ServingImageBuilder(ImageBuilder):
         should_install_system_requirements = file_is_not_empty(
             build_dir / SYSTEM_PACKAGES_TXT_FILENAME
         )
+        remote_ssh = getattr(getattr(config, "runtime", None), "remote_ssh", None)
+        should_install_openssh_server = remote_ssh is not None and remote_ssh.enabled
         should_install_python_requirements = file_is_not_empty(
             build_dir / REQUIREMENTS_TXT_FILENAME
         )
@@ -926,6 +936,7 @@ class ServingImageBuilder(ImageBuilder):
             min_supported_python_minor_version_in_custom_base_image=min_py_version.minor,
             supported_python_major_version_in_custom_base_image=min_py_version.major,
             should_install_system_requirements=should_install_system_requirements,
+            should_install_openssh_server=should_install_openssh_server,
             should_install_requirements=should_install_python_requirements,
             requirements_file_type=config.requirements_file_type.value,
             config=config,

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -895,6 +895,15 @@ class BasetenApi:
         )
         return resp_json
 
+    def sign_ssh_certificate(
+        self, project_id: str, job_id: str, public_key: str, replica_id: str
+    ) -> dict:
+        resp_json = self._rest_api_client.post(
+            f"v1/training_projects/{project_id}/jobs/{job_id}/ssh/sign",
+            body={"public_key": public_key, "replica_id": replica_id},
+        )
+        return resp_json
+
     def _prepare_time_range_query(
         self,
         start_epoch_millis: Optional[int] = None,

--- a/truss/templates/base.Dockerfile.jinja
+++ b/truss/templates/base.Dockerfile.jinja
@@ -126,6 +126,7 @@ RUN apt-get update && apt-get install --yes --no-install-recommends openssh-serv
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/* \
     && chmod +x /usr/local/bin/baseten-ssh-server.sh \
+    && mkdir -p /run/sshd \
     && sed -i 's/^app:!/app:*/' /etc/shadow
     {%- endif %}
 {% endblock %}

--- a/truss/templates/base.Dockerfile.jinja
+++ b/truss/templates/base.Dockerfile.jinja
@@ -120,6 +120,14 @@ RUN apt-get update && apt-get install --yes --no-install-recommends $(cat {{ sys
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
     {%- endif %}
+    {%- if should_install_openssh_server %}
+COPY --chown={{ default_owner }} ./baseten-ssh-server.sh /usr/local/bin/baseten-ssh-server.sh
+RUN apt-get update && apt-get install --yes --no-install-recommends openssh-server \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/* \
+    && chmod +x /usr/local/bin/baseten-ssh-server.sh \
+    && sed -i 's/^app:!/app:*/' /etc/shadow
+    {%- endif %}
 {% endblock %}
 
 

--- a/truss/templates/baseten-ssh-server.sh
+++ b/truss/templates/baseten-ssh-server.sh
@@ -1,0 +1,101 @@
+#!/bin/sh
+
+# SSH server startup script for inference model containers.
+#
+# Starts an OpenSSH server configured for CA-based certificate authentication.
+# The SSH CA public key is mounted from a Kubernetes Secret. Users connect
+# with CA-signed certificates whose principal must match BT_SSH_SUBJECT.
+#
+# This script is designed for non-root containers where the "app" user
+# (uid 60000) already exists in the image. Unlike the training SSH script,
+# it does not create users, modify /etc/passwd, or install packages at
+# runtime. openssh-server must be pre-installed in the image.
+#
+# Environment variables (set by the operator template):
+#   BT_SSH_CA_KEY_PATH   - Path to the SSH CA public key file
+#   BT_SSH_SUBJECT       - Subject identifier (used as authorized principal)
+#   BT_SSH_DIR           - Directory for SSH runtime files (default: /run/baseten-ssh)
+
+_SSH_RESET="\033[0m"
+_SSH_CYAN="\033[36m"
+_SSH_GREEN="\033[32m"
+_SSH_YELLOW="\033[33m"
+_SSH_RED="\033[31m"
+
+_ssh_log()     { printf "${_SSH_CYAN}[baseten-ssh]${_SSH_RESET} %b\n" "$1"; }
+_ssh_log_ok()  { printf "${_SSH_CYAN}[baseten-ssh]${_SSH_RESET} ${_SSH_GREEN}%b${_SSH_RESET}\n" "$1"; }
+_ssh_log_warn() { printf "${_SSH_CYAN}[baseten-ssh]${_SSH_RESET} ${_SSH_YELLOW}WARNING: %b${_SSH_RESET}\n" "$1"; }
+_ssh_log_err() { printf "${_SSH_CYAN}[baseten-ssh]${_SSH_RESET} ${_SSH_RED}ERROR: %b${_SSH_RESET}\n" "$1"; }
+
+start_ssh_server() {
+    local ssh_port="${1:-2222}"
+    local ca_key_path="${BT_SSH_CA_KEY_PATH:-/etc/ssh-ca/ca.pub}"
+    local ssh_dir="${BT_SSH_DIR:-/run/baseten-ssh}"
+    local subject="${BT_SSH_SUBJECT:-}"
+
+    _ssh_log "Starting SSH server setup..."
+
+    if [ -z "$subject" ]; then
+        _ssh_log_err "BT_SSH_SUBJECT is not set. SSH server will not start."
+        return 1
+    fi
+
+    if [ ! -f "$ca_key_path" ]; then
+        _ssh_log_err "SSH CA public key not found at $ca_key_path. SSH server will not start."
+        return 1
+    fi
+
+    if ! command -v sshd >/dev/null 2>&1; then
+        _ssh_log_err "sshd not found. openssh-server must be installed in the image. SSH server will not start."
+        return 1
+    fi
+
+    mkdir -p "$ssh_dir"
+
+    if [ ! -f "$ssh_dir/bt_ssh_host_ed25519_key" ]; then
+        _ssh_log "Generating host keys..."
+        ssh-keygen -t ed25519 -f "$ssh_dir/bt_ssh_host_ed25519_key" -N "" -q
+        ssh-keygen -t rsa -b 4096 -f "$ssh_dir/bt_ssh_host_rsa_key" -N "" -q
+    fi
+
+    mkdir -p /run/sshd
+
+    echo "$subject" > "$ssh_dir/bt_authorized_principals"
+
+    local sftp_server=""
+    for path in /usr/lib/openssh/sftp-server /usr/lib/ssh/sftp-server /usr/libexec/openssh/sftp-server; do
+        if [ -f "$path" ]; then
+            sftp_server="$path"
+            break
+        fi
+    done
+    if [ -z "$sftp_server" ]; then
+        _ssh_log_warn "sftp-server not found, SFTP will not be available"
+    fi
+
+    cat > "$ssh_dir/bt_sshd_config" << SSHD_EOF
+Port $ssh_port
+HostKey $ssh_dir/bt_ssh_host_ed25519_key
+HostKey $ssh_dir/bt_ssh_host_rsa_key
+PidFile $ssh_dir/bt_sshd.pid
+TrustedUserCAKeys $ca_key_path
+AuthorizedPrincipalsFile $ssh_dir/bt_authorized_principals
+AllowUsers app
+StrictModes no
+PasswordAuthentication no
+KbdInteractiveAuthentication no
+PrintMotd no
+AcceptEnv LANG LC_*
+${sftp_server:+Subsystem sftp $sftp_server}
+SSHD_EOF
+
+    local sshd_bin
+    sshd_bin=$(command -v sshd)
+
+    _ssh_log "Starting SSH server on port $ssh_port (subject=$subject)..."
+    "$sshd_bin" -f "$ssh_dir/bt_sshd_config" -D -e &
+    BT_SSH_PID=$!
+    _ssh_log_ok "sshd started (subject=$subject)"
+}
+
+start_ssh_server "$@"

--- a/truss/templates/baseten-ssh-server.sh
+++ b/truss/templates/baseten-ssh-server.sh
@@ -58,8 +58,6 @@ start_ssh_server() {
         ssh-keygen -t rsa -b 4096 -f "$ssh_dir/bt_ssh_host_rsa_key" -N "" -q
     fi
 
-    mkdir -p /run/sshd
-
     echo "$subject" > "$ssh_dir/bt_authorized_principals"
 
     local sftp_server=""

--- a/truss/tests/cli/train/test_ssh.py
+++ b/truss/tests/cli/train/test_ssh.py
@@ -1,0 +1,281 @@
+from unittest import mock
+
+import pytest
+
+
+class TestParseHostname:
+    """Tests for proxy_command.parse_hostname."""
+
+    def _parse(self, hostname):
+        from truss.cli.train.proxy_command import parse_hostname
+
+        return parse_hostname(hostname)
+
+    def test_basic(self):
+        assert self._parse("training-job-5wo5n3y-0.dev.ssh.baseten.co") == (
+            "5wo5n3y",
+            "0",
+            "dev",
+            None,
+        )
+
+    def test_multi_digit_replica(self):
+        assert self._parse("training-job-abc1234-12.baseten.ssh.baseten.co") == (
+            "abc1234",
+            "12",
+            "baseten",
+            None,
+        )
+
+    def test_remote_with_dashes(self):
+        assert self._parse(
+            "training-job-5wo5n3y-0.my-custom-remote.ssh.baseten.co"
+        ) == ("5wo5n3y", "0", "my-custom-remote", None)
+
+    def test_staging_remote(self):
+        assert self._parse("training-job-abc1234-2.staging.ssh.baseten.co") == (
+            "abc1234",
+            "2",
+            "staging",
+            None,
+        )
+
+    def test_api_prefix(self):
+        assert self._parse("training-job-rwn61qy-0.dev.mc-dev.ssh.baseten.co") == (
+            "rwn61qy",
+            "0",
+            "dev",
+            "mc-dev",
+        )
+
+    def test_invalid_no_suffix(self):
+        with pytest.raises(SystemExit):
+            self._parse("training-job-5wo5n3y-0.dev.example.com")
+
+    def test_invalid_no_prefix(self):
+        with pytest.raises(SystemExit):
+            self._parse("5wo5n3y-0.dev.ssh.baseten.co")  # missing training-job- prefix
+
+    def test_no_remote(self):
+        assert self._parse("training-job-5wo5n3y-0.ssh.baseten.co") == (
+            "5wo5n3y",
+            "0",
+            None,
+            None,
+        )
+
+    def test_invalid_no_replica(self):
+        with pytest.raises(SystemExit):
+            self._parse("training-job-5wo5n3y.dev.ssh.baseten.co")  # no -node
+
+
+class TestLoadTrussrc:
+    """Tests for proxy_command.load_trussrc."""
+
+    def test_loads_remote(self, tmp_path):
+        from truss.cli.train.proxy_command import load_trussrc
+
+        rc = tmp_path / ".trussrc"
+        rc.write_text(
+            "[dev]\n"
+            "remote_provider = baseten\n"
+            "api_key = test-key-123\n"
+            "remote_url = https://app.dev.baseten.co\n"
+        )
+        with mock.patch("truss.cli.train.proxy_command.TRUSSRC_PATH", rc):
+            api_key, remote_url = load_trussrc("dev")
+        assert api_key == "test-key-123"
+        assert remote_url == "https://app.dev.baseten.co"
+
+    def test_missing_remote(self, tmp_path):
+        from truss.cli.train.proxy_command import load_trussrc
+
+        rc = tmp_path / ".trussrc"
+        rc.write_text("[baseten]\napi_key = x\nremote_url = y\n")
+        with mock.patch("truss.cli.train.proxy_command.TRUSSRC_PATH", rc):
+            with pytest.raises(SystemExit):
+                load_trussrc("nonexistent")
+
+    def test_missing_file(self, tmp_path):
+        from truss.cli.train.proxy_command import load_trussrc
+
+        with mock.patch(
+            "truss.cli.train.proxy_command.TRUSSRC_PATH", tmp_path / "nope"
+        ):
+            with pytest.raises(SystemExit):
+                load_trussrc("dev")
+
+
+class TestResolveRestApiUrl:
+    def test_default_is_prod(self):
+        from truss.cli.train.proxy_command import resolve_rest_api_url
+
+        assert resolve_rest_api_url() == "https://api.baseten.co"
+
+    def test_api_prefix(self):
+        from truss.cli.train.proxy_command import resolve_rest_api_url
+
+        assert resolve_rest_api_url("mc-dev") == "https://api.mc-dev.baseten.co"
+
+    def test_staging_prefix(self):
+        from truss.cli.train.proxy_command import resolve_rest_api_url
+
+        assert resolve_rest_api_url("staging") == "https://api.staging.baseten.co"
+
+
+class TestResolveRemote:
+    def test_explicit_remote_passthrough(self):
+        import configparser
+
+        from truss.cli.train.proxy_command import resolve_remote
+
+        config = configparser.ConfigParser()
+        config.read_string("[dev]\napi_key = x\n")
+        assert resolve_remote("dev", config) == "dev"
+
+    def test_single_remote_default(self):
+        import configparser
+
+        from truss.cli.train.proxy_command import resolve_remote
+
+        config = configparser.ConfigParser()
+        config.read_string("[dev]\napi_key = x\n")
+        assert resolve_remote(None, config) == "dev"
+
+    def test_multiple_remotes_errors(self):
+        import configparser
+
+        from truss.cli.train.proxy_command import resolve_remote
+
+        config = configparser.ConfigParser()
+        config.read_string("[dev]\napi_key = x\n\n[baseten]\napi_key = y\n")
+        with pytest.raises(SystemExit):
+            resolve_remote(None, config)
+
+
+class TestEnsureSSHKeypair:
+    def test_creates_keypair_ed25519(self, tmp_path):
+        from truss.cli.train.ssh import ensure_ssh_keypair
+
+        key_dir = tmp_path / "ssh" / "baseten"
+        mock_result = mock.Mock(returncode=0)
+        with mock.patch("subprocess.run", return_value=mock_result) as mock_run:
+            result = ensure_ssh_keypair(key_dir)
+            mock_run.assert_called_once()
+            args = mock_run.call_args[0][0]
+            assert args[0] == "ssh-keygen"
+            assert "ed25519" in args
+            assert result == key_dir / "id_ed25519"
+
+    def test_falls_back_to_rsa(self, tmp_path):
+        from truss.cli.train.ssh import ensure_ssh_keypair
+
+        key_dir = tmp_path / "ssh" / "baseten"
+        ed25519_fail = mock.Mock(returncode=1)
+        rsa_ok = mock.Mock(returncode=0)
+        with mock.patch(
+            "subprocess.run", side_effect=[ed25519_fail, rsa_ok]
+        ) as mock_run:
+            result = ensure_ssh_keypair(key_dir)
+            assert mock_run.call_count == 2
+            rsa_args = mock_run.call_args_list[1][0][0]
+            assert "rsa" in rsa_args
+            assert result == key_dir / "id_rsa"
+
+    def test_skips_existing_ed25519(self, tmp_path):
+        from truss.cli.train.ssh import ensure_ssh_keypair
+
+        key_dir = tmp_path / "ssh" / "baseten"
+        key_dir.mkdir(parents=True)
+        (key_dir / "id_ed25519").touch()
+
+        with mock.patch("subprocess.run") as mock_run:
+            result = ensure_ssh_keypair(key_dir)
+            mock_run.assert_not_called()
+            assert result == key_dir / "id_ed25519"
+
+    def test_skips_existing_rsa(self, tmp_path):
+        from truss.cli.train.ssh import ensure_ssh_keypair
+
+        key_dir = tmp_path / "ssh" / "baseten"
+        key_dir.mkdir(parents=True)
+        (key_dir / "id_rsa").touch()
+
+        with mock.patch("subprocess.run") as mock_run:
+            result = ensure_ssh_keypair(key_dir)
+            mock_run.assert_not_called()
+            assert result == key_dir / "id_rsa"
+
+
+class TestInstallProxyCommandScript:
+    def test_installs_with_version(self, tmp_path):
+        from truss.cli.train.ssh import install_proxy_command_script
+
+        key_dir = tmp_path / "ssh" / "baseten"
+        with mock.patch("truss.__version__", "1.2.3"):
+            dest = install_proxy_command_script(key_dir)
+
+        assert dest.exists()
+        content = dest.read_text()
+        assert 'CLIENT_VERSION = "1.2.3"' in content
+        assert "{{CLIENT_VERSION}}" not in content
+
+
+class TestSetupSSHConfig:
+    def test_creates_new_config(self, tmp_path):
+        from truss.cli.train.ssh import MARKER_END, MARKER_START, setup_ssh_config
+
+        ssh_config = tmp_path / "config"
+        key_dir = tmp_path / "baseten"
+        key_dir.mkdir()
+
+        with mock.patch("truss.cli.train.ssh.SSH_CONFIG_PATH", ssh_config):
+            setup_ssh_config(key_dir)
+
+        content = ssh_config.read_text()
+        assert MARKER_START in content
+        assert MARKER_END in content
+        assert "*.ssh.baseten.co" in content
+        assert "proxy-command.py" in content
+        assert "User baseten" in content
+
+    def test_replaces_existing_block(self, tmp_path):
+        from truss.cli.train.ssh import MARKER_END, MARKER_START, setup_ssh_config
+
+        ssh_config = tmp_path / "config"
+        key_dir = tmp_path / "baseten"
+        key_dir.mkdir()
+
+        ssh_config.write_text(
+            "Host other-server\n    User admin\n\n"
+            f"{MARKER_START}\nOLD BLOCK\n{MARKER_END}\n\n"
+            "Host another-server\n    User root\n"
+        )
+
+        with mock.patch("truss.cli.train.ssh.SSH_CONFIG_PATH", ssh_config):
+            setup_ssh_config(key_dir)
+
+        content = ssh_config.read_text()
+        assert content.count(MARKER_START) == 1
+        assert "OLD BLOCK" not in content
+        assert "Host other-server" in content
+        assert "Host another-server" in content
+        assert "*.ssh.baseten.co" in content
+
+    def test_preserves_other_entries(self, tmp_path):
+        from truss.cli.train.ssh import setup_ssh_config
+
+        ssh_config = tmp_path / "config"
+        key_dir = tmp_path / "baseten"
+        key_dir.mkdir()
+
+        existing = "Host myserver\n    User deploy\n    Port 2222\n"
+        ssh_config.write_text(existing)
+
+        with mock.patch("truss.cli.train.ssh.SSH_CONFIG_PATH", ssh_config):
+            setup_ssh_config(key_dir)
+
+        content = ssh_config.read_text()
+        assert "Host myserver" in content
+        assert "User deploy" in content
+        assert "Port 2222" in content

--- a/truss/tests/cli/train/test_ssh.py
+++ b/truss/tests/cli/train/test_ssh.py
@@ -11,42 +11,39 @@ class TestParseHostname:
 
         return parse_hostname(hostname)
 
-    def test_basic(self):
-        assert self._parse("training-job-5wo5n3y-0.dev.ssh.baseten.co") == (
-            "5wo5n3y",
-            "0",
-            "dev",
-            None,
-        )
+    def test_training_basic(self):
+        result = self._parse("training-job-5wo5n3y-0.dev.ssh.baseten.co")
+        assert result.workload_type == "training"
+        assert result.id == "5wo5n3y"
+        assert result.replica == "0"
+        assert result.remote == "dev"
+        assert result.api_prefix is None
 
-    def test_multi_digit_replica(self):
-        assert self._parse("training-job-abc1234-12.baseten.ssh.baseten.co") == (
-            "abc1234",
-            "12",
-            "baseten",
-            None,
-        )
+    def test_training_multi_digit_replica(self):
+        result = self._parse("training-job-abc1234-12.baseten.ssh.baseten.co")
+        assert result.workload_type == "training"
+        assert result.id == "abc1234"
+        assert result.replica == "12"
+        assert result.remote == "baseten"
 
-    def test_remote_with_dashes(self):
-        assert self._parse(
-            "training-job-5wo5n3y-0.my-custom-remote.ssh.baseten.co"
-        ) == ("5wo5n3y", "0", "my-custom-remote", None)
+    def test_training_remote_with_dashes(self):
+        result = self._parse("training-job-5wo5n3y-0.my-custom-remote.ssh.baseten.co")
+        assert result.id == "5wo5n3y"
+        assert result.replica == "0"
+        assert result.remote == "my-custom-remote"
 
-    def test_staging_remote(self):
-        assert self._parse("training-job-abc1234-2.staging.ssh.baseten.co") == (
-            "abc1234",
-            "2",
-            "staging",
-            None,
-        )
+    def test_training_staging_remote(self):
+        result = self._parse("training-job-abc1234-2.staging.ssh.baseten.co")
+        assert result.id == "abc1234"
+        assert result.replica == "2"
+        assert result.remote == "staging"
 
-    def test_api_prefix(self):
-        assert self._parse("training-job-rwn61qy-0.dev.mc-dev.ssh.baseten.co") == (
-            "rwn61qy",
-            "0",
-            "dev",
-            "mc-dev",
-        )
+    def test_training_api_prefix(self):
+        result = self._parse("training-job-rwn61qy-0.dev.mc-dev.ssh.baseten.co")
+        assert result.id == "rwn61qy"
+        assert result.replica == "0"
+        assert result.remote == "dev"
+        assert result.api_prefix == "mc-dev"
 
     def test_invalid_no_suffix(self):
         with pytest.raises(SystemExit):
@@ -56,17 +53,51 @@ class TestParseHostname:
         with pytest.raises(SystemExit):
             self._parse("5wo5n3y-0.dev.ssh.baseten.co")  # missing training-job- prefix
 
-    def test_no_remote(self):
-        assert self._parse("training-job-5wo5n3y-0.ssh.baseten.co") == (
-            "5wo5n3y",
-            "0",
-            None,
-            None,
-        )
+    def test_training_no_remote(self):
+        result = self._parse("training-job-5wo5n3y-0.ssh.baseten.co")
+        assert result.id == "5wo5n3y"
+        assert result.replica == "0"
+        assert result.remote is None
+        assert result.api_prefix is None
 
     def test_invalid_no_replica(self):
         with pytest.raises(SystemExit):
             self._parse("training-job-5wo5n3y.dev.ssh.baseten.co")  # no -node
+
+    def test_model_basic(self):
+        result = self._parse("model-abc123.ssh.baseten.co")
+        assert result.workload_type == "model"
+        assert result.id == "abc123"
+        assert result.environment is None
+        assert result.remote is None
+        assert result.replica is None
+
+    def test_model_with_environment(self):
+        result = self._parse("model-abc123-production.ssh.baseten.co")
+        assert result.workload_type == "model"
+        assert result.id == "abc123"
+        assert result.environment == "production"
+
+    def test_model_with_remote(self):
+        result = self._parse("model-abc123.dev.ssh.baseten.co")
+        assert result.id == "abc123"
+        assert result.remote == "dev"
+        assert result.environment is None
+
+    def test_model_with_env_and_remote(self):
+        result = self._parse("model-abc123-staging.dev.ssh.baseten.co")
+        assert result.id == "abc123"
+        assert result.environment == "staging"
+        assert result.remote == "dev"
+
+    def test_model_with_replica_env_var(self):
+        with mock.patch.dict("os.environ", {"BASETEN_REPLICA": "pod-abc-0"}):
+            result = self._parse("model-abc123.ssh.baseten.co")
+        assert result.replica == "pod-abc-0"
+
+    def test_model_invalid_empty_id(self):
+        with pytest.raises(SystemExit):
+            self._parse("model-.ssh.baseten.co")
 
 
 class TestLoadTrussrc:
@@ -235,9 +266,11 @@ class TestSetupSSHConfig:
         content = ssh_config.read_text()
         assert MARKER_START in content
         assert MARKER_END in content
-        assert "*.ssh.baseten.co" in content
+        assert "training-job-*.ssh.baseten.co" in content
+        assert "model-*.ssh.baseten.co" in content
         assert "proxy-command.py" in content
         assert "User baseten" in content
+        assert "User app" in content
 
     def test_replaces_existing_block(self, tmp_path):
         from truss.cli.train.ssh import MARKER_END, MARKER_START, setup_ssh_config
@@ -260,7 +293,8 @@ class TestSetupSSHConfig:
         assert "OLD BLOCK" not in content
         assert "Host other-server" in content
         assert "Host another-server" in content
-        assert "*.ssh.baseten.co" in content
+        assert "training-job-*.ssh.baseten.co" in content
+        assert "model-*.ssh.baseten.co" in content
 
     def test_preserves_other_entries(self, tmp_path):
         from truss.cli.train.ssh import setup_ssh_config

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.9, <3.15"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -3393,7 +3393,7 @@ wheels = [
 
 [[package]]
 name = "truss"
-version = "0.15.12"
+version = "0.15.13rc1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## :rocket: What

- Add SSH support for inference model containers (previously only training jobs) - leans-on/targets #2344 and includes #2363
- New `baseten-ssh-server.sh` script that can run non-root sshd in inference images
- Split SSH config into two Match blocks: `User baseten` for training, `User app` for inference
- Add `remote_ssh.enabled` + `docker_server.run_as_user_id` validation

## :computer: How

- `baseten-ssh-server.sh` in `truss/templates/`: runs sshd as the `app` user (uid 60000) using `AuthorizedPrincipalsFile`, with `StrictModes no` for compatibility
- `base.Dockerfile.jinja`: when `remote_ssh` enabled, copies script to `/usr/local/bin/`, installs openssh-server, fixes shadow entry (`!` to `*`) so sshd accepts cert auth without PAM
- `serving_image_builder.py`: copies `baseten-ssh-server.sh` to build dir when remote_ssh enabled
- `ssh.py`: two Match blocks in SSH config so training connects as `baseten` and inference connects as `app`
- `truss_config.py`: model validator rejects `remote_ssh.enabled` with custom `run_as_user_id`
- `proxy_command.py`: model hostname parsing + sign endpoint call updates

## :microscope: Testing

- Unit tests for hostname parsing (training + model), SSH config generation, key setup
- End to end tests done outside of this repo