### PR TITLE
fix(encoder): respect max_seq_len for all encoder models

### DIFF
--- a/truss/base/trt_llm_config.py
+++ b/truss/base/trt_llm_config.py
@@ -367,12 +367,6 @@ pip install truss==0.10.8
         """performs embedding specfic optimizations (no kv-cache, high batch size)"""
         if self.base_model == TrussTRTLLMModel.ENCODER:
             # Encoder specific settings
-            if self.max_seq_len:
-                logger.info(
-                    f"Your setting of `build.max_seq_len={self.max_seq_len}` is not used for embedding models, "
-                    "and only respected for SequenceClassification models. "
-                    "Automatically inferred from the model repo config.json -> `max_position_embeddings`"
-                )
             # delayed import, as it is not available in all environments [Briton]
             from truss.base.constants import BEI_REQUIRED_MAX_NUM_TOKENS
 


### PR DESCRIPTION
## Summary
Removes the misleading log message in `_bei_specfic_migration` that claimed `max_seq_len` was "not used for embedding models."

The corresponding `engine-builder` change (in `baseten` repo) updates `auto_max_seq_len` to actually respect `config.max_seq_len` for all encoder models when explicitly set, with safety bounds (128–262144, rounded to multiple of 8) and a warning when it exceeds `max_position_embeddings`.

## Changes
- **`truss/base/trt_llm_config.py`**: Removed misleading log in `_bei_specfic_migration`.