### PR TITLE
Remote SSH support for model containers

### DIFF
--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -590,6 +590,15 @@ Transport = Annotated[
 ]
 
 
+class RemoteSSH(custom_types.ConfigModel):
+    """Configuration for SSH access to running model instances."""
+
+    enabled: bool = pydantic.Field(
+        default=False,
+        description="If true, enables SSH access to running model instances.",
+    )
+
+
 class Runtime(custom_types.ConfigModel):
     """Runtime settings for your model instance."""
 
@@ -619,6 +628,10 @@ class Runtime(custom_types.ConfigModel):
     health_checks: HealthChecks = pydantic.Field(
         default_factory=HealthChecks,
         description="Custom health check configuration for your deployments.",
+    )
+    remote_ssh: RemoteSSH = pydantic.Field(
+        default_factory=RemoteSSH,
+        description="Configuration for SSH access to running model instances.",
     )
     truss_server_version_override: Optional[str] = pydantic.Field(
         None,
@@ -1328,6 +1341,20 @@ class TrussConfig(custom_types.ConfigModel):
                 stacklevel=2,
             )
         return v
+
+    @pydantic.model_validator(mode="after")
+    def _validate_remote_ssh(self) -> "TrussConfig":
+        if (
+            self.runtime.remote_ssh.enabled
+            and self.docker_server is not None
+            and self.docker_server.run_as_user_id is not None
+        ):
+            raise ValueError(
+                "remote_ssh.enabled is not compatible with "
+                "docker_server.run_as_user_id. SSH requires the default "
+                "'app' user (uid 60000)."
+            )
+        return self
 
     @pydantic.model_validator(mode="after")
     def _validate_config(self) -> "TrussConfig":

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -952,6 +952,14 @@ def push(
         f"🪵  View logs for your deployment at {common.format_link(service.logs_url)}"
     )
 
+    if tr.spec.config.runtime.remote_ssh.enabled and isinstance(
+        service, BasetenService
+    ):
+        console.print(
+            "🔐  SSH into this deployment (after 'truss ssh setup'): "
+            f"ssh model-{service.model_id}-{service.model_version_id}.ssh.baseten.co"
+        )
+
     if tail and isinstance(service, BasetenService):
         # When combined with --wait/--watch, tail runs in background so the
         # wait polling loop below can proceed on the main thread.

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -956,7 +956,7 @@ def push(
         service, BasetenService
     ):
         console.print(
-            "🔐  SSH into this deployment (after 'truss ssh setup'): "
+            "🔐  SSH into this deployment (after one-time 'truss ssh setup'): "
             f"ssh model-{service.model_id}-{service.model_version_id}.ssh.baseten.co"
         )
 

--- a/truss/cli/proxy_command.py
+++ b/truss/cli/proxy_command.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-"""SSH helper for Baseten training jobs.
+"""SSH helper for Baseten workloads (training jobs and inference models).
 
-This script is installed to ~/.ssh/baseten/proxy-command.py by `truss train ssh setup`.
+This script is installed to ~/.ssh/baseten/proxy-command.py by `truss ssh setup`.
 It is fully self-contained (only Python stdlib imports, no truss dependency).
 
 It has two modes, both invoked by SSH automatically:
@@ -12,11 +12,14 @@ It has two modes, both invoked by SSH automatically:
   2. Proxy mode (ProxyCommand): Connects to the SSH proxy using the cached JWT.
      Invoked as: proxy-command.py <hostname>
 
-Hostname format: training-job-<job_id>-<node>.<remote>.ssh.baseten.co
-Example: training-job-5wo5n3y-0.dev.ssh.baseten.co
+Hostname formats:
+  training-job-<job_id>-<node>.<remote>.ssh.baseten.co        (training)
+  model-<model_id>.<remote>.ssh.baseten.co                    (inference, default env)
+  model-<model_id>-<env_name>.<remote>.ssh.baseten.co         (inference, specific env)
 """
 
 import configparser
+import dataclasses
 import json
 import os
 import selectors
@@ -28,6 +31,7 @@ import threading
 import urllib.error
 import urllib.request
 from pathlib import Path
+from typing import Optional
 
 # Stamped by `truss train ssh setup` with the truss version at install time.
 # Sent to the signing API so the server can reject outdated clients.
@@ -45,7 +49,11 @@ TRUSSRC_PATH = Path(os.environ.get("USER_TRUSSRC_PATH", Path.home() / ".trussrc"
 JWT_CACHE_DIR = BASETEN_SSH_DIR / ".jwt-cache"
 
 HOSTNAME_SUFFIX = ".ssh.baseten.co"
-HOSTNAME_PREFIX = "training-job-"
+HOSTNAME_PREFIX_TRAINING = "training-job-"
+HOSTNAME_PREFIX_MODEL = "model-"
+
+WORKLOAD_TRAINING = "training"
+WORKLOAD_MODEL = "model"
 
 BASETEN_REST_API_URL = os.environ.get("BASETEN_BASE_URL", "https://api.baseten.co")
 
@@ -66,13 +74,25 @@ def find_key_path():
     return None
 
 
+@dataclasses.dataclass
+class ParsedHostname:
+    """Result of parsing an SSH hostname."""
+
+    workload_type: str
+    id: str
+    replica: Optional[str]
+    environment: Optional[str]
+    remote: Optional[str]
+    api_prefix: Optional[str]
+
+
 def parse_hostname(hostname):
-    """Parse hostname into (job_id, replica, remote, api_prefix).
+    """Parse hostname into a ParsedHostname.
 
     Supported formats:
-      training-job-<job_id>-<node>.ssh.baseten.co                       — default remote, default API
-      training-job-<job_id>-<node>.<remote>.ssh.baseten.co              — explicit remote, default API
-      training-job-<job_id>-<node>.<remote>.<api_prefix>.ssh.baseten.co — explicit remote, custom API
+      training-job-<job_id>-<node>[.<remote>[.<api_prefix>]].ssh.baseten.co
+      model-<model_id>[.<remote>[.<api_prefix>]].ssh.baseten.co
+      model-<model_id>-<env_name>[.<remote>[.<api_prefix>]].ssh.baseten.co
     """
     if not hostname.endswith(HOSTNAME_SUFFIX):
         error(f"Invalid hostname: {hostname} (expected *.ssh.baseten.co)")
@@ -80,43 +100,84 @@ def parse_hostname(hostname):
     prefix = hostname[: -len(HOSTNAME_SUFFIX)]
     dot_idx = prefix.find(".")
     if dot_idx == -1:
-        job_replica = prefix
+        workload_part = prefix
         remote = None
         api_prefix = None
     else:
-        job_replica = prefix[:dot_idx]
+        workload_part = prefix[:dot_idx]
         rest = prefix[dot_idx + 1 :]
         parts = rest.split(".", 1)
         remote = parts[0]
         api_prefix = parts[1] if len(parts) > 1 else None
 
-    if not job_replica.startswith(HOSTNAME_PREFIX):
+    if workload_part.startswith(HOSTNAME_PREFIX_TRAINING):
+        return _parse_training_hostname(hostname, workload_part, remote, api_prefix)
+    elif workload_part.startswith(HOSTNAME_PREFIX_MODEL):
+        return _parse_model_hostname(hostname, workload_part, remote, api_prefix)
+    else:
         error(
             f"Invalid hostname: {hostname} "
-            f"(expected training-job-<job_id>-<node>.ssh.baseten.co)"
+            f"(expected training-job-<job_id>-<node> or model-<model_id>)"
         )
 
-    job_replica = job_replica[len(HOSTNAME_PREFIX) :]
 
-    dash_idx = job_replica.rfind("-")
+def _parse_training_hostname(hostname, workload_part, remote, api_prefix):
+    remainder = workload_part[len(HOSTNAME_PREFIX_TRAINING) :]
+
+    dash_idx = remainder.rfind("-")
     if dash_idx == -1:
         error(f"Invalid hostname: {hostname} (cannot parse job_id and node)")
 
-    job_id = job_replica[:dash_idx]
-    replica_str = job_replica[dash_idx + 1 :]
+    job_id = remainder[:dash_idx]
+    replica_str = remainder[dash_idx + 1 :]
 
     if not replica_str:
         error(f"Invalid hostname: {hostname} (empty replica)")
-
     if not replica_str.isdigit():
         error(f"Invalid hostname: {hostname} (replica must be a number)")
-
-    replica = replica_str
-
     if not job_id:
         error(f"Invalid hostname: {hostname} (empty job_id)")
 
-    return job_id, replica, remote, api_prefix
+    return ParsedHostname(
+        workload_type=WORKLOAD_TRAINING,
+        id=job_id,
+        replica=replica_str,
+        environment=None,
+        remote=remote,
+        api_prefix=api_prefix,
+    )
+
+
+def _parse_model_hostname(hostname, workload_part, remote, api_prefix):
+    remainder = workload_part[len(HOSTNAME_PREFIX_MODEL) :]
+    if not remainder:
+        error(f"Invalid hostname: {hostname} (empty model_id)")
+
+    # Model IDs are [a-z0-9]+ (no hyphens). If there's a hyphen, everything
+    # after the first one is the environment name.
+    dash_idx = remainder.find("-")
+    if dash_idx == -1:
+        model_id = remainder
+        environment = None
+    else:
+        model_id = remainder[:dash_idx]
+        environment = remainder[dash_idx + 1 :]
+        if not environment:
+            error(f"Invalid hostname: {hostname} (empty environment name)")
+
+    if not model_id:
+        error(f"Invalid hostname: {hostname} (empty model_id)")
+
+    replica = os.environ.get("BASETEN_REPLICA") or None
+
+    return ParsedHostname(
+        workload_type=WORKLOAD_MODEL,
+        id=model_id,
+        replica=replica,
+        environment=environment,
+        remote=remote,
+        api_prefix=api_prefix,
+    )
 
 
 def _read_trussrc():
@@ -142,8 +203,8 @@ def resolve_remote(remote, config):
         else:
             error(
                 f"Multiple remotes in ~/.trussrc: {', '.join(sections)}. "
-                f"Specify one in the hostname: ssh training-job-<job_id>-<node>.<remote>.ssh.baseten.co\n"
-                f"Or re-run: truss train ssh setup --default-remote <name>"
+                f"Specify one in the hostname: ssh <workload>.<remote>.ssh.baseten.co\n"
+                f"Or re-run: truss ssh setup --default-remote <name>"
             )
     return remote
 
@@ -234,10 +295,10 @@ def resolve_project_id(rest_url, api_key, job_id):
     return jobs[0]["training_project"]["id"]
 
 
-def sign_certificate(
+def sign_training_certificate(
     rest_url, api_key, project_id, job_id, public_key, replica, key_path
 ):
-    """Call the SSH signing endpoint. Returns (ssh_cert, jwt, proxy_address)."""
+    """Call the training SSH signing endpoint. Returns (jwt, proxy_address)."""
     resp = api_request(
         f"{rest_url}/v1/training_projects/{project_id}/jobs/{job_id}/ssh/sign",
         api_key,
@@ -245,30 +306,51 @@ def sign_certificate(
         body={"public_key": public_key, "replica_id": replica},
     )
 
-    # Write cert next to the key (e.g. id_ed25519-cert.pub)
     cert_path = key_path.parent / (key_path.name + "-cert.pub")
     cert_path.write_text(resp["ssh_certificate"])
+    return resp["jwt"], resp["proxy_address"]
 
+
+def sign_model_certificate(rest_url, api_key, parsed, public_key, key_path):
+    """Call the inference SSH signing endpoint. Returns (jwt, proxy_address)."""
+    body = {"public_key": public_key}
+    if parsed.replica:
+        body["replica_id"] = parsed.replica
+
+    if parsed.environment:
+        url = f"{rest_url}/v1/models/{parsed.id}/environments/{parsed.environment}/ssh/sign"
+    else:
+        url = f"{rest_url}/v1/models/{parsed.id}/ssh/sign"
+
+    resp = api_request(url, api_key, method="POST", body=body)
+
+    cert_path = key_path.parent / (key_path.name + "-cert.pub")
+    cert_path.write_text(resp["ssh_certificate"])
     return resp["jwt"], resp["proxy_address"]
 
 
 # --- JWT cache: shared between sign mode and proxy mode ---
 
 
-def _jwt_cache_path(job_id, replica):
-    return JWT_CACHE_DIR / f"{job_id}-{replica}.json"
+def _jwt_cache_path(parsed):
+    parts = [parsed.workload_type, parsed.id]
+    if parsed.environment:
+        parts.append(parsed.environment)
+    if parsed.replica:
+        parts.append(parsed.replica)
+    return JWT_CACHE_DIR / f"{'-'.join(parts)}.json"
 
 
-def save_jwt_cache(job_id, replica, jwt_token, proxy_address):
+def save_jwt_cache(parsed, jwt_token, proxy_address):
     """Save JWT and proxy address for the proxy command to read."""
     JWT_CACHE_DIR.mkdir(parents=True, exist_ok=True)
-    path = _jwt_cache_path(job_id, replica)
+    path = _jwt_cache_path(parsed)
     path.write_text(json.dumps({"jwt": jwt_token, "proxy_address": proxy_address}))
 
 
-def load_jwt_cache(job_id, replica):
+def load_jwt_cache(parsed):
     """Load cached JWT and proxy address. Returns (jwt, proxy_address) or None."""
-    path = _jwt_cache_path(job_id, replica)
+    path = _jwt_cache_path(parsed)
     if not path.exists():
         return None
     try:
@@ -279,6 +361,25 @@ def load_jwt_cache(job_id, replica):
 
 
 # --- Sign mode (Match exec) ---
+
+
+def _sign_for_parsed(parsed, rest_url, api_key, key_path):
+    """Sign a certificate for the given parsed hostname. Returns (jwt, proxy_address)."""
+    public_key = key_path.with_suffix(".pub").read_text().strip()
+
+    if parsed.workload_type == WORKLOAD_TRAINING:
+        project_id = resolve_project_id(rest_url, api_key, parsed.id)
+        return sign_training_certificate(
+            rest_url,
+            api_key,
+            project_id,
+            parsed.id,
+            public_key,
+            parsed.replica,
+            key_path,
+        )
+    else:
+        return sign_model_certificate(rest_url, api_key, parsed, public_key, key_path)
 
 
 def main_sign():
@@ -295,24 +396,19 @@ def main_sign():
     key_path = find_key_path()
     if not key_path:
         print(
-            "baseten-ssh: SSH keypair not found. Run 'truss train ssh setup' first.",
+            "baseten-ssh: SSH keypair not found. Run 'truss ssh setup' first.",
             file=sys.stderr,
         )
         sys.exit(0)  # Exit 0 so Match still applies; ProxyCommand will show error too
 
-    job_id, replica, remote, api_prefix = parse_hostname(hostname)
+    parsed = parse_hostname(hostname)
     config = _read_trussrc()
-    remote = resolve_remote(remote, config)
+    remote = resolve_remote(parsed.remote, config)
     api_key, _ = load_trussrc(remote, config)
-    rest_url = resolve_rest_api_url(api_prefix)
+    rest_url = resolve_rest_api_url(parsed.api_prefix)
 
-    project_id = resolve_project_id(rest_url, api_key, job_id)
-    public_key = key_path.with_suffix(".pub").read_text().strip()
-    jwt_token, proxy_address = sign_certificate(
-        rest_url, api_key, project_id, job_id, public_key, replica, key_path
-    )
-
-    save_jwt_cache(job_id, replica, jwt_token, proxy_address)
+    jwt_token, proxy_address = _sign_for_parsed(parsed, rest_url, api_key, key_path)
+    save_jwt_cache(parsed, jwt_token, proxy_address)
 
 
 # --- Proxy mode (ProxyCommand) ---
@@ -340,7 +436,9 @@ def connect_proxy(proxy_address, jwt_token):
     status = tls_sock.recv(1)
     if not status or status[0] != STATUS_OK:
         tls_sock.close()
-        error("SSH proxy rejected the connection. Is the job and SSH server running?")
+        error(
+            "SSH proxy rejected the connection. Is the workload and SSH server running?"
+        )
 
     return tls_sock
 
@@ -418,25 +516,21 @@ def main_proxy():
 
     key_path = find_key_path()
     if not key_path:
-        error("SSH keypair not found. Run 'truss train ssh setup' first.")
+        error("SSH keypair not found. Run 'truss ssh setup' first.")
 
-    job_id, replica, remote, api_prefix = parse_hostname(hostname)
+    parsed = parse_hostname(hostname)
 
     # Try to use cached JWT from sign mode
-    cached = load_jwt_cache(job_id, replica)
+    cached = load_jwt_cache(parsed)
     if cached:
         jwt_token, proxy_address = cached
     else:
         # Fallback: sign here if Match exec didn't run (e.g. old SSH config)
         config = _read_trussrc()
-        remote = resolve_remote(remote, config)
+        remote = resolve_remote(parsed.remote, config)
         api_key, _ = load_trussrc(remote, config)
-        rest_url = resolve_rest_api_url(api_prefix)
-        project_id = resolve_project_id(rest_url, api_key, job_id)
-        public_key = key_path.with_suffix(".pub").read_text().strip()
-        jwt_token, proxy_address = sign_certificate(
-            rest_url, api_key, project_id, job_id, public_key, replica, key_path
-        )
+        rest_url = resolve_rest_api_url(parsed.api_prefix)
+        jwt_token, proxy_address = _sign_for_parsed(parsed, rest_url, api_key, key_path)
 
     # Connect to proxy
     tls_sock = connect_proxy(proxy_address, jwt_token)

--- a/truss/cli/proxy_command.py
+++ b/truss/cli/proxy_command.py
@@ -13,9 +13,9 @@ It has two modes, both invoked by SSH automatically:
      Invoked as: proxy-command.py <hostname>
 
 Hostname formats:
-  training-job-<job_id>-<node>.<remote>.ssh.baseten.co        (training)
-  model-<model_id>.<remote>.ssh.baseten.co                    (inference, default env)
-  model-<model_id>-<env_name>.<remote>.ssh.baseten.co         (inference, specific env)
+  training-job-<job_id>-<node>.<remote>.ssh.baseten.co                            (training)
+  model-<model_id>-<deployment_id>.<remote>.ssh.baseten.co                        (inference, specific deployment)
+  model-<model_id>-<deployment_id>-<replica_id>.<remote>.ssh.baseten.co           (inference, specific deployment + replica)
 """
 
 import configparser
@@ -81,7 +81,7 @@ class ParsedHostname:
     workload_type: str
     id: str
     replica: Optional[str]
-    environment: Optional[str]
+    deployment_id: Optional[str]
     remote: Optional[str]
     api_prefix: Optional[str]
 
@@ -91,8 +91,8 @@ def parse_hostname(hostname):
 
     Supported formats:
       training-job-<job_id>-<node>[.<remote>[.<api_prefix>]].ssh.baseten.co
-      model-<model_id>[.<remote>[.<api_prefix>]].ssh.baseten.co
-      model-<model_id>-<env_name>[.<remote>[.<api_prefix>]].ssh.baseten.co
+      model-<model_id>-<deployment_id>[.<remote>[.<api_prefix>]].ssh.baseten.co
+      model-<model_id>-<deployment_id>-<replica_id>[.<remote>[.<api_prefix>]].ssh.baseten.co
     """
     if not hostname.endswith(HOSTNAME_SUFFIX):
         error(f"Invalid hostname: {hostname} (expected *.ssh.baseten.co)")
@@ -142,7 +142,7 @@ def _parse_training_hostname(hostname, workload_part, remote, api_prefix):
         workload_type=WORKLOAD_TRAINING,
         id=job_id,
         replica=replica_str,
-        environment=None,
+        deployment_id=None,
         remote=remote,
         api_prefix=api_prefix,
     )
@@ -153,28 +153,31 @@ def _parse_model_hostname(hostname, workload_part, remote, api_prefix):
     if not remainder:
         error(f"Invalid hostname: {hostname} (empty model_id)")
 
-    # Model IDs are [a-z0-9]+ (no hyphens). If there's a hyphen, everything
-    # after the first one is the environment name.
-    dash_idx = remainder.find("-")
-    if dash_idx == -1:
-        model_id = remainder
-        environment = None
-    else:
-        model_id = remainder[:dash_idx]
-        environment = remainder[dash_idx + 1 :]
-        if not environment:
-            error(f"Invalid hostname: {hostname} (empty environment name)")
+    # Model and deployment IDs are [a-z0-9]+ (no hyphens). Split on the first
+    # two dashes: model_id, deployment_id, then replica_id (which may contain
+    # hyphens).
+    parts = remainder.split("-", 2)
+    if len(parts) < 2:
+        error(
+            f"Invalid hostname: {hostname} "
+            f"(expected model-<model_id>-<deployment_id>[-<replica_id>])"
+        )
+    model_id = parts[0]
+    deployment_id = parts[1]
+    replica = parts[2] if len(parts) >= 3 else None
 
     if not model_id:
         error(f"Invalid hostname: {hostname} (empty model_id)")
-
-    replica = os.environ.get("BASETEN_REPLICA") or None
+    if not deployment_id:
+        error(f"Invalid hostname: {hostname} (empty deployment_id)")
+    if replica is not None and not replica:
+        error(f"Invalid hostname: {hostname} (empty replica_id)")
 
     return ParsedHostname(
         workload_type=WORKLOAD_MODEL,
         id=model_id,
         replica=replica,
-        environment=environment,
+        deployment_id=deployment_id,
         remote=remote,
         api_prefix=api_prefix,
     )
@@ -205,7 +208,7 @@ def resolve_remote(remote, config):
                 f"Multiple remotes in ~/.trussrc: {', '.join(sections)}. "
                 f"Specify one in the hostname, for example:\n"
                 f"  ssh training-job-<job_id>-<node>.<remote>.ssh.baseten.co\n"
-                f"  ssh model-<model_id>.<remote>.ssh.baseten.co\n"
+                f"  ssh model-<model_id>-<deployment_id>.<remote>.ssh.baseten.co\n"
                 f"Or re-run: truss ssh setup --default-remote <name>"
             )
     return remote
@@ -319,10 +322,9 @@ def sign_model_certificate(rest_url, api_key, parsed, public_key, key_path):
     if parsed.replica:
         body["replica_id"] = parsed.replica
 
-    if parsed.environment:
-        url = f"{rest_url}/v1/models/{parsed.id}/environments/{parsed.environment}/ssh/sign"
-    else:
-        url = f"{rest_url}/v1/models/{parsed.id}/ssh/sign"
+    url = (
+        f"{rest_url}/v1/models/{parsed.id}/deployments/{parsed.deployment_id}/ssh/sign"
+    )
 
     resp = api_request(url, api_key, method="POST", body=body)
 
@@ -336,8 +338,8 @@ def sign_model_certificate(rest_url, api_key, parsed, public_key, key_path):
 
 def _jwt_cache_path(parsed):
     parts = [parsed.workload_type, parsed.id]
-    if parsed.environment:
-        parts.append(parsed.environment)
+    if parsed.deployment_id:
+        parts.append(parsed.deployment_id)
     if parsed.replica:
         parts.append(parsed.replica)
     return JWT_CACHE_DIR / f"{'-'.join(parts)}.json"

--- a/truss/cli/proxy_command.py
+++ b/truss/cli/proxy_command.py
@@ -203,7 +203,9 @@ def resolve_remote(remote, config):
         else:
             error(
                 f"Multiple remotes in ~/.trussrc: {', '.join(sections)}. "
-                f"Specify one in the hostname: ssh <workload>.<remote>.ssh.baseten.co\n"
+                f"Specify one in the hostname, for example:\n"
+                f"  ssh training-job-<job_id>-<node>.<remote>.ssh.baseten.co\n"
+                f"  ssh model-<model_id>.<remote>.ssh.baseten.co\n"
                 f"Or re-run: truss ssh setup --default-remote <name>"
             )
     return remote

--- a/truss/cli/ssh.py
+++ b/truss/cli/ssh.py
@@ -21,9 +21,17 @@ MARKER_END = "# --- end baseten-ssh ---"
 
 SSH_CONFIG_BLOCK_UNIX = """\
 {marker_start}
-Match host *.ssh.baseten.co exec "{python} {proxy_script} --sign %n"
-    ProxyCommand sh -c 'test -x "{python}" || {{ echo "baseten-ssh: Python not found at {python}. Please try re-running: truss train ssh setup" >&2; exit 127; }}; exec "{python}" "{proxy_script}" "$1"' -- %n
+Match host training-job-*.ssh.baseten.co exec "{python} {proxy_script} --sign %n"
+    ProxyCommand sh -c 'test -x "{python}" || {{ echo "baseten-ssh: Python not found at {python}. Please try re-running: truss ssh setup" >&2; exit 127; }}; exec "{python}" "{proxy_script}" "$1"' -- %n
     User baseten
+    IdentityFile {key_path}
+    CertificateFile {cert_path}
+    StrictHostKeyChecking no
+    UserKnownHostsFile /dev/null
+
+Match host model-*.ssh.baseten.co exec "{python} {proxy_script} --sign %n"
+    ProxyCommand sh -c 'test -x "{python}" || {{ echo "baseten-ssh: Python not found at {python}. Please try re-running: truss ssh setup" >&2; exit 127; }}; exec "{python}" "{proxy_script}" "$1"' -- %n
+    User app
     IdentityFile {key_path}
     CertificateFile {cert_path}
     StrictHostKeyChecking no
@@ -33,9 +41,17 @@ Match host *.ssh.baseten.co exec "{python} {proxy_script} --sign %n"
 
 SSH_CONFIG_BLOCK_WINDOWS = """\
 {marker_start}
-Match host *.ssh.baseten.co exec "\\"{python}\\" \\"{proxy_script}\\" --sign %n"
+Match host training-job-*.ssh.baseten.co exec "\\"{python}\\" \\"{proxy_script}\\" --sign %n"
     ProxyCommand "{python}" "{proxy_script}" %n
     User baseten
+    IdentityFile {key_path}
+    CertificateFile {cert_path}
+    StrictHostKeyChecking no
+    UserKnownHostsFile /dev/null
+
+Match host model-*.ssh.baseten.co exec "\\"{python}\\" \\"{proxy_script}\\" --sign %n"
+    ProxyCommand "{python}" "{proxy_script}" %n
+    User app
     IdentityFile {key_path}
     CertificateFile {cert_path}
     StrictHostKeyChecking no

--- a/truss/config.schema.json
+++ b/truss/config.schema.json
@@ -653,6 +653,20 @@
       "title": "ModelServer",
       "type": "string"
     },
+    "RemoteSSH": {
+      "additionalProperties": true,
+      "description": "Configuration for SSH access to running model instances.",
+      "properties": {
+        "enabled": {
+          "default": false,
+          "description": "If true, enables SSH access to running model instances.",
+          "title": "Enabled",
+          "type": "boolean"
+        }
+      },
+      "title": "RemoteSSH",
+      "type": "object"
+    },
     "Resources": {
       "additionalProperties": true,
       "description": "Compute resources that your model needs, including CPU, memory, and GPU resources.",
@@ -787,6 +801,9 @@
         },
         "health_checks": {
           "$ref": "#/$defs/HealthChecks"
+        },
+        "remote_ssh": {
+          "$ref": "#/$defs/RemoteSSH"
         },
         "truss_server_version_override": {
           "anyOf": [

--- a/truss/contexts/image_builder/serving_image_builder.py
+++ b/truss/contexts/image_builder/serving_image_builder.py
@@ -787,6 +787,13 @@ class ServingImageBuilder(ImageBuilder):
         )
         (build_dir / SYSTEM_PACKAGES_TXT_FILENAME).write_text(spec.system_packages_txt)
 
+        if config.runtime.remote_ssh.enabled:
+            self._copy_into_build_dir(
+                TEMPLATES_DIR / "baseten-ssh-server.sh",
+                build_dir,
+                "baseten-ssh-server.sh",
+            )
+
         # Copy constraints file to bound versions for user-overridden packages.
         self._copy_into_build_dir(
             SERVER_CODE_DIR / CONSTRAINTS_TXT_FILENAME,

--- a/truss/contexts/image_builder/serving_image_builder.py
+++ b/truss/contexts/image_builder/serving_image_builder.py
@@ -905,6 +905,7 @@ class ServingImageBuilder(ImageBuilder):
         should_install_system_requirements = file_is_not_empty(
             build_dir / SYSTEM_PACKAGES_TXT_FILENAME
         )
+        should_install_openssh_server = config.runtime.remote_ssh.enabled
         should_install_python_requirements = file_is_not_empty(
             build_dir / REQUIREMENTS_TXT_FILENAME
         )
@@ -933,6 +934,7 @@ class ServingImageBuilder(ImageBuilder):
             min_supported_python_minor_version_in_custom_base_image=min_py_version.minor,
             supported_python_major_version_in_custom_base_image=min_py_version.major,
             should_install_system_requirements=should_install_system_requirements,
+            should_install_openssh_server=should_install_openssh_server,
             should_install_requirements=should_install_python_requirements,
             requirements_file_type=config.requirements_file_type.value,
             config=config,

--- a/truss/templates/base.Dockerfile.jinja
+++ b/truss/templates/base.Dockerfile.jinja
@@ -120,6 +120,15 @@ RUN apt-get update && apt-get install --yes --no-install-recommends $(cat {{ sys
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
     {%- endif %}
+    {%- if should_install_openssh_server %}
+COPY --chown={{ default_owner }} ./baseten-ssh-server.sh /usr/local/bin/baseten-ssh-server.sh
+RUN apt-get update && apt-get install --yes --no-install-recommends openssh-server \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/* \
+    && chmod +x /usr/local/bin/baseten-ssh-server.sh \
+    && mkdir -p /run/sshd \
+    && sed -i 's/^app:!/app:*/' /etc/shadow
+    {%- endif %}
 {% endblock %}
 
 

--- a/truss/templates/baseten-ssh-server.sh
+++ b/truss/templates/baseten-ssh-server.sh
@@ -15,6 +15,20 @@
 #   BT_SSH_CA_KEY_PATH   - Path to the SSH CA public key file
 #   BT_SSH_SUBJECT       - Subject identifier (used as authorized principal)
 #   BT_SSH_DIR           - Directory for SSH runtime files (default: /run/baseten-ssh)
+#
+# The SSH CA public key is a verification credential, the same category as
+# GitHub's published host keys and the TrustedUserCAKeys file on every sshd
+# using certificate authentication. Distributing the CA public key across the
+# fleet is standard industry practice for SSH certificate authorities.
+#
+# It cannot be used to forge certificates, decrypt traffic, or impersonate the
+# CA. Those all require the private key, which never leaves Baseten's private
+# secret store.
+#
+# Authorization is not based on possession of this key. Each certificate is
+# scoped to a specific principal (job ID), and sshd enforces that the cert's
+# principal matches the pod's job via AuthorizedPrincipals. A cert signed for
+# job X cannot be used to access job Y's pod, even within the same account.
 
 _SSH_RESET="\033[0m"
 _SSH_CYAN="\033[36m"

--- a/truss/templates/baseten-ssh-server.sh
+++ b/truss/templates/baseten-ssh-server.sh
@@ -1,0 +1,99 @@
+#!/bin/sh
+
+# SSH server startup script for inference model containers.
+#
+# Starts an OpenSSH server configured for CA-based certificate authentication.
+# The SSH CA public key is mounted from a Kubernetes Secret. Users connect
+# with CA-signed certificates whose principal must match BT_SSH_SUBJECT.
+#
+# This script is designed for non-root containers where the "app" user
+# (uid 60000) already exists in the image. Unlike the training SSH script,
+# it does not create users, modify /etc/passwd, or install packages at
+# runtime. openssh-server must be pre-installed in the image.
+#
+# Environment variables (set by the operator template):
+#   BT_SSH_CA_KEY_PATH   - Path to the SSH CA public key file
+#   BT_SSH_SUBJECT       - Subject identifier (used as authorized principal)
+#   BT_SSH_DIR           - Directory for SSH runtime files (default: /run/baseten-ssh)
+
+_SSH_RESET="\033[0m"
+_SSH_CYAN="\033[36m"
+_SSH_GREEN="\033[32m"
+_SSH_YELLOW="\033[33m"
+_SSH_RED="\033[31m"
+
+_ssh_log()     { printf "${_SSH_CYAN}[baseten-ssh]${_SSH_RESET} %b\n" "$1"; }
+_ssh_log_ok()  { printf "${_SSH_CYAN}[baseten-ssh]${_SSH_RESET} ${_SSH_GREEN}%b${_SSH_RESET}\n" "$1"; }
+_ssh_log_warn() { printf "${_SSH_CYAN}[baseten-ssh]${_SSH_RESET} ${_SSH_YELLOW}WARNING: %b${_SSH_RESET}\n" "$1"; }
+_ssh_log_err() { printf "${_SSH_CYAN}[baseten-ssh]${_SSH_RESET} ${_SSH_RED}ERROR: %b${_SSH_RESET}\n" "$1"; }
+
+start_ssh_server() {
+    local ssh_port="${1:-2222}"
+    local ca_key_path="${BT_SSH_CA_KEY_PATH:-/etc/ssh-ca/ca.pub}"
+    local ssh_dir="${BT_SSH_DIR:-/run/baseten-ssh}"
+    local subject="${BT_SSH_SUBJECT:-}"
+
+    _ssh_log "Starting SSH server setup..."
+
+    if [ -z "$subject" ]; then
+        _ssh_log_err "BT_SSH_SUBJECT is not set. SSH server will not start."
+        return 1
+    fi
+
+    if [ ! -f "$ca_key_path" ]; then
+        _ssh_log_err "SSH CA public key not found at $ca_key_path. SSH server will not start."
+        return 1
+    fi
+
+    if ! command -v sshd >/dev/null 2>&1; then
+        _ssh_log_err "sshd not found. openssh-server must be installed in the image. SSH server will not start."
+        return 1
+    fi
+
+    mkdir -p "$ssh_dir"
+
+    if [ ! -f "$ssh_dir/bt_ssh_host_ed25519_key" ]; then
+        _ssh_log "Generating host keys..."
+        ssh-keygen -t ed25519 -f "$ssh_dir/bt_ssh_host_ed25519_key" -N "" -q
+        ssh-keygen -t rsa -b 4096 -f "$ssh_dir/bt_ssh_host_rsa_key" -N "" -q
+    fi
+
+    echo "$subject" > "$ssh_dir/bt_authorized_principals"
+
+    local sftp_server=""
+    for path in /usr/lib/openssh/sftp-server /usr/lib/ssh/sftp-server /usr/libexec/openssh/sftp-server; do
+        if [ -f "$path" ]; then
+            sftp_server="$path"
+            break
+        fi
+    done
+    if [ -z "$sftp_server" ]; then
+        _ssh_log_warn "sftp-server not found, SFTP will not be available"
+    fi
+
+    cat > "$ssh_dir/bt_sshd_config" << SSHD_EOF
+Port $ssh_port
+HostKey $ssh_dir/bt_ssh_host_ed25519_key
+HostKey $ssh_dir/bt_ssh_host_rsa_key
+PidFile $ssh_dir/bt_sshd.pid
+TrustedUserCAKeys $ca_key_path
+AuthorizedPrincipalsFile $ssh_dir/bt_authorized_principals
+AllowUsers app
+StrictModes no
+PasswordAuthentication no
+KbdInteractiveAuthentication no
+PrintMotd no
+AcceptEnv LANG LC_*
+${sftp_server:+Subsystem sftp $sftp_server}
+SSHD_EOF
+
+    local sshd_bin
+    sshd_bin=$(command -v sshd)
+
+    _ssh_log "Starting SSH server on port $ssh_port (subject=$subject)..."
+    "$sshd_bin" -f "$ssh_dir/bt_sshd_config" -D -e &
+    BT_SSH_PID=$!
+    _ssh_log_ok "sshd started (subject=$subject)"
+}
+
+start_ssh_server "$@"

--- a/truss/tests/cli/test_ssh.py
+++ b/truss/tests/cli/test_ssh.py
@@ -6,6 +6,9 @@ import pytest
 from truss.cli import proxy_command
 from truss.cli import ssh as ssh_mod
 from truss.cli.proxy_command import (
+    WORKLOAD_MODEL,
+    WORKLOAD_TRAINING,
+    ParsedHostname,
     load_trussrc,
     parse_hostname,
     resolve_remote,
@@ -28,42 +31,50 @@ class TestParseHostname:
     def _parse(self, hostname):
         return parse_hostname(hostname)
 
-    def test_basic(self):
-        assert self._parse("training-job-5wo5n3y-0.dev.ssh.baseten.co") == (
-            "5wo5n3y",
-            "0",
-            "dev",
-            None,
+    def _training(self, id, replica, remote, api_prefix):
+        return ParsedHostname(
+            workload_type=WORKLOAD_TRAINING,
+            id=id,
+            replica=replica,
+            environment=None,
+            remote=remote,
+            api_prefix=api_prefix,
         )
 
-    def test_multi_digit_replica(self):
-        assert self._parse("training-job-abc1234-12.baseten.ssh.baseten.co") == (
-            "abc1234",
-            "12",
-            "baseten",
-            None,
+    def _model(self, id, environment, replica, remote, api_prefix):
+        return ParsedHostname(
+            workload_type=WORKLOAD_MODEL,
+            id=id,
+            replica=replica,
+            environment=environment,
+            remote=remote,
+            api_prefix=api_prefix,
         )
+
+    def test_basic(self):
+        assert self._parse(
+            "training-job-5wo5n3y-0.dev.ssh.baseten.co"
+        ) == self._training("5wo5n3y", "0", "dev", None)
+
+    def test_multi_digit_replica(self):
+        assert self._parse(
+            "training-job-abc1234-12.baseten.ssh.baseten.co"
+        ) == self._training("abc1234", "12", "baseten", None)
 
     def test_remote_with_dashes(self):
         assert self._parse(
             "training-job-5wo5n3y-0.my-custom-remote.ssh.baseten.co"
-        ) == ("5wo5n3y", "0", "my-custom-remote", None)
+        ) == self._training("5wo5n3y", "0", "my-custom-remote", None)
 
     def test_staging_remote(self):
-        assert self._parse("training-job-abc1234-2.staging.ssh.baseten.co") == (
-            "abc1234",
-            "2",
-            "staging",
-            None,
-        )
+        assert self._parse(
+            "training-job-abc1234-2.staging.ssh.baseten.co"
+        ) == self._training("abc1234", "2", "staging", None)
 
     def test_api_prefix(self):
-        assert self._parse("training-job-rwn61qy-0.dev.mc-dev.ssh.baseten.co") == (
-            "rwn61qy",
-            "0",
-            "dev",
-            "mc-dev",
-        )
+        assert self._parse(
+            "training-job-rwn61qy-0.dev.mc-dev.ssh.baseten.co"
+        ) == self._training("rwn61qy", "0", "dev", "mc-dev")
 
     def test_invalid_no_suffix(self):
         with pytest.raises(SystemExit):
@@ -71,19 +82,50 @@ class TestParseHostname:
 
     def test_invalid_no_prefix(self):
         with pytest.raises(SystemExit):
-            self._parse("5wo5n3y-0.dev.ssh.baseten.co")  # missing training-job- prefix
+            self._parse("5wo5n3y-0.dev.ssh.baseten.co")
 
     def test_no_remote(self):
-        assert self._parse("training-job-5wo5n3y-0.ssh.baseten.co") == (
-            "5wo5n3y",
-            "0",
-            None,
-            None,
+        assert self._parse("training-job-5wo5n3y-0.ssh.baseten.co") == self._training(
+            "5wo5n3y", "0", None, None
         )
 
     def test_invalid_no_replica(self):
         with pytest.raises(SystemExit):
-            self._parse("training-job-5wo5n3y.dev.ssh.baseten.co")  # no -node
+            self._parse("training-job-5wo5n3y.dev.ssh.baseten.co")
+
+    def test_model_basic(self):
+        assert self._parse("model-abc123.dev.ssh.baseten.co") == self._model(
+            "abc123", None, None, "dev", None
+        )
+
+    def test_model_with_environment(self):
+        assert self._parse("model-abc123-staging.dev.ssh.baseten.co") == self._model(
+            "abc123", "staging", None, "dev", None
+        )
+
+    def test_model_no_remote(self):
+        assert self._parse("model-abc123.ssh.baseten.co") == self._model(
+            "abc123", None, None, None, None
+        )
+
+    def test_model_api_prefix(self):
+        assert self._parse("model-abc123.dev.mc-dev.ssh.baseten.co") == self._model(
+            "abc123", None, None, "dev", "mc-dev"
+        )
+
+    def test_model_replica_from_env(self, monkeypatch):
+        monkeypatch.setenv("BASETEN_REPLICA", "pod-xyz")
+        assert self._parse("model-abc123.dev.ssh.baseten.co") == self._model(
+            "abc123", None, "pod-xyz", "dev", None
+        )
+
+    def test_model_empty_id(self):
+        with pytest.raises(SystemExit):
+            self._parse("model-.dev.ssh.baseten.co")
+
+    def test_model_empty_environment(self):
+        with pytest.raises(SystemExit):
+            self._parse("model-abc123-.dev.ssh.baseten.co")
 
 
 class TestLoadTrussrc:
@@ -249,9 +291,11 @@ class TestSetupSSHConfig:
         content = ssh_config.read_text()
         assert MARKER_START in content
         assert MARKER_END in content
-        assert "*.ssh.baseten.co" in content
+        assert "training-job-*.ssh.baseten.co" in content
+        assert "model-*.ssh.baseten.co" in content
         assert "proxy-command.py" in content
         assert "User baseten" in content
+        assert "User app" in content
 
     def test_replaces_existing_block(self, tmp_path):
         ssh_config = tmp_path / "config"

--- a/truss/tests/cli/test_ssh.py
+++ b/truss/tests/cli/test_ssh.py
@@ -36,17 +36,17 @@ class TestParseHostname:
             workload_type=WORKLOAD_TRAINING,
             id=id,
             replica=replica,
-            environment=None,
+            deployment_id=None,
             remote=remote,
             api_prefix=api_prefix,
         )
 
-    def _model(self, id, environment, replica, remote, api_prefix):
+    def _model(self, id, deployment_id, replica, remote, api_prefix):
         return ParsedHostname(
             workload_type=WORKLOAD_MODEL,
             id=id,
             replica=replica,
-            environment=environment,
+            deployment_id=deployment_id,
             remote=remote,
             api_prefix=api_prefix,
         )
@@ -93,39 +93,46 @@ class TestParseHostname:
         with pytest.raises(SystemExit):
             self._parse("training-job-5wo5n3y.dev.ssh.baseten.co")
 
-    def test_model_basic(self):
-        assert self._parse("model-abc123.dev.ssh.baseten.co") == self._model(
-            "abc123", None, None, "dev", None
+    def test_model_with_deployment(self):
+        assert self._parse("model-abc123-def456.dev.ssh.baseten.co") == self._model(
+            "abc123", "def456", None, "dev", None
         )
 
-    def test_model_with_environment(self):
-        assert self._parse("model-abc123-staging.dev.ssh.baseten.co") == self._model(
-            "abc123", "staging", None, "dev", None
-        )
+    def test_model_with_deployment_and_replica(self):
+        assert self._parse(
+            "model-abc123-def456-ghi789.dev.ssh.baseten.co"
+        ) == self._model("abc123", "def456", "ghi789", "dev", None)
+
+    def test_model_replica_with_dashes(self):
+        assert self._parse(
+            "model-abc123-def456-pod-xyz-abc.dev.ssh.baseten.co"
+        ) == self._model("abc123", "def456", "pod-xyz-abc", "dev", None)
 
     def test_model_no_remote(self):
-        assert self._parse("model-abc123.ssh.baseten.co") == self._model(
-            "abc123", None, None, None, None
+        assert self._parse("model-abc123-def456.ssh.baseten.co") == self._model(
+            "abc123", "def456", None, None, None
         )
 
     def test_model_api_prefix(self):
-        assert self._parse("model-abc123.dev.mc-dev.ssh.baseten.co") == self._model(
-            "abc123", None, None, "dev", "mc-dev"
-        )
+        assert self._parse(
+            "model-abc123-def456.dev.mc-dev.ssh.baseten.co"
+        ) == self._model("abc123", "def456", None, "dev", "mc-dev")
 
-    def test_model_replica_from_env(self, monkeypatch):
-        monkeypatch.setenv("BASETEN_REPLICA", "pod-xyz")
-        assert self._parse("model-abc123.dev.ssh.baseten.co") == self._model(
-            "abc123", None, "pod-xyz", "dev", None
-        )
+    def test_model_missing_deployment(self):
+        with pytest.raises(SystemExit):
+            self._parse("model-abc123.dev.ssh.baseten.co")
 
     def test_model_empty_id(self):
         with pytest.raises(SystemExit):
             self._parse("model-.dev.ssh.baseten.co")
 
-    def test_model_empty_environment(self):
+    def test_model_empty_deployment(self):
         with pytest.raises(SystemExit):
             self._parse("model-abc123-.dev.ssh.baseten.co")
+
+    def test_model_empty_replica(self):
+        with pytest.raises(SystemExit):
+            self._parse("model-abc123-def456-.dev.ssh.baseten.co")
 
 
 class TestLoadTrussrc:


### PR DESCRIPTION
## :rocket: What

- Add SSH support for inference model containers (previously only training jobs)
- New `baseten-ssh-server.sh` script that can run non-root sshd in inference images
- Split SSH config into two Match blocks: `User baseten` for training, `User app` for inference
- Add `remote_ssh.enabled` + `docker_server.run_as_user_id` validation

## :computer: How

- `baseten-ssh-server.sh` in `truss/templates/`: runs sshd as the `app` user (uid 60000) using `AuthorizedPrincipalsFile`, with `StrictModes no` for compatibility
- `base.Dockerfile.jinja`: when `remote_ssh` enabled, copies script to `/usr/local/bin/`, installs openssh-server, fixes shadow entry (`!` to `*`) so sshd accepts cert auth without PAM
- `serving_image_builder.py`: copies `baseten-ssh-server.sh` to build dir when remote_ssh enabled
- `ssh.py`: two Match blocks in SSH config so training connects as `baseten` and inference connects as `app`
- `truss_config.py`: model validator rejects `remote_ssh.enabled` with custom `run_as_user_id`
- `proxy_command.py`: parses `model-<model_id>-<deployment_id>[-<replica_id>].ssh.baseten.co` (deployment_id is required) and calls `POST /v1/models/{model_id}/deployments/{deployment_id}/ssh/sign`
- `cli.py`: after `truss push` with `remote_ssh.enabled`, prints a copyable `ssh model-<model_id>-<deployment_id>.ssh.baseten.co` hint

## :microscope: Testing

- Unit tests for hostname parsing (training + model), SSH config generation, key setup
- End to end tests done outside of this repo
