### PR TITLE
feat(chains): add build_commands to RemoteConfig

### DIFF
--- a/truss-chains/truss_chains/deployment/code_gen.py
+++ b/truss-chains/truss_chains/deployment/code_gen.py
@@ -858,6 +858,7 @@ def _gen_truss_config(
     config.runtime.streaming_read_timeout = remote_config.options.streaming_read_timeout
     config.model_metadata = cast(dict[str, Any], remote_config.options.metadata) or {}
     config.environment_variables = dict(remote_config.options.env_variables)
+    config.build_commands = list(remote_config.build_commands)
 
     if remote_config.docker_image.truss_server_version_override:
         config.runtime.truss_server_version_override = (

--- a/truss-chains/truss_chains/public_types.py
+++ b/truss-chains/truss_chains/public_types.py
@@ -492,6 +492,11 @@ class RemoteConfig(custom_types.SafeModelNonSerializable):
     assets: Assets = Assets()
     name: Optional[str] = None
     options: ChainletOptions = ChainletOptions()
+    build_commands: list[str] = pydantic.Field(
+        default_factory=list,
+        description="Shell commands run during the Docker image build, after system "
+        "packages and before chain code (same as Truss `config.yaml` `build_commands`).",
+    )
 
     def get_compute_spec(self) -> ComputeSpec:
         return self.compute.get_spec()


### PR DESCRIPTION
## Summary
- Add `build_commands` to `chains.RemoteConfig`, mapping to Truss `config.yaml` `build_commands` (shell commands run during Docker image build after system packages).
- Wire the field in `_gen_truss_config` so generated chainlet `config.yaml` includes it for all chainlet types (including engine-builder).

## Usage
```python
remote_config = chains.RemoteConfig(
    docker_image=...,
    compute=...,
    build_commands=["apt-get update && apt-get install -y git", "echo step2"],
)
```

## Test plan
- [x] `uv run ruff check truss-chains/truss_chains/public_types.py truss-chains/truss_chains/deployment/code_gen.py`

Made with [Cursor](https://cursor.com)