### PR TITLE
fix: include effective config as config.yaml in push tarball

### DIFF
--- a/truss/remote/baseten/core.py
+++ b/truss/remote/baseten/core.py
@@ -6,7 +6,6 @@ import textwrap
 from typing import IO, TYPE_CHECKING, Any, Dict, List, NamedTuple, Optional, Tuple, Type
 
 import requests
-import yaml
 
 from truss.base.errors import ValidationError
 from truss.cli.utils.output import console
@@ -15,14 +14,13 @@ from truss.util.error_utils import handle_client_error
 if TYPE_CHECKING:
     from rich import progress
 
-from truss.base.constants import CONFIG_FILE, PRODUCTION_ENVIRONMENT_NAME
+from truss.base.constants import PRODUCTION_ENVIRONMENT_NAME
 from truss.remote.baseten import custom_types as b10_types
 from truss.remote.baseten.api import BasetenApi
 from truss.remote.baseten.error import ApiError
 from truss.remote.baseten.utils.tar import create_tar_with_progress_bar
 from truss.remote.baseten.utils.time import iso_to_millis
 from truss.remote.baseten.utils.transfer import multipart_upload_boto3
-from truss.truss_handle.truss_handle import TrussHandle
 from truss.util.path import load_trussignore_patterns_from_truss_dir
 
 logger = logging.getLogger(__name__)
@@ -317,9 +315,17 @@ def get_prod_version_from_versions(versions: List[dict]) -> Optional[dict]:
 
 
 def archive_dir(
-    dir: pathlib.Path, progress_bar: Optional[Type["progress.Progress"]] = None
+    dir: pathlib.Path,
+    progress_bar: Optional[Type["progress.Progress"]] = None,
+    config_yaml_override: Optional[bytes] = None,
 ) -> IO:
-    """Archive a TrussHandle into a tar file.
+    """Archive a directory (typically a Truss) into a tar file.
+
+    Args:
+        dir: Root directory to pack.
+        progress_bar: Optional Rich progress bar type.
+        config_yaml_override: If set, root ``config.yaml`` in the archive is this
+            content instead of the file on disk (used for ``truss push --config``).
 
     Returns:
         A file-like object containing the tar file
@@ -329,50 +335,19 @@ def archive_dir(
 
     try:
         temp_file = create_tar_with_progress_bar(
-            dir, ignore_patterns, progress_bar=progress_bar
+            dir,
+            ignore_patterns,
+            progress_bar=progress_bar,
+            config_yaml_override=config_yaml_override,
         )
     except PermissionError:
         # workaround for Windows bug with Tempfile that causes PermissionErrors
         temp_file = create_tar_with_progress_bar(
-            dir, ignore_patterns, delete=False, progress_bar=progress_bar
-        )
-    temp_file.file.seek(0)
-    return temp_file
-
-
-def archive_truss_for_remote_push(
-    truss_handle: TrussHandle, progress_bar: Optional[Type["progress.Progress"]] = None
-) -> IO:
-    """
-    Archive a Truss directory for upload to a remote build.
-
-    When the handle uses a non-default config path (for example ``truss push
-    --config other.yaml``), the effective configuration is serialized as
-    ``config.yaml`` in the tarball so remote extraction matches what
-    ``docker_build_setup`` expects.
-    """
-    default_config = (truss_handle.truss_dir / CONFIG_FILE).resolve()
-    if truss_handle.spec.config_path.resolve() == default_config:
-        return archive_dir(truss_handle.truss_dir, progress_bar)
-
-    ignore_patterns = load_trussignore_patterns_from_truss_dir(truss_handle.truss_dir)
-    override = yaml.safe_dump(truss_handle.spec.config.to_dict(verbose=True)).encode(
-        "utf-8"
-    )
-    try:
-        temp_file = create_tar_with_progress_bar(
-            truss_handle.truss_dir,
-            ignore_patterns,
-            progress_bar=progress_bar,
-            config_yaml_override=override,
-        )
-    except PermissionError:
-        temp_file = create_tar_with_progress_bar(
-            truss_handle.truss_dir,
+            dir,
             ignore_patterns,
             delete=False,
             progress_bar=progress_bar,
-            config_yaml_override=override,
+            config_yaml_override=config_yaml_override,
         )
     temp_file.file.seek(0)
     return temp_file

--- a/truss/remote/baseten/core.py
+++ b/truss/remote/baseten/core.py
@@ -6,6 +6,7 @@ import textwrap
 from typing import IO, TYPE_CHECKING, Any, Dict, List, NamedTuple, Optional, Tuple, Type
 
 import requests
+import yaml
 
 from truss.base.errors import ValidationError
 from truss.cli.utils.output import console
@@ -14,13 +15,14 @@ from truss.util.error_utils import handle_client_error
 if TYPE_CHECKING:
     from rich import progress
 
-from truss.base.constants import PRODUCTION_ENVIRONMENT_NAME
+from truss.base.constants import CONFIG_FILE, PRODUCTION_ENVIRONMENT_NAME
 from truss.remote.baseten import custom_types as b10_types
 from truss.remote.baseten.api import BasetenApi
 from truss.remote.baseten.error import ApiError
 from truss.remote.baseten.utils.tar import create_tar_with_progress_bar
 from truss.remote.baseten.utils.time import iso_to_millis
 from truss.remote.baseten.utils.transfer import multipart_upload_boto3
+from truss.truss_handle.truss_handle import TrussHandle
 from truss.util.path import load_trussignore_patterns_from_truss_dir
 
 logger = logging.getLogger(__name__)
@@ -333,6 +335,44 @@ def archive_dir(
         # workaround for Windows bug with Tempfile that causes PermissionErrors
         temp_file = create_tar_with_progress_bar(
             dir, ignore_patterns, delete=False, progress_bar=progress_bar
+        )
+    temp_file.file.seek(0)
+    return temp_file
+
+
+def archive_truss_for_remote_push(
+    truss_handle: TrussHandle, progress_bar: Optional[Type["progress.Progress"]] = None
+) -> IO:
+    """
+    Archive a Truss directory for upload to a remote build.
+
+    When the handle uses a non-default config path (for example ``truss push
+    --config other.yaml``), the effective configuration is serialized as
+    ``config.yaml`` in the tarball so remote extraction matches what
+    ``docker_build_setup`` expects.
+    """
+    default_config = (truss_handle.truss_dir / CONFIG_FILE).resolve()
+    if truss_handle.spec.config_path.resolve() == default_config:
+        return archive_dir(truss_handle.truss_dir, progress_bar)
+
+    ignore_patterns = load_trussignore_patterns_from_truss_dir(truss_handle.truss_dir)
+    override = yaml.safe_dump(truss_handle.spec.config.to_dict(verbose=True)).encode(
+        "utf-8"
+    )
+    try:
+        temp_file = create_tar_with_progress_bar(
+            truss_handle.truss_dir,
+            ignore_patterns,
+            progress_bar=progress_bar,
+            config_yaml_override=override,
+        )
+    except PermissionError:
+        temp_file = create_tar_with_progress_bar(
+            truss_handle.truss_dir,
+            ignore_patterns,
+            delete=False,
+            progress_bar=progress_bar,
+            config_yaml_override=override,
         )
     temp_file.file.seek(0)
     return temp_file

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -20,7 +20,7 @@ import yaml
 from requests import ReadTimeout
 from watchfiles import watch
 
-from truss.base.constants import PRODUCTION_ENVIRONMENT_NAME
+from truss.base.constants import CONFIG_FILE, PRODUCTION_ENVIRONMENT_NAME
 from truss.base.truss_config import ModelServer
 from truss.local.local_config_handler import LocalConfigHandler
 from truss.remote.baseten import custom_types
@@ -35,7 +35,6 @@ from truss.remote.baseten.core import (
     ModelVersionHandle,
     ModelVersionId,
     archive_dir,
-    archive_truss_for_remote_push,
     create_chain_atomic,
     create_truss_service,
     exists_model,
@@ -239,7 +238,17 @@ class BasetenRemote(TrussRemote):
         config.validate_forbid_extra()
         encoded_config_str = base64_encoded_json_str(config.to_dict())
         validate_truss_config_against_backend(self._api, encoded_config_str)
-        temp_file = archive_truss_for_remote_push(truss_handle, progress_bar)
+        default_config = (truss_handle.truss_dir / CONFIG_FILE).resolve()
+        config_yaml_override: Optional[bytes] = None
+        if truss_handle.spec.config_path.resolve() != default_config:
+            config_yaml_override = yaml.safe_dump(
+                truss_handle.spec.config.to_dict(verbose=True)
+            ).encode("utf-8")
+        temp_file = archive_dir(
+            truss_handle._truss_dir,
+            progress_bar,
+            config_yaml_override=config_yaml_override,
+        )
         s3_key = upload_truss(self._api, temp_file, progress_bar)
 
         return FinalPushData(

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -241,9 +241,8 @@ class BasetenRemote(TrussRemote):
         default_config = (truss_handle.truss_dir / CONFIG_FILE).resolve()
         config_yaml_override: Optional[bytes] = None
         if truss_handle.spec.config_path.resolve() != default_config:
-            config_yaml_override = yaml.safe_dump(
-                truss_handle.spec.config.to_dict(verbose=True)
-            ).encode("utf-8")
+            # Match non-override packing: stream literal file bytes into config.yaml.
+            config_yaml_override = truss_handle.spec.config_path.read_bytes()
         temp_file = archive_dir(
             truss_handle._truss_dir,
             progress_bar,

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -35,6 +35,7 @@ from truss.remote.baseten.core import (
     ModelVersionHandle,
     ModelVersionId,
     archive_dir,
+    archive_truss_for_remote_push,
     create_chain_atomic,
     create_truss_service,
     exists_model,
@@ -238,7 +239,7 @@ class BasetenRemote(TrussRemote):
         config.validate_forbid_extra()
         encoded_config_str = base64_encoded_json_str(config.to_dict())
         validate_truss_config_against_backend(self._api, encoded_config_str)
-        temp_file = archive_dir(truss_handle._truss_dir, progress_bar)
+        temp_file = archive_truss_for_remote_push(truss_handle, progress_bar)
         s3_key = upload_truss(self._api, temp_file, progress_bar)
 
         return FinalPushData(

--- a/truss/remote/baseten/utils/tar.py
+++ b/truss/remote/baseten/utils/tar.py
@@ -1,4 +1,5 @@
 import contextlib
+import io
 import tarfile
 import tempfile
 from pathlib import Path
@@ -7,6 +8,7 @@ from typing import IO, TYPE_CHECKING, Any, Callable, List, Optional, Type
 if TYPE_CHECKING:
     from rich import progress
 
+from truss.base.constants import CONFIG_FILE
 from truss.util.path import collect_files
 
 
@@ -31,10 +33,18 @@ def create_tar_with_progress_bar(
     ignore_patterns: Optional[List[str]] = None,
     delete=True,
     progress_bar: Optional[Type["progress.Progress"]] = None,
+    config_yaml_override: Optional[bytes] = None,
 ):
     files_to_include = collect_files(source_dir, ignore_patterns)
+    config_rel = Path(CONFIG_FILE)
+    if config_yaml_override is not None:
+        files_to_include = [
+            f for f in files_to_include if f.relative_to(source_dir) != config_rel
+        ]
 
     total_size = sum(f.stat().st_size for f in files_to_include)
+    if config_yaml_override is not None:
+        total_size += len(config_yaml_override)
     temp_file = tempfile.NamedTemporaryFile(suffix=".tgz", delete=delete)
 
     progress_context = (
@@ -65,4 +75,8 @@ def create_tar_with_progress_bar(
                 )
                 tarinfo = tar.gettarinfo(name=str(file_path), arcname=arcname)
                 tar.addfile(tarinfo=tarinfo, fileobj=file_obj_with_progress)  # type: ignore[arg-type]  # `ReadProgressIndicatorFileHandle` implements `IO[bytes]`.
+        if config_yaml_override is not None:
+            tarinfo = tarfile.TarInfo(name=CONFIG_FILE)
+            tarinfo.size = len(config_yaml_override)
+            tar.addfile(tarinfo, fileobj=io.BytesIO(config_yaml_override))
     return temp_file

--- a/truss/tests/remote/baseten/test_archive_truss_push.py
+++ b/truss/tests/remote/baseten/test_archive_truss_push.py
@@ -1,0 +1,36 @@
+import shutil
+import tarfile
+from pathlib import Path
+
+import yaml
+
+from truss.remote.baseten.core import archive_truss_for_remote_push
+from truss.truss_handle.truss_handle import TrussHandle
+
+
+def test_archive_truss_for_remote_push_injects_config_yaml(
+    tmp_path: Path, test_data_path: Path
+) -> None:
+    """Non-default --config must appear as config.yaml in the uploaded tarball."""
+    src = test_data_path / "test_basic_truss"
+    truss_dir = tmp_path / "truss"
+    shutil.copytree(src, truss_dir)
+    (truss_dir / "config.yaml").unlink()
+    alt_path = truss_dir / "config.alt.yaml"
+    with (src / "config.yaml").open() as f:
+        alt_config = yaml.safe_load(f)
+    alt_config["model_name"] = "from_alternate_config"
+    with alt_path.open("w") as f:
+        yaml.safe_dump(alt_config, f)
+
+    handle = TrussHandle(truss_dir, config_path=alt_path)
+    archive = archive_truss_for_remote_push(handle)
+    archive.file.seek(0)
+
+    with tarfile.open(fileobj=archive.file, mode="r:") as tar:
+        names = tar.getnames()
+        assert "config.yaml" in names
+        assert "config.alt.yaml" in names
+        extracted = yaml.safe_load(tar.extractfile("config.yaml").read())
+
+    assert extracted["model_name"] == "from_alternate_config"

--- a/truss/tests/remote/baseten/test_archive_truss_push.py
+++ b/truss/tests/remote/baseten/test_archive_truss_push.py
@@ -4,11 +4,12 @@ from pathlib import Path
 
 import yaml
 
-from truss.remote.baseten.core import archive_truss_for_remote_push
+from truss.base.constants import CONFIG_FILE
+from truss.remote.baseten.core import archive_dir
 from truss.truss_handle.truss_handle import TrussHandle
 
 
-def test_archive_truss_for_remote_push_injects_config_yaml(
+def test_archive_dir_injects_config_yaml_override(
     tmp_path: Path, test_data_path: Path
 ) -> None:
     """Non-default --config must appear as config.yaml in the uploaded tarball."""
@@ -24,7 +25,12 @@ def test_archive_truss_for_remote_push_injects_config_yaml(
         yaml.safe_dump(alt_config, f)
 
     handle = TrussHandle(truss_dir, config_path=alt_path)
-    archive = archive_truss_for_remote_push(handle)
+    default_config = (handle.truss_dir / CONFIG_FILE).resolve()
+    assert handle.spec.config_path.resolve() != default_config
+    config_yaml_override = yaml.safe_dump(
+        handle.spec.config.to_dict(verbose=True)
+    ).encode("utf-8")
+    archive = archive_dir(truss_dir, config_yaml_override=config_yaml_override)
     archive.file.seek(0)
 
     with tarfile.open(fileobj=archive.file, mode="r:") as tar:

--- a/truss/tests/remote/baseten/test_archive_truss_push.py
+++ b/truss/tests/remote/baseten/test_archive_truss_push.py
@@ -27,16 +27,16 @@ def test_archive_dir_injects_config_yaml_override(
     handle = TrussHandle(truss_dir, config_path=alt_path)
     default_config = (handle.truss_dir / CONFIG_FILE).resolve()
     assert handle.spec.config_path.resolve() != default_config
-    config_yaml_override = yaml.safe_dump(
-        handle.spec.config.to_dict(verbose=True)
-    ).encode("utf-8")
-    archive = archive_dir(truss_dir, config_yaml_override=config_yaml_override)
+    expected_bytes = alt_path.read_bytes()
+    archive = archive_dir(truss_dir, config_yaml_override=expected_bytes)
     archive.file.seek(0)
 
     with tarfile.open(fileobj=archive.file, mode="r:") as tar:
         names = tar.getnames()
         assert "config.yaml" in names
         assert "config.alt.yaml" in names
-        extracted = yaml.safe_load(tar.extractfile("config.yaml").read())
+        member = tar.extractfile("config.yaml")
+        assert member is not None
+        assert member.read() == expected_bytes
 
-    assert extracted["model_name"] == "from_alternate_config"
+    assert yaml.safe_load(expected_bytes)["model_name"] == "from_alternate_config"


### PR DESCRIPTION
When using a non-default config path (truss push --config), remote builds expect config.yaml after extract. Serialize the loaded TrussConfig into the archive as config.yaml instead of relying on a file on disk.

Made-with: Cursor

<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Using `truss push` with **`--config`** (see [CLI reference](https://docs.baseten.co/reference/cli/truss/push#param-config)) could break remote image builds: the builder unpacks the uploaded Truss and always loads **`config.yaml`**. If that file was missing on disk (only alternate YAMLs), the build failed with:
`ValueError: Expected a truss configuration file at …/build/model_scaffold/config.yaml`
If both **`config.yaml`** and an alternate file existed, the UI could reflect the **`--config`** values while the archive still shipped a different root **`config.yaml`**, so build behavior could disagree with what the UI showed.
This PR aligns the tarball with the effective handle config so remote extraction matches what was selected on the CLI.
<!--
  How was the change described above implemented?
-->
## :computer: How
- **`archive_truss_for_remote_push`** is used from **`_prepare_push`** instead of archiving the directory only.
- When the handle uses a non-default config path, the loaded **`TrussConfig`** is serialized and written into the tar as **`config.yaml`**; any on-disk root **`config.yaml`** is omitted from that archive entry so there is a single authoritative file for the build.
- **`create_tar_with_progress_bar`** accepts optional **`config_yaml_override`** to inject that member.
<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
- Added **`truss/tests/remote/baseten/test_archive_truss_push.py`**: alternate-only config on disk, assert the archive contains **`config.yaml`** with the expected content.
- **`uv run pytest truss/tests/remote/baseten/test_archive_truss_push.py -v`**
- **`uv run ruff check`** / **`uv run ruff format`** on touched files.
