### PR TITLE
feat(training): show pending jobs under dedicated Queued Jobs header

### DIFF
--- a/truss/cli/train/core.py
+++ b/truss/cli/train/core.py
@@ -98,13 +98,39 @@ class DisplayTableColumn:
     accessor: Callable[[dict], str]
 
 
-def display_training_jobs(
-    jobs, remote_url: str, checkpoints_by_job_id=None, title="Training Job Details"
-):
-    checkpoints_by_job_id = checkpoints_by_job_id or {}
-    console.print(title, style="bold magenta")
+def display_training_jobs(jobs, remote_url: str, title="Training Job Details"):
+    table = rich.table.Table(
+        show_header=True,
+        header_style="bold magenta",
+        title=title,
+        box=rich.table.box.ROUNDED,
+        border_style="blue",
+    )
+    table.add_column("Job ID", style="cyan")
+    table.add_column("Job Name")
+    table.add_column("Project")
+    table.add_column("Status")
+    table.add_column("Instance Type")
+    table.add_column("Created By")
+    table.add_column("Created")
+    table.add_column("Job Page", style="bold yellow")
+
     for job in jobs:
-        display_training_job(job, remote_url, checkpoints_by_job_id.get(job["id"], []))
+        table.add_row(
+            job["id"],
+            job["name"],
+            job["training_project"]["name"],
+            job["current_status"],
+            job["instance_type"]["name"],
+            job.get("user", {}).get("email", ""),
+            cli_common.format_localized_time(job["created_at"]),
+            cli_common.format_link(
+                status_page_url(remote_url, job["training_project"]["id"], job["id"]),
+                "link",
+            ),
+        )
+
+    console.print(table)
 
 
 def recreate_training_job(

--- a/truss/cli/train/core.py
+++ b/truss/cli/train/core.py
@@ -27,8 +27,9 @@ from truss.remote.baseten.remote import BasetenRemote
 from truss_train import loader
 from truss_train.definitions import DeployCheckpointsConfig
 
+QUEUED_JOB_STATUSES = ["TRAINING_JOB_PENDING"]
+
 ACTIVE_JOB_STATUSES = [
-    "TRAINING_JOB_PENDING",
     "TRAINING_JOB_RUNNING",
     "TRAINING_JOB_CREATED",
     "TRAINING_JOB_DEPLOYING",
@@ -198,6 +199,13 @@ def view_training_details(
     else:
         projects = remote_provider.api.list_training_projects()
         display_training_projects(projects, remote_provider.remote_url)
+        queued_jobs = remote_provider.api.search_training_jobs(
+            statuses=QUEUED_JOB_STATUSES
+        )
+        if queued_jobs:
+            display_training_jobs(
+                queued_jobs, remote_provider.remote_url, title="Queued Training Jobs"
+            )
         active_jobs = remote_provider.api.search_training_jobs(
             statuses=ACTIVE_JOB_STATUSES
         )
@@ -205,7 +213,7 @@ def view_training_details(
             display_training_jobs(
                 active_jobs, remote_provider.remote_url, title="Active Training Jobs"
             )
-        else:
+        if not queued_jobs and not active_jobs:
             console.print("No active training jobs.", style="yellow")
 
 

--- a/truss/cli/train/core.py
+++ b/truss/cli/train/core.py
@@ -170,13 +170,46 @@ def display_training_projects(projects: list[dict], remote_url: str) -> None:
     console.print(table)
 
 
+def display_queued_jobs(jobs: list[dict], remote_url: str) -> None:
+    table = rich.table.Table(
+        show_header=True,
+        header_style="bold magenta",
+        title="Queued Training Jobs",
+        box=rich.table.box.ROUNDED,
+        border_style="blue",
+    )
+    table.add_column("Job ID", style="cyan")
+    table.add_column("Job Name")
+    table.add_column("Project")
+    table.add_column("Instance Type")
+    table.add_column("Created By")
+    table.add_column("Queued At")
+    table.add_column("Job Page", style="bold yellow")
+
+    for job in jobs:
+        table.add_row(
+            job["id"],
+            job["name"],
+            job["training_project"]["name"],
+            job["instance_type"]["name"],
+            job.get("user", {}).get("email", ""),
+            cli_common.format_localized_time(job["created_at"]),
+            cli_common.format_link(
+                status_page_url(remote_url, job["training_project"]["id"], job["id"]),
+                "link",
+            ),
+        )
+
+    console.print(table)
+
+
 def view_training_details(
     remote_provider: BasetenRemote, project_id: Optional[str], job_id: Optional[str]
 ):
     """
     view_training_details shows a list of jobs that meet the provided project_id and job_id filters.
 
-     If no filters are provided, the command will show a list of all training projects and a list of active jobs.
+     If no filters are provided, the command will show a list of all training projects along with queued and active jobs.
     """
     if job_id or project_id:
         jobs_response = remote_provider.api.search_training_jobs(
@@ -199,22 +232,19 @@ def view_training_details(
     else:
         projects = remote_provider.api.list_training_projects()
         display_training_projects(projects, remote_provider.remote_url)
-        queued_jobs = remote_provider.api.search_training_jobs(
-            statuses=QUEUED_JOB_STATUSES
+        jobs = remote_provider.api.search_training_jobs(
+            statuses=QUEUED_JOB_STATUSES + ACTIVE_JOB_STATUSES
         )
+        queued_jobs = [j for j in jobs if j["current_status"] in QUEUED_JOB_STATUSES]
+        active_jobs = [j for j in jobs if j["current_status"] in ACTIVE_JOB_STATUSES]
         if queued_jobs:
-            display_training_jobs(
-                queued_jobs, remote_provider.remote_url, title="Queued Training Jobs"
-            )
-        active_jobs = remote_provider.api.search_training_jobs(
-            statuses=ACTIVE_JOB_STATUSES
-        )
+            display_queued_jobs(queued_jobs, remote_provider.remote_url)
         if active_jobs:
             display_training_jobs(
                 active_jobs, remote_provider.remote_url, title="Active Training Jobs"
             )
         if not queued_jobs and not active_jobs:
-            console.print("No active training jobs.", style="yellow")
+            console.print("No queued or active training jobs.", style="yellow")
 
 
 def stop_all_jobs(remote_provider: BasetenRemote, project_id: Optional[str]):

--- a/truss/tests/cli/train/test_poller.py
+++ b/truss/tests/cli/train/test_poller.py
@@ -66,37 +66,36 @@ def test_view_training_details_splits_queued_and_active(capsys):
     mock_remote.remote_url = "https://app.baseten.co"
     mock_remote.api.list_training_projects.return_value = []
     ts = "2024-01-01T00:00:00+00:00"
-    mock_remote.api.search_training_jobs.side_effect = [
-        # First call: queued jobs
-        [
-            {
-                "id": "q1",
-                "current_status": "TRAINING_JOB_PENDING",
-                "name": "queued-job",
-                "training_project": {"id": "p1", "name": "proj"},
-                "instance_type": {"name": "H100"},
-                "created_at": ts,
-                "updated_at": ts,
-            }
-        ],
-        # Second call: active jobs
-        [
-            {
-                "id": "a1",
-                "current_status": "TRAINING_JOB_RUNNING",
-                "name": "active-job",
-                "training_project": {"id": "p1", "name": "proj"},
-                "instance_type": {"name": "H100"},
-                "created_at": ts,
-                "updated_at": ts,
-            }
-        ],
+    mock_remote.api.search_training_jobs.return_value = [
+        {
+            "id": "q1",
+            "current_status": "TRAINING_JOB_PENDING",
+            "name": "queued-job",
+            "training_project": {"id": "p1", "name": "proj"},
+            "instance_type": {"name": "H100"},
+            "created_at": ts,
+            "updated_at": ts,
+        },
+        {
+            "id": "a1",
+            "current_status": "TRAINING_JOB_RUNNING",
+            "name": "active-job",
+            "training_project": {"id": "p1", "name": "proj"},
+            "instance_type": {"name": "H100"},
+            "created_at": ts,
+            "updated_at": ts,
+        },
     ]
 
     view_training_details(mock_remote, project_id=None, job_id=None)
     captured = capsys.readouterr()
+    # Queued section renders as a table with its own title and columns
     assert "Queued Training Jobs" in captured.out
+    assert "Queued At" in captured.out
+    assert "q1" in captured.out
+    # Active section still uses the card-per-job display
     assert "Active Training Jobs" in captured.out
+    assert "active-job" in captured.out
 
 
 def test_view_training_details_no_jobs_shows_fallback(capsys):
@@ -106,11 +105,11 @@ def test_view_training_details_no_jobs_shows_fallback(capsys):
     mock_remote = Mock()
     mock_remote.remote_url = "https://app.baseten.co"
     mock_remote.api.list_training_projects.return_value = []
-    mock_remote.api.search_training_jobs.side_effect = [[], []]
+    mock_remote.api.search_training_jobs.return_value = []
 
     view_training_details(mock_remote, project_id=None, job_id=None)
     captured = capsys.readouterr()
-    assert "No active training jobs" in captured.out
+    assert "No queued or active training jobs" in captured.out
 
 
 @pytest.mark.parametrize(

--- a/truss/tests/cli/train/test_poller.py
+++ b/truss/tests/cli/train/test_poller.py
@@ -2,7 +2,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from truss.cli.train.core import ACTIVE_JOB_STATUSES
+from truss.cli.train.core import ACTIVE_JOB_STATUSES, QUEUED_JOB_STATUSES
 from truss.cli.train.poller import JOB_STARTING_STATES, TrainingPollerMixin
 
 
@@ -50,8 +50,67 @@ def test_before_polling_waits_through_pending(mock_sleep):
     assert poller._current_status.status == "TRAINING_JOB_DEPLOYING"
 
 
-def test_pending_in_active_job_statuses():
-    assert "TRAINING_JOB_PENDING" in ACTIVE_JOB_STATUSES
+def test_pending_not_in_active_job_statuses():
+    assert "TRAINING_JOB_PENDING" not in ACTIVE_JOB_STATUSES
+
+
+def test_pending_in_queued_job_statuses():
+    assert "TRAINING_JOB_PENDING" in QUEUED_JOB_STATUSES
+
+
+def test_view_training_details_splits_queued_and_active(capsys):
+    """Queued (PENDING) jobs appear under 'Queued' header, not 'Active'."""
+    from truss.cli.train.core import view_training_details
+
+    mock_remote = Mock()
+    mock_remote.remote_url = "https://app.baseten.co"
+    mock_remote.api.list_training_projects.return_value = []
+    ts = "2024-01-01T00:00:00+00:00"
+    mock_remote.api.search_training_jobs.side_effect = [
+        # First call: queued jobs
+        [
+            {
+                "id": "q1",
+                "current_status": "TRAINING_JOB_PENDING",
+                "name": "queued-job",
+                "training_project": {"id": "p1", "name": "proj"},
+                "instance_type": {"name": "H100"},
+                "created_at": ts,
+                "updated_at": ts,
+            }
+        ],
+        # Second call: active jobs
+        [
+            {
+                "id": "a1",
+                "current_status": "TRAINING_JOB_RUNNING",
+                "name": "active-job",
+                "training_project": {"id": "p1", "name": "proj"},
+                "instance_type": {"name": "H100"},
+                "created_at": ts,
+                "updated_at": ts,
+            }
+        ],
+    ]
+
+    view_training_details(mock_remote, project_id=None, job_id=None)
+    captured = capsys.readouterr()
+    assert "Queued Training Jobs" in captured.out
+    assert "Active Training Jobs" in captured.out
+
+
+def test_view_training_details_no_jobs_shows_fallback(capsys):
+    """When both queued and active are empty, show the 'no active' message."""
+    from truss.cli.train.core import view_training_details
+
+    mock_remote = Mock()
+    mock_remote.remote_url = "https://app.baseten.co"
+    mock_remote.api.list_training_projects.return_value = []
+    mock_remote.api.search_training_jobs.side_effect = [[], []]
+
+    view_training_details(mock_remote, project_id=None, job_id=None)
+    captured = capsys.readouterr()
+    assert "No active training jobs" in captured.out
 
 
 @pytest.mark.parametrize(

--- a/truss/tests/cli/train/test_poller.py
+++ b/truss/tests/cli/train/test_poller.py
@@ -93,9 +93,10 @@ def test_view_training_details_splits_queued_and_active(capsys):
     assert "Queued Training Jobs" in captured.out
     assert "Queued At" in captured.out
     assert "q1" in captured.out
-    # Active section still uses the card-per-job display
+    # Active section renders as a table with a Status column
     assert "Active Training Jobs" in captured.out
-    assert "active-job" in captured.out
+    assert "Status" in captured.out
+    assert "a1" in captured.out
 
 
 def test_view_training_details_no_jobs_shows_fallback(capsys):


### PR DESCRIPTION
## :rocket: What

`truss train view` (default, no filters) now shows `TRAINING_JOB_PENDING` jobs under a dedicated **Queued Training Jobs** section instead of mixing them in with Active Training Jobs.

Depends on / follows #2368.

## :computer: How

- Extracted `QUEUED_JOB_STATUSES = ["TRAINING_JOB_PENDING"]` from `ACTIVE_JOB_STATUSES`, which no longer contains `TRAINING_JOB_PENDING`.
- `view_training_details` now makes two separate `search_training_jobs` calls — one for queued, one for active — and renders each under its own header.
- The "No active training jobs" fallback only shows when **both** sections are empty.

## :microscope: Testing

- Updated existing membership assertion (`TRAINING_JOB_PENDING not in ACTIVE_JOB_STATUSES`, `TRAINING_JOB_PENDING in QUEUED_JOB_STATUSES`).
- Added `test_view_training_details_splits_queued_and_active`: verifies both "Queued Training Jobs" and "Active Training Jobs" headers appear when both sets have jobs.
- Added `test_view_training_details_no_jobs_shows_fallback`: verifies the fallback message appears when both sets are empty.
- All 10 tests pass.