### PR TITLE
fix(docker_server): relocate nginx pid file off /run

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "truss"
-version = "0.16.1"
+version = "0.16.2rc500"
 description = "A seamless bridge from model development to model delivery"
 authors = [
     { name = "Pankaj Gupta", email = "no-reply@baseten.co" },

--- a/truss/templates/server.Dockerfile.jinja
+++ b/truss/templates/server.Dockerfile.jinja
@@ -117,6 +117,22 @@ RUN {% for secret,path in config.build.secret_to_path_mapping.items() %} --mount
 {%- if config.docker_server %}
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
         curl nginx && rm -rf /var/lib/apt/lists/*
+{#-
+  Relocate nginx's PID file off /run. The Ubuntu/Debian nginx package hardcodes
+  `pid /run/nginx.pid;` in /etc/nginx/nginx.conf, so when nginx runs as a
+  non-root UID via `run_as_user_id`, it needs /run to be writable by that UID
+  to create its pid file. Whether /run ends up writable in the final image
+  depends on how the base image was built, which makes relying on it fragile.
+  /tmp is world-writable with the sticky bit so it works regardless of what
+  the base image does with /run.
+  Note: `pid` must live in nginx's main context, so this cannot be overridden
+  from /etc/nginx/conf.d (which is included inside the http block), and it
+  cannot be overridden via `nginx -g` either (nginx errors on a duplicate `pid`
+  directive). Editing nginx.conf directly is the only workable option.
+#}
+RUN sed -i -e 's|^pid\s*/run/nginx.pid;|pid /tmp/nginx.pid;|' \
+           -e 's|^pid\s*/var/run/nginx.pid;|pid /tmp/nginx.pid;|' \
+           /etc/nginx/nginx.conf
 COPY --chown={{ default_owner }} ./docker_server_requirements.txt ${APP_HOME}/docker_server_requirements.txt
 
 {# NB(nikhil): Use the same python version for custom server proxy as the control server, for consistency. #}

--- a/uv.lock
+++ b/uv.lock
@@ -3393,7 +3393,7 @@ wheels = [
 
 [[package]]
 name = "truss"
-version = "0.16.1"
+version = "0.16.2rc500"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Problem

When a Truss is deployed with a `docker_server` config that sets `run_as_user_id` to a non-root UID, and the base image preinstalls nginx (or the image build ends up with nginx installed from the Debian/Ubuntu archive), nginx fails to start at container runtime:

```
nginx: [warn] the "user" directive makes sense only if the master process runs with super-user privileges, ignored
nginx: [emerg] open() "/run/nginx.pid" failed (13: Permission denied)
```

The Ubuntu/Debian `nginx` package hard-codes `pid /run/nginx.pid;` in `/etc/nginx/nginx.conf`. Starting nginx as a non-root user therefore requires `/run` to be writable by that user, and the state of `/run` inside the final image is sensitive to how the base image was built (e.g. whether `/run` is declared as a `VOLUME`, whether ownership changes applied during the Truss build are preserved in the committed layer, etc.). Depending on `/run` being writable by a non-root user for nginx's PID file is fragile.

## Fix

Relocate nginx's PID file from `/run/nginx.pid` to `/tmp/nginx.pid` at image build time by patching `/etc/nginx/nginx.conf` with `sed` right after nginx is installed. `/tmp` is world-writable with the sticky bit in standard base images, so it works regardless of what the base image does with `/run`.

Notes on why `sed` (rather than an override via `conf.d` or `-g`):
- `pid` must appear in nginx's main context. It cannot be overridden from files included inside `http { ... }` (which is how `/etc/nginx/conf.d/*.conf` is wired up).
- It cannot be overridden via `nginx -g "pid /tmp/nginx.pid;"` either — nginx treats two `pid` directives as a duplicate and errors on startup.
- Editing `/etc/nginx/nginx.conf` directly is the only workable option.

## Test plan

- [ ] Build a `docker_server` Truss with `run_as_user_id` set to a non-root UID against a base image where `/run` is not writable by that UID, and confirm nginx starts successfully (previously emitted the `/run/nginx.pid` permission error).
- [ ] Confirm normal predictions route through nginx to the upstream docker server.
- [ ] Confirm `/tmp/nginx.pid` is created at runtime.