### PR TITLE
feat(trainers): sampling client e2e example

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "truss"
-version = "0.15.12"
+version = "0.16.0"
 description = "A seamless bridge from model development to model delivery"
 authors = [
     { name = "Pankaj Gupta", email = "no-reply@baseten.co" },

--- a/trainers/examples/sample_prediction.py
+++ b/trainers/examples/sample_prediction.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Example: create a sampling client and get a prediction.
+
+Usage:
+    TRAINERS_BASE_URL=http://<worker-url> python sample_prediction.py
+    python sample_prediction.py --base-url http://<worker-url> --model Qwen/Qwen3-8B
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "trainers"))
+
+import trainers
+from trainers import EncodedTextChunk, ModelInput, SamplingParams
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Sample a prediction from a deployed model")
+    parser.add_argument("--base-url", help="Worker base URL (or set TRAINERS_BASE_URL)")
+    parser.add_argument("--model", default="Qwen/Qwen3-8B", help="HuggingFace model name")
+    parser.add_argument("--prompt", default="What is the capital of France?")
+    parser.add_argument("--max-tokens", type=int, default=200)
+    parser.add_argument("--temperature", type=float, default=0.7)
+    args = parser.parse_args()
+
+    # Create a sampling client (no training client needed)
+    service_client = trainers.ServiceClient(base_url=args.base_url)
+    sampling_client = service_client.create_sampling_client(base_model=args.model)
+
+    # Tokenize the prompt
+    print(f"Loading tokenizer for {args.model}...")
+    tokenizer = sampling_client.get_tokenizer()
+    tokens = tokenizer.encode(args.prompt, add_special_tokens=False)
+    print(f'Prompt: "{args.prompt}"')
+
+    # Get a prediction
+    print("Sampling...")
+    response = sampling_client.sample(
+        prompt=ModelInput(chunks=[EncodedTextChunk(tokens=tokens)]),
+        sampling_params=SamplingParams(
+            max_tokens=args.max_tokens,
+            temperature=args.temperature,
+        ),
+    )
+
+    # Decode and print
+    print()
+    for seq in response.sequences:
+        text = tokenizer.decode(seq.tokens, skip_special_tokens=True)
+        print(text)
+
+
+if __name__ == "__main__":
+    main()

--- a/trainers/trainers/sampling_client.py
+++ b/trainers/trainers/sampling_client.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from trainers.models import ModelInput, SampleResponse, SamplingParams
+import httpx
+
+from trainers.models import ModelInput, SamplingParams
+from trainers.training_client import SampleResult, _load_tokenizer
 
 
 class SamplingClient:
@@ -14,9 +17,18 @@ class SamplingClient:
     Supports pickling for use with multiprocessing.
     """
 
-    def __init__(self, base_url: str, *, api_key: str | None = None) -> None:
-        self._base_url = base_url
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        api_key: str | None = None,
+        base_model: str | None = None,
+        timeout: float = 300.0,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
         self._api_key = api_key
+        self._base_model = base_model
+        self._timeout = timeout
 
     def sample(
         self,
@@ -25,24 +37,49 @@ class SamplingClient:
         sampling_params: SamplingParams | None = None,
         include_prompt_logprobs: bool = False,
         topk_prompt_logprobs: int = 0,
-    ) -> SampleResponse:
+    ) -> SampleResult:
         """Generate text completions from a prompt."""
-        raise NotImplementedError("SamplingClient.sample() is not yet implemented")
+        body = {
+            "prompt": prompt.model_dump(mode="json"),
+            "num_samples": num_samples,
+            "sampling_params": (sampling_params or SamplingParams()).model_dump(mode="json"),
+        }
+        headers = {}
+        if self._api_key:
+            headers["Authorization"] = f"Bearer {self._api_key}"
+        with httpx.Client(timeout=self._timeout) as client:
+            resp = client.post(f"{self._base_url}/sample", json=body, headers=headers)
+            resp.raise_for_status()
+            return SampleResult.model_validate(resp.json())
 
     def compute_logprobs(self, prompt: ModelInput) -> list[float | None]:
         """Compute log-probabilities for each token in the prompt."""
         raise NotImplementedError("SamplingClient.compute_logprobs() is not yet implemented")
 
     def get_tokenizer(self):
-        """Return the tokenizer used by the model."""
-        raise NotImplementedError("SamplingClient.get_tokenizer() is not yet implemented")
+        """Return the tokenizer used by the model.
+
+        Requires base_model to be set via ServiceClient.create_sampling_client(base_model=...).
+        """
+        if self._base_model is None:
+            raise ValueError(
+                "base_model was not set. Pass base_model= to create_sampling_client()."
+            )
+        return _load_tokenizer(self._base_model)
 
     def close(self) -> None:
         pass
 
     def __getstate__(self):
-        return {"base_url": self._base_url, "api_key": self._api_key}
+        return {
+            "base_url": self._base_url,
+            "api_key": self._api_key,
+            "base_model": self._base_model,
+            "timeout": self._timeout,
+        }
 
     def __setstate__(self, state):
         self._base_url = state["base_url"]
         self._api_key = state["api_key"]
+        self._base_model = state.get("base_model")
+        self._timeout = state.get("timeout", 300.0)

--- a/trainers/trainers/service_client.py
+++ b/trainers/trainers/service_client.py
@@ -90,7 +90,7 @@ class ServiceClient:
             base_model: HuggingFace model ID for base model sampling.
             model_path: Path to saved weights for fine-tuned sampling.
         """
-        return SamplingClient(self._base_url, api_key=self._api_key)
+        return SamplingClient(self._base_url, api_key=self._api_key, base_model=base_model)
 
     def get_server_capabilities(self) -> dict:
         """Query the backend for supported features."""

--- a/trainers/trainers/service_client.py
+++ b/trainers/trainers/service_client.py
@@ -20,7 +20,7 @@ class ServiceClient:
 
     Configuration is read from environment variables:
         TRAINERS_BASE_URL — worker base URL (required)
-        TRAINERS_API_KEY  — API key for authentication (optional)
+        BASETEN_API_KEY   — API key for authentication (optional)
 
     Or pass base_url/api_key directly to __init__.
     """
@@ -32,7 +32,7 @@ class ServiceClient:
         api_key: str | None = None,
     ) -> None:
         self._base_url = base_url or os.environ.get("TRAINERS_BASE_URL", "")
-        self._api_key = api_key or os.environ.get("TRAINERS_API_KEY")
+        self._api_key = api_key or os.environ.get("BASETEN_API_KEY")
         if not self._base_url:
             raise ValueError(
                 "base_url is required. Pass it directly or set TRAINERS_BASE_URL."

--- a/truss-chains/truss_chains/deployment/deployment_client.py
+++ b/truss-chains/truss_chains/deployment/deployment_client.py
@@ -326,6 +326,9 @@ class DockerChainletService(b10_service.TrussService):
     def predict_url(self) -> str:
         return f"{self._service_url}/v1/models/model:predict"
 
+    def poll_deployment(self, sleep_secs: int = 1) -> Iterator[dict]:
+        raise NotImplementedError()
+
     def poll_deployment_status(self, sleep_secs: int = 1) -> Iterator[str]:
         raise NotImplementedError()
 

--- a/truss-train/truss_train/definitions.py
+++ b/truss-train/truss_train/definitions.py
@@ -209,7 +209,7 @@ class TrainingJob(custom_types.SafeModelNoExtra):
     workspace: Optional[Workspace] = None
     weights: List[truss_config.WeightsSource] = []
     """MDN weight sources to mount in the training container. Weights are mirrored and cached for fast startup."""
-    enable_baseten_workdir: bool = False
+    enable_baseten_workdir: bool = True
 
     @model_validator(mode="after")
     def _validate_weights_auth_only_custom_secret(self) -> "TrainingJob":

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -26,7 +26,7 @@ from truss.cli.resolvers.model_team_resolver import (
     resolve_model_team_name,
 )
 from truss.cli.utils import common, self_upgrade
-from truss.cli.utils.output import console, error_console
+from truss.cli.utils.output import console, error_console, json_command
 from truss.remote.baseten.core import (
     ACTIVE_STATUS,
     DEPLOYING_STATUSES,
@@ -673,7 +673,18 @@ def run_python(script, target_directory):
     default=False,
     help="Keep the development model warm by preventing scale-to-zero while watching. Requires --watch.",
 )
+@click.option(
+    "--output",
+    "output_format",
+    type=click.Choice(["text", "json"]),
+    default="text",
+    help=(
+        "Output format. 'json' emits structured JSON to stdout and "
+        "all other output (progress, logs) to stderr."
+    ),
+)
 @common.common_options()
+@json_command
 def push(
     target_directory: str,
     config: Optional[str],
@@ -698,6 +709,7 @@ def push(
     watch_hot_reload: bool = False,
     no_cache: bool = False,
     watch_no_sleep: bool = False,
+    output_format: str = "text",
 ) -> None:
     """
     Pushes a truss to a TrussRemote.
@@ -775,6 +787,8 @@ def push(
         include_git_info = user_config.settings.include_git_info
 
     remote_provider = RemoteFactory.create(remote=remote)
+    if output_format == "json" and isinstance(remote_provider, BasetenRemote):
+        remote_provider.api.suppress_error_print = True
 
     # model_name from CLI flag (explicit), or fall back to config
     cli_model_name = model_name  # what the user inputted for `--model-name`
@@ -893,7 +907,7 @@ def push(
         labels=labels_dict,
     )
 
-    click.echo(f"✨ Model {model_name} was successfully pushed ✨")
+    console.print(f"✨ Model {model_name} was successfully pushed ✨")
 
     if service.is_draft:
         draft_model_text = """
@@ -907,7 +921,7 @@ def push(
 |---------------------------------------------------------------------------------------|
 """
 
-        click.echo(draft_model_text)
+        console.print(draft_model_text)
 
     if environment:
         promotion_text = (
@@ -919,16 +933,18 @@ def push(
     console.print(
         f"🪵  View logs for your deployment at {common.format_link(service.logs_url)}"
     )
+    last_deployment = None
     if wait:
         start_time = time.time()
         with console.status("[bold green]Deploying...") as status:
-            for deployment_status in service.poll_deployment_status():
+            for deployment in service.poll_deployment():
+                last_deployment = deployment
+                deployment_status = deployment["status"]
                 if (
                     timeout_seconds is not None
                     and time.time() - start_time > timeout_seconds
                 ):
-                    console.print("Deployment timed out.", style="red")
-                    sys.exit(1)
+                    raise TimeoutError("Deployment timed out.")
 
                 status.update(
                     f"[bold green]Deploying...Current Status: {deployment_status}"
@@ -949,11 +965,11 @@ def push(
                     break
 
                 if deployment_status not in DEPLOYING_STATUSES:
-                    console.print(
-                        f"Deployment failed with status {deployment_status}.",
-                        style="red",
+                    exc = RuntimeError(
+                        f"Deployment failed with status {deployment_status}."
                     )
-                    sys.exit(1)
+                    setattr(exc, "json_data", {"deployment": deployment})
+                    raise exc
 
         # If --watch was used, start watching after deploy success
         if watch_after_push:
@@ -988,6 +1004,18 @@ def push(
         )
         for log in log_watcher.watch():
             cli_log_utils.output_log(log)
+
+    if output_format == "json" and isinstance(service, BasetenService):
+        result: dict = {
+            "model_id": service.model_id,
+            "model_version_id": service.model_version_id,
+            "predict_url": service.predict_url,
+            "logs_url": service.logs_url,
+            "is_draft": service.is_draft,
+        }
+        if last_deployment is not None:
+            result["deployment"] = last_deployment
+        print(json.dumps(result, indent=2), file=sys.stdout)
 
 
 @truss_cli.command()

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -691,9 +691,9 @@ def run_python(script, target_directory):
 )
 @click.option(
     "--watch-no-sleep",
-    is_flag=True,
+    type=bool,
     required=False,
-    default=False,
+    default=True,
     help="Keep the development model warm by preventing scale-to-zero while watching. Requires --watch.",
 )
 @click.option(
@@ -707,8 +707,10 @@ def run_python(script, target_directory):
     ),
 )
 @common.common_options()
+@click.pass_context
 @json_command
 def push(
+    ctx: click.Context,
     target_directory: str,
     config: Optional[str],
     remote: str,
@@ -731,7 +733,7 @@ def push(
     watch_after_push: bool = False,
     watch_hot_reload: bool = False,
     no_cache: bool = False,
-    watch_no_sleep: bool = False,
+    watch_no_sleep: bool = True,
     output_format: str = "text",
 ) -> None:
     """
@@ -745,11 +747,6 @@ def push(
         console.print(
             "[DEPRECATED] The --publish flag is deprecated. Published deployments are now the default.",
             style="yellow",
-        )
-
-    if watch_no_sleep and not watch_after_push:
-        raise click.UsageError(
-            "Cannot use --watch-no-sleep without --watch. --watch-no-sleep prevents scale-to-zero during watch mode."
         )
 
     # Handle --watch flag: deploys as development and then watches
@@ -772,6 +769,11 @@ def push(
     else:
         if watch_hot_reload:
             raise click.UsageError("--watch-hot-reload requires --watch.")
+        if (
+            ctx.get_parameter_source("watch_no_sleep")
+            != click.core.ParameterSource.DEFAULT  # type: ignore[attr-defined]
+        ):
+            raise click.UsageError("--watch-no-sleep requires --watch.")
         # Default is now published deployment
         publish = True
         console.print(
@@ -1090,8 +1092,8 @@ def model_logs(
 )
 @click.option(
     "--no-sleep",
-    is_flag=True,
-    default=False,
+    type=bool,
+    default=True,
     help="Keep the development model warm by preventing scale-to-zero while watching.",
 )
 @click.option(
@@ -1117,7 +1119,7 @@ def watch(
     config: Optional[str],
     remote: str,
     provided_team_name: Optional[str] = None,
-    no_sleep: bool = False,
+    no_sleep: bool = True,
     hot_reload: bool = False,
     model_name: Optional[str] = None,
     tail: bool = False,

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -2,6 +2,7 @@ import inspect
 import json
 import os
 import sys
+import threading
 import time
 from pathlib import Path
 from typing import Optional, cast
@@ -89,6 +90,28 @@ def _get_truss_from_directory(
 
     truss_dir = code_gen.gen_truss_model_from_source(Path(target_directory))
     return load(truss_dir, config_path=config_path)
+
+
+def _start_tail(
+    remote: BasetenRemote, model_id: str, version_id: str, in_background: bool
+) -> None:
+    log_watcher = ModelDeploymentLogWatcher(remote.api, model_id, version_id)
+
+    def _tail_logs():
+        try:
+            for log in log_watcher.watch(show_spinner=not in_background):
+                cli_log_utils.output_log(log)
+        except Exception as exc:
+            error_console.print(
+                f"[red]Log tailing stopped due to an error:[/red] {exc}"
+            )
+            raise
+
+    if in_background:
+        thread = threading.Thread(target=_tail_logs, daemon=True)
+        thread.start()
+    else:
+        _tail_logs()
 
 
 def _start_watch_mode(
@@ -643,7 +666,7 @@ def run_python(script, target_directory):
     help=(
         "Deploy as a development model and watch for changes. "
         "Waits for deployment to complete, then starts watching for code changes "
-        "to apply live patches. Cannot be used with --promote, --environment, or --tail."
+        "to apply live patches. Cannot be used with --promote or --environment."
     ),
 )
 @click.option(
@@ -743,8 +766,6 @@ def push(
             raise click.UsageError(
                 "Cannot use --watch with --environment. Watch mode runs a development deployment."
             )
-        if tail:
-            raise click.UsageError("Cannot use --watch with --tail.")
         # Development deployment for watch mode
         publish = False
         wait = True
@@ -756,11 +777,6 @@ def push(
         console.print(
             "Deploying as a published deployment. Use --watch for a development deployment.",
             style="green",
-        )
-
-    if wait and tail:
-        raise click.UsageError(
-            "Cannot use --wait with --tail. Use --tail by itself to wait for deployment and tail logs."
         )
 
     tr = _get_truss_from_directory(target_directory=target_directory, config=config)
@@ -933,6 +949,17 @@ def push(
     console.print(
         f"🪵  View logs for your deployment at {common.format_link(service.logs_url)}"
     )
+
+    if tail and isinstance(service, BasetenService):
+        # When combined with --wait/--watch, tail runs in background so the
+        # wait polling loop below can proceed on the main thread.
+        _start_tail(
+            cast(BasetenRemote, remote_provider),
+            service.model_id,
+            service.model_version_id,
+            in_background=wait,
+        )
+
     last_deployment = None
     if wait:
         start_time = time.time()
@@ -996,14 +1023,6 @@ def push(
                 error_console=error_console,
                 hot_reload=watch_hot_reload,
             )
-
-    elif tail and isinstance(service, BasetenService):
-        bt_remote = cast(BasetenRemote, remote_provider)
-        log_watcher = ModelDeploymentLogWatcher(
-            bt_remote.api, service.model_id, service.model_version_id
-        )
-        for log in log_watcher.watch():
-            cli_log_utils.output_log(log)
 
     if output_format == "json" and isinstance(service, BasetenService):
         result: dict = {
@@ -1091,6 +1110,7 @@ def model_logs(
     required=False,
     help="Temporarily override the name of the model",
 )
+@click.option("--tail", is_flag=True, help="Tail logs while watching.")
 @common.common_options()
 def watch(
     target_directory: str,
@@ -1100,6 +1120,7 @@ def watch(
     no_sleep: bool = False,
     hot_reload: bool = False,
     model_name: Optional[str] = None,
+    tail: bool = False,
 ) -> None:
     """
     Seamless remote development with truss
@@ -1163,6 +1184,9 @@ def watch(
 
     if no_sleep:
         common.start_keepalive(model_hostname, api_key)
+
+    if tail:
+        _start_tail(remote_provider, model_id, dev_version_id, in_background=True)
 
     # Re-resolve the model to get the latest version and truss hash and latest push before watching
     resolved_model, versions = resolve_model_for_watch(

--- a/truss/cli/logs/base_watcher.py
+++ b/truss/cli/logs/base_watcher.py
@@ -1,3 +1,4 @@
+import contextlib
 import hashlib
 import time
 from abc import ABC, abstractmethod
@@ -64,9 +65,13 @@ class LogWatcher(ABC):
 
         self._last_poll_time_ms = now_ms
 
-    def watch(self) -> Iterator[ParsedLog]:
+    def watch(self, show_spinner: bool = True) -> Iterator[ParsedLog]:
         self.before_polling()
-        with console.status("Polling logs", spinner="aesthetic"):
+        with (
+            console.status("Polling logs", spinner="aesthetic")
+            if show_spinner
+            else contextlib.nullcontext()
+        ):
             while True:
                 for log in self.poll():
                     yield log

--- a/truss/cli/utils/output.py
+++ b/truss/cli/utils/output.py
@@ -1,3 +1,10 @@
+import contextlib
+import functools
+import json
+import sys
+from typing import Any, Dict
+
+import requests
 import rich
 import rich.live
 import rich.logging
@@ -5,6 +12,8 @@ import rich.spinner
 import rich.table
 import rich.traceback
 from rich.console import Console
+
+from truss.remote.baseten.error import ApiError
 
 rich.spinner.SPINNERS["deploying"] = {"interval": 500, "frames": ["👾 ", " 👾"]}
 rich.spinner.SPINNERS["building"] = {"interval": 500, "frames": ["🛠️ ", " 🛠️"]}
@@ -15,3 +24,70 @@ rich.spinner.SPINNERS["failed"] = {"interval": 500, "frames": ["😤 ", " 😤"]
 
 console = Console()
 error_console = Console(stderr=True, style="bold red")
+
+
+def json_command(fn):
+    """Decorator for CLI commands that support --output json.
+
+    When output_format="json", redirects console to stderr and catches
+    exceptions to emit structured JSON errors to stdout.
+    In text mode, behaves as a passthrough.
+    """
+
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        output_format = kwargs.get("output_format", "text")
+        if output_format != "json":
+            return fn(*args, **kwargs)
+
+        with console_to_stderr():
+            try:
+                return fn(*args, **kwargs)
+            except Exception as exc:
+                print(json.dumps(_format_json_error(exc)), file=sys.stdout)
+                print(f"Error: {exc}", file=sys.stderr)
+                sys.exit(1)
+
+    return wrapper
+
+
+@contextlib.contextmanager
+def console_to_stderr():
+    """Redirect all Rich consoles to stderr.
+
+    Redirects both the module-level console and Rich's global console
+    (used by RichHandler for logging and by progress bars).
+    Used in JSON output mode so stdout is reserved for structured JSON.
+    """
+    global_console = rich.get_console()
+    original = console.stderr
+    original_global = global_console.stderr
+    console.stderr = True
+    global_console.stderr = True
+    try:
+        yield
+    finally:
+        console.stderr = original
+        global_console.stderr = original_global
+
+
+def _format_json_error(exc: Exception) -> Dict[str, Any]:
+    """Format an exception as a JSON-serializable error dict."""
+    error: Dict[str, Any] = {"message": str(exc)}
+
+    if isinstance(exc, requests.HTTPError) and exc.response is not None:
+        error["status_code"] = exc.response.status_code
+        try:
+            error["response_body"] = exc.response.json()
+        except ValueError:
+            error["response_body"] = exc.response.text
+    elif isinstance(exc, ApiError):
+        error["message"] = exc.message
+        if exc.graphql_error_code:
+            error["error_code"] = exc.graphql_error_code
+
+    # Include any additional data attached to the exception.
+    if hasattr(exc, "json_data") and exc.json_data:
+        error.update(exc.json_data)
+
+    return {"error": error}

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -149,6 +149,14 @@ class BasetenApi:
     def auth_token(self) -> ApiKey:
         return self._auth_token
 
+    @property
+    def suppress_error_print(self) -> bool:
+        return self._rest_api_client.suppress_error_print
+
+    @suppress_error_print.setter
+    def suppress_error_print(self, value: bool) -> None:
+        self._rest_api_client.suppress_error_print = value
+
     def _post_graphql_query(self, query: str, variables: Optional[dict] = None) -> dict:
         headers = self._auth_token.header()
         payload: Dict[str, Any] = {"query": query}

--- a/truss/remote/baseten/rest_client.py
+++ b/truss/remote/baseten/rest_client.py
@@ -10,12 +10,13 @@ class RestAPIClient:
     def __init__(self, base_url: str, headers: Dict[str, str]):
         self.base_url = base_url
         self.headers = headers
+        self.suppress_error_print = False
 
     def _handle_error(self, resp: requests.Response):
         if 400 <= resp.status_code < 500:
             try:
                 data = resp.json()
-                if "message" in data:
+                if "message" in data and not self.suppress_error_print:
                     print(f"Client error: {data['message']}")
             except ValueError:
                 pass

--- a/truss/remote/baseten/service.py
+++ b/truss/remote/baseten/service.py
@@ -163,15 +163,17 @@ class BasetenService(TrussService):
     def _fetch_deployment(self) -> Any:
         return self._api.get_deployment(self.model_id, self.model_version_id)
 
-    def poll_deployment_status(self, sleep_secs: int = 1) -> Iterator[str]:
-        """
-        Wait for the service to be deployed.
-        """
+    def poll_deployment(self, sleep_secs: int = 1) -> Iterator[Dict[str, Any]]:
+        """Poll for deployment, yielding the full deployment dict."""
         while True:
             time.sleep(sleep_secs)
             try:
-                deployment = self._fetch_deployment()
-                yield deployment["status"]
+                yield self._fetch_deployment()
             except requests.exceptions.RequestException:
                 logger.warning("Network error, unable to reach Baseten. Retrying...")
                 continue
+
+    def poll_deployment_status(self, sleep_secs: int = 1) -> Iterator[str]:
+        """Poll for deployment status, yielding only the status string."""
+        for deployment in self.poll_deployment(sleep_secs):
+            yield deployment["status"]

--- a/truss/remote/truss_remote.py
+++ b/truss/remote/truss_remote.py
@@ -176,6 +176,13 @@ class TrussService(ABC):
         pass
 
     @abstractmethod
+    def poll_deployment(self, sleep_secs: int = 1) -> Iterator[Dict[str, Any]]:
+        """
+        Poll for a deployment, yielding the full deployment dict.
+        """
+        pass
+
+    @abstractmethod
     def poll_deployment_status(self, sleep_secs: int = 1) -> Iterator[str]:
         """
         Poll for a deployment status.

--- a/truss/tests/cli/test_cli.py
+++ b/truss/tests/cli/test_cli.py
@@ -1,3 +1,4 @@
+import json
 import threading
 from unittest.mock import MagicMock, Mock, patch
 
@@ -8,6 +9,7 @@ from click.testing import CliRunner
 from truss.cli.cli import truss_cli
 from truss.cli.utils import common
 from truss.remote.baseten.custom_types import OidcInfo, OidcTeamInfo
+from truss.remote.baseten.service import BasetenService
 from truss.remote.truss_remote import RemoteUser
 
 
@@ -786,7 +788,7 @@ def test_push_watch_creates_development_deployment(
     mock_service = MagicMock()
     mock_service.is_draft = True
     mock_service.logs_url = "https://example.com/logs"
-    mock_service.poll_deployment_status.return_value = iter(["MODEL_READY"])
+    mock_service.poll_deployment.return_value = iter([{"status": "MODEL_READY"}])
     remote.push = Mock(return_value=mock_service)
 
     with patch("truss.cli.cli.RemoteFactory.create", return_value=remote):
@@ -986,7 +988,7 @@ def test_push_watch_no_sleep_starts_keepalive(
     mock_service = MagicMock()
     mock_service.is_draft = True
     mock_service.logs_url = "https://example.com/logs"
-    mock_service.poll_deployment_status.return_value = iter(["LOADING_MODEL"])
+    mock_service.poll_deployment.return_value = iter([{"status": "LOADING_MODEL"}])
     remote.push = Mock(return_value=mock_service)
 
     mock_resolve = Mock(
@@ -1078,8 +1080,8 @@ def test_push_watch_enters_watch_mode_on_deploying_status(
     mock_service.is_draft = True
     mock_service.logs_url = "https://example.com/logs"
     # Simulate: BUILDING -> LOADING_MODEL — never reaches ACTIVE
-    mock_service.poll_deployment_status.return_value = iter(
-        ["BUILDING", "LOADING_MODEL"]
+    mock_service.poll_deployment.return_value = iter(
+        [{"status": "BUILDING"}, {"status": "LOADING_MODEL"}]
     )
     remote.push = Mock(return_value=mock_service)
 
@@ -1126,8 +1128,8 @@ def test_push_watch_still_exits_on_deploy_failed(
     mock_service = MagicMock()
     mock_service.is_draft = True
     mock_service.logs_url = "https://example.com/logs"
-    mock_service.poll_deployment_status.return_value = iter(
-        ["BUILDING", "DEPLOY_FAILED"]
+    mock_service.poll_deployment.return_value = iter(
+        [{"status": "BUILDING"}, {"status": "DEPLOY_FAILED"}]
     )
     remote.push = Mock(return_value=mock_service)
 
@@ -1221,3 +1223,91 @@ def test_watch_model_name_flag_overrides_config(
     # The flag value should be used, not the config value
     first_call_args = mock_resolve.call_args_list[0]
     assert first_call_args[0][1] == "flag-name"
+
+
+def _make_mock_service(**overrides):
+    mock_service = MagicMock(spec=BasetenService)
+    mock_service.is_draft = False
+    mock_service.model_id = "model_id"
+    mock_service.model_version_id = "version_id"
+    mock_service.predict_url = (
+        "https://model.api.baseten.co/deployment/version_id/predict"
+    )
+    mock_service.logs_url = "https://app.baseten.co/models/model_id/logs/version_id"
+    for k, v in overrides.items():
+        setattr(mock_service, k, v)
+    return mock_service
+
+
+def _invoke_push_json(runner, truss_dir, remote, extra_args=None):
+    args = [
+        "push",
+        str(truss_dir),
+        "--remote",
+        "baseten",
+        "--model-name",
+        "model_name",
+        "--output",
+        "json",
+    ]
+    if extra_args:
+        args.extend(extra_args)
+
+    with patch("truss.cli.cli.RemoteFactory.create", return_value=remote):
+        remote.api.get_teams = Mock(return_value={})
+        with patch("truss.cli.cli.resolve_model_team_name", return_value=(None, None)):
+            return runner.invoke(truss_cli, args)
+
+
+def test_push_json_output_success(custom_model_truss_dir_with_pre_and_post, remote):
+    runner = CliRunner()
+    remote.push = Mock(return_value=_make_mock_service())
+    result = _invoke_push_json(runner, custom_model_truss_dir_with_pre_and_post, remote)
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["model_id"] == "model_id"
+    assert data["model_version_id"] == "version_id"
+    assert "predict_url" in data
+    assert "logs_url" in data
+    assert data["is_draft"] is False
+    assert "deployment" not in data
+
+
+def test_push_json_output_wait_success(
+    custom_model_truss_dir_with_pre_and_post, remote
+):
+    runner = CliRunner()
+    deployment_response = {"status": "ACTIVE", "id": "deploy_id", "replicas": 1}
+    mock_service = _make_mock_service()
+    mock_service.poll_deployment.return_value = iter([deployment_response])
+    remote.push = Mock(return_value=mock_service)
+    result = _invoke_push_json(
+        runner, custom_model_truss_dir_with_pre_and_post, remote, ["--wait"]
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["model_id"] == "model_id"
+    assert data["deployment"] == deployment_response
+
+
+def test_push_json_output_wait_deploy_failed(
+    custom_model_truss_dir_with_pre_and_post, remote
+):
+    runner = CliRunner()
+    failed_deployment = {"status": "DEPLOY_FAILED", "id": "deploy_id", "error": "OOM"}
+    mock_service = _make_mock_service()
+    mock_service.poll_deployment.return_value = iter(
+        [{"status": "BUILDING"}, failed_deployment]
+    )
+    remote.push = Mock(return_value=mock_service)
+    result = _invoke_push_json(
+        runner, custom_model_truss_dir_with_pre_and_post, remote, ["--wait"]
+    )
+
+    assert result.exit_code == 1
+    data = json.loads(result.stdout)
+    assert "error" in data
+    assert "DEPLOY_FAILED" in data["error"]["message"]
+    assert data["error"]["deployment"] == failed_deployment

--- a/truss/tests/cli/test_cli.py
+++ b/truss/tests/cli/test_cli.py
@@ -270,11 +270,13 @@ def test_watch_sends_wake_request():
         with patch("truss.cli.utils.common.requests_lib") as mock_requests:
             mock_requests.post.return_value = Mock(status_code=202)
             mock_requests.RequestException = requests.RequestException
-            with patch.object(remote_provider, "sync_truss_to_dev_version_with_model"):
-                _result = runner.invoke(
-                    truss_cli,
-                    ["watch", "/tmp/fake", "--remote", "baseten"],  # No --no-sleep
-                )
+            with patch("truss.cli.utils.common.start_keepalive"):
+                with patch.object(
+                    remote_provider, "sync_truss_to_dev_version_with_model"
+                ):
+                    _result = runner.invoke(
+                        truss_cli, ["watch", "/tmp/fake", "--remote", "baseten"]
+                    )
 
     mock_requests.post.assert_called_once_with(
         "https://model-abc123.api.baseten.co/development/wake",
@@ -284,7 +286,7 @@ def test_watch_sends_wake_request():
 
 
 def test_watch_no_sleep_starts_keepalive_thread():
-    """--no-sleep should start a daemon keepalive thread after model is ready."""
+    """No-sleep is default, so keepalive thread should start without explicit flag."""
     resolved_model, versions, dev_version, mock_tr, remote_provider = (
         _make_watch_mocks()
     )
@@ -304,8 +306,7 @@ def test_watch_no_sleep_starts_keepalive_thread():
                     remote_provider, "sync_truss_to_dev_version_with_model"
                 ):
                     _result = runner.invoke(
-                        truss_cli,
-                        ["watch", "/tmp/fake", "--remote", "baseten", "--no-sleep"],
+                        truss_cli, ["watch", "/tmp/fake", "--remote", "baseten"]
                     )
 
     mock_thread_cls.assert_called_once()
@@ -376,8 +377,7 @@ def test_watch_no_sleep_waits_for_active_status():
                     remote_provider, "sync_truss_to_dev_version_with_model"
                 ):
                     result = runner.invoke(
-                        truss_cli,
-                        ["watch", "/tmp/fake", "--remote", "baseten", "--no-sleep"],
+                        truss_cli, ["watch", "/tmp/fake", "--remote", "baseten"]
                     )
 
     assert result.exit_code == 0
@@ -399,7 +399,7 @@ def test_watch_no_sleep_exits_on_failed_deployment():
             mock_requests.post.return_value = Mock(status_code=202)
             mock_requests.RequestException = requests.RequestException
             result = runner.invoke(
-                truss_cli, ["watch", "/tmp/fake", "--remote", "baseten", "--no-sleep"]
+                truss_cli, ["watch", "/tmp/fake", "--remote", "baseten"]
             )
 
     assert result.exit_code != 0
@@ -407,7 +407,7 @@ def test_watch_no_sleep_exits_on_failed_deployment():
 
 
 def test_watch_without_no_sleep_does_not_start_thread():
-    """Without --no-sleep, no keepalive thread should be started."""
+    """With --no-sleep=false, no keepalive thread should be started."""
     resolved_model, versions, dev_version, mock_tr, remote_provider = (
         _make_watch_mocks()
     )
@@ -426,7 +426,14 @@ def test_watch_without_no_sleep_does_not_start_thread():
                     remote_provider, "sync_truss_to_dev_version_with_model"
                 ):
                     _result = runner.invoke(
-                        truss_cli, ["watch", "/tmp/fake", "--remote", "baseten"]
+                        truss_cli,
+                        [
+                            "watch",
+                            "/tmp/fake",
+                            "--remote",
+                            "baseten",
+                            "--no-sleep=false",
+                        ],
                     )
 
     mock_start_keepalive.assert_not_called()
@@ -1014,15 +1021,14 @@ def test_push_watch_no_sleep_without_watch_fails():
                 "remote1",
                 "--model-name",
                 "name",
-                "--watch-no-sleep",
+                "--watch-no-sleep=false",
             ],
         )
 
     assert result.exit_code != 0
-    assert "Cannot use --watch-no-sleep without --watch" in result.output or (
+    assert "--watch-no-sleep requires --watch" in result.output or (
         result.exception
-        and "Cannot use --watch-no-sleep without --watch"
-        in str(result.exception.__context__)
+        and "--watch-no-sleep requires --watch" in str(result.exception.__context__)
     )
 
 
@@ -1033,7 +1039,7 @@ def test_push_watch_no_sleep_starts_keepalive(
     mock_upload_truss,
     mock_create_truss_service,
 ):
-    """Test that --watch --no-sleep starts the keepalive thread before entering watch mode."""
+    """Test that --watch starts the keepalive thread by default before entering watch mode."""
     runner = CliRunner()
 
     mock_service = MagicMock()
@@ -1073,7 +1079,6 @@ def test_push_watch_no_sleep_starts_keepalive(
                                 "--model-name",
                                 "model_name",
                                 "--watch",
-                                "--watch-no-sleep",
                             ],
                         )
 
@@ -1148,7 +1153,11 @@ def test_push_watch_enters_watch_mode_on_deploying_status(
 
     mock_resolve = Mock(
         return_value=(
-            {"id": "model_id", "name": "model_name"},
+            {
+                "id": "model_id",
+                "name": "model_name",
+                "hostname": "https://model.api.baseten.co",
+            },
             [{"id": "version_id", "is_draft": True}],
         )
     )
@@ -1159,18 +1168,19 @@ def test_push_watch_enters_watch_mode_on_deploying_status(
         with patch("truss.cli.cli.resolve_model_team_name", return_value=(None, None)):
             with patch("truss.cli.cli.resolve_model_for_watch", mock_resolve):
                 with patch("truss.cli.cli._start_watch_mode", mock_start_watch):
-                    result = runner.invoke(
-                        truss_cli,
-                        [
-                            "push",
-                            str(custom_model_truss_dir_with_pre_and_post),
-                            "--remote",
-                            "baseten",
-                            "--model-name",
-                            "model_name",
-                            "--watch",
-                        ],
-                    )
+                    with patch("truss.cli.cli.common.start_keepalive"):
+                        result = runner.invoke(
+                            truss_cli,
+                            [
+                                "push",
+                                str(custom_model_truss_dir_with_pre_and_post),
+                                "--remote",
+                                "baseten",
+                                "--model-name",
+                                "model_name",
+                                "--watch",
+                            ],
+                        )
 
     assert result.exit_code == 0
     mock_start_watch.assert_called_once()
@@ -1266,20 +1276,21 @@ def test_watch_model_name_flag_overrides_config(
             with patch("truss.cli.utils.common.requests_lib") as mock_requests:
                 mock_requests.post.return_value = Mock(status_code=202)
                 mock_requests.RequestException = __import__("requests").RequestException
-                with patch.object(
-                    remote_provider, "sync_truss_to_dev_version_with_model"
-                ):
-                    runner.invoke(
-                        truss_cli,
-                        [
-                            "watch",
-                            "/tmp/fake",
-                            "--remote",
-                            "baseten",
-                            "--model-name",
-                            "flag-name",
-                        ],
-                    )
+                with patch("truss.cli.utils.common.start_keepalive"):
+                    with patch.object(
+                        remote_provider, "sync_truss_to_dev_version_with_model"
+                    ):
+                        runner.invoke(
+                            truss_cli,
+                            [
+                                "watch",
+                                "/tmp/fake",
+                                "--remote",
+                                "baseten",
+                                "--model-name",
+                                "flag-name",
+                            ],
+                        )
 
     # The flag value should be used, not the config value
     first_call_args = mock_resolve.call_args_list[0]

--- a/truss/tests/cli/test_cli.py
+++ b/truss/tests/cli/test_cli.py
@@ -432,6 +432,34 @@ def test_watch_without_no_sleep_does_not_start_thread():
     mock_start_keepalive.assert_not_called()
 
 
+def test_watch_with_tail_starts_background_tail():
+    """Test that watch --tail starts tail in background."""
+    resolved_model, versions, dev_version, mock_tr, remote_provider = (
+        _make_watch_mocks()
+    )
+    runner = CliRunner()
+
+    with _patch_watch_common(
+        remote_provider, mock_tr, resolved_model, versions, dev_version
+    ):
+        with patch("truss.cli.utils.common.requests_lib") as mock_requests:
+            mock_requests.post.return_value = Mock(status_code=202)
+            mock_requests.RequestException = requests.RequestException
+            with patch("truss.cli.cli._start_tail") as mock_start_tail:
+                with patch.object(
+                    remote_provider, "sync_truss_to_dev_version_with_model"
+                ):
+                    result = runner.invoke(
+                        truss_cli,
+                        ["watch", "/tmp/fake", "--remote", "baseten", "--tail"],
+                    )
+
+    assert result.exit_code == 0, result.output
+    mock_start_tail.assert_called_once_with(
+        remote_provider, "model_id", "dev_version_id", in_background=True
+    )
+
+
 def test_keepalive_loop_continues_before_max_duration():
     """Keepalive loop should keep running before 24 hours."""
     stop_event = threading.Event()
@@ -879,35 +907,58 @@ def test_push_watch_with_environment_fails():
     )
 
 
-def test_push_watch_with_tail_fails():
-    """Test that --watch with --tail fails."""
-    mock_truss = Mock()
-    mock_truss.spec.config.runtime.transport.kind = "http"
-    mock_truss.spec.config.resources.instance_type = None
-    mock_truss.spec.config.build = None
-    mock_truss.spec.config.trt_llm = None
-
+def test_push_watch_with_tail_starts_background_tail(
+    custom_model_truss_dir_with_pre_and_post,
+    remote,
+    mock_baseten_requests,
+    mock_upload_truss,
+    mock_create_truss_service,
+):
+    """Test that --watch with --tail starts tail in background."""
     runner = CliRunner()
 
-    with patch("truss.cli.cli._get_truss_from_directory", return_value=mock_truss):
-        result = runner.invoke(
-            truss_cli,
-            [
-                "push",
-                "test_truss",
-                "--remote",
-                "remote1",
-                "--model-name",
-                "name",
-                "--watch",
-                "--tail",
-            ],
-        )
+    mock_service = MagicMock(spec=BasetenService)
+    mock_service.is_draft = True
+    mock_service.logs_url = "https://example.com/logs"
+    mock_service.model_id = "model_id"
+    mock_service.model_version_id = "version_id"
+    mock_service.poll_deployment.return_value = iter([{"status": "LOADING_MODEL"}])
+    remote.push = Mock(return_value=mock_service)
 
-    assert result.exit_code == 2
-    assert "Cannot use --watch with --tail" in result.output or (
-        result.exception
-        and "Cannot use --watch with --tail" in str(result.exception.__context__)
+    mock_resolve = Mock(
+        return_value=(
+            {
+                "id": "model_id",
+                "name": "model_name",
+                "hostname": "https://model.api.baseten.co",
+            },
+            [{"id": "version_id", "is_draft": True}],
+        )
+    )
+
+    with patch("truss.cli.cli.RemoteFactory.create", return_value=remote):
+        remote.api.get_teams = Mock(return_value={})
+        with patch("truss.cli.cli.resolve_model_team_name", return_value=(None, None)):
+            with patch("truss.cli.cli.resolve_model_for_watch", mock_resolve):
+                with patch("truss.cli.cli._start_watch_mode"):
+                    with patch("truss.cli.cli._start_tail") as mock_start_tail:
+                        result = runner.invoke(
+                            truss_cli,
+                            [
+                                "push",
+                                str(custom_model_truss_dir_with_pre_and_post),
+                                "--remote",
+                                "baseten",
+                                "--model-name",
+                                "model_name",
+                                "--watch",
+                                "--tail",
+                            ],
+                        )
+
+    assert result.exit_code == 0, result.output
+    mock_start_tail.assert_called_once_with(
+        remote, "model_id", "version_id", in_background=True
     )
 
 
@@ -1033,35 +1084,45 @@ def test_push_watch_no_sleep_starts_keepalive(
     mock_start_watch.assert_called_once()
 
 
-def test_push_wait_with_tail_fails():
-    """Test that --wait with --tail fails."""
-    mock_truss = Mock()
-    mock_truss.spec.config.runtime.transport.kind = "http"
-    mock_truss.spec.config.resources.instance_type = None
-    mock_truss.spec.config.build = None
-    mock_truss.spec.config.trt_llm = None
-
+def test_push_wait_with_tail_starts_background_tail(
+    custom_model_truss_dir_with_pre_and_post,
+    remote,
+    mock_baseten_requests,
+    mock_upload_truss,
+    mock_create_truss_service,
+):
+    """Test that --wait with --tail starts tail in background."""
     runner = CliRunner()
 
-    with patch("truss.cli.cli._get_truss_from_directory", return_value=mock_truss):
-        result = runner.invoke(
-            truss_cli,
-            [
-                "push",
-                "test_truss",
-                "--remote",
-                "remote1",
-                "--model-name",
-                "name",
-                "--wait",
-                "--tail",
-            ],
-        )
+    mock_service = MagicMock(spec=BasetenService)
+    mock_service.is_draft = False
+    mock_service.logs_url = "https://example.com/logs"
+    mock_service.model_id = "model_id"
+    mock_service.model_version_id = "version_id"
+    mock_service.poll_deployment.return_value = iter([{"status": "ACTIVE"}])
+    remote.push = Mock(return_value=mock_service)
 
-    assert result.exit_code == 2
-    assert "Cannot use --wait with --tail" in result.output or (
-        result.exception
-        and "Cannot use --wait with --tail" in str(result.exception.__context__)
+    with patch("truss.cli.cli.RemoteFactory.create", return_value=remote):
+        remote.api.get_teams = Mock(return_value={})
+        with patch("truss.cli.cli.resolve_model_team_name", return_value=(None, None)):
+            with patch("truss.cli.cli._start_tail") as mock_start_tail:
+                result = runner.invoke(
+                    truss_cli,
+                    [
+                        "push",
+                        str(custom_model_truss_dir_with_pre_and_post),
+                        "--remote",
+                        "baseten",
+                        "--model-name",
+                        "model_name",
+                        "--wait",
+                        "--tail",
+                    ],
+                )
+
+    assert result.exit_code == 0, result.output
+    mock_start_tail.assert_called_once_with(
+        remote, "model_id", "version_id", in_background=True
     )
 
 

--- a/truss/tests/remote/test_truss_remote.py
+++ b/truss/tests/remote/test_truss_remote.py
@@ -36,9 +36,13 @@ class TrussTestService(TrussService):
     def predict_url(self) -> str:
         return f"{self._service_url}/v1/models/model:predict"
 
-    def poll_deployment_status(self, sleep_secs: int = 1) -> Iterator[str]:
+    def poll_deployment(self, sleep_secs: int = 1) -> Iterator[dict]:
         for status in ["DEPLOYING", "ACTIVE"]:
-            yield status
+            yield {"status": status}
+
+    def poll_deployment_status(self, sleep_secs: int = 1) -> Iterator[str]:
+        for deployment in self.poll_deployment(sleep_secs):
+            yield deployment["status"]
 
 
 def mock_successful_response():

--- a/uv.lock
+++ b/uv.lock
@@ -3393,7 +3393,7 @@ wheels = [
 
 [[package]]
 name = "truss"
-version = "0.15.12"
+version = "0.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## :rocket: What

* Implements `SamplingClient.sample()` — POST `/sample` via httpx, returns `SampleResult`
* Implements `SamplingClient.get_tokenizer()` — loads tokenizer from HuggingFace using `base_model`
* Threads `base_model` through `ServiceClient.create_sampling_client()` to `SamplingClient`
* Adds `trainers/examples/sample_prediction.py` — a minimal e2e script that creates a sampling client (no training client), tokenizes a prompt, calls `sample()`, and prints the decoded response

## :computer: How

The example is a self-contained script that demonstrates the intended SDK usage:

```bash
python sample_prediction.py --base-url http://<worker-url> --model Qwen/Qwen3-8B
# or via env var:
TRAINERS_BASE_URL=http://... python sample_prediction.py
```

## :microscope: Testing

Manual testing against a live worker.