### PR TITLE
Add truss download CLI command

### DIFF
--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -1079,13 +1079,13 @@ def model_logs(
 @click.option("--deployment-id", type=str, required=True, help="ID of the deployment.")
 @click.option(
     "--out-file",
-    type=click.Path(),
+    type=click.Path(dir_okay=False),
     required=False,
     help="Save the truss as a tar file at this path.",
 )
 @click.option(
     "--out-dir",
-    type=click.Path(),
+    type=click.Path(file_okay=False),
     required=False,
     help="Extract the truss into this directory.",
 )
@@ -1138,20 +1138,24 @@ def download(
     )
 
     console.print("Downloading truss...")
-    response = requests.get(download_url, stream=True)
-    response.raise_for_status()
-    response.raw.decode_content = True
+    with requests.get(download_url, stream=True, timeout=(10, None)) as response:
+        response.raise_for_status()
+        response.raw.decode_content = True
 
-    if out_file:
-        with open(out_path, "wb") as f:
-            for chunk in response.iter_content(chunk_size=8192):
-                f.write(chunk)
-        console.print(f"Saved to {out_path}")
-    else:
-        out_path.mkdir(exist_ok=True)
-        with tarfile.open(fileobj=response.raw, mode="r|*") as tar:
-            tar.extractall(path=out_path)
-        console.print(f"Extracted to {out_path}")
+        if out_file:
+            with open(out_path, "wb") as f:
+                for chunk in response.iter_content(chunk_size=8192):
+                    f.write(chunk)
+            console.print(f"Saved to {out_path}")
+        else:
+            out_path.mkdir(exist_ok=True)
+            with tarfile.open(fileobj=response.raw, mode="r|*") as tar:
+                # filter="data" prevents path traversal; only available in 3.12+
+                if sys.version_info >= (3, 12):
+                    tar.extractall(path=out_path, filter="data")
+                else:
+                    tar.extractall(path=out_path)
+            console.print(f"Extracted to {out_path}")
 
 
 @truss_cli.command()

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -2,11 +2,13 @@ import inspect
 import json
 import os
 import sys
+import tarfile
 import threading
 import time
 from pathlib import Path
 from typing import Optional, cast
 
+import requests
 import rich.table
 import rich_click as click
 from rich import console as rich_console
@@ -1067,6 +1069,89 @@ def model_logs(
         )
         for log in log_watcher.watch():
             cli_log_utils.output_log(log)
+
+
+@truss_cli.command()
+@click.option(
+    "--remote", type=str, required=False, help="Name of the remote in .trussrc."
+)
+@click.option("--model-id", type=str, required=True, help="ID of the model.")
+@click.option("--deployment-id", type=str, required=True, help="ID of the deployment.")
+@click.option(
+    "--out-file",
+    type=click.Path(),
+    required=False,
+    help="Save the truss as a tar file at this path.",
+)
+@click.option(
+    "--out-dir",
+    type=click.Path(),
+    required=False,
+    help="Extract the truss into this directory.",
+)
+@click.option(
+    "--overwrite",
+    is_flag=True,
+    default=False,
+    help="Allow overwriting an existing file or non-empty directory.",
+)
+@common.common_options()
+def download(
+    remote: Optional[str],
+    model_id: str,
+    deployment_id: str,
+    out_file: Optional[str],
+    out_dir: Optional[str],
+    overwrite: bool,
+) -> None:
+    """
+    Downloads the truss for a deployed model.
+    """
+    if out_file and out_dir:
+        raise click.UsageError("Cannot specify both --out-file and --out-dir.")
+
+    if not out_file and not out_dir:
+        raise click.UsageError("Must specify either --out-file or --out-dir.")
+
+    out_path = Path(out_file or out_dir)  # type: ignore[arg-type]
+
+    if not out_path.parent.exists():
+        raise click.UsageError(f"Parent directory does not exist: {out_path.parent}")
+
+    if not overwrite:
+        if out_file and out_path.exists():
+            raise click.UsageError(
+                f"File already exists: {out_path}. Use --overwrite to replace it."
+            )
+        if out_dir and out_path.exists() and any(out_path.iterdir()):
+            raise click.UsageError(
+                f"Directory is not empty: {out_path}. Use --overwrite to write into it."
+            )
+
+    if not remote:
+        remote = remote_cli.inquire_remote_name()
+    remote_provider = cast(BasetenRemote, RemoteFactory.create(remote=remote))
+
+    console.print("Fetching download URL...")
+    download_url = remote_provider.api.get_deployment_download_url(
+        model_id, deployment_id
+    )
+
+    console.print("Downloading truss...")
+    response = requests.get(download_url, stream=True)
+    response.raise_for_status()
+    response.raw.decode_content = True
+
+    if out_file:
+        with open(out_path, "wb") as f:
+            for chunk in response.iter_content(chunk_size=8192):
+                f.write(chunk)
+        console.print(f"Saved to {out_path}")
+    else:
+        out_path.mkdir(exist_ok=True)
+        with tarfile.open(fileobj=response.raw, mode="r|*") as tar:
+            tar.extractall(path=out_path)
+        console.print(f"Extracted to {out_path}")
 
 
 @truss_cli.command()

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -989,6 +989,12 @@ class BasetenApi:
         response = requests.get(presigned_url)
         return response.content
 
+    def get_deployment_download_url(self, model_id: str, deployment_id: str) -> str:
+        response = self._rest_api_client.get(
+            f"v1/models/{model_id}/deployments/{deployment_id}/download"
+        )
+        return response["download_url"]
+
     def get_model_deployment_logs(
         self,
         model_id: str,

--- a/truss/tests/cli/test_cli.py
+++ b/truss/tests/cli/test_cli.py
@@ -1383,3 +1383,91 @@ def test_push_json_output_wait_deploy_failed(
     assert "error" in data
     assert "DEPLOY_FAILED" in data["error"]["message"]
     assert data["error"]["deployment"] == failed_deployment
+
+
+def _invoke_download(args):
+    runner = CliRunner()
+    return runner.invoke(truss_cli, ["download", *args])
+
+
+def test_download_requires_out_file_or_out_dir():
+    result = _invoke_download(["--model-id", "m", "--deployment-id", "d"])
+    assert result.exit_code != 0
+    assert "Must specify either --out-file or --out-dir" in result.output
+
+
+def test_download_rejects_both_out_file_and_out_dir():
+    result = _invoke_download(
+        [
+            "--model-id",
+            "m",
+            "--deployment-id",
+            "d",
+            "--out-file",
+            "f.tar",
+            "--out-dir",
+            "dir",
+        ]
+    )
+    assert result.exit_code != 0
+    assert "Cannot specify both --out-file and --out-dir" in result.output
+
+
+def test_download_rejects_missing_parent_dir(tmp_path):
+    result = _invoke_download(
+        [
+            "--model-id",
+            "m",
+            "--deployment-id",
+            "d",
+            "--out-file",
+            str(tmp_path / "nonexistent" / "f.tar"),
+        ]
+    )
+    assert result.exit_code != 0
+    assert "Parent directory does not exist" in result.output
+
+
+def test_download_rejects_existing_file_without_overwrite(tmp_path):
+    existing = tmp_path / "model.tar"
+    existing.touch()
+    result = _invoke_download(
+        ["--model-id", "m", "--deployment-id", "d", "--out-file", str(existing)]
+    )
+    assert result.exit_code != 0
+    assert "File already exists" in result.output
+    assert "--overwrite" in result.output
+
+
+def test_download_rejects_nonempty_dir_without_overwrite(tmp_path):
+    out = tmp_path / "model"
+    out.mkdir()
+    (out / "something.txt").touch()
+    result = _invoke_download(
+        ["--model-id", "m", "--deployment-id", "d", "--out-dir", str(out)]
+    )
+    assert result.exit_code != 0
+    assert "Directory is not empty" in result.output
+    assert "--overwrite" in result.output
+
+
+def test_download_allows_existing_empty_dir(tmp_path):
+    out = tmp_path / "model"
+    out.mkdir()
+    mock_remote = MagicMock()
+    mock_remote.api.get_deployment_download_url.return_value = (
+        "https://presigned.example.com"
+    )
+    mock_response = MagicMock()
+    mock_response.raw = MagicMock()
+    with (
+        patch("truss.cli.cli.RemoteFactory.create", return_value=mock_remote),
+        patch("truss.cli.remote_cli.inquire_remote_name", return_value="remote1"),
+        patch("truss.cli.cli.requests.get", return_value=mock_response),
+        patch("truss.cli.cli.tarfile.open"),
+    ):
+        result = _invoke_download(
+            ["--model-id", "m", "--deployment-id", "d", "--out-dir", str(out)]
+        )
+    assert result.exit_code == 0
+    assert "Extracted to" in result.output

--- a/truss/tests/cli/test_cli.py
+++ b/truss/tests/cli/test_cli.py
@@ -1393,7 +1393,8 @@ def _invoke_download(args):
 def test_download_requires_out_file_or_out_dir():
     result = _invoke_download(["--model-id", "m", "--deployment-id", "d"])
     assert result.exit_code != 0
-    assert "Must specify either --out-file or --out-dir" in result.output
+    assert "--out-file" in result.output
+    assert "--out-dir" in result.output
 
 
 def test_download_rejects_both_out_file_and_out_dir():
@@ -1410,7 +1411,8 @@ def test_download_rejects_both_out_file_and_out_dir():
         ]
     )
     assert result.exit_code != 0
-    assert "Cannot specify both --out-file and --out-dir" in result.output
+    assert "--out-file" in result.output
+    assert "--out-dir" in result.output
 
 
 def test_download_rejects_missing_parent_dir(tmp_path):


### PR DESCRIPTION
## :rocket: What

Add `truss download` CLI command for downloading a deployed model's truss.

## :computer: How

New `download` command accepting `--model-id`, `--deployment-id`, `--out-file` or `--out-dir`, and `--overwrite`. Calls the new REST API endpoint to get a presigned URL, then either streams the tar to a file (`--out-file`) or extracts directly from the HTTP stream via `tarfile.open(fileobj=response.raw, mode="r|*")` (`--out-dir`).  Validates parent dir exists, file/dir overwrite safety, and mutually exclusive options.

## :microscope: Testing

Unit tests for all validation paths and a mock integration test for the happy path. Manually tested end to end.