### PR TITLE
Fix config schema to allow null accelerator

### DIFF
--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -149,11 +149,7 @@ class AcceleratorSpec(custom_types.ConfigModel):
         core_schema: pydantic_core.CoreSchema,
         handler: pydantic.GetJsonSchemaHandler,
     ) -> json_schema.JsonSchemaValue:
-        schema = handler(core_schema)
-        schema.update(type="string")
-        schema.pop("properties", None)
-        schema.pop("required", None)
-        return schema
+        return {"anyOf": [{"type": "string"}, {"type": "null"}]}
 
 
 class ModelRepoSourceKind(str, enum.Enum):

--- a/truss/config.schema.json
+++ b/truss/config.schema.json
@@ -1,9 +1,14 @@
 {
   "$defs": {
     "AcceleratorSpec": {
-      "additionalProperties": true,
-      "title": "AcceleratorSpec",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "BaseImage": {
       "additionalProperties": true,


### PR DESCRIPTION
## :rocket: What

Fix issue where `null` was not an acceptable `accelerator` value in config schema.

Fixes #2388

## :computer: How

Adjusting JSON schema

## :microscope: Testing

Confirmed with language server