### PR TITLE
fix: make `import truss` not create ~/.config/truss as a side effect

### DIFF
--- a/integration_tests/self_upgrade/test_in_container.py
+++ b/integration_tests/self_upgrade/test_in_container.py
@@ -48,7 +48,7 @@ def test_settings_check_for_updates(enabled: bool):
     src = f"/tests/settings_{'enabled' if enabled else 'disabled'}.toml"
     shutil.copy(src, SETTINGS_DIR / "settings.toml")
     importlib.reload(uc)
-    assert uc.settings.check_for_updates is enabled
+    assert uc.get_settings().check_for_updates is enabled
     return f"check_for_updates={enabled} loaded correctly"
 
 

--- a/integration_tests/self_upgrade/test_settings_toml.py
+++ b/integration_tests/self_upgrade/test_settings_toml.py
@@ -55,7 +55,9 @@ def test_no_settings_file_creates_default():
 def test_settings_value_is_read(value: bool):
     write_settings(f"[preferences]\ncheck_for_updates = {str(value).lower()}\n")
     uc = reload_user_config()
-    assert uc.get_settings().check_for_updates is value, f"Should read {value} from file"
+    assert uc.get_settings().check_for_updates is value, (
+        f"Should read {value} from file"
+    )
     print(f"  Read check_for_updates = {uc.get_settings().check_for_updates}")
     return f"check_for_updates={value} read correctly"
 
@@ -118,7 +120,9 @@ def test_old_settings_file_gets_new_keys():
     )
 
     uc = reload_user_config()
-    assert uc.get_settings().check_for_updates is True, "Default should be True in memory"
+    assert uc.get_settings().check_for_updates is True, (
+        "Default should be True in memory"
+    )
 
     updated = SETTINGS_PATH.read_text()
     assert "check_for_updates" in updated, "check_for_updates should be added to file"

--- a/integration_tests/self_upgrade/test_settings_toml.py
+++ b/integration_tests/self_upgrade/test_settings_toml.py
@@ -44,7 +44,7 @@ def test_no_settings_file_creates_default():
     uc = reload_user_config()
 
     assert SETTINGS_PATH.exists(), "Settings file should be created"
-    assert uc.settings.check_for_updates is True, "Default should be True"
+    assert uc.get_settings().check_for_updates is True, "Default should be True"
 
     content = SETTINGS_PATH.read_text()
     assert "check_for_updates" in content, "check_for_updates should be in file"
@@ -55,8 +55,8 @@ def test_no_settings_file_creates_default():
 def test_settings_value_is_read(value: bool):
     write_settings(f"[preferences]\ncheck_for_updates = {str(value).lower()}\n")
     uc = reload_user_config()
-    assert uc.settings.check_for_updates is value, f"Should read {value} from file"
-    print(f"  Read check_for_updates = {uc.settings.check_for_updates}")
+    assert uc.get_settings().check_for_updates is value, f"Should read {value} from file"
+    print(f"  Read check_for_updates = {uc.get_settings().check_for_updates}")
     return f"check_for_updates={value} read correctly"
 
 
@@ -118,7 +118,7 @@ def test_old_settings_file_gets_new_keys():
     )
 
     uc = reload_user_config()
-    assert uc.settings.check_for_updates is True, "Default should be True in memory"
+    assert uc.get_settings().check_for_updates is True, "Default should be True in memory"
 
     updated = SETTINGS_PATH.read_text()
     assert "check_for_updates" in updated, "check_for_updates should be added to file"
@@ -146,7 +146,7 @@ def test_notification_shows_only_once_per_day():
 
     uc = reload_user_config()
 
-    result1 = uc.state.should_notify_upgrade("0.1.0")
+    result1 = uc.get_state().should_notify_upgrade("0.1.0")
     assert result1 is not None, "First call should return notification info"
     print(f"  First call returned: {result1}")
 
@@ -156,7 +156,7 @@ def test_notification_shows_only_once_per_day():
 
     uc = reload_user_config()
 
-    result2 = uc.state.should_notify_upgrade("0.1.0")
+    result2 = uc.get_state().should_notify_upgrade("0.1.0")
     assert result2 is None, f"Second call should return None, got: {result2}"
     print("  Second call returned None (as expected)")
 

--- a/truss-chains/truss_chains/deployment/deployment_client.py
+++ b/truss-chains/truss_chains/deployment/deployment_client.py
@@ -546,7 +546,7 @@ def _create_baseten_chain(
             remote_factory.RemoteFactory.create(remote=baseten_options.remote),
         )
 
-    if user_config.settings.include_git_info or baseten_options.include_git_info:
+    if user_config.get_settings().include_git_info or baseten_options.include_git_info:
         truss_user_env = b10_types.TrussUserEnv.collect_with_git_info(
             baseten_options.working_dir
         )

--- a/truss/cli/chains_commands.py
+++ b/truss/cli/chains_commands.py
@@ -323,7 +323,7 @@ def push_chain(
             remote = remote_cli.inquire_remote_name()
 
     if not include_git_info:
-        include_git_info = user_config.settings.include_git_info
+        include_git_info = user_config.get_settings().include_git_info
 
     # Resolve team if not in dryrun mode
     team_id = None

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -802,7 +802,7 @@ def push(
         remote = remote_cli.inquire_remote_name()
 
     if not include_git_info:
-        include_git_info = user_config.settings.include_git_info
+        include_git_info = user_config.get_settings().include_git_info
 
     remote_provider = RemoteFactory.create(remote=remote)
     if output_format == "json" and isinstance(remote_provider, BasetenRemote):

--- a/truss/cli/utils/self_upgrade.py
+++ b/truss/cli/utils/self_upgrade.py
@@ -115,10 +115,10 @@ def run_upgrade(target_version: Optional[str] = None, interactive: bool = True) 
 
 
 def notify_if_outdated(current_version: str) -> None:
-    if not user_config.settings.check_for_updates:
+    if not user_config.get_settings().check_for_updates:
         return
 
-    update_info = user_config.state.should_notify_upgrade(current_version)
+    update_info = user_config.get_state().should_notify_upgrade(current_version)
     if not update_info:
         return
 

--- a/truss/tests/cli/test_self_upgrade.py
+++ b/truss/tests/cli/test_self_upgrade.py
@@ -275,8 +275,8 @@ class TestNotifyIfOutdated:
         mock_settings = mock.Mock()
         mock_settings.check_for_updates = True
 
-        monkeypatch.setattr(user_config, "state", mock_state)
-        monkeypatch.setattr(user_config, "settings", mock_settings)
+        monkeypatch.setattr(user_config, "get_state", lambda: mock_state)
+        monkeypatch.setattr(user_config, "get_settings", lambda: mock_settings)
 
         self_upgrade.notify_if_outdated("0.11.0")
 
@@ -292,8 +292,8 @@ class TestNotifyIfOutdated:
         mock_settings = mock.Mock()
         mock_settings.check_for_updates = True
 
-        monkeypatch.setattr(user_config, "state", mock_state)
-        monkeypatch.setattr(user_config, "settings", mock_settings)
+        monkeypatch.setattr(user_config, "get_state", lambda: mock_state)
+        monkeypatch.setattr(user_config, "get_settings", lambda: mock_settings)
 
         self_upgrade.notify_if_outdated("0.12.3")
 
@@ -305,8 +305,8 @@ class TestNotifyIfOutdated:
         mock_settings = mock.Mock()
         mock_settings.check_for_updates = False
 
-        monkeypatch.setattr(user_config, "state", mock_state)
-        monkeypatch.setattr(user_config, "settings", mock_settings)
+        monkeypatch.setattr(user_config, "get_state", lambda: mock_state)
+        monkeypatch.setattr(user_config, "get_settings", lambda: mock_settings)
 
         self_upgrade.notify_if_outdated("0.11.0")
 
@@ -320,8 +320,8 @@ class TestNotifyIfOutdated:
         mock_settings = mock.Mock()
         mock_settings.check_for_updates = True
 
-        monkeypatch.setattr(user_config, "state", mock_state)
-        monkeypatch.setattr(user_config, "settings", mock_settings)
+        monkeypatch.setattr(user_config, "get_state", lambda: mock_state)
+        monkeypatch.setattr(user_config, "get_settings", lambda: mock_settings)
 
         # Exception handling moved to upgrade_dialogue() in common.py
         with pytest.raises(Exception, match="Network error"):

--- a/truss/tests/test_user_config.py
+++ b/truss/tests/test_user_config.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import sys
 
@@ -11,12 +12,12 @@ def test_import_truss_does_not_create_config_dir(tmp_path):
             (
                 "import pathlib, os; "
                 "import truss; "
-                "config_dir = pathlib.Path.home() / '.config' / 'truss'; "
+                "config_dir = pathlib.Path(os.environ['XDG_CONFIG_HOME']) / 'truss'; "
                 "assert not config_dir.exists(), "
                 "f'{config_dir} was created as an import side effect'"
             ),
         ],
-        env={**dict(HOME=str(tmp_path)), "PATH": ""},
+        env={**os.environ, "XDG_CONFIG_HOME": str(tmp_path)},
         capture_output=True,
         text=True,
     )

--- a/truss/tests/test_user_config.py
+++ b/truss/tests/test_user_config.py
@@ -1,0 +1,23 @@
+import subprocess
+import sys
+
+
+def test_import_truss_does_not_create_config_dir(tmp_path):
+    """Regression test: `import truss` must not create ~/.config/truss as a side effect."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import pathlib, os; "
+                "import truss; "
+                "config_dir = pathlib.Path.home() / '.config' / 'truss'; "
+                "assert not config_dir.exists(), "
+                "f'{config_dir} was created as an import side effect'"
+            ),
+        ],
+        env={**dict(HOME=str(tmp_path)), "PATH": ""},
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr

--- a/truss/util/user_config.py
+++ b/truss/util/user_config.py
@@ -1,6 +1,7 @@
 """Tools to configure and track the Truss CLI state and behavior, e.g. auto-upgrades."""
 
 import datetime
+import functools
 import logging
 import os
 import pathlib
@@ -313,5 +314,11 @@ class _StateWrapper:
         return update_info
 
 
-state = _StateWrapper.read_or_create()
-settings = _SettingsWrapper.read_or_create()
+@functools.cache
+def get_state() -> _StateWrapper:
+    return _StateWrapper.read_or_create()
+
+
+@functools.cache
+def get_settings() -> _SettingsWrapper:
+    return _SettingsWrapper.read_or_create()


### PR DESCRIPTION
## :rocket: What

Fixes `import truss` eagerly creating `~/.config/truss/` as a side effect. This broke environments with non-writable home directories (e.g. Bazel sandboxes).

## :computer: How

The module-level globals `state` and `settings` in `truss/util/user_config.py` were eagerly initialized at import time, triggering `_get_dir()` → `mkdir(~/.config/truss)` through this import chain:

`truss/__init__` → `truss/api` → `model_team_resolver` → `remote_cli` → `common` → `self_upgrade` → `user_config`

Replaced the eager globals with `@functools.cache` accessor functions `get_state()` and `get_settings()`, so the config directory is only created when the CLI actually needs it (not on import).

## :microscope: Testing

- All 21 existing tests in `test_self_upgrade.py` pass
- Verified `import truss` no longer creates `~/.config/truss`:
  ```
  HOME=/tmp/test python -c "import truss; assert not os.path.exists('/tmp/test/.config/truss')"
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)