### PR TITLE
feat(train): add optional --priority flag to job submission

### DIFF
--- a/truss-train/truss_train/definitions.py
+++ b/truss-train/truss_train/definitions.py
@@ -207,6 +207,7 @@ class TrainingJob(custom_types.SafeModelNoExtra):
     runtime: Runtime = Runtime()
     interactive_session: Optional[InteractiveSession] = None
     name: Optional[str] = None
+    priority: Optional[int] = None
     workspace: Optional[Workspace] = None
     weights: List[truss_config.WeightsSource] = []
     """MDN weight sources to mount in the training container. Weights are mirrored and cached for fast startup."""

--- a/truss-train/truss_train/deployment.py
+++ b/truss-train/truss_train/deployment.py
@@ -287,6 +287,7 @@ def prepare_push(
         runtime=training_job.runtime,
         compute=training_job.compute,
         name=training_job.name,
+        priority=training_job.priority,
         interactive_session=training_job.interactive_session,
         workspace=training_job.workspace,
         weights=training_job.weights,
@@ -330,6 +331,7 @@ def _apply_cli_overrides(
     accelerator: Optional[str] = None,
     node_count: Optional[int] = None,
     entrypoint: Optional[str] = None,
+    priority: Optional[int] = None,
 ) -> None:
     """Apply CLI flag overrides to the training project configuration."""
     if interactive_trigger is not None or interactive_timeout_minutes is not None:
@@ -381,6 +383,14 @@ def _apply_cli_overrides(
             )
         training_project.job.runtime.start_commands = [entrypoint]
 
+    if priority is not None:
+        existing_priority = training_project.job.priority
+        if existing_priority is not None:
+            console.print(
+                f"[bold yellow]⚠ Warning:[/bold yellow] priority '{existing_priority}' provided in config file will be ignored. Using '{priority}' provided via --priority flag."
+            )
+        training_project.job.priority = priority
+
 
 def create_training_job(
     remote_provider: BasetenRemote,
@@ -394,6 +404,7 @@ def create_training_job(
     accelerator: Optional[str] = None,
     node_count: Optional[int] = None,
     entrypoint: Optional[str] = None,
+    priority: Optional[int] = None,
 ) -> dict:
     if job_name_from_cli:
         if training_project.job.name:
@@ -414,6 +425,7 @@ def create_training_job(
         accelerator=accelerator,
         node_count=node_count,
         entrypoint=entrypoint,
+        priority=priority,
     )
 
     source_dir = config.absolute().parent

--- a/truss/cli/train_commands.py
+++ b/truss/cli/train_commands.py
@@ -170,6 +170,12 @@ def _resolve_team_name(
 )
 @click.option("--node-count", type=int, required=False, help="Number of compute nodes")
 @click.option("--entrypoint", type=str, required=False, help="Entrypoint command.")
+@click.option(
+    "--priority",
+    type=int,
+    required=False,
+    help="Job priority (higher values run first when capacity frees up).",
+)
 @common.common_options()
 def push_training_job(
     config: Path,
@@ -182,6 +188,7 @@ def push_training_job(
     accelerator: Optional[str],
     node_count: Optional[int],
     entrypoint: Optional[str],
+    priority: Optional[int],
 ):
     """Run a training job"""
     from truss_train import deployment, loader
@@ -218,6 +225,7 @@ def push_training_job(
                 accelerator=accelerator,
                 node_count=node_count,
                 entrypoint=entrypoint,
+                priority=priority,
             )
 
     # Note: This post create logic needs to happen outside the context


### PR DESCRIPTION
## :rocket: What

Add an optional `--priority` flag to `truss train push` so users can control which queued jobs run first when GPU capacity frees up. Higher values = higher priority. Jobs without priority preserve existing FIFO behavior.

Companion to backend PR: https://github.com/basetenlabs/baseten/pull/18914

## :computer: How

- **Model** (`definitions.py`): Added `priority: Optional[int] = None` to `TrainingJob`
- **CLI** (`train_commands.py`): Added `--priority` option to the `push` command
- **Deployment** (`deployment.py`): Threaded `priority` through `_apply_cli_overrides`, `create_training_job`, and `prepare_push` — includes config-file override warning consistent with other CLI flags

## :microscope: Testing

- All existing deployment tests pass (26/26)
- All loader and public API tests pass (10/10)
- Priority field is optional and backward-compatible — no existing behavior changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)