### PR TITLE
reduced arg drilling by creating container for push options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,138 @@
+# Changelog
+
+## Unreleased
+
+### Internal refactor: consolidate push argument set into `PushOptions`
+
+Resolves the TODO from Tyron in `truss/remote/baseten/remote.py` about the set of
+user-intent flags being drilled through `BasetenRemote.push`, `_prepare_push`,
+and `create_truss_service`.
+
+#### What changed
+
+**New:** `PushOptions` Pydantic model in `truss/remote/baseten/custom_types.py`.
+Holds the full set of user-intent flags that used to be passed as positional
+kwargs through every layer: `publish`, `promote`,
+`preserve_previous_prod_deployment`, `disable_truss_download`, `deployment_name`,
+`origin`, `environment`, `deploy_timeout_minutes`, `team_id`, `labels`,
+`preserve_env_instance_type`, `include_git_info`.
+
+**Moved and slimmed:** `FinalPushData` moved from `remote.py` to
+`custom_types.py`. Removed the duplicated fields (`preserve_previous_prod_deployment`,
+`origin`, `environment`, `allow_truss_download`, `team_id`, `labels`) and replaced
+them with a single `options: PushOptions` reference. `is_draft` and
+`allow_truss_download` are now derived `@property` accessors on the options.
+
+**Internal signatures:**
+- `BasetenRemote._prepare_push(truss_handle, model_name, options, progress_bar)`
+- `create_truss_service(api, push_data, truss_user_env, semver_bump)`
+
+**Public surfaces unchanged:**
+- `truss.api.push(**kwargs)` — same signature, same kwarg names, same defaults
+- `BasetenRemote.push(**kwargs)` — same signature; constructs `PushOptions`
+  internally
+- `BasetenRemote.push_chain_atomic(**kwargs)` — same; constructs `PushOptions`
+  internally for its call to `_prepare_push`
+
+**No wire-format change:** every inner API method (`api.create_model_from_truss`,
+`api.create_model_version_from_truss`, `api.create_development_model_from_truss`)
+is called with identical kwargs before and after. The GraphQL payload is
+byte-identical. No base image rebuild, no user-facing config migration, no
+change to deployed-model behavior.
+
+#### Why these specific choices
+
+**Why keep kwargs on `BasetenRemote.push` and `truss.api.push`?**
+Both functions are part of the documented SDK. External callers (Baseten users
+writing Python scripts) construct push calls with named kwargs. Changing to
+`push(options: PushOptions)` would be a breaking change for every script that
+calls `truss.push(target_dir, publish=True, environment="staging")`. The
+duplication cost of marshalling kwargs into `PushOptions` inside these two
+functions is contained and acceptable; the backwards-compatibility benefit is
+not negotiable for a public SDK.
+
+**Why make `create_truss_service` take `FinalPushData` (option "4b")?**
+Originally we considered leaving its signature alone and having `push()` unpack
+the struct when calling it. We chose the full refactor because
+`create_truss_service` has exactly one non-test caller (`BasetenRemote.push`),
+and every test call-site was going to be rewritten anyway as part of the
+`FinalPushData` reshape. Taking the slightly bigger change in one atomic PR is
+cleaner than leaving the internal surface half-migrated with a follow-up ticket
+that might never get picked up.
+
+**Why is `PushOptions` frozen, and why does `normalize()` return a new
+instance?**
+Previously `_prepare_push` mutated its `publish` and `environment` parameters in
+place based on model-server type and promote/environment interactions. That
+mutation was easy to miss when reading the code. A frozen struct plus an
+explicit `options = options.normalize(model_server)` line at the top of
+`_prepare_push` makes the mutation impossible to overlook, and makes it unit
+testable in isolation (see `test_push_options.py`).
+
+**Why did some validation move to `PushOptions` but `disable-truss-download`
+validation did not?**
+The pure validators — `deploy_timeout_minutes` range, `deployment_name`
+character set, `preserve_previous_prod_deployment` requires `promote` — only
+need the options themselves and nothing else, so they moved to field validators
+and a model validator on `PushOptions`. This lets them fail at construction time
+rather than after an S3 upload has started.
+
+The `disable-truss-download can only be used for new models` check requires an
+API lookup (`exists_model`) to determine whether the model name is new. It
+stayed in `_prepare_push` because `PushOptions` must not reach out to a network
+service during construction.
+
+**Why default `PushOptions.publish` to `False`?**
+Pre-existing inconsistency in the codebase: `truss.api.push` (public SDK)
+defaults `publish=False`, but `BasetenRemote.push` defaults `publish=True`.
+`PushOptions` must pick one default for direct construction
+(`PushOptions()`-style callers). We chose `False` to match the public SDK
+contract, since that is the documented default. Internal code that wants
+publishing must opt in explicitly — which is the safer default: a typo or
+missing field produces a draft deployment (recoverable) rather than an
+unintended published one (harder to reverse).
+
+**Why is `include_git_info` on `PushOptions` even though it doesn't get drilled
+through downstream?**
+`include_git_info` is only read inside `BasetenRemote.push` itself (to pick
+between `TrussUserEnv.collect()` and `TrussUserEnv.collect_with_git_info()`).
+Strictly speaking it does not solve the duplicated-args problem Tyron flagged.
+We included it in `PushOptions` anyway for consistency: all user-intent flags
+live in one place, so future readers do not have to remember which knobs are in
+the struct and which are loose kwargs.
+
+**Why did `push_chain_atomic` keep its local `publish = True` mutation before
+constructing `PushOptions`?**
+`push_chain_atomic` iterates over multiple chainlet artifacts and calls
+`_prepare_push` for each. Each call normalizes independently based on the
+artifact's model-server. By computing the `publish` upgrade upfront once
+(matching current behavior exactly) we avoid any chance of different chainlets
+making different normalization decisions. Preserves existing semantics with
+zero behavior drift.
+
+#### Risks evaluated and accepted
+
+- **`FinalPushData` field-shape change.** Verified via grep that no code outside
+  `truss/remote/baseten/` constructs or destructures `FinalPushData`, so
+  removing fields is safe.
+- **Validator error messages.** Kept verbatim from the previous `_prepare_push`
+  versions so existing `pytest.raises(ValueError, match="...")` assertions
+  continue to pass with no regex changes.
+- **Subclasses of `BasetenRemote`.** Verified via grep that no subclasses exist
+  in this repo or its siblings (`truss-chains`, `truss-train`), so internal
+  signature changes are safe.
+- **Smoketests.** Verified smoketest scripts construct `BasetenRemote` but do
+  not call `.push()`, so no smoketest contract depends on internals.
+
+#### Test coverage
+
+- New `truss/tests/remote/baseten/test_push_options.py` — 20 unit tests
+  covering field validators, model validator, `normalize()` rules, and frozen
+  semantics.
+- Updated `test_core.py` with a `_make_push_data` helper to keep each test's
+  setup minimal.
+- Updated mock assertions in `test_remote.py`, `test_cli.py`, and
+  `test_chain_upload.py` to read through `kwargs["push_data"].options.X`
+  instead of direct kwargs on the `create_truss_service` mock.
+
+Full test suite for `truss/tests/remote/` and `truss/tests/cli/`: 367 passed.

--- a/truss/remote/baseten/core.py
+++ b/truss/remote/baseten/core.py
@@ -391,53 +391,38 @@ def upload_chain_artifact(
 
 def create_truss_service(
     api: BasetenApi,
-    model_name: str,
-    s3_key: str,
-    config: str,
+    push_data: b10_types.FinalPushData,
     truss_user_env: b10_types.TrussUserEnv,
     semver_bump: str = "MINOR",
-    preserve_previous_prod_deployment: bool = False,
-    allow_truss_download: bool = False,
-    is_draft: Optional[bool] = False,
-    model_id: Optional[str] = None,
-    deployment_name: Optional[str] = None,
-    origin: Optional[b10_types.ModelOrigin] = None,
-    environment: Optional[str] = None,
-    preserve_env_instance_type: bool = True,
-    deploy_timeout_minutes: Optional[int] = None,
-    team_id: Optional[str] = None,
-    labels: Optional[dict] = None,
 ) -> ModelVersionHandle:
     """
     Create a model in the Baseten remote.
 
     Args:
         api: BasetenApi instance.
-        model_name: Name of the model to create.
-        s3_key: S3 key of the uploaded TrussHandle.
-        config: Base64 encoded JSON string of the Truss config.
+        push_data: FinalPushData produced by BasetenRemote._prepare_push.
+        truss_user_env: Client environment metadata.
         semver_bump: Semver bump type, defaults to "MINOR".
-        promote: Whether to promote the model after deploy, defaults to False.
-        preserve_previous_prod_deployment: Whether to scale old production deployment
-            to zero.
-        deployment_name: Name to apply to the created deployment. Not applied to
-            development model.
-        team_id: ID of the team to create the model in.
 
     Returns:
         A Model Version handle.
     """
-    if is_draft:
+    options = push_data.options
+    model_name = push_data.model_name
+    s3_key = push_data.s3_key
+    config = push_data.encoded_config_str
+
+    if push_data.is_draft:
         model_version_json = api.create_development_model_from_truss(
             model_name,
             s3_key,
             config,
             truss_user_env,
-            allow_truss_download=allow_truss_download,
-            origin=origin,
-            deploy_timeout_minutes=deploy_timeout_minutes,
-            team_id=team_id,
-            labels=labels,
+            allow_truss_download=push_data.allow_truss_download,
+            origin=options.origin,
+            deploy_timeout_minutes=options.deploy_timeout_minutes,
+            team_id=options.team_id,
+            labels=options.labels,
         )
 
         return ModelVersionHandle(
@@ -451,20 +436,20 @@ def create_truss_service(
             ),
         )
 
-    if model_id is None:
+    if push_data.model_id is None:
         model_version_json = api.create_model_from_truss(
             model_name,
             s3_key,
             config,
             semver_bump,
             truss_user_env,
-            allow_truss_download=allow_truss_download,
-            deployment_name=deployment_name,
-            origin=origin,
-            environment=environment,
-            deploy_timeout_minutes=deploy_timeout_minutes,
-            team_id=team_id,
-            labels=labels,
+            allow_truss_download=push_data.allow_truss_download,
+            deployment_name=options.deployment_name,
+            origin=options.origin,
+            environment=options.environment,
+            deploy_timeout_minutes=options.deploy_timeout_minutes,
+            team_id=options.team_id,
+            labels=options.labels,
         )
 
         return ModelVersionHandle(
@@ -479,22 +464,22 @@ def create_truss_service(
         )
 
     model_version_json = api.create_model_version_from_truss(
-        model_id,
+        push_data.model_id,
         s3_key,
         config,
         semver_bump,
         truss_user_env,
-        preserve_previous_prod_deployment=preserve_previous_prod_deployment,
-        deployment_name=deployment_name,
-        environment=environment,
-        preserve_env_instance_type=preserve_env_instance_type,
-        deploy_timeout_minutes=deploy_timeout_minutes,
-        labels=labels,
+        preserve_previous_prod_deployment=options.preserve_previous_prod_deployment,
+        deployment_name=options.deployment_name,
+        environment=options.environment,
+        preserve_env_instance_type=options.preserve_env_instance_type,
+        deploy_timeout_minutes=options.deploy_timeout_minutes,
+        labels=options.labels,
     )
 
     return ModelVersionHandle(
         version_id=model_version_json["id"],
-        model_id=model_id,
+        model_id=push_data.model_id,
         hostname=model_version_json["oracle"]["hostname"],
         instance_type_name=(
             model_version_json["instance_type"]["name"]

--- a/truss/remote/baseten/custom_types.py
+++ b/truss/remote/baseten/custom_types.py
@@ -1,12 +1,15 @@
 import pathlib
+import re
 import subprocess
 import sys
 from enum import Enum
-from typing import Optional
+from typing import Any, Dict, Optional
 
 import pydantic
 
 import truss
+from truss.base.constants import PRODUCTION_ENVIRONMENT_NAME
+from truss.base.truss_config import ModelServer
 
 
 class DeployedChainlet(pydantic.BaseModel):
@@ -38,6 +41,91 @@ class OracleData(pydantic.BaseModel):
     encoded_config_str: str
     semver_bump: Optional[str] = "MINOR"
     version_name: Optional[str] = None
+
+
+class PushOptions(pydantic.BaseModel):
+    # Frozen so normalize() returns a new instance rather than mutating in place.
+    class Config:
+        frozen = True
+
+    publish: bool = False
+    promote: bool = False
+    preserve_previous_prod_deployment: bool = False
+    disable_truss_download: bool = False
+    deployment_name: Optional[str] = None
+    origin: Optional[ModelOrigin] = None
+    environment: Optional[str] = None
+    deploy_timeout_minutes: Optional[int] = None
+    team_id: Optional[str] = None
+    labels: Optional[Dict[str, Any]] = None
+    preserve_env_instance_type: bool = True
+    include_git_info: bool = False
+
+    @pydantic.field_validator("deploy_timeout_minutes")
+    @classmethod
+    def _validate_deploy_timeout_minutes(cls, v: Optional[int]) -> Optional[int]:
+        if v is not None and (v < 10 or v > 1440):
+            raise ValueError(
+                "deploy-timeout-minutes must be between 10 minutes and 1440 minutes (24 hours)"
+            )
+        return v
+
+    @pydantic.field_validator("deployment_name")
+    @classmethod
+    def _validate_deployment_name(cls, v: Optional[str]) -> Optional[str]:
+        if v is not None and not re.match(r"^[0-9a-zA-Z_\-\.]*$", v):
+            raise ValueError(
+                "Deployment name must only contain alphanumeric, -, _ and . characters"
+            )
+        return v
+
+    @pydantic.model_validator(mode="after")
+    def _validate_preserve_requires_promote(self) -> "PushOptions":
+        if not self.promote and self.preserve_previous_prod_deployment:
+            raise ValueError(
+                "preserve-previous-production-deployment can only be used "
+                "with the '--promote' option"
+            )
+        return self
+
+    def normalize(self, model_server: ModelServer) -> "PushOptions":
+        # Apply server-dependent rules. Invariant: is_draft (= not publish) is
+        # only correct *after* normalize runs — callers must normalize before
+        # reading publish-derived state.
+        publish = self.publish
+        environment = self.environment
+
+        if model_server != ModelServer.TrussServer:
+            publish = True
+
+        if self.promote:
+            environment = PRODUCTION_ENVIRONMENT_NAME
+
+        if environment and not publish:
+            publish = True
+
+        if not publish and self.deployment_name:
+            raise ValueError(
+                "Deployment name cannot be used for development deployment"
+            )
+
+        return self.model_copy(update={"publish": publish, "environment": environment})
+
+
+class FinalPushData(OracleData):
+    class Config:
+        protected_namespaces = ()
+
+    model_id: Optional[str] = None
+    options: PushOptions
+
+    @property
+    def is_draft(self) -> bool:
+        return not self.options.publish
+
+    @property
+    def allow_truss_download(self) -> bool:
+        return not self.options.disable_truss_download
 
 
 # This corresponds to `ChainletInputAtomicGraphene` in the backend.

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -1,6 +1,5 @@
 import enum
 import logging
-import re
 import sys
 import time
 from pathlib import Path
@@ -20,8 +19,6 @@ import yaml
 from requests import ReadTimeout
 from watchfiles import watch
 
-from truss.base.constants import PRODUCTION_ENVIRONMENT_NAME
-from truss.base.truss_config import ModelServer
 from truss.local.local_config_handler import LocalConfigHandler
 from truss.remote.baseten import custom_types
 from truss.remote.baseten import custom_types as b10_types
@@ -45,6 +42,7 @@ from truss.remote.baseten.core import (
     upload_truss,
     validate_truss_config_against_backend,
 )
+from truss.remote.baseten.custom_types import FinalPushData, PushOptions
 from truss.remote.baseten.error import ApiError, RemoteError
 from truss.remote.baseten.service import BasetenService, URLConfig
 from truss.remote.baseten.utils.transfer import base64_encoded_json_str
@@ -92,20 +90,6 @@ def retry_patch(
                 f"Initial sync failed after {max_retries} attempts: {msg}"
             )
             sys.exit(1)
-
-
-class FinalPushData(custom_types.OracleData):
-    class Config:
-        protected_namespaces = ()
-
-    is_draft: bool
-    model_id: Optional[str]
-    preserve_previous_prod_deployment: bool
-    origin: Optional[custom_types.ModelOrigin] = None
-    environment: Optional[str] = None
-    allow_truss_download: bool
-    team_id: Optional[str] = None
-    labels: Optional[Dict[str, Any]] = None
 
 
 class BasetenRemote(TrussRemote):
@@ -173,17 +157,8 @@ class BasetenRemote(TrussRemote):
         self,
         truss_handle: TrussHandle,
         model_name: str,
-        publish: bool = True,
-        promote: bool = False,
-        preserve_previous_prod_deployment: bool = False,
-        disable_truss_download: bool = False,
-        deployment_name: Optional[str] = None,
-        origin: Optional[custom_types.ModelOrigin] = None,
-        environment: Optional[str] = None,
+        options: PushOptions,
         progress_bar: Optional[Type["progress.Progress"]] = None,
-        deploy_timeout_minutes: Optional[int] = None,
-        team_id: Optional[str] = None,
-        labels: Optional[Dict[str, Any]] = None,
     ) -> FinalPushData:
         if model_name.isspace():
             raise ValueError("Model name cannot be empty")
@@ -191,46 +166,20 @@ class BasetenRemote(TrussRemote):
         if truss_handle.is_scattered():
             truss_handle = TrussHandle(truss_handle.gather())
 
-        if truss_handle.spec.model_server != ModelServer.TrussServer:
-            publish = True
-
-        if promote:
-            environment = PRODUCTION_ENVIRONMENT_NAME
-
-        # If there is a target environment, it must be published.
-        # Draft models cannot be promoted.
-        if environment and not publish:
+        # Log auto-publish before normalization mutates publish.
+        if options.environment and not options.publish:
             logging.info(
                 f"Automatically publishing model '{model_name}' based on environment setting."
             )
-            publish = True
 
-        if not publish and deployment_name:
-            raise ValueError(
-                "Deployment name cannot be used for development deployment"
-            )
+        # Apply server-dependent rules (non-TrussServer forces publish, promote
+        # sets environment, environment forces publish, etc.). Returns a new
+        # PushOptions; subsequent reads must use the normalized instance.
+        options = options.normalize(truss_handle.spec.model_server)
 
-        if not promote and preserve_previous_prod_deployment:
-            raise ValueError(
-                "preserve-previous-production-deployment can only be used "
-                "with the '--promote' option"
-            )
-
-        if deployment_name and not re.match(r"^[0-9a-zA-Z_\-\.]*$", deployment_name):
-            raise ValueError(
-                "Deployment name must only contain alphanumeric, -, _ and . characters"
-            )
-
-        if deploy_timeout_minutes is not None and (
-            deploy_timeout_minutes < 10 or deploy_timeout_minutes > 1440
-        ):
-            raise ValueError(
-                "deploy-timeout-minutes must be between 10 minutes and 1440 minutes (24 hours)"
-            )
-
-        model_id = exists_model(self._api, model_name, team_id=team_id)
-
-        if model_id is not None and disable_truss_download:
+        # This check requires an API lookup and cannot move into PushOptions.
+        model_id = exists_model(self._api, model_name, team_id=options.team_id)
+        if model_id is not None and options.disable_truss_download:
             raise ValueError("disable-truss-download can only be used for new models")
 
         config = truss_handle._spec._config
@@ -245,15 +194,9 @@ class BasetenRemote(TrussRemote):
             model_name=model_name,
             s3_key=s3_key,
             encoded_config_str=encoded_config_str,
-            is_draft=not publish,
+            version_name=options.deployment_name,
             model_id=model_id,
-            preserve_previous_prod_deployment=preserve_previous_prod_deployment,
-            version_name=deployment_name,
-            origin=origin,
-            environment=environment,
-            allow_truss_download=not disable_truss_download,
-            team_id=team_id,
-            labels=labels,
+            options=options,
         )
 
     def push(  # type: ignore
@@ -275,9 +218,7 @@ class BasetenRemote(TrussRemote):
         team_id: Optional[str] = None,
         labels: Optional[Dict[str, Any]] = None,
     ) -> BasetenService:
-        push_data = self._prepare_push(
-            truss_handle=truss_handle,
-            model_name=model_name,
+        options = PushOptions(
             publish=publish,
             promote=promote,
             preserve_previous_prod_deployment=preserve_previous_prod_deployment,
@@ -285,38 +226,26 @@ class BasetenRemote(TrussRemote):
             deployment_name=deployment_name,
             origin=origin,
             environment=environment,
-            progress_bar=progress_bar,
             deploy_timeout_minutes=deploy_timeout_minutes,
             team_id=team_id,
             labels=labels,
+            preserve_env_instance_type=preserve_env_instance_type,
+            include_git_info=include_git_info,
+        )
+        push_data = self._prepare_push(
+            truss_handle=truss_handle,
+            model_name=model_name,
+            options=options,
+            progress_bar=progress_bar,
         )
 
-        if include_git_info:
+        if push_data.options.include_git_info:
             truss_user_env = b10_types.TrussUserEnv.collect_with_git_info(working_dir)
         else:
             truss_user_env = b10_types.TrussUserEnv.collect()
 
-        # TODO(Tyron): This set of args is duplicated across
-        # many functions. We should consolidate them into a
-        # data class with standardized default values so
-        # we're not drilling these arguments everywhere.
         model_version_handle = create_truss_service(
-            api=self._api,
-            model_name=push_data.model_name,
-            s3_key=push_data.s3_key,
-            config=push_data.encoded_config_str,
-            is_draft=push_data.is_draft,
-            model_id=push_data.model_id,
-            preserve_previous_prod_deployment=push_data.preserve_previous_prod_deployment,
-            allow_truss_download=push_data.allow_truss_download,
-            deployment_name=push_data.version_name,
-            origin=push_data.origin,
-            environment=push_data.environment,
-            truss_user_env=truss_user_env,
-            preserve_env_instance_type=preserve_env_instance_type,
-            deploy_timeout_minutes=deploy_timeout_minutes,
-            team_id=push_data.team_id,
-            labels=push_data.labels,
+            api=self._api, push_data=push_data, truss_user_env=truss_user_env
         )
 
         if model_version_handle.instance_type_name:
@@ -352,6 +281,15 @@ class BasetenRemote(TrussRemote):
         if environment and not publish:
             publish = True
 
+        options = PushOptions(
+            publish=publish,
+            environment=environment,
+            origin=custom_types.ModelOrigin.CHAINS,
+            disable_truss_download=disable_chain_download,
+            deployment_name=deployment_name,
+            team_id=team_id,
+        )
+
         chainlet_data: List[custom_types.ChainletDataAtomic] = []
 
         for artifact in [entrypoint_artifact, *dependency_artifacts]:
@@ -362,18 +300,13 @@ class BasetenRemote(TrussRemote):
             push_data = self._prepare_push(
                 truss_handle=truss_handle,
                 model_name=model_name,
-                publish=publish,
-                origin=custom_types.ModelOrigin.CHAINS,
+                options=options,
                 progress_bar=progress_bar,
-                disable_truss_download=disable_chain_download,
-                deployment_name=deployment_name,
             )
             oracle_data = custom_types.OracleData(
                 model_name=push_data.model_name,
                 s3_key=push_data.s3_key,
                 encoded_config_str=push_data.encoded_config_str,
-                is_draft=push_data.is_draft,
-                model_id=push_data.model_id,
                 version_name=push_data.version_name,
             )
             chainlet_data.append(

--- a/truss/tests/cli/test_cli.py
+++ b/truss/tests/cli/test_cli.py
@@ -528,7 +528,7 @@ def test_cli_push_passes_deploy_timeout_minutes_to_create_truss_service(
     assert result.exit_code == 0
     mock_create_truss_service.assert_called_once()
     _, kwargs = mock_create_truss_service.call_args
-    assert kwargs["deploy_timeout_minutes"] == 450
+    assert kwargs["push_data"].options.deploy_timeout_minutes == 450
 
 
 def test_cli_push_passes_none_deploy_timeout_minutes_when_not_specified(
@@ -557,7 +557,7 @@ def test_cli_push_passes_none_deploy_timeout_minutes_when_not_specified(
     assert result.exit_code == 0
     mock_create_truss_service.assert_called_once()
     _, kwargs = mock_create_truss_service.call_args
-    assert kwargs.get("deploy_timeout_minutes") is None
+    assert kwargs["push_data"].options.deploy_timeout_minutes is None
 
 
 def test_cli_push_integration_deploy_timeout_minutes_propagated(
@@ -590,8 +590,8 @@ def test_cli_push_integration_deploy_timeout_minutes_propagated(
     assert result.exit_code == 0
     mock_create_truss_service.assert_called_once()
     _, kwargs = mock_create_truss_service.call_args
-    assert kwargs["deploy_timeout_minutes"] == 750
-    assert kwargs["environment"] == "staging"
+    assert kwargs["push_data"].options.deploy_timeout_minutes == 750
+    assert kwargs["push_data"].options.environment == "staging"
 
 
 def test_cli_push_api_integration_deploy_timeout_minutes_propagated(
@@ -708,7 +708,7 @@ def test_push_defaults_to_published(
     assert result.exit_code == 0
     mock_create_truss_service.assert_called_once()
     _, kwargs = mock_create_truss_service.call_args
-    assert kwargs["is_draft"] is False
+    assert kwargs["push_data"].is_draft is False
 
 
 def test_push_no_cache_sets_build_no_cache_on_config(
@@ -1254,7 +1254,7 @@ def test_push_with_model_name_flag_does_not_write_to_config(
     assert result.exit_code == 0
     mock_write.assert_not_called()
     _, kwargs = mock_create_truss_service.call_args
-    assert kwargs["model_name"] == "override-name"
+    assert kwargs["push_data"].model_name == "override-name"
 
 
 def test_watch_model_name_flag_overrides_config(

--- a/truss/tests/remote/baseten/test_chain_upload.py
+++ b/truss/tests/remote/baseten/test_chain_upload.py
@@ -207,7 +207,7 @@ def test_push_chain_atomic_with_chain_upload(
     assert create_kwargs["deployment_name"] == deployment_name
 
     prepare_kwargs = context["mock_prepare_push"].call_args.kwargs
-    assert prepare_kwargs["deployment_name"] == deployment_name
+    assert prepare_kwargs["options"].deployment_name == deployment_name
 
 
 @patch("truss.remote.baseten.remote.create_chain_atomic")

--- a/truss/tests/remote/baseten/test_core.py
+++ b/truss/tests/remote/baseten/test_core.py
@@ -1,5 +1,6 @@
 import json
 from tempfile import NamedTemporaryFile
+from typing import Optional
 from unittest import mock
 from unittest.mock import MagicMock
 
@@ -16,6 +17,44 @@ from truss.remote.baseten.core import (
     get_training_job_logs_with_pagination,
 )
 from truss.remote.baseten.utils.time import iso_to_millis
+
+
+def _make_push_data(
+    *,
+    publish: bool = True,
+    model_id: Optional[str] = None,
+    deployment_name: Optional[str] = None,
+    environment: Optional[str] = None,
+    preserve_previous_prod_deployment: bool = False,
+    allow_truss_download: bool = True,
+    deploy_timeout_minutes: Optional[int] = None,
+    preserve_env_instance_type: bool = True,
+    labels: Optional[dict] = None,
+    origin: Optional[b10_types.ModelOrigin] = None,
+    team_id: Optional[str] = None,
+) -> b10_types.FinalPushData:
+    # preserve_previous_prod_deployment requires promote=True per PushOptions
+    # validator; tests that set preserve get promote=True implicitly.
+    return b10_types.FinalPushData(
+        model_name="model_name",
+        s3_key="s3_key",
+        encoded_config_str="config",
+        version_name=deployment_name,
+        model_id=model_id,
+        options=b10_types.PushOptions(
+            publish=publish,
+            promote=preserve_previous_prod_deployment,
+            preserve_previous_prod_deployment=preserve_previous_prod_deployment,
+            disable_truss_download=not allow_truss_download,
+            deployment_name=deployment_name,
+            environment=environment,
+            deploy_timeout_minutes=deploy_timeout_minutes,
+            preserve_env_instance_type=preserve_env_instance_type,
+            labels=labels,
+            origin=origin,
+            team_id=team_id,
+        ),
+    )
 
 
 def test_exists_model():
@@ -193,15 +232,13 @@ def test_create_truss_service_handles_eligible_environment_values(environment):
     api.create_model_from_truss.return_value = return_value
     version_handle = create_truss_service(
         api,
-        "model_name",
-        "s3_key",
-        "config",
+        _make_push_data(
+            publish=True,
+            model_id=None,
+            deployment_name="deployment_name",
+            environment=environment,
+        ),
         b10_types.TrussUserEnv.collect(),
-        preserve_previous_prod_deployment=False,
-        is_draft=False,
-        model_id=None,
-        deployment_name="deployment_name",
-        environment=environment,
     )
     assert version_handle.version_id == "model_version_id"
     assert version_handle.model_id == "model_id"
@@ -219,14 +256,8 @@ def test_create_truss_services_handles_is_draft(model_id):
     api.create_development_model_from_truss.return_value = return_value
     version_handle = create_truss_service(
         api,
-        "model_name",
-        "s3_key",
-        "config",
+        _make_push_data(publish=False, model_id=model_id),
         b10_types.TrussUserEnv.collect(),
-        preserve_previous_prod_deployment=False,
-        is_draft=True,
-        model_id=model_id,
-        deployment_name="deployment_name",
     )
     assert version_handle.version_id == "model_version_id"
     assert version_handle.model_id == "model_id"
@@ -238,7 +269,7 @@ def test_create_truss_services_handles_is_draft(model_id):
     [
         {
             "environment": None,
-            "deployment_name": "some deployment",
+            "deployment_name": "some_deployment",
             "preserve_previous_prod_deployment": False,
         },
         {
@@ -263,13 +294,8 @@ def test_create_truss_service_handles_existing_model(inputs):
     api.create_model_version_from_truss.return_value = return_value
     version_handle = create_truss_service(
         api,
-        "model_name",
-        "s3_key",
-        "config",
+        _make_push_data(publish=True, model_id="model_id", **inputs),
         b10_types.TrussUserEnv.collect(),
-        is_draft=False,
-        model_id="model_id",
-        **inputs,
     )
 
     assert version_handle.version_id == "model_version_id"
@@ -296,15 +322,13 @@ def test_create_truss_service_handles_allow_truss_download_for_new_models(
 
     version_handle = create_truss_service(
         api,
-        "model_name",
-        "s3_key",
-        "config",
+        _make_push_data(
+            publish=not is_draft,
+            model_id=None,
+            deployment_name="deployment_name",
+            allow_truss_download=allow_truss_download,
+        ),
         b10_types.TrussUserEnv.collect(),
-        preserve_previous_prod_deployment=False,
-        is_draft=is_draft,
-        model_id=None,
-        deployment_name="deployment_name",
-        allow_truss_download=allow_truss_download,
     )
     assert version_handle.version_id == "model_version_id"
     assert version_handle.model_id == "model_id"
@@ -906,14 +930,13 @@ def test_create_truss_service_passes_deploy_timeout_minutes():
     api.create_model_version_from_truss.return_value = return_value
     version_handle = create_truss_service(
         api,
-        "model_name",
-        "s3_key",
-        "config",
+        _make_push_data(
+            publish=True,
+            model_id="model_id",
+            environment="staging",
+            deploy_timeout_minutes=600,
+        ),
         b10_types.TrussUserEnv.collect(),
-        is_draft=False,
-        model_id="model_id",
-        environment="staging",
-        deploy_timeout_minutes=600,
     )
 
     assert version_handle.version_id == "model_version_id"
@@ -934,15 +957,14 @@ def test_create_truss_service_passes_deploy_timeout_minutes_with_other_params():
     api.create_model_version_from_truss.return_value = return_value
     version_handle = create_truss_service(
         api,
-        "model_name",
-        "s3_key",
-        "config",
+        _make_push_data(
+            publish=True,
+            model_id="model_id",
+            environment="production",
+            preserve_env_instance_type=False,
+            deploy_timeout_minutes=900,
+        ),
         b10_types.TrussUserEnv.collect(),
-        is_draft=False,
-        model_id="model_id",
-        environment="production",
-        preserve_env_instance_type=False,
-        deploy_timeout_minutes=900,
     )
 
     assert version_handle.version_id == "model_version_id"
@@ -964,13 +986,8 @@ def test_create_truss_service_passes_deploy_timeout_minutes_for_development_mode
     api.create_development_model_from_truss.return_value = return_value
     version_handle = create_truss_service(
         api,
-        "model_name",
-        "s3_key",
-        "config",
+        _make_push_data(publish=False, model_id=None, deploy_timeout_minutes=600),
         b10_types.TrussUserEnv.collect(),
-        is_draft=True,
-        model_id=None,
-        deploy_timeout_minutes=600,
     )
 
     assert version_handle.version_id == "model_version_id"
@@ -992,13 +1009,8 @@ def test_create_truss_service_passes_labels():
 
     version_handle = create_truss_service(
         api,
-        "model_name",
-        "s3_key",
-        "config",
+        _make_push_data(publish=True, model_id=None, labels=labels),
         b10_types.TrussUserEnv.collect(),
-        is_draft=False,
-        model_id=None,
-        labels=labels,
     )
 
     assert version_handle.version_id == "model_version_id"
@@ -1020,13 +1032,8 @@ def test_create_truss_service_passes_labels_for_development_model():
 
     version_handle = create_truss_service(
         api,
-        "model_name",
-        "s3_key",
-        "config",
+        _make_push_data(publish=False, model_id=None, labels=labels),
         b10_types.TrussUserEnv.collect(),
-        is_draft=True,
-        model_id=None,
-        labels=labels,
     )
 
     assert version_handle.version_id == "model_version_id"
@@ -1048,13 +1055,8 @@ def test_create_truss_service_passes_labels_for_existing_model():
 
     version_handle = create_truss_service(
         api,
-        "model_name",
-        "s3_key",
-        "config",
+        _make_push_data(publish=True, model_id="existing_model_id", labels=labels),
         b10_types.TrussUserEnv.collect(),
-        is_draft=False,
-        model_id="existing_model_id",
-        labels=labels,
     )
 
     assert version_handle.version_id == "model_version_id"

--- a/truss/tests/remote/baseten/test_push_options.py
+++ b/truss/tests/remote/baseten/test_push_options.py
@@ -1,0 +1,106 @@
+import pytest
+
+from truss.base.constants import PRODUCTION_ENVIRONMENT_NAME
+from truss.base.truss_config import ModelServer
+from truss.remote.baseten.custom_types import ModelOrigin, PushOptions
+
+
+def test_push_options_default_publish_is_false():
+    # Matches the public SDK (truss.api.push) default. Internal callers
+    # must opt-in to publishing.
+    options = PushOptions()
+    assert options.publish is False
+
+
+def test_deploy_timeout_minutes_validator_rejects_below_range():
+    with pytest.raises(
+        ValueError,
+        match=r"deploy-timeout-minutes must be between 10 minutes and 1440 minutes \(24 hours\)",
+    ):
+        PushOptions(deploy_timeout_minutes=9)
+
+
+def test_deploy_timeout_minutes_validator_rejects_above_range():
+    with pytest.raises(
+        ValueError,
+        match=r"deploy-timeout-minutes must be between 10 minutes and 1440 minutes \(24 hours\)",
+    ):
+        PushOptions(deploy_timeout_minutes=1441)
+
+
+@pytest.mark.parametrize("value", [10, 500, 1440, None])
+def test_deploy_timeout_minutes_validator_accepts_valid(value):
+    options = PushOptions(deploy_timeout_minutes=value)
+    assert options.deploy_timeout_minutes == value
+
+
+def test_deployment_name_validator_rejects_invalid_chars():
+    with pytest.raises(
+        ValueError,
+        match="Deployment name must only contain alphanumeric, -, _ and . characters",
+    ):
+        PushOptions(deployment_name="has space")
+
+
+@pytest.mark.parametrize("value", ["abc_123", "dep.name-v1", "", None])
+def test_deployment_name_validator_accepts_valid(value):
+    options = PushOptions(deployment_name=value)
+    assert options.deployment_name == value
+
+
+def test_preserve_requires_promote():
+    with pytest.raises(
+        ValueError,
+        match="preserve-previous-production-deployment can only be used with the '--promote' option",
+    ):
+        PushOptions(preserve_previous_prod_deployment=True, promote=False)
+
+
+def test_preserve_with_promote_is_valid():
+    options = PushOptions(preserve_previous_prod_deployment=True, promote=True)
+    assert options.preserve_previous_prod_deployment is True
+
+
+def test_normalize_non_truss_server_forces_publish():
+    options = PushOptions(publish=False)
+    normalized = options.normalize(ModelServer.TRT_LLM)
+    assert normalized.publish is True
+    # Original is unchanged (frozen).
+    assert options.publish is False
+
+
+def test_normalize_promote_sets_environment_to_production():
+    options = PushOptions(publish=True, promote=True)
+    normalized = options.normalize(ModelServer.TrussServer)
+    assert normalized.environment == PRODUCTION_ENVIRONMENT_NAME
+
+
+def test_normalize_environment_forces_publish():
+    options = PushOptions(publish=False, environment="staging")
+    normalized = options.normalize(ModelServer.TrussServer)
+    assert normalized.publish is True
+    assert normalized.environment == "staging"
+
+
+def test_normalize_deployment_name_without_publish_raises():
+    options = PushOptions(publish=False, deployment_name="dep_name")
+    with pytest.raises(
+        ValueError, match="Deployment name cannot be used for development deployment"
+    ):
+        options.normalize(ModelServer.TrussServer)
+
+
+def test_normalize_noop_when_already_published():
+    options = PushOptions(
+        publish=True, environment="staging", origin=ModelOrigin.BASETEN
+    )
+    normalized = options.normalize(ModelServer.TrussServer)
+    assert normalized.publish is True
+    assert normalized.environment == "staging"
+    assert normalized.origin == ModelOrigin.BASETEN
+
+
+def test_push_options_is_frozen():
+    options = PushOptions()
+    with pytest.raises(ValueError):
+        options.publish = True  # type: ignore[misc]

--- a/truss/tests/remote/baseten/test_remote.py
+++ b/truss/tests/remote/baseten/test_remote.py
@@ -664,7 +664,7 @@ def test_push_passes_deploy_timeout_minutes_to_create_truss_service(
 
     mock_create_truss_service.assert_called_once()
     _, kwargs = mock_create_truss_service.call_args
-    assert kwargs["deploy_timeout_minutes"] == 450
+    assert kwargs["push_data"].options.deploy_timeout_minutes == 450
 
 
 def test_push_passes_none_deploy_timeout_minutes_when_not_specified(
@@ -681,7 +681,7 @@ def test_push_passes_none_deploy_timeout_minutes_when_not_specified(
 
     mock_create_truss_service.assert_called_once()
     _, kwargs = mock_create_truss_service.call_args
-    assert kwargs.get("deploy_timeout_minutes") is None
+    assert kwargs["push_data"].options.deploy_timeout_minutes is None
 
 
 def test_push_integration_deploy_timeout_minutes_propagated(
@@ -703,8 +703,8 @@ def test_push_integration_deploy_timeout_minutes_propagated(
 
     mock_create_truss_service.assert_called_once()
     _, kwargs = mock_create_truss_service.call_args
-    assert kwargs["deploy_timeout_minutes"] == 750
-    assert kwargs["environment"] == "staging"
+    assert kwargs["push_data"].options.deploy_timeout_minutes == 750
+    assert kwargs["push_data"].options.environment == "staging"
 
 
 def test_api_push_integration_deploy_timeout_minutes_propagated(


### PR DESCRIPTION
# Changelog

## Unreleased

### Internal refactor: consolidate push argument set into `PushOptions`

Resolves the TODO from Tyron in `truss/remote/baseten/remote.py` about the set of
user-intent flags being drilled through `BasetenRemote.push`, `_prepare_push`,
and `create_truss_service`.

#### What changed

**New:** `PushOptions` Pydantic model in `truss/remote/baseten/custom_types.py`.
Holds the full set of user-intent flags that used to be passed as positional
kwargs through every layer: `publish`, `promote`,
`preserve_previous_prod_deployment`, `disable_truss_download`, `deployment_name`,
`origin`, `environment`, `deploy_timeout_minutes`, `team_id`, `labels`,
`preserve_env_instance_type`, `include_git_info`.

**Moved and slimmed:** `FinalPushData` moved from `remote.py` to
`custom_types.py`. Removed the duplicated fields (`preserve_previous_prod_deployment`,
`origin`, `environment`, `allow_truss_download`, `team_id`, `labels`) and replaced
them with a single `options: PushOptions` reference. `is_draft` and
`allow_truss_download` are now derived `@property` accessors on the options.

**Internal signatures:**
- `BasetenRemote._prepare_push(truss_handle, model_name, options, progress_bar)`
- `create_truss_service(api, push_data, truss_user_env, semver_bump)`

**Public surfaces unchanged:**
- `truss.api.push(**kwargs)` — same signature, same kwarg names, same defaults
- `BasetenRemote.push(**kwargs)` — same signature; constructs `PushOptions`
  internally
- `BasetenRemote.push_chain_atomic(**kwargs)` — same; constructs `PushOptions`
  internally for its call to `_prepare_push`

**No wire-format change:** every inner API method (`api.create_model_from_truss`,
`api.create_model_version_from_truss`, `api.create_development_model_from_truss`)
is called with identical kwargs before and after. The GraphQL payload is
byte-identical. No base image rebuild, no user-facing config migration, no
change to deployed-model behavior.

#### Why these specific choices

**Why keep kwargs on `BasetenRemote.push` and `truss.api.push`?**
Both functions are part of the documented SDK. External callers (Baseten users
writing Python scripts) construct push calls with named kwargs. Changing to
`push(options: PushOptions)` would be a breaking change for every script that
calls `truss.push(target_dir, publish=True, environment="staging")`. The
duplication cost of marshalling kwargs into `PushOptions` inside these two
functions is contained and acceptable; the backwards-compatibility benefit is
not negotiable for a public SDK.

**Why make `create_truss_service` take `FinalPushData`?**
Originally we considered leaving its signature alone and having `push()` unpack
the struct when calling it. We chose the full refactor because
`create_truss_service` has exactly one non-test caller (`BasetenRemote.push`),
and every test call-site was going to be rewritten anyway as part of the
`FinalPushData` reshape. Taking the slightly bigger change in one atomic PR is
cleaner than leaving the internal surface half-migrated with a follow-up ticket
that might never get picked up.

**Why is `PushOptions` frozen, and why does `normalize()` return a new
instance?**
Previously `_prepare_push` mutated its `publish` and `environment` parameters in
place based on model-server type and promote/environment interactions. That
mutation was easy to miss when reading the code. A frozen struct plus an
explicit `options = options.normalize(model_server)` line at the top of
`_prepare_push` makes the mutation impossible to overlook, and makes it unit
testable in isolation (see `test_push_options.py`).

**Why did some validation move to `PushOptions` but `disable-truss-download`
validation did not?**
The pure validators — `deploy_timeout_minutes` range, `deployment_name`
character set, `preserve_previous_prod_deployment` requires `promote` — only
need the options themselves and nothing else, so they moved to field validators
and a model validator on `PushOptions`. This lets them fail at construction time
rather than after an S3 upload has started.

The `disable-truss-download can only be used for new models` check requires an
API lookup (`exists_model`) to determine whether the model name is new. It
stayed in `_prepare_push` because `PushOptions` must not reach out to a network
service during construction.

**Why default `PushOptions.publish` to `False`?**
Pre-existing inconsistency in the codebase: `truss.api.push` (public SDK)
defaults `publish=False`, but `BasetenRemote.push` defaults `publish=True`.
`PushOptions` must pick one default for direct construction
(`PushOptions()`-style callers). We chose `False` to match the public SDK
contract, since that is the documented default. Internal code that wants
publishing must opt in explicitly — which is the safer default: a typo or
missing field produces a draft deployment (recoverable) rather than an
unintended published one (harder to reverse).

**Why is `include_git_info` on `PushOptions` even though it doesn't get drilled
through downstream?**
`include_git_info` is only read inside `BasetenRemote.push` itself (to pick
between `TrussUserEnv.collect()` and `TrussUserEnv.collect_with_git_info()`).
Strictly speaking it does not solve the duplicated-args problem Tyron flagged.
We included it in `PushOptions` anyway for consistency: all user-intent flags
live in one place, so future readers do not have to remember which knobs are in
the struct and which are loose kwargs.

**Why did `push_chain_atomic` keep its local `publish = True` mutation before
constructing `PushOptions`?**
`push_chain_atomic` iterates over multiple chainlet artifacts and calls
`_prepare_push` for each. Each call normalizes independently based on the
artifact's model-server. By computing the `publish` upgrade upfront once
(matching current behavior exactly) we avoid any chance of different chainlets
making different normalization decisions. Preserves existing semantics with
zero behavior drift.

#### Testing

- **`FinalPushData` field-shape change.** Verified via grep that no code outside
  `truss/remote/baseten/` constructs or destructures `FinalPushData`, so
  removing fields is safe.
- **Validator error messages.** Kept verbatim from the previous `_prepare_push`
  versions so existing `pytest.raises(ValueError, match="...")` assertions
  continue to pass with no regex changes.
- **Subclasses of `BasetenRemote`.** Verified via grep that no subclasses exist
  in this repo or its siblings (`truss-chains`, `truss-train`), so internal
  signature changes are safe.
- **Smoketests.** Verified smoketest scripts construct `BasetenRemote` but do
  not call `.push()`, so no smoketest contract depends on internals.
- New `truss/tests/remote/baseten/test_push_options.py` — 20 unit tests
  covering field validators, model validator, `normalize()` rules, and frozen
  semantics.
- Updated `test_core.py` with a `_make_push_data` helper to keep each test's
  setup minimal.
- Updated mock assertions in `test_remote.py`, `test_cli.py`, and
  `test_chain_upload.py` to read through `kwargs["push_data"].options.X`
  instead of direct kwargs on the `create_truss_service` mock.

Full test suite for `truss/tests/remote/` and `truss/tests/cli/`: 367 passed.
