### PR TITLE
feat(chains): Enables BDN weight mirroring for engine builder checkpoints.

### DIFF
--- a/truss-chains/truss_chains/deployment/code_gen.py
+++ b/truss-chains/truss_chains/deployment/code_gen.py
@@ -867,6 +867,11 @@ def _gen_truss_config(
 
     if issubclass(chainlet_descriptor.chainlet_cls, framework.EngineBuilderChainlet):
         config.trt_llm = chainlet_descriptor.chainlet_cls.engine_builder_config
+        # MDN / BDN: `assets.weights` is allowed on engine builder chainlets (unlike
+        # `cached` / `external_data`) and must be copied so weight resolution can run
+        # before the TRT engine build when the platform uses `config.weights` for that.
+        if assets.weights:
+            config.weights = truss_config.Weights(assets.weights)
         truss_config.TrussConfig.model_validate(config)
         return config
 

--- a/truss-chains/truss_chains/deployment/code_gen.py
+++ b/truss-chains/truss_chains/deployment/code_gen.py
@@ -866,7 +866,7 @@ def _gen_truss_config(
 
     if issubclass(chainlet_descriptor.chainlet_cls, framework.EngineBuilderChainlet):
         config.trt_llm = chainlet_descriptor.chainlet_cls.engine_builder_config
-        # Enables MDN weight mirroring for engine builder checkpoints.
+        # Enables BDN weight mirroring for engine builder checkpoints.
         if assets.weights:
             config.weights = truss_config.Weights(assets.weights)
         truss_config.TrussConfig.model_validate(config)

--- a/truss-chains/truss_chains/deployment/code_gen.py
+++ b/truss-chains/truss_chains/deployment/code_gen.py
@@ -866,9 +866,7 @@ def _gen_truss_config(
 
     if issubclass(chainlet_descriptor.chainlet_cls, framework.EngineBuilderChainlet):
         config.trt_llm = chainlet_descriptor.chainlet_cls.engine_builder_config
-        # MDN / BDN: `assets.weights` is allowed on engine builder chainlets (unlike
-        # `cached` / `external_data`) and must be copied so weight resolution can run
-        # before the TRT engine build when the platform uses `config.weights` for that.
+        # Enables MDN weight mirroring for engine builder checkpoints.
         if assets.weights:
             config.weights = truss_config.Weights(assets.weights)
         truss_config.TrussConfig.model_validate(config)

--- a/truss-chains/truss_chains/deployment/code_gen.py
+++ b/truss-chains/truss_chains/deployment/code_gen.py
@@ -858,6 +858,7 @@ def _gen_truss_config(
     config.runtime.streaming_read_timeout = remote_config.options.streaming_read_timeout
     config.model_metadata = cast(dict[str, Any], remote_config.options.metadata) or {}
     config.environment_variables = dict(remote_config.options.env_variables)
+    config.build_commands = list(remote_config.build_commands)
 
     if remote_config.docker_image.truss_server_version_override:
         config.runtime.truss_server_version_override = (

--- a/truss-chains/truss_chains/deployment/code_gen.py
+++ b/truss-chains/truss_chains/deployment/code_gen.py
@@ -858,7 +858,6 @@ def _gen_truss_config(
     config.runtime.streaming_read_timeout = remote_config.options.streaming_read_timeout
     config.model_metadata = cast(dict[str, Any], remote_config.options.metadata) or {}
     config.environment_variables = dict(remote_config.options.env_variables)
-    config.build_commands = list(remote_config.build_commands)
 
     if remote_config.docker_image.truss_server_version_override:
         config.runtime.truss_server_version_override = (

--- a/truss-chains/truss_chains/public_types.py
+++ b/truss-chains/truss_chains/public_types.py
@@ -492,11 +492,6 @@ class RemoteConfig(custom_types.SafeModelNonSerializable):
     assets: Assets = Assets()
     name: Optional[str] = None
     options: ChainletOptions = ChainletOptions()
-    build_commands: list[str] = pydantic.Field(
-        default_factory=list,
-        description="Shell commands run during the Docker image build, after system "
-        "packages and before chain code (same as Truss `config.yaml` `build_commands`).",
-    )
 
     def get_compute_spec(self) -> ComputeSpec:
         return self.compute.get_spec()

--- a/truss-chains/truss_chains/public_types.py
+++ b/truss-chains/truss_chains/public_types.py
@@ -492,6 +492,11 @@ class RemoteConfig(custom_types.SafeModelNonSerializable):
     assets: Assets = Assets()
     name: Optional[str] = None
     options: ChainletOptions = ChainletOptions()
+    build_commands: list[str] = pydantic.Field(
+        default_factory=list,
+        description="Shell commands run during the Docker image build, after system "
+        "packages and before chain code (same as Truss `config.yaml` `build_commands`).",
+    )
 
     def get_compute_spec(self) -> ComputeSpec:
         return self.compute.get_spec()


### PR DESCRIPTION
## Summary
- **Engine builder chainlets**: copy **`assets.weights`** into generated `config.yaml` before the early return. Engine-builder paths previously dropped `config.weights`, so BDN/MDN-style weight sources were never present for TRT-LLM chain jobs. Non–engine-builder chainlets were already correct.

Tested with gpt-oss-20b config that uses BDN.