### PR TITLE
Add truss model-config command and send raw config.yaml on push

### DIFF
--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -11,6 +11,7 @@ from typing import Optional, cast
 import requests
 import rich.table
 import rich_click as click
+import yaml
 from rich import console as rich_console
 from rich import progress
 
@@ -20,7 +21,7 @@ from truss.base.constants import (
     TRTLLM_MIN_MEMORY_REQUEST_GI,
 )
 from truss.base.trt_llm_config import TrussTRTLLMQuantizationType
-from truss.base.truss_config import Build, ModelServer, TransportKind
+from truss.base.truss_config import Build, ModelServer, TransportKind, TrussConfig
 from truss.cli import remote_cli
 from truss.cli.logs import utils as cli_log_utils
 from truss.cli.logs.model_log_watcher import ModelDeploymentLogWatcher
@@ -1164,6 +1165,54 @@ def download(
                 else:
                     tar.extractall(path=out_path)
             console.print(f"Extracted to {out_path}")
+
+
+@truss_cli.command(name="model-config")
+@click.option(
+    "--remote", type=str, required=False, help="Name of the remote in .trussrc."
+)
+@click.option("--model-id", type=str, required=True, help="ID of the model.")
+@click.option("--deployment-id", type=str, required=True, help="ID of the deployment.")
+@click.option(
+    "--output",
+    "output_format",
+    type=click.Choice(["text", "json"]),
+    default="text",
+    help=(
+        "Output format. 'text' prints the original config.yaml (or the parsed config "
+        "rendered as YAML if no original is stored). 'json' emits the full response "
+        "{config, raw_config} as JSON to stdout."
+    ),
+)
+@common.common_options()
+@json_command
+def model_config(
+    remote: Optional[str],
+    model_id: str,
+    deployment_id: str,
+    output_format: str = "text",
+) -> None:
+    """
+    Fetches the config of a deployed model.
+    """
+    if not remote:
+        remote = remote_cli.inquire_remote_name()
+    remote_provider = cast(BasetenRemote, RemoteFactory.create(remote=remote))
+
+    response = remote_provider.api.get_deployment_config(model_id, deployment_id)
+
+    if output_format == "json":
+        print(json.dumps(response))
+        return
+
+    raw_config = response.get("raw_config")
+    if raw_config:
+        click.echo(raw_config, nl=False)
+    else:
+        parsed = TrussConfig.from_dict(response.get("config") or {})
+        click.echo(
+            yaml.safe_dump(parsed.to_dict(verbose=False), sort_keys=False), nl=False
+        )
 
 
 @truss_cli.command()

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -1206,7 +1206,7 @@ def model_config(
         return
 
     raw_config = response.get("raw_config")
-    if raw_config:
+    if raw_config is not None:
         click.echo(raw_config, nl=False)
     else:
         parsed = TrussConfig.from_dict(response.get("config") or {})

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -1,3 +1,4 @@
+import base64
 import json
 import logging
 from enum import Enum
@@ -212,9 +213,10 @@ class BasetenApi:
         deploy_timeout_minutes: Optional[int] = None,
         team_id: Optional[str] = None,
         labels: Optional[dict] = None,
+        raw_config: Optional[bytes] = None,
     ):
         query_string = f"""
-            mutation ($trussUserEnv: String, $userDeployMetadata: JSONString) {{
+            mutation ($trussUserEnv: String, $userDeployMetadata: JSONString, $rawConfig: String) {{
                 create_model_from_truss(
                     name: "{model_name}"
                     s3_key: "{s3_key}"
@@ -228,6 +230,7 @@ class BasetenApi:
                     {f"deploy_timeout_minutes: {deploy_timeout_minutes}" if deploy_timeout_minutes is not None else ""}
                     {f'team_id: "{team_id}"' if team_id else ""}
                     user_deploy_metadata: $userDeployMetadata
+                    raw_config: $rawConfig
                 ) {{
                     model_version {{
                         id
@@ -249,6 +252,9 @@ class BasetenApi:
                 "trussUserEnv": truss_user_env.json(),
                 "userDeployMetadata": json.dumps(labels)
                 if labels is not None
+                else None,
+                "rawConfig": base64.b64encode(raw_config).decode("utf-8")
+                if raw_config is not None
                 else None,
             },
         )
@@ -267,9 +273,10 @@ class BasetenApi:
         preserve_env_instance_type: bool = True,
         deploy_timeout_minutes: Optional[int] = None,
         labels: Optional[dict] = None,
+        raw_config: Optional[bytes] = None,
     ):
         query_string = f"""
-            mutation ($trussUserEnv: String, $userDeployMetadata: JSONString) {{
+            mutation ($trussUserEnv: String, $userDeployMetadata: JSONString, $rawConfig: String) {{
                 create_model_version_from_truss(
                     model_id: "{model_id}"
                     s3_key: "{s3_key}"
@@ -282,6 +289,7 @@ class BasetenApi:
                     {f'environment_name: "{environment}"' if environment else ""}
                     {f"deploy_timeout_minutes: {deploy_timeout_minutes}" if deploy_timeout_minutes is not None else ""}
                     user_deploy_metadata: $userDeployMetadata
+                    raw_config: $rawConfig
                 ) {{
                     model_version {{
                         id
@@ -305,6 +313,9 @@ class BasetenApi:
                 "userDeployMetadata": json.dumps(labels)
                 if labels is not None
                 else None,
+                "rawConfig": base64.b64encode(raw_config).decode("utf-8")
+                if raw_config is not None
+                else None,
             },
         )
         return resp["data"]["create_model_version_from_truss"]["model_version"]
@@ -320,9 +331,10 @@ class BasetenApi:
         deploy_timeout_minutes: Optional[int] = None,
         team_id: Optional[str] = None,
         labels: Optional[dict] = None,
+        raw_config: Optional[bytes] = None,
     ):
         query_string = f"""
-            mutation ($trussUserEnv: String, $userDeployMetadata: JSONString) {{
+            mutation ($trussUserEnv: String, $userDeployMetadata: JSONString, $rawConfig: String) {{
                 deploy_draft_truss(name: "{model_name}"
                     s3_key: "{s3_key}"
                     config: "{config}"
@@ -332,6 +344,7 @@ class BasetenApi:
                     {f"deploy_timeout_minutes: {deploy_timeout_minutes}" if deploy_timeout_minutes is not None else ""}
                     {f'team_id: "{team_id}"' if team_id else ""}
                     user_deploy_metadata: $userDeployMetadata
+                    raw_config: $rawConfig
                 ) {{
                     model_version {{
                         id
@@ -354,6 +367,9 @@ class BasetenApi:
                 "trussUserEnv": truss_user_env.json(),
                 "userDeployMetadata": json.dumps(labels)
                 if labels is not None
+                else None,
+                "rawConfig": base64.b64encode(raw_config).decode("utf-8")
+                if raw_config is not None
                 else None,
             },
         )
@@ -1007,6 +1023,13 @@ class BasetenApi:
             f"v1/models/{model_id}/deployments/{deployment_id}/download"
         )
         return response["download_url"]
+
+    def get_deployment_config(
+        self, model_id: str, deployment_id: str
+    ) -> Dict[str, Any]:
+        return self._rest_api_client.get(
+            f"v1/models/{model_id}/deployments/{deployment_id}/config"
+        )
 
     def get_model_deployment_logs(
         self,

--- a/truss/remote/baseten/core.py
+++ b/truss/remote/baseten/core.py
@@ -422,6 +422,7 @@ def create_truss_service(
     deploy_timeout_minutes: Optional[int] = None,
     team_id: Optional[str] = None,
     labels: Optional[dict] = None,
+    raw_config: Optional[bytes] = None,
 ) -> ModelVersionHandle:
     """
     Create a model in the Baseten remote.
@@ -453,6 +454,7 @@ def create_truss_service(
             deploy_timeout_minutes=deploy_timeout_minutes,
             team_id=team_id,
             labels=labels,
+            raw_config=raw_config,
         )
 
         return ModelVersionHandle(
@@ -480,6 +482,7 @@ def create_truss_service(
             deploy_timeout_minutes=deploy_timeout_minutes,
             team_id=team_id,
             labels=labels,
+            raw_config=raw_config,
         )
 
         return ModelVersionHandle(
@@ -505,6 +508,7 @@ def create_truss_service(
         preserve_env_instance_type=preserve_env_instance_type,
         deploy_timeout_minutes=deploy_timeout_minutes,
         labels=labels,
+        raw_config=raw_config,
     )
 
     return ModelVersionHandle(

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -59,6 +59,10 @@ if TYPE_CHECKING:
     from rich import progress
 
 
+# Server-side cap on raw config.yaml; payloads larger than this are dropped.
+RAW_CONFIG_MAX_BYTES = 100 * 1024
+
+
 class PatchStatus(enum.Enum):
     SUCCESS = enum.auto()
     FAILED = enum.auto()
@@ -106,6 +110,7 @@ class FinalPushData(custom_types.OracleData):
     allow_truss_download: bool
     team_id: Optional[str] = None
     labels: Optional[Dict[str, Any]] = None
+    raw_config: Optional[bytes] = None
 
 
 class BasetenRemote(TrussRemote):
@@ -243,6 +248,25 @@ class BasetenRemote(TrussRemote):
         if truss_handle.spec.config_path.resolve() != default_config:
             # Match non-override packing: stream literal file bytes into config.yaml.
             config_yaml_override = truss_handle.spec.config_path.read_bytes()
+        # Capture the original config.yaml bytes so the server can persist them as-is.
+        # Best-effort: if the file cannot be read or is too large, push proceeds without raw.
+        raw_config_bytes = config_yaml_override
+        if raw_config_bytes is None:
+            try:
+                raw_config_bytes = truss_handle.spec.config_path.read_bytes()
+            except OSError as exc:
+                logging.warning(
+                    f"Could not read raw config.yaml ({exc}); proceeding without uploading raw config."
+                )
+        if (
+            raw_config_bytes is not None
+            and len(raw_config_bytes) > RAW_CONFIG_MAX_BYTES
+        ):
+            logging.warning(
+                f"Raw config.yaml is {len(raw_config_bytes)} bytes, exceeds "
+                f"{RAW_CONFIG_MAX_BYTES} byte cap; proceeding without uploading raw config."
+            )
+            raw_config_bytes = None
         temp_file = archive_dir(
             truss_handle._truss_dir,
             progress_bar,
@@ -263,6 +287,7 @@ class BasetenRemote(TrussRemote):
             allow_truss_download=not disable_truss_download,
             team_id=team_id,
             labels=labels,
+            raw_config=raw_config_bytes,
         )
 
     def push(  # type: ignore
@@ -326,6 +351,7 @@ class BasetenRemote(TrussRemote):
             deploy_timeout_minutes=deploy_timeout_minutes,
             team_id=push_data.team_id,
             labels=push_data.labels,
+            raw_config=push_data.raw_config,
         )
 
         if model_version_handle.instance_type_name:

--- a/truss/tests/cli/test_cli.py
+++ b/truss/tests/cli/test_cli.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 import requests
+import yaml
 from click.testing import CliRunner
 
 from truss.cli.cli import truss_cli
@@ -1473,3 +1474,95 @@ def test_download_allows_existing_empty_dir(tmp_path):
         )
     assert result.exit_code == 0
     assert "Extracted to" in result.output
+
+
+def _invoke_model_config(args):
+    runner = CliRunner()
+    return runner.invoke(truss_cli, ["model-config", *args])
+
+
+def _patch_model_config_remote(response):
+    mock_remote = MagicMock()
+    mock_remote.api.get_deployment_config.return_value = response
+    return mock_remote
+
+
+def test_model_config_text_prefers_raw():
+    mock_remote = _patch_model_config_remote(
+        {"config": {"model_name": "foo"}, "raw_config": "model_name: foo  # neat\n"}
+    )
+    with (
+        patch("truss.cli.cli.RemoteFactory.create", return_value=mock_remote),
+        patch("truss.cli.remote_cli.inquire_remote_name", return_value="remote1"),
+    ):
+        result = _invoke_model_config(["--model-id", "m", "--deployment-id", "d"])
+    assert result.exit_code == 0
+    assert result.output == "model_name: foo  # neat\n"
+    mock_remote.api.get_deployment_config.assert_called_once_with("m", "d")
+
+
+def test_model_config_text_falls_back_to_parsed_when_raw_null():
+    mock_remote = _patch_model_config_remote(
+        {"config": {"model_name": "foo", "resources": {"cpu": "1"}}, "raw_config": None}
+    )
+    with (
+        patch("truss.cli.cli.RemoteFactory.create", return_value=mock_remote),
+        patch("truss.cli.remote_cli.inquire_remote_name", return_value="remote1"),
+    ):
+        result = _invoke_model_config(["--model-id", "m", "--deployment-id", "d"])
+    assert result.exit_code == 0
+    # Output is a TrussConfig roundtrip with verbose=False: caller-set fields are present,
+    # but TrussConfig.to_dict always emits resources and python_version blocks.
+    parsed = yaml.safe_load(result.output)
+    assert parsed["model_name"] == "foo"
+    assert parsed["resources"]["cpu"] == "1"
+    assert "python_version" in parsed
+
+
+def test_model_config_text_with_empty_config_and_no_raw():
+    mock_remote = _patch_model_config_remote({"config": {}, "raw_config": None})
+    with (
+        patch("truss.cli.cli.RemoteFactory.create", return_value=mock_remote),
+        patch("truss.cli.remote_cli.inquire_remote_name", return_value="remote1"),
+    ):
+        result = _invoke_model_config(["--model-id", "m", "--deployment-id", "d"])
+    assert result.exit_code == 0
+    parsed = yaml.safe_load(result.output)
+    # Empty input still emits the always-included blocks from TrussConfig.to_dict.
+    assert "resources" in parsed
+    assert "python_version" in parsed
+
+
+def test_model_config_json_output():
+    response = {"config": {"model_name": "foo"}, "raw_config": "model_name: foo\n"}
+    mock_remote = _patch_model_config_remote(response)
+    with (
+        patch("truss.cli.cli.RemoteFactory.create", return_value=mock_remote),
+        patch("truss.cli.remote_cli.inquire_remote_name", return_value="remote1"),
+    ):
+        result = _invoke_model_config(
+            ["--model-id", "m", "--deployment-id", "d", "--output", "json"]
+        )
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == response
+
+
+def test_model_config_json_output_on_error():
+    mock_remote = MagicMock()
+    mock_remote.api.get_deployment_config.side_effect = RuntimeError("boom")
+    with (
+        patch("truss.cli.cli.RemoteFactory.create", return_value=mock_remote),
+        patch("truss.cli.remote_cli.inquire_remote_name", return_value="remote1"),
+    ):
+        result = _invoke_model_config(
+            ["--model-id", "m", "--deployment-id", "d", "--output", "json"]
+        )
+    assert result.exit_code == 1
+    data = json.loads(result.stdout)
+    assert data["error"]["message"] == "boom"
+
+
+def test_model_config_requires_model_id_and_deployment_id():
+    result = _invoke_model_config([])
+    assert result.exit_code != 0
+    assert "--model-id" in result.output

--- a/truss/tests/remote/baseten/test_api.py
+++ b/truss/tests/remote/baseten/test_api.py
@@ -178,6 +178,7 @@ def test_create_model_version_from_truss(mock_post, baseten_api):
     assert {
         "trussUserEnv": b10_types.TrussUserEnv.collect().model_dump_json(),
         "userDeployMetadata": None,
+        "rawConfig": None,
     } == mock_post.call_args[1]["json"]["variables"]
     assert "scale_down_old_production: true" in gql_mutation
     assert 'name: "deployment_name"' in gql_mutation
@@ -209,6 +210,7 @@ def test_create_model_version_from_truss_does_not_send_deployment_name_if_not_sp
     assert {
         "trussUserEnv": b10_types.TrussUserEnv.collect().model_dump_json(),
         "userDeployMetadata": None,
+        "rawConfig": None,
     } == mock_post.call_args[1]["json"]["variables"]
     assert "scale_down_old_production: true" in gql_mutation
     assert " name: " not in gql_mutation
@@ -242,6 +244,7 @@ def test_create_model_version_from_truss_does_not_scale_old_prod_to_zero_if_keep
     assert {
         "trussUserEnv": b10_types.TrussUserEnv.collect().model_dump_json(),
         "userDeployMetadata": None,
+        "rawConfig": None,
     } == mock_post.call_args[1]["json"]["variables"]
     assert "scale_down_old_production: false" in gql_mutation
     assert " name: " not in gql_mutation
@@ -274,6 +277,7 @@ def test_create_model_version_from_truss_with_deploy_timeout_minutes(
     assert {
         "trussUserEnv": b10_types.TrussUserEnv.collect().model_dump_json(),
         "userDeployMetadata": None,
+        "rawConfig": None,
     } == mock_post.call_args[1]["json"]["variables"]
     assert "scale_down_old_production: true" in gql_mutation
     assert 'name: "deployment_name"' in gql_mutation
@@ -320,6 +324,7 @@ def test_create_model_from_truss(mock_post, baseten_api):
     assert {
         "trussUserEnv": b10_types.TrussUserEnv.collect().model_dump_json(),
         "userDeployMetadata": None,
+        "rawConfig": None,
     } == mock_post.call_args[1]["json"]["variables"]
     assert 'version_name: "deployment_name"' in gql_mutation
 
@@ -345,6 +350,7 @@ def test_create_model_from_truss_does_not_send_deployment_name_if_not_specified(
     assert {
         "trussUserEnv": b10_types.TrussUserEnv.collect().model_dump_json(),
         "userDeployMetadata": None,
+        "rawConfig": None,
     } == mock_post.call_args[1]["json"]["variables"]
     assert "version_name: " not in gql_mutation
 
@@ -368,6 +374,7 @@ def test_create_model_from_truss_with_allow_truss_download(mock_post, baseten_ap
     assert {
         "trussUserEnv": b10_types.TrussUserEnv.collect().model_dump_json(),
         "userDeployMetadata": None,
+        "rawConfig": None,
     } == mock_post.call_args[1]["json"]["variables"]
     assert "allow_truss_download: false" in gql_mutation
 
@@ -391,6 +398,7 @@ def test_create_development_model_from_truss_with_allow_truss_download(
     assert {
         "trussUserEnv": b10_types.TrussUserEnv.collect().model_dump_json(),
         "userDeployMetadata": None,
+        "rawConfig": None,
     } == mock_post.call_args[1]["json"]["variables"]
     assert "allow_truss_download: false" in gql_mutation
     assert "deploy_timeout_minutes: " not in gql_mutation
@@ -416,6 +424,7 @@ def test_create_development_model_from_truss_with_deploy_timeout_minutes(
     assert {
         "trussUserEnv": b10_types.TrussUserEnv.collect().model_dump_json(),
         "userDeployMetadata": None,
+        "rawConfig": None,
     } == mock_post.call_args[1]["json"]["variables"]
     assert "allow_truss_download: false" in gql_mutation
     assert "deploy_timeout_minutes: 300" in gql_mutation

--- a/truss/tests/remote/baseten/test_remote.py
+++ b/truss/tests/remote/baseten/test_remote.py
@@ -684,6 +684,47 @@ def test_push_passes_none_deploy_timeout_minutes_when_not_specified(
     assert kwargs.get("deploy_timeout_minutes") is None
 
 
+def test_push_propagates_raw_config_bytes(
+    custom_model_truss_dir_with_pre_and_post,
+    remote,
+    mock_baseten_requests,
+    mock_upload_truss,
+    mock_create_truss_service,
+    mock_truss_handle,
+):
+    expected = mock_truss_handle.spec.config_path.read_bytes()
+
+    remote.push(
+        mock_truss_handle, "model_name", mock_truss_handle.truss_dir, publish=True
+    )
+
+    mock_create_truss_service.assert_called_once()
+    _, kwargs = mock_create_truss_service.call_args
+    assert kwargs["raw_config"] == expected
+
+
+def test_push_drops_oversize_raw_config(
+    custom_model_truss_dir_with_pre_and_post,
+    remote,
+    mock_baseten_requests,
+    mock_upload_truss,
+    mock_create_truss_service,
+    mock_truss_handle,
+    monkeypatch,
+    caplog,
+):
+    monkeypatch.setattr("truss.remote.baseten.remote.RAW_CONFIG_MAX_BYTES", 1)
+    with caplog.at_level("WARNING"):
+        remote.push(
+            mock_truss_handle, "model_name", mock_truss_handle.truss_dir, publish=True
+        )
+
+    mock_create_truss_service.assert_called_once()
+    _, kwargs = mock_create_truss_service.call_args
+    assert kwargs["raw_config"] is None
+    assert any("exceeds" in record.message for record in caplog.records)
+
+
 def test_push_integration_deploy_timeout_minutes_propagated(
     custom_model_truss_dir_with_pre_and_post,
     remote,


### PR DESCRIPTION

## :rocket: What

Adds a `truss model-config` CLI command and starts sending the original `config.yaml` text alongside `truss push` so the server can persist it.

`truss model-config --model-id <id> --deployment-id <id>` fetches the config of a deployed model from the new REST endpoint.

- Default text output prints the original `config.yaml` (raw bytes, comments and ordering preserved). If no raw is stored on the deployment, falls back to the parsed config rendered via `TrussConfig.from_dict(...).to_dict(verbose=False)`
- `--output json` emits `{config, raw_config}` to stdout (errors via the standard `json_command` decorator).

## :computer: How

- New `model-config` command in `truss/cli/cli.py`. Reuses the existing `--output text|json` and `json_command` pattern.
- `BasetenApi.get_deployment_config(model_id, deployment_id)` in `truss/remote/baseten/api.py` calls the REST endpoint.
- `BasetenRemote._prepare_push` reads the `config.yaml` bytes (best-effort: warns and proceeds without raw on `OSError` or if oversize). Plumbed through `FinalPushData.raw_config: Optional[bytes]`, then `create_truss_service`, then to all three GraphQL mutations.
- Mutations send `raw_config` via a `$rawConfig: String` GraphQL variable (matches the existing pattern for arbitrary-content fields like `$trussUserEnv` and `$userDeployMetadata`). Bytes are base64-encoded at the GraphQL boundary so intermediate code carries the unencoded payload.
- 100 KB client-side cap (`RAW_CONFIG_MAX_BYTES`) matches the server cap; oversize payloads are dropped with a warning, push proceeds.

## :microscope: Testing

- New CLI tests cover: text output prefers raw when present, falls back to TrussConfig roundtrip when raw is null, behaves with empty config, JSON output mode, JSON error mode, and required arg validation.
- Existing GraphQL mutation tests updated to include `rawConfig: None` in the variable assertions for the three modified mutations.