### PR TITLE
OAuth login support and new Truss auth commands

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "httpx>=0.24.1",
     "httpx-ws>=0.7.1,<0.8",
     "inquirerpy>=0.3.4,<0.4",
+    "keyring>=25,<26",
     "libcst>=1.1.2",
     "loguru>=0.7.2",
     "packaging>=20.9",

--- a/truss-chains/truss_chains/deployment/deployment_client.py
+++ b/truss-chains/truss_chains/deployment/deployment_client.py
@@ -468,7 +468,7 @@ class BasetenChainService(ChainService):
 
         Returns:
             The JSON response."""
-        headers = self._remote._auth_service.authenticate().header()
+        headers = self._remote.auth_header()
         response = requests.post(
             self.run_remote_url, json=json_data, headers=headers, stream=True
         )

--- a/truss-chains/truss_chains/deployment/deployment_client.py
+++ b/truss-chains/truss_chains/deployment/deployment_client.py
@@ -468,7 +468,7 @@ class BasetenChainService(ChainService):
 
         Returns:
             The JSON response."""
-        headers = self._remote.auth_header()
+        headers = self._remote.fetch_auth_header()
         response = requests.post(
             self.run_remote_url, json=json_data, headers=headers, stream=True
         )

--- a/truss/api/__init__.py
+++ b/truss/api/__init__.py
@@ -6,10 +6,11 @@ if TYPE_CHECKING:
     from rich import progress
 
 from truss.api import definitions
+from truss.base.constants import DEFAULT_REMOTE_NAME, DEFAULT_REMOTE_URL
 from truss.cli.resolvers.model_team_resolver import resolve_model_team_name
 from truss.remote.baseten.remote import BasetenRemote
 from truss.remote.baseten.service import BasetenService
-from truss.remote.remote_factory import RemoteFactory
+from truss.remote.remote_factory import AuthType, RemoteFactory
 from truss.remote.truss_remote import RemoteConfig
 from truss.truss_handle.build import load
 
@@ -21,14 +22,13 @@ def login(api_key: str):
     Args:
         api_key: Baseten API Key
     """
-    remote_url = "https://app.baseten.co"
     remote_config = RemoteConfig(
-        name="baseten",
+        name=DEFAULT_REMOTE_NAME,
         configs={
-            "remote_provider": "baseten",
-            "auth_type": "api_key",
+            "remote_provider": DEFAULT_REMOTE_NAME,
+            "auth_type": AuthType.API_KEY,
             "api_key": api_key,
-            "remote_url": remote_url,
+            "remote_url": DEFAULT_REMOTE_URL,
         },
     )
     RemoteFactory.update_remote_config(remote_config)

--- a/truss/api/__init__.py
+++ b/truss/api/__init__.py
@@ -26,6 +26,7 @@ def login(api_key: str):
         name="baseten",
         configs={
             "remote_provider": "baseten",
+            "auth_type": "api_key",
             "api_key": api_key,
             "remote_url": remote_url,
         },

--- a/truss/base/constants.py
+++ b/truss/base/constants.py
@@ -90,4 +90,7 @@ PRODUCTION_ENVIRONMENT_NAME = "production"
 
 TRUSS_BASE_IMAGE_NAME = "baseten/truss-server-base"
 
+DEFAULT_REMOTE_NAME = "baseten"
+DEFAULT_REMOTE_URL = "https://app.baseten.co"
+
 DEFAULT_TRAINING_CHECKPOINT_FOLDER = "/tmp/loaded_checkpoints"

--- a/truss/cli/auth.py
+++ b/truss/cli/auth.py
@@ -1,0 +1,167 @@
+"""`truss auth` command group: login, logout, status."""
+
+from typing import Optional
+
+import rich_click as click
+
+from truss.cli.remote_cli import (
+    DEFAULT_REMOTE_NAME,
+    DEFAULT_REMOTE_URL,
+    inquire_remote_config,
+    inquire_remote_name,
+)
+from truss.cli.utils import common
+from truss.cli.utils.common import check_is_interactive
+from truss.cli.utils.output import console
+from truss.remote.baseten import oauth
+from truss.remote.baseten.api import resolve_rest_api_url
+from truss.remote.baseten.oauth import OAuthCredential, OAuthError
+from truss.remote.remote_factory import (
+    _INLINE_SECRET_KEYS,
+    USER_TRUSSRC_PATH,
+    RemoteFactory,
+    load_config,
+)
+from truss.remote.truss_remote import RemoteConfig
+
+
+@click.group(name="auth")
+def auth_group() -> None:
+    """Manage authentication."""
+
+
+@auth_group.command(name="login")
+@click.option("--browser", is_flag=True, help="Log in via browser (OAuth device flow).")
+@click.option(
+    "--api-key", "api_key", type=str, default=None, help="API key for authentication."
+)
+@click.option("--remote", type=str, default=None, help="Remote name to create.")
+@common.common_options()
+def auth_login(browser: bool, api_key: Optional[str], remote: Optional[str]) -> None:
+    """Log in to a Baseten remote."""
+    do_login(browser=browser, api_key=api_key, remote=remote)
+
+
+@auth_group.command(name="logout")
+@click.option(
+    "--remote",
+    type=str,
+    default=None,
+    help="Remote name. Inferred when only one is configured.",
+)
+@common.common_options()
+def auth_logout(remote: Optional[str]) -> None:
+    """Log out of a Baseten remote and remove it from the trussrc."""
+    remote_name = remote or inquire_remote_name(allow_create=False)
+    try:
+        cfg = RemoteFactory.load_remote_config(remote_name)
+    except (FileNotFoundError, ValueError) as exc:
+        raise click.ClickException(f"Not logged in to remote {remote_name!r}: {exc}")
+
+    if cfg.configs.get("auth_type") == "oauth":
+        credential = OAuthCredential(
+            access_token=cfg.configs["oauth_access_token"],
+            refresh_token=cfg.configs["oauth_refresh_token"],
+            expires_at=int(cfg.configs["oauth_expires_at"]),
+        )
+        oauth.revoke(resolve_rest_api_url(cfg.configs["remote_url"]), credential)
+
+    RemoteFactory.remove_remote_config(remote_name)
+    console.print(f"👋 Logged out of remote `{remote_name}`.")
+
+
+@auth_group.command(name="status")
+@click.option(
+    "--remote",
+    type=str,
+    default=None,
+    help="Remote name. Inferred when only one is configured.",
+)
+@common.common_options()
+def auth_status(remote: Optional[str]) -> None:
+    """Show the active authentication for a remote."""
+    remote_name = remote or inquire_remote_name(allow_create=False)
+    if not USER_TRUSSRC_PATH.exists():
+        raise click.ClickException(f"No trussrc found at {USER_TRUSSRC_PATH}.")
+    raw = load_config()
+    if remote_name not in raw:
+        raise click.ClickException(f"No remote {remote_name!r} configured.")
+    section = raw[remote_name]
+    auth_type = section.get("auth_type")
+    if not auth_type:
+        if "api_key" in section:
+            auth_type = "api_key (legacy plaintext)"
+            source = "trussrc-inline"
+        else:
+            raise click.ClickException(
+                f"Remote {remote_name!r} has no credentials configured."
+            )
+    elif any(key in section for key in _INLINE_SECRET_KEYS):
+        source = "trussrc-inline"
+    else:
+        source = "keyring"
+    remote_url = section.get("remote_url", "(unset)")
+    console.print(f"remote: {remote_name}")
+    console.print(f"remote_url: {remote_url}")
+    console.print(f"auth_type: {auth_type}")
+    console.print(f"source: {source}")
+
+
+def do_login(
+    *, browser: bool, api_key: Optional[str], remote: Optional[str] = None
+) -> None:
+    """Shared implementation for `truss login` and `truss auth login`."""
+    if browser and api_key is not None:
+        raise click.UsageError("--browser and --api-key are mutually exclusive.")
+
+    remote_name = remote or DEFAULT_REMOTE_NAME
+    remote_url = _existing_remote_url(remote_name) or DEFAULT_REMOTE_URL
+
+    if api_key is not None:
+        RemoteFactory.update_remote_config(
+            RemoteConfig(
+                name=remote_name,
+                configs={
+                    "remote_provider": "baseten",
+                    "remote_url": remote_url,
+                    "auth_type": "api_key",
+                    "api_key": api_key,
+                },
+            )
+        )
+    elif browser:
+        try:
+            credential = oauth.run_device_flow(resolve_rest_api_url(remote_url))
+        except OAuthError as exc:
+            raise click.ClickException(str(exc))
+        RemoteFactory.update_remote_config(
+            RemoteConfig(
+                name=remote_name,
+                configs={
+                    "remote_provider": "baseten",
+                    "remote_url": remote_url,
+                    "auth_type": "oauth",
+                    "oauth_access_token": credential.access_token,
+                    "oauth_refresh_token": credential.refresh_token,
+                    "oauth_expires_at": str(credential.expires_at),
+                },
+            )
+        )
+    else:
+        if not check_is_interactive():
+            raise click.UsageError(
+                "Specify --browser or --api-key when running non-interactively."
+            )
+        config = inquire_remote_config(remote_name=remote_name, remote_url=remote_url)
+        RemoteFactory.update_remote_config(config)
+        remote_name = config.name
+    console.print(f"🔓 Logged in to remote `{remote_name}`.")
+
+
+def _existing_remote_url(remote_name: str) -> Optional[str]:
+    if not USER_TRUSSRC_PATH.exists():
+        return None
+    raw = load_config()
+    if remote_name not in raw:
+        return None
+    return raw[remote_name].get("remote_url")

--- a/truss/cli/auth.py
+++ b/truss/cli/auth.py
@@ -4,12 +4,8 @@ from typing import Optional
 
 import rich_click as click
 
-from truss.cli.remote_cli import (
-    DEFAULT_REMOTE_NAME,
-    DEFAULT_REMOTE_URL,
-    inquire_remote_config,
-    inquire_remote_name,
-)
+from truss.base.constants import DEFAULT_REMOTE_NAME, DEFAULT_REMOTE_URL
+from truss.cli.remote_cli import inquire_remote_config, inquire_remote_name
 from truss.cli.utils import common
 from truss.cli.utils.common import check_is_interactive
 from truss.cli.utils.output import console
@@ -19,6 +15,7 @@ from truss.remote.baseten.oauth import OAuthCredential, OAuthError
 from truss.remote.remote_factory import (
     _INLINE_SECRET_KEYS,
     USER_TRUSSRC_PATH,
+    AuthType,
     RemoteFactory,
     load_config,
 )
@@ -58,7 +55,7 @@ def auth_logout(remote: Optional[str]) -> None:
     except (FileNotFoundError, ValueError) as exc:
         raise click.ClickException(f"Not logged in to remote {remote_name!r}: {exc}")
 
-    if cfg.configs.get("auth_type") == "oauth":
+    if cfg.configs.get("auth_type") == AuthType.OAUTH:
         credential = OAuthCredential(
             access_token=cfg.configs["oauth_access_token"],
             refresh_token=cfg.configs["oauth_refresh_token"],
@@ -122,9 +119,9 @@ def do_login(
             RemoteConfig(
                 name=remote_name,
                 configs={
-                    "remote_provider": "baseten",
+                    "remote_provider": DEFAULT_REMOTE_NAME,
                     "remote_url": remote_url,
-                    "auth_type": "api_key",
+                    "auth_type": AuthType.API_KEY,
                     "api_key": api_key,
                 },
             )
@@ -138,9 +135,9 @@ def do_login(
             RemoteConfig(
                 name=remote_name,
                 configs={
-                    "remote_provider": "baseten",
+                    "remote_provider": DEFAULT_REMOTE_NAME,
                     "remote_url": remote_url,
-                    "auth_type": "oauth",
+                    "auth_type": AuthType.OAUTH,
                     "oauth_access_token": credential.access_token,
                     "oauth_refresh_token": credential.refresh_token,
                     "oauth_expires_at": str(credential.expires_at),

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -1023,7 +1023,7 @@ def push(
             )
             if watch_no_sleep:
                 model_hostname = resolved_model["hostname"]
-                common.start_keepalive(model_hostname, bt_remote.auth_header)
+                common.start_keepalive(model_hostname, bt_remote.fetch_auth_header)
             _start_watch_mode(
                 target_directory=target_directory,
                 model_name=model_name,
@@ -1278,7 +1278,7 @@ def watch(
     )
 
     if no_sleep:
-        common.start_keepalive(model_hostname, remote_provider.auth_header)
+        common.start_keepalive(model_hostname, remote_provider.fetch_auth_header)
 
     if tail:
         _start_tail(remote_provider, model_id, dev_version_id, in_background=True)

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -20,6 +20,7 @@ from truss.base.constants import (
 from truss.base.trt_llm_config import TrussTRTLLMQuantizationType
 from truss.base.truss_config import Build, ModelServer, TransportKind
 from truss.cli import remote_cli
+from truss.cli.auth import auth_group, do_login
 from truss.cli.logs import utils as cli_log_utils
 from truss.cli.logs.model_log_watcher import ModelDeploymentLogWatcher
 from truss.cli.resolvers.model_team_resolver import (
@@ -169,16 +170,15 @@ def truss_cli(ctx) -> None:
 
 
 @truss_cli.command()
+@click.option("--browser", is_flag=True, help="Log in via browser (OAuth device flow).")
 @click.option("--api-key", type=str, required=False, help="API key for authentication.")
+@click.option("--remote", type=str, default=None, help="Remote name to create.")
 @common.common_options()
-def login(api_key: Optional[str]):
-    from truss.api import login
+def login(browser: bool, api_key: Optional[str], remote: Optional[str]):
+    do_login(browser=browser, api_key=api_key, remote=remote)
 
-    if not api_key:
-        remote_config = remote_cli.inquire_remote_config()
-        RemoteFactory.update_remote_config(remote_config)
-    else:
-        login(api_key)
+
+truss_cli.add_command(auth_group)
 
 
 @truss_cli.command()
@@ -1021,8 +1021,7 @@ def push(
             )
             if watch_no_sleep:
                 model_hostname = resolved_model["hostname"]
-                api_key = bt_remote._auth_service.authenticate().value
-                common.start_keepalive(model_hostname, api_key)
+                common.start_keepalive(model_hostname, bt_remote.auth_header)
             _start_watch_mode(
                 target_directory=target_directory,
                 model_name=model_name,
@@ -1181,19 +1180,16 @@ def watch(
         console.print("❌ Could not determine model hostname", style="red")
         sys.exit(1)
 
-    api_key = remote_provider._auth_service.authenticate().value
-
     common.wait_for_development_model_ready(
         model_hostname=model_hostname,
         model_id=model_id,
         dev_version_id=dev_version_id,
         remote_provider=remote_provider,
         console=console,
-        api_key=api_key,
     )
 
     if no_sleep:
-        common.start_keepalive(model_hostname, api_key)
+        common.start_keepalive(model_hostname, remote_provider.auth_header)
 
     if tail:
         _start_tail(remote_provider, model_id, dev_version_id, in_background=True)

--- a/truss/cli/remote_cli.py
+++ b/truss/cli/remote_cli.py
@@ -5,17 +5,15 @@ from InquirerPy import inquirer
 from InquirerPy.base.control import Choice
 from InquirerPy.validator import ValidationError, Validator
 
+from truss.base.constants import DEFAULT_REMOTE_NAME, DEFAULT_REMOTE_URL
 from truss.cli.utils.common import check_is_interactive
 from truss.cli.utils.output import console
 from truss.remote.baseten import oauth
 from truss.remote.baseten.api import resolve_rest_api_url
 from truss.remote.baseten.custom_types import TeamType
 from truss.remote.baseten.oauth import OAuthError
-from truss.remote.remote_factory import USER_TRUSSRC_PATH, RemoteFactory
+from truss.remote.remote_factory import USER_TRUSSRC_PATH, AuthType, RemoteFactory
 from truss.remote.truss_remote import RemoteConfig
-
-DEFAULT_REMOTE_NAME = "baseten"
-DEFAULT_REMOTE_URL = "https://app.baseten.co"
 
 
 class NonEmptyValidator(Validator):
@@ -50,9 +48,9 @@ def inquire_remote_config(
         return RemoteConfig(
             name=remote_name,
             configs={
-                "remote_provider": "baseten",
+                "remote_provider": DEFAULT_REMOTE_NAME,
                 "remote_url": remote_url,
-                "auth_type": "oauth",
+                "auth_type": AuthType.OAUTH,
                 "oauth_access_token": credential.access_token,
                 "oauth_refresh_token": credential.refresh_token,
                 "oauth_expires_at": str(credential.expires_at),
@@ -64,8 +62,8 @@ def inquire_remote_config(
     return RemoteConfig(
         name=remote_name,
         configs={
-            "remote_provider": "baseten",
-            "auth_type": "api_key",
+            "remote_provider": DEFAULT_REMOTE_NAME,
+            "auth_type": AuthType.API_KEY,
             "api_key": api_key,
             "remote_url": remote_url,
         },

--- a/truss/cli/remote_cli.py
+++ b/truss/cli/remote_cli.py
@@ -7,9 +7,15 @@ from InquirerPy.validator import ValidationError, Validator
 
 from truss.cli.utils.common import check_is_interactive
 from truss.cli.utils.output import console
+from truss.remote.baseten import oauth
+from truss.remote.baseten.api import resolve_rest_api_url
 from truss.remote.baseten.custom_types import TeamType
+from truss.remote.baseten.oauth import OAuthError
 from truss.remote.remote_factory import USER_TRUSSRC_PATH, RemoteFactory
 from truss.remote.truss_remote import RemoteConfig
+
+DEFAULT_REMOTE_NAME = "baseten"
+DEFAULT_REMOTE_URL = "https://app.baseten.co"
 
 
 class NonEmptyValidator(Validator):
@@ -21,28 +27,58 @@ class NonEmptyValidator(Validator):
             )
 
 
-def inquire_remote_config() -> RemoteConfig:
+def inquire_remote_config(
+    *, remote_name: str = DEFAULT_REMOTE_NAME, remote_url: str = DEFAULT_REMOTE_URL
+) -> RemoteConfig:
     # TODO(bola): extract questions from remote
     console.print("💻 Let's add a Baseten remote!")
     # If users need to adjust the remote url, they
     # can do so manually in the .trussrc file.
-    remote_url = "https://app.baseten.co"
+    method = inquirer.select(
+        message="How would you like to authenticate?",
+        qmark="",
+        choices=[
+            Choice(value="api_key", name="Paste an API key"),
+            Choice(value="browser", name="Log in via browser (OAuth)"),
+        ],
+    ).execute()
+    if method == "browser":
+        try:
+            credential = oauth.run_device_flow(resolve_rest_api_url(remote_url))
+        except OAuthError as exc:
+            raise click.ClickException(str(exc))
+        return RemoteConfig(
+            name=remote_name,
+            configs={
+                "remote_provider": "baseten",
+                "remote_url": remote_url,
+                "auth_type": "oauth",
+                "oauth_access_token": credential.access_token,
+                "oauth_refresh_token": credential.refresh_token,
+                "oauth_expires_at": str(credential.expires_at),
+            },
+        )
     api_key = inquirer.secret(
         message="🤫 Quietly paste your API_KEY:", qmark="", validate=NonEmptyValidator()
     ).execute()
     return RemoteConfig(
-        name="baseten",
+        name=remote_name,
         configs={
             "remote_provider": "baseten",
+            "auth_type": "api_key",
             "api_key": api_key,
             "remote_url": remote_url,
         },
     )
 
 
-def inquire_remote_name() -> str:
+def inquire_remote_name(*, allow_create: bool = True) -> str:
     available_remotes = RemoteFactory.get_available_config_names()
     if len(available_remotes) == 0:
+        if not allow_create:
+            raise click.ClickException(
+                "No remotes configured. Run `truss auth login` first."
+            )
         if not check_is_interactive():
             raise click.UsageError(
                 "No remote configured. Please configure a remote first "

--- a/truss/cli/utils/common.py
+++ b/truss/cli/utils/common.py
@@ -7,7 +7,7 @@ import threading
 import time
 import warnings
 from functools import wraps
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, Optional
 
 import pydantic
 import requests as requests_lib
@@ -265,13 +265,11 @@ def wait_for_development_model_ready(
     dev_version_id: str,
     remote_provider: BasetenRemote,
     console: "rich_console.Console",
-    api_key: str,
 ) -> None:
     # Wake the model in case it's scaled to zero
     wake_url = f"{model_hostname}/development/wake"
-    headers = {"Authorization": f"Api-Key {api_key}"}
     try:
-        requests_lib.post(wake_url, headers=headers, timeout=10)
+        requests_lib.post(wake_url, headers=remote_provider.auth_header(), timeout=10)
     except requests_lib.RequestException:
         # best effort
         pass
@@ -307,21 +305,26 @@ def wait_for_development_model_ready(
                 sys.exit(1)
 
 
-def start_keepalive(model_hostname: str, api_key: str) -> threading.Event:
+def start_keepalive(
+    model_hostname: str, header_provider: Callable[[], Dict[str, str]]
+) -> threading.Event:
     """Start a keepalive thread to prevent scale-to-zero. Returns the stop event."""
     console.print("💤 --no-sleep enabled: keeping development model warm")
     stop_event = threading.Event()
     keepalive_thread = threading.Thread(
-        target=keepalive_loop, args=(model_hostname, api_key, stop_event), daemon=True
+        target=keepalive_loop,
+        args=(model_hostname, header_provider, stop_event),
+        daemon=True,
     )
     keepalive_thread.start()
     return stop_event
 
 
 def keepalive_loop(
-    model_hostname: str, api_key: str, stop_event: threading.Event
+    model_hostname: str,
+    header_provider: Callable[[], Dict[str, str]],
+    stop_event: threading.Event,
 ) -> None:
-    headers = {"Authorization": f"Api-Key {api_key}"}
     consecutive_failures = 0
     start_time = time.time()
     keepalive_url = f"{model_hostname}/development/sync/v1/models/model"
@@ -348,7 +351,9 @@ def keepalive_loop(
             warning_emitted = True
 
         try:
-            resp = requests_lib.get(keepalive_url, headers=headers, timeout=10)
+            resp = requests_lib.get(
+                keepalive_url, headers=header_provider(), timeout=10
+            )
             if resp.status_code == 200:
                 consecutive_failures = 0
             elif 400 <= resp.status_code < 500:

--- a/truss/cli/utils/common.py
+++ b/truss/cli/utils/common.py
@@ -7,7 +7,7 @@ import threading
 import time
 import warnings
 from functools import wraps
-from typing import TYPE_CHECKING, Any, Callable, Dict, Optional
+from typing import TYPE_CHECKING, Any, Callable, Optional
 
 import pydantic
 import requests as requests_lib
@@ -269,7 +269,9 @@ def wait_for_development_model_ready(
     # Wake the model in case it's scaled to zero
     wake_url = f"{model_hostname}/development/wake"
     try:
-        requests_lib.post(wake_url, headers=remote_provider.auth_header(), timeout=10)
+        requests_lib.post(
+            wake_url, headers=remote_provider.fetch_auth_header(), timeout=10
+        )
     except requests_lib.RequestException:
         # best effort
         pass
@@ -306,7 +308,7 @@ def wait_for_development_model_ready(
 
 
 def start_keepalive(
-    model_hostname: str, header_provider: Callable[[], Dict[str, str]]
+    model_hostname: str, header_provider: Callable[[], dict[str, str]]
 ) -> threading.Event:
     """Start a keepalive thread to prevent scale-to-zero. Returns the stop event."""
     console.print("💤 --no-sleep enabled: keeping development model warm")
@@ -322,7 +324,7 @@ def start_keepalive(
 
 def keepalive_loop(
     model_hostname: str,
-    header_provider: Callable[[], Dict[str, str]],
+    header_provider: Callable[[], dict[str, str]],
     stop_event: threading.Event,
 ) -> None:
     consecutive_failures = 0

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -137,7 +137,8 @@ class BasetenApi:
         self._rest_api_url = rest_api_url
         self._auth_service = auth_service
         self._rest_api_client = RestAPIClient(
-            base_url=self._rest_api_url, header_provider=self._auth_service.auth_header
+            base_url=self._rest_api_url,
+            header_provider=self._auth_service.fetch_auth_header,
         )
 
     @property
@@ -157,7 +158,7 @@ class BasetenApi:
         self._rest_api_client.suppress_error_print = value
 
     def _post_graphql_query(self, query: str, variables: Optional[dict] = None) -> dict:
-        headers = self._auth_service.auth_header()
+        headers = self._auth_service.fetch_auth_header()
         payload: Dict[str, Any] = {"query": query}
         if variables is not None:
             payload["variables"] = variables

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Field
 
 from truss.base.custom_types import SafeModel
 from truss.remote.baseten import custom_types as b10_types
-from truss.remote.baseten.auth import ApiKey, AuthService
+from truss.remote.baseten.auth import AuthService
 from truss.remote.baseten.custom_types import APIKeyCategory, TeamType
 from truss.remote.baseten.error import ApiError
 from truss.remote.baseten.rest_client import RestAPIClient
@@ -86,6 +86,11 @@ API_URL_MAPPING = {
 DEFAULT_API_DOMAIN = "https://api.baseten.co"
 
 
+def resolve_rest_api_url(remote_url: str) -> str:
+    """Map an app remote_url (e.g. https://app.baseten.co) to its REST API base."""
+    return API_URL_MAPPING.get(remote_url.strip("/"), DEFAULT_API_DOMAIN)
+
+
 def _oracle_data_to_graphql_mutation(oracle: b10_types.OracleData) -> str:
     args = [
         f'model_name: "{oracle.model_name}"',
@@ -125,16 +130,14 @@ class BasetenApi:
 
     def __init__(self, remote_url: str, auth_service: AuthService) -> None:
         graphql_api_url = f"{remote_url}/graphql/"
-        # Ensure we strip off trailing '/' to denormalize URLs.
-        rest_api_url = API_URL_MAPPING.get(remote_url.strip("/"), DEFAULT_API_DOMAIN)
+        rest_api_url = resolve_rest_api_url(remote_url)
 
         self._remote_url = remote_url
         self._graphql_api_url = graphql_api_url
         self._rest_api_url = rest_api_url
         self._auth_service = auth_service
-        self._auth_token = self._auth_service.authenticate()
         self._rest_api_client = RestAPIClient(
-            base_url=self._rest_api_url, headers=self._auth_token.header()
+            base_url=self._rest_api_url, header_provider=self._auth_service.auth_header
         )
 
     @property
@@ -146,10 +149,6 @@ class BasetenApi:
         return self._rest_api_url
 
     @property
-    def auth_token(self) -> ApiKey:
-        return self._auth_token
-
-    @property
     def suppress_error_print(self) -> bool:
         return self._rest_api_client.suppress_error_print
 
@@ -158,7 +157,7 @@ class BasetenApi:
         self._rest_api_client.suppress_error_print = value
 
     def _post_graphql_query(self, query: str, variables: Optional[dict] = None) -> dict:
-        headers = self._auth_token.header()
+        headers = self._auth_service.auth_header()
         payload: Dict[str, Any] = {"query": query}
         if variables is not None:
             payload["variables"] = variables

--- a/truss/remote/baseten/auth.py
+++ b/truss/remote/baseten/auth.py
@@ -1,32 +1,68 @@
 import logging
 import os
-from typing import Optional
+from dataclasses import replace
+from typing import Callable, Dict, Optional
 
 from truss.remote.baseten.error import AuthorizationError
+from truss.remote.baseten.oauth import OAuthCredential, refresh
 
 logger = logging.getLogger(__name__)
 
 
-class ApiKey:
-    value: str
-
-    def __init__(self, value: str) -> None:
-        self.value = value
-
-    def header(self):
-        return {"Authorization": f"Api-Key {self.value}"}
-
-
 class AuthService:
-    def __init__(self, api_key: Optional[str] = None) -> None:
+    """Holds the active credential for a remote and yields request headers.
+
+    Two credential modes:
+    - API key (legacy): ``AuthService(api_key="...")`` or ``BASETEN_API_KEY``.
+    - OAuth: ``AuthService(api_url=..., oauth_credential=...)``. Access
+      token is refreshed in-process via ``oauth.refresh`` when within the
+      leeway of ``expires_at``; refreshed credential is handed to
+      ``on_token_refresh`` so the caller can persist it.
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        *,
+        api_url: Optional[str] = None,
+        oauth_credential: Optional[OAuthCredential] = None,
+        on_token_refresh: Optional[Callable[[OAuthCredential], None]] = None,
+    ) -> None:
+        self._oauth_credential: Optional[OAuthCredential] = oauth_credential
+        self._api_url: Optional[str] = api_url
+        self._on_token_refresh: Optional[Callable[[OAuthCredential], None]] = None
+        self._api_key: Optional[str] = None
+        if oauth_credential is not None:
+            if api_url is None:
+                raise ValueError("api_url is required for OAuth credentials")
+            self._on_token_refresh = on_token_refresh
+            return
         if not api_key:
-            api_key = os.environ.get("BASETEN_API_KEY", None)
+            api_key = os.environ.get("BASETEN_API_KEY")
         self._api_key = api_key
 
-    def validate(self) -> None:
-        if not self._api_key:
-            raise AuthorizationError("No API key provided.")
+    def auth_header(self) -> Dict[str, str]:
+        """Return a fresh ``Authorization`` header for any credential type.
 
-    def authenticate(self) -> ApiKey:
-        self.validate()
-        return ApiKey(self._api_key)  # type: ignore
+        Refreshes the OAuth access token in-place when within the leeway of
+        its ``expires_at``.
+        """
+        if self._oauth_credential is not None:
+            self._refresh_if_expired()
+            return {"Authorization": f"Bearer {self._oauth_credential.access_token}"}
+        if not self._api_key:
+            raise AuthorizationError("No credentials provided.")
+        return {"Authorization": f"Api-Key {self._api_key}"}
+
+    def _refresh_if_expired(self) -> None:
+        assert self._oauth_credential is not None
+        if not self._oauth_credential.is_expired():
+            return
+        assert self._api_url is not None
+        refreshed = refresh(self._api_url, self._oauth_credential)
+        self._oauth_credential = refreshed
+        if self._on_token_refresh is not None:
+            try:
+                self._on_token_refresh(replace(refreshed))
+            except Exception as exc:
+                logger.warning("Persisting refreshed OAuth token failed: %s", exc)

--- a/truss/remote/baseten/auth.py
+++ b/truss/remote/baseten/auth.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import threading
 from dataclasses import replace
 from typing import Callable, Dict, Optional
 
@@ -32,6 +33,7 @@ class AuthService:
         self._api_url: Optional[str] = api_url
         self._on_token_refresh: Optional[Callable[[OAuthCredential], None]] = None
         self._api_key: Optional[str] = None
+        self._refresh_lock = threading.Lock()
         if oauth_credential is not None:
             if api_url is None:
                 raise ValueError("api_url is required for OAuth credentials")
@@ -48,8 +50,11 @@ class AuthService:
         its ``expires_at``.
         """
         if self._oauth_credential is not None:
-            self._refresh_if_expired()
-            return {"Authorization": f"Bearer {self._oauth_credential.access_token}"}
+            with self._refresh_lock:
+                self._refresh_if_expired()
+                return {
+                    "Authorization": f"Bearer {self._oauth_credential.access_token}"
+                }
         if not self._api_key:
             raise AuthorizationError("No credentials provided.")
         return {"Authorization": f"Api-Key {self._api_key}"}

--- a/truss/remote/baseten/auth.py
+++ b/truss/remote/baseten/auth.py
@@ -1,73 +1,61 @@
 import logging
-import os
 import threading
-from dataclasses import replace
-from typing import Callable, Dict, Optional
+from typing import Callable, Optional, Union
 
-from truss.remote.baseten.error import AuthorizationError
+import pydantic
+
 from truss.remote.baseten.oauth import OAuthCredential, refresh
 
 logger = logging.getLogger(__name__)
 
 
+class ApiKeyCredential(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(frozen=True)
+
+    api_key: str = pydantic.Field(min_length=1)
+
+
+class OAuthSession(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(frozen=True)
+
+    api_url: str
+    credential: OAuthCredential
+    on_token_refresh: Optional[Callable[[OAuthCredential], None]] = None
+
+
 class AuthService:
     """Holds the active credential for a remote and yields request headers.
 
-    Two credential modes:
-    - API key (legacy): ``AuthService(api_key="...")`` or ``BASETEN_API_KEY``.
-    - OAuth: ``AuthService(api_url=..., oauth_credential=...)``. Access
-      token is refreshed in-process via ``oauth.refresh`` when within the
-      leeway of ``expires_at``; refreshed credential is handed to
-      ``on_token_refresh`` so the caller can persist it.
+    OAuth access tokens are refreshed in-process via ``oauth.refresh`` when
+    within the leeway of ``expires_at``; refreshed credential is handed to
+    ``OAuthSession.on_token_refresh`` so the caller can persist it.
     """
 
-    def __init__(
-        self,
-        api_key: Optional[str] = None,
-        *,
-        api_url: Optional[str] = None,
-        oauth_credential: Optional[OAuthCredential] = None,
-        on_token_refresh: Optional[Callable[[OAuthCredential], None]] = None,
-    ) -> None:
-        self._oauth_credential: Optional[OAuthCredential] = oauth_credential
-        self._api_url: Optional[str] = api_url
-        self._on_token_refresh: Optional[Callable[[OAuthCredential], None]] = None
-        self._api_key: Optional[str] = None
+    def __init__(self, credential: Union[ApiKeyCredential, OAuthSession]) -> None:
+        self._credential = credential
         self._refresh_lock = threading.Lock()
-        if oauth_credential is not None:
-            if api_url is None:
-                raise ValueError("api_url is required for OAuth credentials")
-            self._on_token_refresh = on_token_refresh
-            return
-        if not api_key:
-            api_key = os.environ.get("BASETEN_API_KEY")
-        self._api_key = api_key
 
-    def auth_header(self) -> Dict[str, str]:
+    def fetch_auth_header(self) -> dict[str, str]:
         """Return a fresh ``Authorization`` header for any credential type.
 
         Refreshes the OAuth access token in-place when within the leeway of
         its ``expires_at``.
         """
-        if self._oauth_credential is not None:
+        if isinstance(self._credential, OAuthSession):
             with self._refresh_lock:
-                self._refresh_if_expired()
-                return {
-                    "Authorization": f"Bearer {self._oauth_credential.access_token}"
-                }
-        if not self._api_key:
-            raise AuthorizationError("No credentials provided.")
-        return {"Authorization": f"Api-Key {self._api_key}"}
+                session = self._refresh_if_expired(self._credential)
+            return {"Authorization": f"Bearer {session.credential.access_token}"}
+        return {"Authorization": f"Api-Key {self._credential.api_key}"}
 
-    def _refresh_if_expired(self) -> None:
-        assert self._oauth_credential is not None
-        if not self._oauth_credential.is_expired():
-            return
-        assert self._api_url is not None
-        refreshed = refresh(self._api_url, self._oauth_credential)
-        self._oauth_credential = refreshed
-        if self._on_token_refresh is not None:
+    def _refresh_if_expired(self, session: OAuthSession) -> OAuthSession:
+        if not session.credential.is_expired():
+            return session
+        refreshed = refresh(session.api_url, session.credential)
+        updated = session.model_copy(update={"credential": refreshed})
+        self._credential = updated
+        if session.on_token_refresh is not None:
             try:
-                self._on_token_refresh(replace(refreshed))
+                session.on_token_refresh(refreshed.model_copy())
             except Exception as exc:
                 logger.warning("Persisting refreshed OAuth token failed: %s", exc)
+        return updated

--- a/truss/remote/baseten/oauth.py
+++ b/truss/remote/baseten/oauth.py
@@ -6,9 +6,9 @@ Tokens are returned as :class:`OAuthCredential` with an absolute Unix
 
 import logging
 import time
-from dataclasses import dataclass
 from typing import Optional
 
+import pydantic
 import requests
 
 logger = logging.getLogger(__name__)
@@ -25,41 +25,43 @@ DEFAULT_POLL_INTERVAL_SECONDS = 5
 EXPIRY_LEEWAY_SECONDS = 60
 
 
-@dataclass(frozen=True)
-class OAuthCredential:
-    access_token: str
-    refresh_token: str
+class OAuthError(Exception):
+    """Raised on terminal OAuth failures (denied, expired, invalid request)."""
+
+
+class OAuthCredential(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(frozen=True, extra="ignore")
+
+    access_token: str = pydantic.Field(min_length=1)
+    refresh_token: str = pydantic.Field(min_length=1)
     expires_at: int  # absolute Unix timestamp seconds
 
     def is_expired(self, leeway: int = EXPIRY_LEEWAY_SECONDS) -> bool:
         return time.time() + leeway >= self.expires_at
 
+    @classmethod
+    def from_token_response(cls, payload: dict) -> "OAuthCredential":
+        expires_in = payload.get("expires_in")
+        if expires_in is None:
+            raise OAuthError(
+                f"Token response missing required fields: {sorted(payload)}"
+            )
+        payload = {**payload, "expires_at": int(time.time()) + int(expires_in)}
+        try:
+            return cls.model_validate(payload)
+        except pydantic.ValidationError as exc:
+            raise OAuthError(f"Token response missing required fields: {exc}") from exc
 
-@dataclass(frozen=True)
-class DeviceAuthorization:
+
+class DeviceAuthorization(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(frozen=True, extra="ignore")
+
     device_code: str
     user_code: str
     verification_uri: str
-    verification_uri_complete: Optional[str]
-    expires_in: int
-    interval: int
-
-
-class OAuthError(Exception):
-    """Raised on terminal OAuth failures (denied, expired, invalid request)."""
-
-
-def _token_from_response(payload: dict) -> OAuthCredential:
-    access_token = payload.get("access_token")
-    refresh_token = payload.get("refresh_token")
-    expires_in = payload.get("expires_in")
-    if not access_token or not refresh_token or expires_in is None:
-        raise OAuthError(f"Token response missing required fields: {sorted(payload)}")
-    return OAuthCredential(
-        access_token=access_token,
-        refresh_token=refresh_token,
-        expires_at=int(time.time()) + int(expires_in),
-    )
+    verification_uri_complete: Optional[str] = None
+    expires_in: int = 600
+    interval: int = DEFAULT_POLL_INTERVAL_SECONDS
 
 
 def request_device_authorization(api_url: str) -> DeviceAuthorization:
@@ -72,15 +74,10 @@ def request_device_authorization(api_url: str) -> DeviceAuthorization:
         raise OAuthError(
             f"Device authorize failed ({resp.status_code}): {resp.text.strip()}"
         )
-    body = resp.json()
-    return DeviceAuthorization(
-        device_code=body["device_code"],
-        user_code=body["user_code"],
-        verification_uri=body["verification_uri"],
-        verification_uri_complete=body.get("verification_uri_complete"),
-        expires_in=int(body.get("expires_in", 600)),
-        interval=int(body.get("interval", DEFAULT_POLL_INTERVAL_SECONDS)),
-    )
+    try:
+        return DeviceAuthorization.model_validate(resp.json())
+    except pydantic.ValidationError as exc:
+        raise OAuthError(f"Device authorize response malformed: {exc}") from exc
 
 
 def poll_device_token(
@@ -107,7 +104,7 @@ def poll_device_token(
             timeout=30,
         )
         if resp.ok:
-            return _token_from_response(resp.json())
+            return OAuthCredential.from_token_response(resp.json())
         try:
             err = resp.json()
         except ValueError:
@@ -152,7 +149,7 @@ def refresh(api_url: str, credential: OAuthCredential) -> OAuthCredential:
         raise OAuthError(
             f"Token refresh failed ({resp.status_code}): {resp.text.strip()}"
         )
-    return _token_from_response(resp.json())
+    return OAuthCredential.from_token_response(resp.json())
 
 
 def revoke(api_url: str, credential: OAuthCredential) -> None:

--- a/truss/remote/baseten/oauth.py
+++ b/truss/remote/baseten/oauth.py
@@ -1,0 +1,172 @@
+"""OAuth 2.0 device authorization grant (RFC 8628) for the Baseten backend.
+
+Tokens are returned as :class:`OAuthCredential` with an absolute Unix
+``expires_at`` so callers can do proactive refresh before sending.
+"""
+
+import logging
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+CLIENT_ID = "baseten-cli"
+DEVICE_AUTHORIZE_PATH = "/v1/users/auth/device/authorize"
+DEVICE_TOKEN_PATH = "/v1/users/auth/device/token"
+LOGOUT_PATH = "/v1/users/auth/logout"
+
+DEVICE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code"
+REFRESH_GRANT_TYPE = "refresh_token"
+
+DEFAULT_POLL_INTERVAL_SECONDS = 5
+EXPIRY_LEEWAY_SECONDS = 60
+
+
+@dataclass(frozen=True)
+class OAuthCredential:
+    access_token: str
+    refresh_token: str
+    expires_at: int  # absolute Unix timestamp seconds
+
+    def is_expired(self, leeway: int = EXPIRY_LEEWAY_SECONDS) -> bool:
+        return time.time() + leeway >= self.expires_at
+
+
+@dataclass(frozen=True)
+class DeviceAuthorization:
+    device_code: str
+    user_code: str
+    verification_uri: str
+    verification_uri_complete: Optional[str]
+    expires_in: int
+    interval: int
+
+
+class OAuthError(Exception):
+    """Raised on terminal OAuth failures (denied, expired, invalid request)."""
+
+
+def _token_from_response(payload: dict) -> OAuthCredential:
+    access_token = payload.get("access_token")
+    refresh_token = payload.get("refresh_token")
+    expires_in = payload.get("expires_in")
+    if not access_token or not refresh_token or expires_in is None:
+        raise OAuthError(f"Token response missing required fields: {sorted(payload)}")
+    return OAuthCredential(
+        access_token=access_token,
+        refresh_token=refresh_token,
+        expires_at=int(time.time()) + int(expires_in),
+    )
+
+
+def request_device_authorization(api_url: str) -> DeviceAuthorization:
+    resp = requests.post(
+        api_url.rstrip("/") + DEVICE_AUTHORIZE_PATH,
+        data={"client_id": CLIENT_ID},
+        timeout=30,
+    )
+    if not resp.ok:
+        raise OAuthError(
+            f"Device authorize failed ({resp.status_code}): {resp.text.strip()}"
+        )
+    body = resp.json()
+    return DeviceAuthorization(
+        device_code=body["device_code"],
+        user_code=body["user_code"],
+        verification_uri=body["verification_uri"],
+        verification_uri_complete=body.get("verification_uri_complete"),
+        expires_in=int(body.get("expires_in", 600)),
+        interval=int(body.get("interval", DEFAULT_POLL_INTERVAL_SECONDS)),
+    )
+
+
+def poll_device_token(
+    api_url: str, authorization: DeviceAuthorization
+) -> OAuthCredential:
+    """Poll the token endpoint until the user authorizes or the grant fails.
+
+    Implements RFC 8628 polling: ``authorization_pending`` → keep polling,
+    ``slow_down`` → bump interval, terminal errors → raise.
+    """
+    token_url = api_url.rstrip("/") + DEVICE_TOKEN_PATH
+    interval = max(1, authorization.interval)
+    deadline = time.time() + authorization.expires_in
+    while True:
+        if time.time() >= deadline:
+            raise OAuthError("Device authorization expired before completion.")
+        resp = requests.post(
+            token_url,
+            data={
+                "grant_type": DEVICE_GRANT_TYPE,
+                "device_code": authorization.device_code,
+                "client_id": CLIENT_ID,
+            },
+            timeout=30,
+        )
+        if resp.ok:
+            return _token_from_response(resp.json())
+        try:
+            err = resp.json()
+        except ValueError:
+            raise OAuthError(
+                f"Device token endpoint returned {resp.status_code}: "
+                f"{resp.text.strip()}"
+            )
+        code = err.get("error")
+        if code == "authorization_pending":
+            time.sleep(interval)
+            continue
+        if code == "slow_down":
+            interval += 5
+            time.sleep(interval)
+            continue
+        raise OAuthError(
+            f"Device authorization failed: {code or resp.status_code} "
+            f"{err.get('error_description', '')}".strip()
+        )
+
+
+def run_device_flow(api_url: str) -> OAuthCredential:
+    """Drive the full device flow: authorize, prompt, poll, return credential."""
+    authorization = request_device_authorization(api_url)
+    logger.info(
+        "Enter code %s at %s", authorization.user_code, authorization.verification_uri
+    )
+    return poll_device_token(api_url, authorization)
+
+
+def refresh(api_url: str, credential: OAuthCredential) -> OAuthCredential:
+    resp = requests.post(
+        api_url.rstrip("/") + DEVICE_TOKEN_PATH,
+        data={
+            "grant_type": REFRESH_GRANT_TYPE,
+            "refresh_token": credential.refresh_token,
+            "client_id": CLIENT_ID,
+        },
+        timeout=30,
+    )
+    if not resp.ok:
+        raise OAuthError(
+            f"Token refresh failed ({resp.status_code}): {resp.text.strip()}"
+        )
+    return _token_from_response(resp.json())
+
+
+def revoke(api_url: str, credential: OAuthCredential) -> None:
+    """Best-effort logout. Logs and swallows non-2xx so cleanup proceeds."""
+    try:
+        resp = requests.post(
+            api_url.rstrip("/") + LOGOUT_PATH,
+            headers={"Authorization": f"Bearer {credential.access_token}"},
+            timeout=30,
+        )
+    except requests.RequestException as exc:
+        logger.warning("Token revoke request failed: %s", exc)
+        return
+    if not resp.ok:
+        logger.warning(
+            "Token revoke returned %s: %s", resp.status_code, resp.text.strip()
+        )

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -1,5 +1,6 @@
 import enum
 import logging
+import os
 import re
 import sys
 import time
@@ -20,13 +21,17 @@ import yaml
 from requests import ReadTimeout
 from watchfiles import watch
 
-from truss.base.constants import CONFIG_FILE, PRODUCTION_ENVIRONMENT_NAME
+from truss.base.constants import (
+    CONFIG_FILE,
+    DEFAULT_REMOTE_NAME,
+    PRODUCTION_ENVIRONMENT_NAME,
+)
 from truss.base.truss_config import ModelServer
 from truss.local.local_config_handler import LocalConfigHandler
 from truss.remote.baseten import custom_types
 from truss.remote.baseten import custom_types as b10_types
 from truss.remote.baseten.api import BasetenApi, resolve_rest_api_url
-from truss.remote.baseten.auth import AuthService
+from truss.remote.baseten.auth import ApiKeyCredential, AuthService, OAuthSession
 from truss.remote.baseten.core import (
     ChainDeploymentHandleAtomic,
     ModelId,
@@ -46,7 +51,7 @@ from truss.remote.baseten.core import (
     upload_truss,
     validate_truss_config_against_backend,
 )
-from truss.remote.baseten.error import ApiError, RemoteError
+from truss.remote.baseten.error import ApiError, AuthorizationError, RemoteError
 from truss.remote.baseten.oauth import OAuthCredential
 from truss.remote.baseten.service import BasetenService, URLConfig
 from truss.remote.baseten.utils.transfer import base64_encoded_json_str
@@ -134,31 +139,35 @@ class BasetenRemote(TrussRemote):
                     f"Remote {oauth_remote_name!r}: OAuth credentials require "
                     "access_token, refresh_token, and expires_at."
                 )
-            credential = OAuthCredential(
-                access_token=oauth_access_token,
-                refresh_token=oauth_refresh_token,
-                expires_at=int(oauth_expires_at),
-            )
             self._auth_service = AuthService(
-                api_url=resolve_rest_api_url(remote_url),
-                oauth_credential=credential,
-                on_token_refresh=self._persist_refreshed_credential,
+                OAuthSession(
+                    api_url=resolve_rest_api_url(remote_url),
+                    credential=OAuthCredential(
+                        access_token=oauth_access_token,
+                        refresh_token=oauth_refresh_token,
+                        expires_at=int(oauth_expires_at),
+                    ),
+                    on_token_refresh=self._persist_refreshed_credential,
+                )
             )
         else:
-            self._auth_service = AuthService(api_key=api_key)
+            api_key = api_key or os.environ.get("BASETEN_API_KEY")
+            if not api_key:
+                raise AuthorizationError("No credentials provided.")
+            self._auth_service = AuthService(ApiKeyCredential(api_key=api_key))
         self._api = BasetenApi(remote_url, self._auth_service)
 
-    def auth_header(self) -> Dict[str, str]:
+    def fetch_auth_header(self) -> dict[str, str]:
         """Return a fresh ``Authorization`` header for the active credential.
 
         Call this per-request rather than caching the return value: for OAuth
         credentials the access token is refreshed in-place when near expiry,
         so a stored header can become stale.
         """
-        return self._auth_service.auth_header()
+        return self._auth_service.fetch_auth_header()
 
     def _persist_refreshed_credential(self, credential: OAuthCredential) -> None:
-        from truss.remote.remote_factory import RemoteFactory
+        from truss.remote.remote_factory import AuthType, RemoteFactory
         from truss.remote.truss_remote import RemoteConfig
 
         if not self._oauth_remote_name:
@@ -167,9 +176,9 @@ class BasetenRemote(TrussRemote):
             RemoteConfig(
                 name=self._oauth_remote_name,
                 configs={
-                    "remote_provider": "baseten",
+                    "remote_provider": DEFAULT_REMOTE_NAME,
                     "remote_url": self.remote_url,
-                    "auth_type": "oauth",
+                    "auth_type": AuthType.OAUTH,
                     "oauth_access_token": credential.access_token,
                     "oauth_refresh_token": credential.refresh_token,
                     "oauth_expires_at": str(credential.expires_at),
@@ -461,7 +470,7 @@ class BasetenRemote(TrussRemote):
             return BasetenService(
                 model_version_handle=model_version_handle,
                 is_draft=False,
-                header_provider=self.auth_header,
+                header_provider=self.fetch_auth_header,
                 service_url=f"{self._remote_url}/model_versions/{model_version_handle.version_id}",
                 truss_handle=truss_handle,
                 api=self._api,
@@ -504,7 +513,7 @@ class BasetenRemote(TrussRemote):
         return BasetenService(
             model_version_handle=model_version_handle,
             is_draft=push_data.is_draft,
-            header_provider=self.auth_header,
+            header_provider=self.fetch_auth_header,
             service_url=f"{self._remote_url}/model_versions/{model_version_handle.version_id}",
             truss_handle=truss_handle,
             api=self._api,
@@ -677,7 +686,7 @@ class BasetenRemote(TrussRemote):
         return BasetenService(
             model_version_handle=model_version_handle,
             is_draft=not published,
-            header_provider=self.auth_header,
+            header_provider=self.fetch_auth_header,
             service_url=f"{self._remote_url}{service_url_path}",
             api=self._api,
         )

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -461,7 +461,7 @@ class BasetenRemote(TrussRemote):
             return BasetenService(
                 model_version_handle=model_version_handle,
                 is_draft=False,
-                api_key=self._auth_service.authenticate().value,
+                header_provider=self.auth_header,
                 service_url=f"{self._remote_url}/model_versions/{model_version_handle.version_id}",
                 truss_handle=truss_handle,
                 api=self._api,

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -25,7 +25,7 @@ from truss.base.truss_config import ModelServer
 from truss.local.local_config_handler import LocalConfigHandler
 from truss.remote.baseten import custom_types
 from truss.remote.baseten import custom_types as b10_types
-from truss.remote.baseten.api import BasetenApi
+from truss.remote.baseten.api import BasetenApi, resolve_rest_api_url
 from truss.remote.baseten.auth import AuthService
 from truss.remote.baseten.core import (
     ChainDeploymentHandleAtomic,
@@ -46,6 +46,7 @@ from truss.remote.baseten.core import (
     validate_truss_config_against_backend,
 )
 from truss.remote.baseten.error import ApiError, RemoteError
+from truss.remote.baseten.oauth import OAuthCredential
 from truss.remote.baseten.service import BasetenService, URLConfig
 from truss.remote.baseten.utils.transfer import base64_encoded_json_str
 from truss.remote.truss_remote import RemoteUser, TrussRemote
@@ -109,10 +110,71 @@ class FinalPushData(custom_types.OracleData):
 
 
 class BasetenRemote(TrussRemote):
-    def __init__(self, remote_url: str, api_key: str):
+    def __init__(
+        self,
+        remote_url: str,
+        api_key: Optional[str] = None,
+        *,
+        oauth_remote_name: Optional[str] = None,
+        oauth_access_token: Optional[str] = None,
+        oauth_refresh_token: Optional[str] = None,
+        oauth_expires_at: Optional[str] = None,
+    ):
         super().__init__(remote_url)
-        self._auth_service = AuthService(api_key=api_key)
+        self._oauth_remote_name = oauth_remote_name
+        if oauth_access_token:
+            if api_key:
+                raise ValueError(
+                    f"Remote {oauth_remote_name!r}: cannot specify both api_key "
+                    "and OAuth credentials."
+                )
+            if not (oauth_refresh_token and oauth_expires_at):
+                raise ValueError(
+                    f"Remote {oauth_remote_name!r}: OAuth credentials require "
+                    "access_token, refresh_token, and expires_at."
+                )
+            credential = OAuthCredential(
+                access_token=oauth_access_token,
+                refresh_token=oauth_refresh_token,
+                expires_at=int(oauth_expires_at),
+            )
+            self._auth_service = AuthService(
+                api_url=resolve_rest_api_url(remote_url),
+                oauth_credential=credential,
+                on_token_refresh=self._persist_refreshed_credential,
+            )
+        else:
+            self._auth_service = AuthService(api_key=api_key)
         self._api = BasetenApi(remote_url, self._auth_service)
+
+    def auth_header(self) -> Dict[str, str]:
+        """Return a fresh ``Authorization`` header for the active credential.
+
+        Call this per-request rather than caching the return value: for OAuth
+        credentials the access token is refreshed in-place when near expiry,
+        so a stored header can become stale.
+        """
+        return self._auth_service.auth_header()
+
+    def _persist_refreshed_credential(self, credential: OAuthCredential) -> None:
+        from truss.remote.remote_factory import RemoteFactory
+        from truss.remote.truss_remote import RemoteConfig
+
+        if not self._oauth_remote_name:
+            return
+        RemoteFactory.update_remote_config(
+            RemoteConfig(
+                name=self._oauth_remote_name,
+                configs={
+                    "remote_provider": "baseten",
+                    "remote_url": self.remote_url,
+                    "auth_type": "oauth",
+                    "oauth_access_token": credential.access_token,
+                    "oauth_refresh_token": credential.refresh_token,
+                    "oauth_expires_at": str(credential.expires_at),
+                },
+            )
+        )
 
     @property
     def api(self) -> BasetenApi:
@@ -327,7 +389,7 @@ class BasetenRemote(TrussRemote):
         return BasetenService(
             model_version_handle=model_version_handle,
             is_draft=push_data.is_draft,
-            api_key=self._auth_service.authenticate().value,
+            header_provider=self.auth_header,
             service_url=f"{self._remote_url}/model_versions/{model_version_handle.version_id}",
             truss_handle=truss_handle,
             api=self._api,
@@ -499,7 +561,7 @@ class BasetenRemote(TrussRemote):
         return BasetenService(
             model_version_handle=model_version_handle,
             is_draft=not published,
-            api_key=self._auth_service.authenticate().value,
+            header_provider=self.auth_header,
             service_url=f"{self._remote_url}{service_url_path}",
             api=self._api,
         )

--- a/truss/remote/baseten/rest_client.py
+++ b/truss/remote/baseten/rest_client.py
@@ -1,15 +1,14 @@
-from typing import Any, Dict
+from typing import Any, Callable, Dict
 
 import requests
 
 
 class RestAPIClient:
     base_url: str
-    headers: Dict[str, str]
 
-    def __init__(self, base_url: str, headers: Dict[str, str]):
+    def __init__(self, base_url: str, header_provider: Callable[[], Dict[str, str]]):
         self.base_url = base_url
-        self.headers = headers
+        self._header_provider = header_provider
         self.suppress_error_print = False
 
     def _handle_error(self, resp: requests.Response):
@@ -24,24 +23,30 @@ class RestAPIClient:
 
     def get(self, path: str, url_params: Dict[str, str] = {}):
         resp = requests.get(
-            f"{self.base_url}/{path}", headers=self.headers, params=url_params
+            f"{self.base_url}/{path}",
+            headers=self._header_provider(),
+            params=url_params,
         )
         self._handle_error(resp)
         return resp.json()
 
     def post(self, path: str, body: Any):
-        resp = requests.post(f"{self.base_url}/{path}", headers=self.headers, json=body)
+        resp = requests.post(
+            f"{self.base_url}/{path}", headers=self._header_provider(), json=body
+        )
         self._handle_error(resp)
         return resp.json()
 
     def delete(self, path: str):
-        resp = requests.delete(f"{self.base_url}/{path}", headers=self.headers)
+        resp = requests.delete(
+            f"{self.base_url}/{path}", headers=self._header_provider()
+        )
         self._handle_error(resp)
         return resp.json()
 
     def patch(self, path: str, body: Any):
         resp = requests.patch(
-            f"{self.base_url}/{path}", headers=self.headers, json=body
+            f"{self.base_url}/{path}", headers=self._header_provider(), json=body
         )
         self._handle_error(resp)
         return resp.json()

--- a/truss/remote/baseten/service.py
+++ b/truss/remote/baseten/service.py
@@ -3,13 +3,12 @@ import logging
 import time
 import urllib.parse
 import warnings
-from typing import Any, Dict, Iterator, NamedTuple, Optional
+from typing import Any, Callable, Dict, Iterator, NamedTuple, Optional
 
 import requests
 from tenacity import retry, stop_after_delay, wait_fixed
 
 from truss.remote.baseten.api import BasetenApi
-from truss.remote.baseten.auth import AuthService
 from truss.remote.baseten.core import ModelVersionHandle
 from truss.remote.truss_remote import TrussService
 from truss.truss_handle.truss_handle import TrussHandle
@@ -90,14 +89,14 @@ class BasetenService(TrussService):
         self,
         model_version_handle: ModelVersionHandle,
         is_draft: bool,
-        api_key: str,
+        header_provider: Callable[[], Dict[str, str]],
         service_url: str,
         api: BasetenApi,
         truss_handle: Optional[TrussHandle] = None,
     ):
         super().__init__(is_draft=is_draft, service_url=service_url)
         self._model_version_handle = model_version_handle
-        self._auth_service = AuthService(api_key=api_key)
+        self._header_provider = header_provider
         self._api = api
         self._truss_handle = truss_handle
 
@@ -140,7 +139,7 @@ class BasetenService(TrussService):
         return response.json()
 
     def authenticate(self) -> dict:
-        return self._auth_service.authenticate().header()
+        return self._header_provider()
 
     @property
     def logs_url(self) -> str:

--- a/truss/remote/remote_factory.py
+++ b/truss/remote/remote_factory.py
@@ -228,7 +228,7 @@ def _apply_secrets_to_config(remote_config: RemoteConfig) -> None:
             f"Keyring entry for remote {remote_config.name!r} is malformed."
         )
     for key in secret_keys:
-        configs[key] = payload[key]
+        configs.setdefault(key, payload[key])
 
 
 def _offload_secrets_from_config(remote_config: RemoteConfig) -> None:

--- a/truss/remote/remote_factory.py
+++ b/truss/remote/remote_factory.py
@@ -1,4 +1,6 @@
 import inspect
+import json
+import logging
 import os
 
 try:
@@ -14,8 +16,28 @@ from operator import is_not
 from pathlib import Path
 from typing import Dict, List, Optional, Type
 
+import keyring
+import keyring.backends.fail
+import keyring.backends.null
+import keyring.errors
+
 from truss.remote.baseten import BasetenRemote
 from truss.remote.truss_remote import RemoteConfig, TrussRemote
+
+logger = logging.getLogger(__name__)
+
+KEYRING_SERVICE = "baseten-truss"
+KEYRING_DISABLED_ENV = "BASETEN_TRUSS_AUTH_KEYRING_DISABLED"
+_AUTH_TYPE_API_KEY = "api_key"
+_AUTH_TYPE_OAUTH = "oauth"
+_INLINE_SECRET_KEYS_BY_AUTH_TYPE = {
+    _AUTH_TYPE_API_KEY: ("api_key",),
+    _AUTH_TYPE_OAUTH: ("oauth_access_token", "oauth_refresh_token", "oauth_expires_at"),
+}
+_INLINE_SECRET_KEYS = tuple(
+    key for keys in _INLINE_SECRET_KEYS_BY_AUTH_TYPE.values() for key in keys
+)
+_keyring_fallback_warned = False
 
 USER_TRUSSRC_PATH = Path(os.environ.get("USER_TRUSSRC_PATH", "~/.trussrc")).expanduser()
 
@@ -59,13 +81,21 @@ class RemoteFactory:
         if remote_name not in config:
             raise ValueError(f"Service provider {remote_name} not found in ~/.trussrc")
 
-        return RemoteConfig(name=remote_name, configs=dict(config[remote_name]))
+        remote_config = RemoteConfig(
+            name=remote_name, configs=dict(config[remote_name])
+        )
+        _apply_secrets_to_config(remote_config)
+        return remote_config
 
     @staticmethod
     def update_remote_config(remote_config: RemoteConfig):
         """
         Load and validate a remote config from the .trussrc file
         """
+        remote_config = RemoteConfig(
+            name=remote_config.name, configs=dict(remote_config.configs)
+        )
+        _offload_secrets_from_config(remote_config)
         config = load_config()
         config[remote_config.name] = remote_config.configs
         update_config(config)
@@ -81,9 +111,31 @@ class RemoteFactory:
         except (FileNotFoundError, ValueError):
             return None
 
+    @staticmethod
+    def remove_remote_config(remote_name: str) -> None:
+        """Remove a remote entirely: keyring entry and trussrc section.
+
+        ``truss auth login`` adds a remote section; ``truss auth logout`` is the
+        inverse. Caller is expected to have verified the remote exists.
+        """
+        if not _keyring_disabled_by_env() and _keyring_backend_usable():
+            try:
+                keyring.delete_password(KEYRING_SERVICE, remote_name)
+            except keyring.errors.PasswordDeleteError:
+                pass
+            except keyring.errors.KeyringError as exc:
+                logger.warning("Keyring delete failed for %s: %s", remote_name, exc)
+        if not USER_TRUSSRC_PATH.exists():
+            return
+        config = load_config()
+        if remote_name in config:
+            config.remove_section(remote_name)
+            update_config(config)
+
     @classmethod
     def create(cls, remote: str) -> TrussRemote:
         remote_config = cls.load_remote_config(remote).configs
+        remote_config.setdefault("oauth_remote_name", remote)
         if "remote_provider" not in remote_config:
             raise ValueError(f"Missing 'remote_provider' field for remote `{remote}`.")
         provider = remote_config.pop("remote_provider")
@@ -115,3 +167,110 @@ class RemoteFactory:
                 f"Missing required parameter(s) {list(missing)} for remote `{remote}`."
             )
         return remote_class(**passed_config)
+
+
+def _keyring_disabled_by_env() -> bool:
+    return os.environ.get(KEYRING_DISABLED_ENV, "").lower() in ("1", "true", "yes")
+
+
+def _keyring_backend_usable() -> bool:
+    backend = keyring.get_keyring()
+    return not isinstance(
+        backend, (keyring.backends.fail.Keyring, keyring.backends.null.Keyring)
+    )
+
+
+def _apply_secrets_to_config(remote_config: RemoteConfig) -> None:
+    """Merge any keyring-stored secrets into ``remote_config.configs``.
+
+    Sections without ``auth_type`` (legacy plaintext) are returned unchanged.
+    Sections opted into ``auth_type`` get their secret keys filled from the
+    keyring entry under (service=baseten-truss, account=remote_name). Inline
+    secrets already present on the section win (env-disabled or
+    backend-unavailable fallback). If neither inline nor keyring can supply
+    all expected secrets, raises so callers see a clear failure.
+    """
+    configs = remote_config.configs
+    auth_type = configs.get("auth_type")
+    if not isinstance(auth_type, str):
+        return
+    secret_keys = _INLINE_SECRET_KEYS_BY_AUTH_TYPE.get(auth_type)
+    if secret_keys is None:
+        return
+    if all(key in configs for key in secret_keys):
+        return
+    if _keyring_disabled_by_env() or not _keyring_backend_usable():
+        raise ValueError(
+            f"No credentials for remote {remote_config.name!r}: keyring is "
+            "unavailable and no inline secret is present."
+        )
+    try:
+        blob = keyring.get_password(KEYRING_SERVICE, remote_config.name)
+    except keyring.errors.KeyringError as exc:
+        raise ValueError(
+            f"Keyring read failed for remote {remote_config.name!r}: {exc}"
+        ) from exc
+    if not blob:
+        raise ValueError(
+            f"No credentials in keyring for remote {remote_config.name!r}; "
+            "run `truss login`."
+        )
+    try:
+        payload = json.loads(blob)
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            f"Keyring entry for remote {remote_config.name!r} is not valid JSON."
+        ) from exc
+    if payload.get("auth_type") != auth_type or not all(
+        key in payload for key in secret_keys
+    ):
+        raise ValueError(
+            f"Keyring entry for remote {remote_config.name!r} is malformed."
+        )
+    for key in secret_keys:
+        configs[key] = payload[key]
+
+
+def _offload_secrets_from_config(remote_config: RemoteConfig) -> None:
+    """If the section opts into ``auth_type``, push secrets into the keyring.
+
+    Only triggers when the caller has set ``auth_type`` on ``configs``. Legacy
+    callers writing plaintext ``api_key`` (no ``auth_type``) flow through
+    unchanged. When the keyring is disabled by env var, the secrets are left
+    inline silently (the user opted in to that). When the keyring backend is
+    unavailable or a write fails, we warn once and leave the secrets inline.
+    """
+    global _keyring_fallback_warned
+    configs = remote_config.configs
+    auth_type = configs.get("auth_type")
+    if not isinstance(auth_type, str):
+        return
+    secret_keys = _INLINE_SECRET_KEYS_BY_AUTH_TYPE.get(auth_type)
+    if secret_keys is None or not all(key in configs for key in secret_keys):
+        return
+    if _keyring_disabled_by_env():
+        return
+    if not _keyring_backend_usable():
+        if not _keyring_fallback_warned:
+            logger.warning(
+                "Warning: no usable OS keyring backend; storing credentials for "
+                "%s in plaintext in %s.",
+                remote_config.name,
+                USER_TRUSSRC_PATH,
+            )
+            _keyring_fallback_warned = True
+        return
+    payload = json.dumps(
+        {"auth_type": auth_type, **{key: configs[key] for key in secret_keys}}
+    )
+    try:
+        keyring.set_password(KEYRING_SERVICE, remote_config.name, payload)
+    except keyring.errors.KeyringError as exc:
+        logger.warning(
+            "Warning: keyring write failed for %s (%s); leaving secret in plaintext.",
+            remote_config.name,
+            exc,
+        )
+        return
+    for key in _INLINE_SECRET_KEYS:
+        configs.pop(key, None)

--- a/truss/remote/remote_factory.py
+++ b/truss/remote/remote_factory.py
@@ -1,3 +1,4 @@
+import enum
 import inspect
 import json
 import logging
@@ -14,7 +15,7 @@ except ImportError:
 from functools import partial
 from operator import is_not
 from pathlib import Path
-from typing import Dict, List, Optional, Type
+from typing import Dict, List, Optional, Tuple, Type
 
 import keyring
 import keyring.backends.fail
@@ -28,11 +29,19 @@ logger = logging.getLogger(__name__)
 
 KEYRING_SERVICE = "baseten-truss"
 KEYRING_DISABLED_ENV = "BASETEN_TRUSS_AUTH_KEYRING_DISABLED"
-_AUTH_TYPE_API_KEY = "api_key"
-_AUTH_TYPE_OAUTH = "oauth"
-_INLINE_SECRET_KEYS_BY_AUTH_TYPE = {
-    _AUTH_TYPE_API_KEY: ("api_key",),
-    _AUTH_TYPE_OAUTH: ("oauth_access_token", "oauth_refresh_token", "oauth_expires_at"),
+
+
+class AuthType(str, enum.Enum):
+    API_KEY = "api_key"
+    OAUTH = "oauth"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+_INLINE_SECRET_KEYS_BY_AUTH_TYPE: Dict[str, Tuple[str, ...]] = {
+    AuthType.API_KEY: ("api_key",),
+    AuthType.OAUTH: ("oauth_access_token", "oauth_refresh_token", "oauth_expires_at"),
 }
 _INLINE_SECRET_KEYS = tuple(
     key for keys in _INLINE_SECRET_KEYS_BY_AUTH_TYPE.values() for key in keys

--- a/truss/tests/cli/test_auth_cli.py
+++ b/truss/tests/cli/test_auth_cli.py
@@ -51,7 +51,8 @@ def test_login_no_flags_non_interactive_errors(trussrc):
     with patch("truss.cli.auth.check_is_interactive", return_value=False):
         result = CliRunner().invoke(truss_cli, ["auth", "login"])
     assert result.exit_code == 2
-    assert "--browser or --api-key" in result.output
+    assert "--browser" in result.output
+    assert "--api-key" in result.output
 
 
 def test_truss_login_alias_runs_browser_flow(memory_keyring, trussrc):

--- a/truss/tests/cli/test_auth_cli.py
+++ b/truss/tests/cli/test_auth_cli.py
@@ -1,0 +1,191 @@
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from truss.cli.cli import truss_cli
+from truss.remote import remote_factory as rf_module
+from truss.remote.baseten.oauth import OAuthCredential, OAuthError
+from truss.remote.remote_factory import KEYRING_SERVICE, RemoteFactory
+
+
+def test_login_browser_writes_oauth_config(memory_keyring, trussrc):
+    cred = OAuthCredential(
+        access_token="atk", refresh_token="rtk", expires_at=9999999999
+    )
+    with patch("truss.cli.auth.oauth.run_device_flow", return_value=cred) as mock_flow:
+        result = CliRunner().invoke(truss_cli, ["auth", "login", "--browser"])
+
+    assert result.exit_code == 0, result.output
+    mock_flow.assert_called_once_with("https://api.baseten.co")
+    loaded = RemoteFactory.load_remote_config("baseten")
+    assert loaded.configs["auth_type"] == "oauth"
+    assert loaded.configs["oauth_access_token"] == "atk"
+
+
+def test_login_browser_propagates_oauth_error(memory_keyring, trussrc):
+    with patch(
+        "truss.cli.auth.oauth.run_device_flow", side_effect=OAuthError("denied")
+    ):
+        result = CliRunner().invoke(truss_cli, ["auth", "login", "--browser"])
+    assert result.exit_code != 0
+    assert "denied" in result.output
+
+
+def test_login_browser_and_api_key_mutually_exclusive(trussrc):
+    result = CliRunner().invoke(
+        truss_cli, ["auth", "login", "--browser", "--api-key", "k"]
+    )
+    assert result.exit_code == 2
+    assert "mutually exclusive" in result.output
+
+
+def test_login_api_key_writes_config(memory_keyring, trussrc):
+    result = CliRunner().invoke(truss_cli, ["auth", "login", "--api-key", "abc"])
+    assert result.exit_code == 0, result.output
+    loaded = RemoteFactory.load_remote_config("baseten")
+    assert loaded.configs["auth_type"] == "api_key"
+    assert loaded.configs["api_key"] == "abc"
+
+
+def test_login_no_flags_non_interactive_errors(trussrc):
+    with patch("truss.cli.auth.check_is_interactive", return_value=False):
+        result = CliRunner().invoke(truss_cli, ["auth", "login"])
+    assert result.exit_code == 2
+    assert "--browser or --api-key" in result.output
+
+
+def test_truss_login_alias_runs_browser_flow(memory_keyring, trussrc):
+    cred = OAuthCredential(access_token="a", refresh_token="r", expires_at=9999999999)
+    with patch("truss.cli.auth.oauth.run_device_flow", return_value=cred):
+        result = CliRunner().invoke(truss_cli, ["login", "--browser"])
+    assert result.exit_code == 0, result.output
+    assert RemoteFactory.load_remote_config("baseten").configs["auth_type"] == "oauth"
+
+
+def test_logout_oauth_revokes_and_removes(memory_keyring, trussrc):
+    RemoteFactory.update_remote_config(
+        rf_module.RemoteConfig(
+            name="baseten",
+            configs={
+                "remote_provider": "baseten",
+                "remote_url": "http://x",
+                "auth_type": "oauth",
+                "oauth_access_token": "atk",
+                "oauth_refresh_token": "rtk",
+                "oauth_expires_at": "9999999999",
+            },
+        )
+    )
+    with patch("truss.cli.auth.oauth.revoke") as mock_revoke:
+        result = CliRunner().invoke(truss_cli, ["auth", "logout"])
+    assert result.exit_code == 0, result.output
+    mock_revoke.assert_called_once()
+    assert "[baseten]" not in trussrc.read_text()
+    assert memory_keyring.get_password(KEYRING_SERVICE, "baseten") is None
+
+
+def test_logout_api_key_skips_revoke(memory_keyring, trussrc):
+    RemoteFactory.update_remote_config(
+        rf_module.RemoteConfig(
+            name="baseten",
+            configs={
+                "remote_provider": "baseten",
+                "remote_url": "http://x",
+                "auth_type": "api_key",
+                "api_key": "k",
+            },
+        )
+    )
+    with patch("truss.cli.auth.oauth.revoke") as mock_revoke:
+        result = CliRunner().invoke(truss_cli, ["auth", "logout"])
+    assert result.exit_code == 0, result.output
+    mock_revoke.assert_not_called()
+    assert "[baseten]" not in trussrc.read_text()
+
+
+def test_logout_unknown_remote_errors(trussrc):
+    trussrc.write_text("")
+    result = CliRunner().invoke(truss_cli, ["auth", "logout", "--remote", "missing"])
+    assert result.exit_code != 0
+    assert "Not logged in" in result.output
+
+
+def test_status_keyring_source(memory_keyring, trussrc):
+    RemoteFactory.update_remote_config(
+        rf_module.RemoteConfig(
+            name="baseten",
+            configs={
+                "remote_provider": "baseten",
+                "remote_url": "http://x",
+                "auth_type": "api_key",
+                "api_key": "secret",
+            },
+        )
+    )
+    result = CliRunner().invoke(truss_cli, ["auth", "status"])
+    assert result.exit_code == 0, result.output
+    assert "auth_type: api_key" in result.output
+    assert "source: keyring" in result.output
+
+
+def test_status_legacy_plaintext(trussrc):
+    trussrc.write_text(
+        "[baseten]\nremote_provider = baseten\nremote_url = http://x\napi_key = legacy\n"
+    )
+    result = CliRunner().invoke(truss_cli, ["auth", "status"])
+    assert result.exit_code == 0, result.output
+    assert "legacy plaintext" in result.output
+    assert "source: trussrc-inline" in result.output
+
+
+def test_status_missing_remote_errors(trussrc):
+    trussrc.write_text("")
+    result = CliRunner().invoke(truss_cli, ["auth", "status", "--remote", "missing"])
+    assert result.exit_code != 0
+
+
+def test_login_browser_writes_named_remote(memory_keyring, trussrc):
+    cred = OAuthCredential(access_token="a", refresh_token="r", expires_at=9999999999)
+    with patch("truss.cli.auth.oauth.run_device_flow", return_value=cred):
+        result = CliRunner().invoke(
+            truss_cli, ["auth", "login", "--browser", "--remote", "staging"]
+        )
+    assert result.exit_code == 0, result.output
+    loaded = RemoteFactory.load_remote_config("staging")
+    assert loaded.configs["auth_type"] == "oauth"
+    assert loaded.configs["remote_url"] == "https://app.baseten.co"
+
+
+def test_login_api_key_writes_named_remote(memory_keyring, trussrc):
+    result = CliRunner().invoke(
+        truss_cli, ["auth", "login", "--api-key", "k", "--remote", "alt"]
+    )
+    assert result.exit_code == 0, result.output
+    loaded = RemoteFactory.load_remote_config("alt")
+    assert loaded.configs["auth_type"] == "api_key"
+    assert loaded.configs["api_key"] == "k"
+
+
+def test_login_reuses_existing_remote_url(memory_keyring, trussrc):
+    trussrc.write_text(
+        "[staging]\nremote_provider = baseten\n"
+        "remote_url = https://app.staging.baseten.co\n"
+    )
+    cred = OAuthCredential(access_token="a", refresh_token="r", expires_at=9999999999)
+    with patch("truss.cli.auth.oauth.run_device_flow", return_value=cred) as mock_flow:
+        result = CliRunner().invoke(
+            truss_cli, ["auth", "login", "--browser", "--remote", "staging"]
+        )
+    assert result.exit_code == 0, result.output
+    mock_flow.assert_called_once_with("https://api.staging.baseten.co")
+    loaded = RemoteFactory.load_remote_config("staging")
+    assert loaded.configs["remote_url"] == "https://app.staging.baseten.co"
+
+
+def test_login_prints_success_message(memory_keyring, trussrc):
+    result = CliRunner().invoke(
+        truss_cli, ["auth", "login", "--api-key", "k", "--remote", "alt"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "Logged in to remote" in result.output
+    assert "alt" in result.output

--- a/truss/tests/cli/test_cli.py
+++ b/truss/tests/cli/test_cli.py
@@ -69,7 +69,11 @@ def test_successful_ping_resets_failure_count():
         with patch("truss.cli.utils.common.console"):
             # Use a very short wait so the test runs fast
             with patch.object(stop_event, "wait", side_effect=lambda timeout: None):
-                common.keepalive_loop("http://fake", "test_api_key", stop_event)
+                common.keepalive_loop(
+                    "http://fake",
+                    lambda: {"Authorization": "Api-Key test_api_key"},
+                    stop_event,
+                )
     assert call_count == 4  # All calls were made, no early exit
 
 
@@ -85,7 +89,11 @@ def test_exits_after_max_consecutive_failures():
                 side_effect=lambda code: stop_event.set(),
             ) as mock_exit:
                 with patch.object(stop_event, "wait", side_effect=lambda timeout: None):
-                    common.keepalive_loop("http://fake", "test_api_key", stop_event)
+                    common.keepalive_loop(
+                        "http://fake",
+                        lambda: {"Authorization": "Api-Key test_api_key"},
+                        stop_event,
+                    )
     mock_exit.assert_called_once_with(1)
 
 
@@ -103,7 +111,11 @@ def test_request_exception_counts_as_failure():
                 side_effect=lambda code: stop_event.set(),
             ) as mock_exit:
                 with patch.object(stop_event, "wait", side_effect=lambda timeout: None):
-                    common.keepalive_loop("http://fake", "test_api_key", stop_event)
+                    common.keepalive_loop(
+                        "http://fake",
+                        lambda: {"Authorization": "Api-Key test_api_key"},
+                        stop_event,
+                    )
 
     mock_exit.assert_called_once_with(1)
 
@@ -132,7 +144,11 @@ def test_model_not_ready_does_not_count_as_failure():
                 side_effect=lambda code: stop_event.set(),
             ) as mock_exit:
                 with patch.object(stop_event, "wait", side_effect=lambda timeout: None):
-                    common.keepalive_loop("http://fake", "test_api_key", stop_event)
+                    common.keepalive_loop(
+                        "http://fake",
+                        lambda: {"Authorization": "Api-Key test_api_key"},
+                        stop_event,
+                    )
 
     mock_exit.assert_not_called()
 
@@ -150,7 +166,11 @@ def test_5xx_errors_count_as_failures():
                 side_effect=lambda code: stop_event.set(),
             ) as mock_exit:
                 with patch.object(stop_event, "wait", side_effect=lambda timeout: None):
-                    common.keepalive_loop("http://fake", "test_api_key", stop_event)
+                    common.keepalive_loop(
+                        "http://fake",
+                        lambda: {"Authorization": "Api-Key test_api_key"},
+                        stop_event,
+                    )
 
     mock_exit.assert_called_once_with(1)
 
@@ -189,7 +209,7 @@ def test_keepalive_loop_emits_30min_warning():
 
                 common.keepalive_loop(
                     model_hostname="https://test.baseten.co",
-                    api_key="test-key",
+                    header_provider=lambda: {"Authorization": "Api-Key test-key"},
                     stop_event=stop_event,
                 )
 
@@ -220,7 +240,7 @@ def _make_watch_mocks(
     mock_tr.spec.config.model_name = "test_model"
 
     remote_provider = MagicMock()
-    remote_provider._auth_service.authenticate.return_value = Mock(value="test_key")
+    remote_provider.auth_header.return_value = {"Authorization": "Api-Key test_key"}
     remote_provider.remote_url = "https://app.baseten.co"
     remote_provider.api.get_deployment.return_value = {"status": "ACTIVE"}
 
@@ -315,7 +335,7 @@ def test_watch_no_sleep_starts_keepalive_thread():
     assert kwargs["target"] == common.keepalive_loop
     thread_args = kwargs["args"]
     assert thread_args[0] == "https://model-abc123.api.baseten.co"
-    assert thread_args[1] == "test_key"
+    assert thread_args[1] is remote_provider.auth_header
     mock_thread.start.assert_called_once()
 
 
@@ -340,7 +360,7 @@ def test_keepalive_loop_constructs_correct_url():
             with patch.object(stop_event, "wait", side_effect=stop_after_first):
                 common.keepalive_loop(
                     model_hostname="https://model-abc123.api.baseten.co",
-                    api_key="test-key",
+                    header_provider=lambda: {"Authorization": "Api-Key test-key"},
                     stop_event=stop_event,
                 )
 
@@ -492,7 +512,7 @@ def test_keepalive_loop_continues_before_max_duration():
                     with pytest.raises(SystemExit):
                         common.keepalive_loop(
                             "https://model-abc123.api.baseten.co",
-                            "fake_key",
+                            lambda: {"Authorization": "Api-Key fake_key"},
                             stop_event,
                         )
 
@@ -1084,7 +1104,7 @@ def test_push_watch_no_sleep_starts_keepalive(
 
     assert result.exit_code == 0
     mock_start_keepalive.assert_called_once_with(
-        "https://model.api.baseten.co", remote._auth_service.authenticate().value
+        "https://model.api.baseten.co", remote.auth_header
     )
     mock_start_watch.assert_called_once()
 

--- a/truss/tests/cli/test_cli.py
+++ b/truss/tests/cli/test_cli.py
@@ -240,7 +240,9 @@ def _make_watch_mocks(
     mock_tr.spec.config.model_name = "test_model"
 
     remote_provider = MagicMock()
-    remote_provider.auth_header.return_value = {"Authorization": "Api-Key test_key"}
+    remote_provider.fetch_auth_header.return_value = {
+        "Authorization": "Api-Key test_key"
+    }
     remote_provider.remote_url = "https://app.baseten.co"
     remote_provider.api.get_deployment.return_value = {"status": "ACTIVE"}
 
@@ -335,7 +337,7 @@ def test_watch_no_sleep_starts_keepalive_thread():
     assert kwargs["target"] == common.keepalive_loop
     thread_args = kwargs["args"]
     assert thread_args[0] == "https://model-abc123.api.baseten.co"
-    assert thread_args[1] is remote_provider.auth_header
+    assert thread_args[1] is remote_provider.fetch_auth_header
     mock_thread.start.assert_called_once()
 
 
@@ -1104,7 +1106,7 @@ def test_push_watch_no_sleep_starts_keepalive(
 
     assert result.exit_code == 0
     mock_start_keepalive.assert_called_once_with(
-        "https://model.api.baseten.co", remote.auth_header
+        "https://model.api.baseten.co", remote.fetch_auth_header
     )
     mock_start_watch.assert_called_once()
 

--- a/truss/tests/conftest.py
+++ b/truss/tests/conftest.py
@@ -12,6 +12,10 @@ from pathlib import Path
 from typing import Any, Dict
 from unittest import mock
 
+import keyring
+import keyring.backend
+import keyring.backends.fail
+import keyring.errors
 import pytest
 import requests
 import requests_mock
@@ -24,6 +28,7 @@ from truss.contexts.image_builder.serving_image_builder import (
     ServingImageBuilderContext,
 )
 from truss.contexts.local_loader.docker_build_emulator import DockerBuildEmulator
+from truss.remote import remote_factory
 from truss.remote.baseten.core import ModelVersionHandle
 from truss.remote.baseten.remote import BasetenRemote
 from truss.truss_handle.build import init_directory
@@ -1065,3 +1070,53 @@ def mock_truss_handle(custom_model_truss_dir_with_pre_and_post):
 
     truss_handle = TrussHandle(custom_model_truss_dir_with_pre_and_post)
     return truss_handle
+
+
+class _InMemoryKeyring(keyring.backend.KeyringBackend):
+    priority = 1000
+
+    def __init__(self):
+        self._store = {}
+
+    def get_password(self, service, username):
+        return self._store.get((service, username))
+
+    def set_password(self, service, username, password):
+        self._store[(service, username)] = password
+
+    def delete_password(self, service, username):
+        try:
+            del self._store[(service, username)]
+        except KeyError as exc:
+            raise keyring.errors.PasswordDeleteError(str(exc)) from exc
+
+
+@pytest.fixture
+def trussrc(tmp_path, monkeypatch):
+    path = tmp_path / "trussrc"
+    monkeypatch.setattr(remote_factory, "USER_TRUSSRC_PATH", path)
+    monkeypatch.setattr("truss.cli.auth.USER_TRUSSRC_PATH", path)
+    monkeypatch.delenv(remote_factory.KEYRING_DISABLED_ENV, raising=False)
+    monkeypatch.setattr(remote_factory, "_keyring_fallback_warned", False)
+    return path
+
+
+@pytest.fixture
+def memory_keyring(trussrc):
+    backend = _InMemoryKeyring()
+    prior = keyring.get_keyring()
+    keyring.set_keyring(backend)
+    try:
+        yield backend
+    finally:
+        keyring.set_keyring(prior)
+
+
+@pytest.fixture
+def fail_keyring(trussrc):
+    prior = keyring.get_keyring()
+    keyring.set_keyring(keyring.backends.fail.Keyring())
+    try:
+        yield
+    finally:
+        keyring.set_keyring(prior)

--- a/truss/tests/remote/baseten/test_auth.py
+++ b/truss/tests/remote/baseten/test_auth.py
@@ -1,30 +1,30 @@
 import time
 
+import pydantic
 import pytest
 
 from truss.remote.baseten import oauth as oauth_mod
-from truss.remote.baseten.auth import AuthService
-from truss.remote.baseten.error import AuthorizationError
+from truss.remote.baseten.auth import ApiKeyCredential, AuthService, OAuthSession
 
 
 def test_api_key_auth_header():
-    auth_service = AuthService("test_key")
-    assert auth_service.auth_header() == {"Authorization": "Api-Key test_key"}
+    auth_service = AuthService(ApiKeyCredential(api_key="test_key"))
+    assert auth_service.fetch_auth_header() == {"Authorization": "Api-Key test_key"}
 
 
-def test_auth_service_no_key(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.delenv("BASETEN_API_KEY", raising=False)
-    auth_service = AuthService()
-    with pytest.raises(AuthorizationError):
-        auth_service.auth_header()
+def test_api_key_credential_rejects_empty():
+    with pytest.raises(pydantic.ValidationError):
+        ApiKeyCredential(api_key="")
 
 
 def test_oauth_auth_header_is_bearer():
     cred = oauth_mod.OAuthCredential(
         access_token="at", refresh_token="rt", expires_at=int(time.time()) + 3600
     )
-    auth_service = AuthService(api_url="https://api.baseten.co", oauth_credential=cred)
-    assert auth_service.auth_header() == {"Authorization": "Bearer at"}
+    auth_service = AuthService(
+        OAuthSession(api_url="https://api.baseten.co", credential=cred)
+    )
+    assert auth_service.fetch_auth_header() == {"Authorization": "Bearer at"}
 
 
 def test_oauth_refresh_when_expired(monkeypatch):
@@ -42,10 +42,12 @@ def test_oauth_refresh_when_expired(monkeypatch):
 
     monkeypatch.setattr("truss.remote.baseten.auth.refresh", fake_refresh)
     auth_service = AuthService(
-        api_url="https://api.baseten.co",
-        oauth_credential=cred,
-        on_token_refresh=persisted.append,
+        OAuthSession(
+            api_url="https://api.baseten.co",
+            credential=cred,
+            on_token_refresh=persisted.append,
+        )
     )
-    assert auth_service.auth_header() == {"Authorization": "Bearer new"}
+    assert auth_service.fetch_auth_header() == {"Authorization": "Bearer new"}
     assert len(persisted) == 1
     assert persisted[0].access_token == "new"

--- a/truss/tests/remote/baseten/test_auth.py
+++ b/truss/tests/remote/baseten/test_auth.py
@@ -1,23 +1,51 @@
+import time
+
 import pytest
 
-from truss.remote.baseten.auth import ApiKey, AuthService
+from truss.remote.baseten import oauth as oauth_mod
+from truss.remote.baseten.auth import AuthService
 from truss.remote.baseten.error import AuthorizationError
 
 
-def test_api_key():
-    key = ApiKey("test_key")
-    assert key.value == "test_key"
-    assert key.header() == {"Authorization": "Api-Key test_key"}
+def test_api_key_auth_header():
+    auth_service = AuthService("test_key")
+    assert auth_service.auth_header() == {"Authorization": "Api-Key test_key"}
 
 
 def test_auth_service_no_key(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.delenv("BASETEN_API_KEY", raising=False)
     auth_service = AuthService()
     with pytest.raises(AuthorizationError):
-        auth_service.authenticate()
+        auth_service.auth_header()
 
 
-def test_auth_service_with_key():
-    auth_service = AuthService("test_key")
-    key = auth_service.authenticate()
-    assert key.value == "test_key"
+def test_oauth_auth_header_is_bearer():
+    cred = oauth_mod.OAuthCredential(
+        access_token="at", refresh_token="rt", expires_at=int(time.time()) + 3600
+    )
+    auth_service = AuthService(api_url="https://api.baseten.co", oauth_credential=cred)
+    assert auth_service.auth_header() == {"Authorization": "Bearer at"}
+
+
+def test_oauth_refresh_when_expired(monkeypatch):
+    cred = oauth_mod.OAuthCredential(
+        access_token="old", refresh_token="rt-old", expires_at=int(time.time()) - 1
+    )
+    new_cred = oauth_mod.OAuthCredential(
+        access_token="new", refresh_token="rt-new", expires_at=int(time.time()) + 3600
+    )
+    persisted = []
+
+    def fake_refresh(api_url, credential):
+        assert credential.refresh_token == "rt-old"
+        return new_cred
+
+    monkeypatch.setattr("truss.remote.baseten.auth.refresh", fake_refresh)
+    auth_service = AuthService(
+        api_url="https://api.baseten.co",
+        oauth_credential=cred,
+        on_token_refresh=persisted.append,
+    )
+    assert auth_service.auth_header() == {"Authorization": "Bearer new"}
+    assert len(persisted) == 1
+    assert persisted[0].access_token == "new"

--- a/truss/tests/remote/baseten/test_chain_upload.py
+++ b/truss/tests/remote/baseten/test_chain_upload.py
@@ -76,7 +76,7 @@ def test_get_blob_credentials_for_chain():
 
     # Create a real API instance and mock the GraphQL call
     mock_auth_service = Mock()
-    mock_auth_service.authenticate.return_value = Mock(value="test-token")
+    mock_auth_service.auth_header.return_value = {"Authorization": "Api-Key test-token"}
     api = BasetenApi("https://test.baseten.co", mock_auth_service)
     with patch.object(api, "_post_graphql_query") as mock_graphql:
         mock_graphql.return_value = mock_graphql_response
@@ -107,7 +107,7 @@ def test_get_blob_credentials_for_other_types_uses_rest():
     }
 
     mock_auth_service = Mock()
-    mock_auth_service.authenticate.return_value = Mock(value="test-token")
+    mock_auth_service.auth_header.return_value = {"Authorization": "Api-Key test-token"}
     api = BasetenApi("https://test.baseten.co", mock_auth_service)
     with (
         patch.object(api, "_rest_api_client") as mock_client,

--- a/truss/tests/remote/baseten/test_chain_upload.py
+++ b/truss/tests/remote/baseten/test_chain_upload.py
@@ -76,7 +76,9 @@ def test_get_blob_credentials_for_chain():
 
     # Create a real API instance and mock the GraphQL call
     mock_auth_service = Mock()
-    mock_auth_service.auth_header.return_value = {"Authorization": "Api-Key test-token"}
+    mock_auth_service.fetch_auth_header.return_value = {
+        "Authorization": "Api-Key test-token"
+    }
     api = BasetenApi("https://test.baseten.co", mock_auth_service)
     with patch.object(api, "_post_graphql_query") as mock_graphql:
         mock_graphql.return_value = mock_graphql_response
@@ -107,7 +109,9 @@ def test_get_blob_credentials_for_other_types_uses_rest():
     }
 
     mock_auth_service = Mock()
-    mock_auth_service.auth_header.return_value = {"Authorization": "Api-Key test-token"}
+    mock_auth_service.fetch_auth_header.return_value = {
+        "Authorization": "Api-Key test-token"
+    }
     api = BasetenApi("https://test.baseten.co", mock_auth_service)
     with (
         patch.object(api, "_rest_api_client") as mock_client,

--- a/truss/tests/remote/baseten/test_oauth.py
+++ b/truss/tests/remote/baseten/test_oauth.py
@@ -1,0 +1,206 @@
+import time
+
+import pytest
+import requests_mock
+
+from truss.remote.baseten import oauth
+
+API_URL = "https://api.baseten.co"
+DEVICE_AUTHORIZE_URL = API_URL + oauth.DEVICE_AUTHORIZE_PATH
+DEVICE_TOKEN_URL = API_URL + oauth.DEVICE_TOKEN_PATH
+LOGOUT_URL = API_URL + oauth.LOGOUT_PATH
+
+
+def _device_authorize_body() -> dict:
+    return {
+        "device_code": "dc",
+        "user_code": "USER",
+        "verification_uri": "https://login.baseten.co/device",
+        "verification_uri_complete": "https://login.baseten.co/device?user_code=USER",
+        "expires_in": 600,
+        "interval": 0,
+    }
+
+
+def test_request_device_authorization_success():
+    with requests_mock.Mocker() as m:
+        m.post(DEVICE_AUTHORIZE_URL, json=_device_authorize_body())
+        auth = oauth.request_device_authorization(API_URL)
+    assert auth.device_code == "dc"
+    assert auth.user_code == "USER"
+    assert auth.verification_uri == "https://login.baseten.co/device"
+
+
+def test_request_device_authorization_404_raises():
+    with requests_mock.Mocker() as m:
+        m.post(DEVICE_AUTHORIZE_URL, status_code=404, text="<html>not found</html>")
+        with pytest.raises(oauth.OAuthError, match="404"):
+            oauth.request_device_authorization(API_URL)
+
+
+def test_poll_device_token_success():
+    auth = oauth.DeviceAuthorization(
+        device_code="dc",
+        user_code="USER",
+        verification_uri="https://login.baseten.co/device",
+        verification_uri_complete=None,
+        expires_in=600,
+        interval=0,
+    )
+    with requests_mock.Mocker() as m:
+        m.post(
+            DEVICE_TOKEN_URL,
+            json={"access_token": "at", "refresh_token": "rt", "expires_in": 3600},
+        )
+        cred = oauth.poll_device_token(API_URL, auth)
+    assert cred.access_token == "at"
+    assert cred.refresh_token == "rt"
+    assert cred.expires_at > int(time.time())
+
+
+def test_poll_device_token_authorization_pending_then_success():
+    auth = oauth.DeviceAuthorization(
+        device_code="dc",
+        user_code="USER",
+        verification_uri="https://login.baseten.co/device",
+        verification_uri_complete=None,
+        expires_in=600,
+        interval=0,
+    )
+    with requests_mock.Mocker() as m:
+        m.post(
+            DEVICE_TOKEN_URL,
+            [
+                {"json": {"error": "authorization_pending"}, "status_code": 400},
+                {
+                    "json": {
+                        "access_token": "at",
+                        "refresh_token": "rt",
+                        "expires_in": 3600,
+                    },
+                    "status_code": 200,
+                },
+            ],
+        )
+        cred = oauth.poll_device_token(API_URL, auth)
+    assert cred.access_token == "at"
+
+
+def test_poll_device_token_slow_down_increases_interval():
+    auth = oauth.DeviceAuthorization(
+        device_code="dc",
+        user_code="USER",
+        verification_uri="https://login.baseten.co/device",
+        verification_uri_complete=None,
+        expires_in=600,
+        interval=0,
+    )
+    sleeps: list[float] = []
+    with requests_mock.Mocker() as m, pytest.MonkeyPatch.context() as mp:
+        mp.setattr(oauth.time, "sleep", lambda s: sleeps.append(s))
+        m.post(
+            DEVICE_TOKEN_URL,
+            [
+                {"json": {"error": "slow_down"}, "status_code": 400},
+                {
+                    "json": {
+                        "access_token": "at",
+                        "refresh_token": "rt",
+                        "expires_in": 3600,
+                    },
+                    "status_code": 200,
+                },
+            ],
+        )
+        oauth.poll_device_token(API_URL, auth)
+    assert sleeps and sleeps[0] >= 5
+
+
+def test_poll_device_token_expired_token_raises():
+    auth = oauth.DeviceAuthorization(
+        device_code="dc",
+        user_code="USER",
+        verification_uri="https://login.baseten.co/device",
+        verification_uri_complete=None,
+        expires_in=600,
+        interval=0,
+    )
+    with requests_mock.Mocker() as m:
+        m.post(DEVICE_TOKEN_URL, json={"error": "expired_token"}, status_code=400)
+        with pytest.raises(oauth.OAuthError, match="expired_token"):
+            oauth.poll_device_token(API_URL, auth)
+
+
+def test_poll_device_token_access_denied_raises():
+    auth = oauth.DeviceAuthorization(
+        device_code="dc",
+        user_code="USER",
+        verification_uri="https://login.baseten.co/device",
+        verification_uri_complete=None,
+        expires_in=600,
+        interval=0,
+    )
+    with requests_mock.Mocker() as m:
+        m.post(
+            DEVICE_TOKEN_URL,
+            json={"error": "access_denied", "error_description": "user denied"},
+            status_code=400,
+        )
+        with pytest.raises(oauth.OAuthError, match="access_denied"):
+            oauth.poll_device_token(API_URL, auth)
+
+
+def test_poll_device_token_deadline_raises(monkeypatch):
+    auth = oauth.DeviceAuthorization(
+        device_code="dc",
+        user_code="USER",
+        verification_uri="https://login.baseten.co/device",
+        verification_uri_complete=None,
+        expires_in=0,
+        interval=0,
+    )
+    with pytest.raises(oauth.OAuthError, match="expired"):
+        oauth.poll_device_token(API_URL, auth)
+
+
+def test_refresh_success():
+    cred = oauth.OAuthCredential(
+        access_token="old", refresh_token="rt-old", expires_at=0
+    )
+    with requests_mock.Mocker() as m:
+        m.post(
+            DEVICE_TOKEN_URL,
+            json={"access_token": "new", "refresh_token": "rt-new", "expires_in": 3600},
+        )
+        refreshed = oauth.refresh(API_URL, cred)
+    assert refreshed.access_token == "new"
+    assert refreshed.refresh_token == "rt-new"
+
+
+def test_refresh_failure_raises():
+    cred = oauth.OAuthCredential(
+        access_token="old", refresh_token="rt-old", expires_at=0
+    )
+    with requests_mock.Mocker() as m:
+        m.post(DEVICE_TOKEN_URL, status_code=401, text="invalid_grant")
+        with pytest.raises(oauth.OAuthError, match="401"):
+            oauth.refresh(API_URL, cred)
+
+
+def test_revoke_swallows_errors(caplog):
+    cred = oauth.OAuthCredential(access_token="at", refresh_token="rt", expires_at=0)
+    with requests_mock.Mocker() as m:
+        m.post(LOGOUT_URL, status_code=500, text="boom")
+        oauth.revoke(API_URL, cred)
+    assert any("revoke" in r.message.lower() for r in caplog.records)
+
+
+def test_run_device_flow_end_to_end():
+    with requests_mock.Mocker() as m:
+        m.post(DEVICE_AUTHORIZE_URL, json=_device_authorize_body())
+        m.post(
+            DEVICE_TOKEN_URL,
+            json={"access_token": "at", "refresh_token": "rt", "expires_in": 3600},
+        )
+        cred = oauth.run_device_flow(API_URL)
+    assert cred.access_token == "at"

--- a/truss/tests/remote/baseten/test_service.py
+++ b/truss/tests/remote/baseten/test_service.py
@@ -84,7 +84,7 @@ def test_predict_response_to_json():
     service_instance = service.BasetenService(
         model_version_handle=mock_handle,
         is_draft=False,
-        api_key="test-key",
+        header_provider=lambda: {"Authorization": "Api-Key test-key"},
         service_url="https://test.com",
         api=mock_api,
     )
@@ -121,3 +121,47 @@ def test_predict_response_to_json():
     mock_response.json.return_value = True
     result = service_instance.predict({"input": "test"})
     assert result is True
+
+
+def test_predict_uses_header_provider_for_each_request():
+    """Inference works with any auth (api_key or OAuth Bearer) supplied by the
+    header_provider; the provider is consulted per request so refreshed OAuth
+    tokens are picked up."""
+    mock_handle = MagicMock(spec=ModelVersionHandle)
+    mock_handle.model_id = "test-model"
+    mock_handle.version_id = "test-version"
+    mock_handle.hostname = "https://model-test.api.baseten.co"
+
+    mock_api = MagicMock()
+    mock_api.app_url = "https://app.baseten.co"
+
+    headers_seen = []
+    tokens = iter(["t1", "t2"])
+
+    def header_provider():
+        return {"Authorization": f"Bearer {next(tokens)}"}
+
+    service_instance = service.BasetenService(
+        model_version_handle=mock_handle,
+        is_draft=False,
+        header_provider=header_provider,
+        service_url="https://test.com",
+        api=mock_api,
+    )
+
+    def fake_send_request(url, method, **kwargs):
+        headers_seen.append(service_instance.authenticate())
+        resp = MagicMock()
+        resp.json.return_value = {"ok": True}
+        resp.headers = {}
+        return resp
+
+    service_instance._send_request = fake_send_request
+
+    service_instance.predict({"input": "a"})
+    service_instance.predict({"input": "b"})
+
+    assert headers_seen == [
+        {"Authorization": "Bearer t1"},
+        {"Authorization": "Bearer t2"},
+    ]

--- a/truss/tests/remote/test_remote_factory.py
+++ b/truss/tests/remote/test_remote_factory.py
@@ -2,7 +2,8 @@ from unittest import mock
 
 import pytest
 
-from truss.remote.remote_factory import RemoteFactory
+from truss.remote import remote_factory as rf_module
+from truss.remote.remote_factory import KEYRING_SERVICE, RemoteFactory
 from truss.remote.truss_remote import RemoteConfig, RemoteUser, TrussRemote
 
 SAMPLE_CONFIG = {"api_key": "test_key", "remote_url": "http://test.com"}
@@ -200,3 +201,146 @@ def test_get_remote_team_returns_none_when_remote_not_found(mock_exists, mock_op
 def test_get_remote_team_returns_team_with_spaces(mock_exists, mock_open):
     team = RemoteFactory.get_remote_team("test_team_spaces")
     assert team == "my team with spaces"
+
+
+def test_legacy_plaintext_round_trip(trussrc):
+    RemoteFactory.update_remote_config(
+        RemoteConfig(
+            name="legacy",
+            configs={
+                "remote_provider": "baseten",
+                "remote_url": "http://x",
+                "api_key": "plain",
+            },
+        )
+    )
+    assert "api_key = plain" in trussrc.read_text()
+    loaded = RemoteFactory.load_remote_config("legacy")
+    assert loaded.configs["api_key"] == "plain"
+    assert "auth_type" not in loaded.configs
+
+
+def test_keyring_offload_round_trip(memory_keyring, trussrc):
+    RemoteFactory.update_remote_config(
+        RemoteConfig(
+            name="baseten",
+            configs={
+                "remote_provider": "baseten",
+                "auth_type": "api_key",
+                "api_key": "secret",
+                "remote_url": "http://x",
+            },
+        )
+    )
+    text = trussrc.read_text()
+    assert "api_key = " not in text
+    assert "auth_type = api_key" in text
+    assert memory_keyring.get_password(KEYRING_SERVICE, "baseten") is not None
+
+    loaded = RemoteFactory.load_remote_config("baseten")
+    assert loaded.configs["api_key"] == "secret"
+    assert loaded.configs["auth_type"] == "api_key"
+
+
+def test_env_disabled_keeps_inline_silently(
+    memory_keyring, trussrc, monkeypatch, caplog
+):
+    monkeypatch.setenv(rf_module.KEYRING_DISABLED_ENV, "1")
+    with caplog.at_level("WARNING", logger=rf_module.logger.name):
+        RemoteFactory.update_remote_config(
+            RemoteConfig(
+                name="baseten",
+                configs={
+                    "remote_provider": "baseten",
+                    "auth_type": "api_key",
+                    "api_key": "secret",
+                    "remote_url": "http://x",
+                },
+            )
+        )
+    assert caplog.records == []
+    assert "api_key = secret" in trussrc.read_text()
+    assert memory_keyring.get_password(KEYRING_SERVICE, "baseten") is None
+
+    loaded = RemoteFactory.load_remote_config("baseten")
+    assert loaded.configs["api_key"] == "secret"
+
+
+def test_unusable_backend_warns_and_keeps_inline(fail_keyring, trussrc, caplog):
+    with caplog.at_level("WARNING", logger=rf_module.logger.name):
+        RemoteFactory.update_remote_config(
+            RemoteConfig(
+                name="baseten",
+                configs={
+                    "remote_provider": "baseten",
+                    "auth_type": "api_key",
+                    "api_key": "secret",
+                    "remote_url": "http://x",
+                },
+            )
+        )
+    assert any("plaintext" in r.message for r in caplog.records)
+    assert "api_key = secret" in trussrc.read_text()
+
+    loaded = RemoteFactory.load_remote_config("baseten")
+    assert loaded.configs["api_key"] == "secret"
+
+
+def test_load_raises_when_secret_missing_and_keyring_unavailable(fail_keyring, trussrc):
+    trussrc.write_text(
+        "[baseten]\n"
+        "remote_provider = baseten\n"
+        "auth_type = api_key\n"
+        "remote_url = http://x\n"
+    )
+    with pytest.raises(ValueError, match="keyring is unavailable"):
+        RemoteFactory.load_remote_config("baseten")
+
+
+def test_load_raises_when_keyring_entry_missing(memory_keyring, trussrc):
+    trussrc.write_text(
+        "[baseten]\n"
+        "remote_provider = baseten\n"
+        "auth_type = api_key\n"
+        "remote_url = http://x\n"
+    )
+    with pytest.raises(ValueError, match="No credentials in keyring"):
+        RemoteFactory.load_remote_config("baseten")
+
+
+def test_load_raises_when_keyring_entry_malformed(memory_keyring, trussrc):
+    trussrc.write_text(
+        "[baseten]\n"
+        "remote_provider = baseten\n"
+        "auth_type = api_key\n"
+        "remote_url = http://x\n"
+    )
+    memory_keyring.set_password(KEYRING_SERVICE, "baseten", "not-json")
+    with pytest.raises(ValueError, match="not valid JSON"):
+        RemoteFactory.load_remote_config("baseten")
+
+
+def test_remove_remote_config_drops_section_and_keyring(memory_keyring, trussrc):
+    RemoteFactory.update_remote_config(
+        RemoteConfig(
+            name="baseten",
+            configs={
+                "remote_provider": "baseten",
+                "auth_type": "api_key",
+                "api_key": "secret",
+                "remote_url": "http://x",
+            },
+        )
+    )
+    assert memory_keyring.get_password(KEYRING_SERVICE, "baseten") is not None
+
+    RemoteFactory.remove_remote_config("baseten")
+
+    assert "[baseten]" not in trussrc.read_text()
+    assert memory_keyring.get_password(KEYRING_SERVICE, "baseten") is None
+
+
+def test_remove_remote_config_missing_is_noop(memory_keyring, trussrc):
+    trussrc.write_text("[other]\nremote_provider = baseten\n")
+    RemoteFactory.remove_remote_config("baseten")
+    assert "[other]" in trussrc.read_text()

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.9, <3.15"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -203,6 +203,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backports-tarfile"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/72/cd9b395f25e290e633655a100af28cb253e4393396264a98bd5f5951d50f/backports_tarfile-1.2.0.tar.gz", hash = "sha256:d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991", size = 86406, upload-time = "2024-05-28T17:01:54.731Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/fa/123043af240e49752f1c4bd24da5053b6bd00cad78c2be53c0d1e8b975bc/backports.tarfile-1.2.0-py3-none-any.whl", hash = "sha256:77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34", size = 30181, upload-time = "2024-05-28T17:01:53.112Z" },
+]
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.13.4"
 source = { registry = "https://pypi.org/simple" }
@@ -370,71 +379,96 @@ wheels = [
 
 [[package]]
 name = "cffi"
-version = "1.17.1"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/97/c783634659c2920c3fc70419e3af40972dbaf758daa229a7d6ea6135c90d/cffi-1.17.1.tar.gz", hash = "sha256:1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824", size = 516621, upload-time = "2024-09-04T20:45:21.852Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/07/f44ca684db4e4f08a3fdc6eeb9a0d15dc6883efc7b8c90357fdbf74e186c/cffi-1.17.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:df8b1c11f177bc2313ec4b2d46baec87a5f3e71fc8b45dab2ee7cae86d9aba14", size = 182191, upload-time = "2024-09-04T20:43:30.027Z" },
-    { url = "https://files.pythonhosted.org/packages/08/fd/cc2fedbd887223f9f5d170c96e57cbf655df9831a6546c1727ae13fa977a/cffi-1.17.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8f2cdc858323644ab277e9bb925ad72ae0e67f69e804f4898c070998d50b1a67", size = 178592, upload-time = "2024-09-04T20:43:32.108Z" },
-    { url = "https://files.pythonhosted.org/packages/de/cc/4635c320081c78d6ffc2cab0a76025b691a91204f4aa317d568ff9280a2d/cffi-1.17.1-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:edae79245293e15384b51f88b00613ba9f7198016a5948b5dddf4917d4d26382", size = 426024, upload-time = "2024-09-04T20:43:34.186Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/7b/3b2b250f3aab91abe5f8a51ada1b717935fdaec53f790ad4100fe2ec64d1/cffi-1.17.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:45398b671ac6d70e67da8e4224a065cec6a93541bb7aebe1b198a61b58c7b702", size = 448188, upload-time = "2024-09-04T20:43:36.286Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/48/1b9283ebbf0ec065148d8de05d647a986c5f22586b18120020452fff8f5d/cffi-1.17.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ad9413ccdeda48c5afdae7e4fa2192157e991ff761e7ab8fdd8926f40b160cc3", size = 455571, upload-time = "2024-09-04T20:43:38.586Z" },
-    { url = "https://files.pythonhosted.org/packages/40/87/3b8452525437b40f39ca7ff70276679772ee7e8b394934ff60e63b7b090c/cffi-1.17.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5da5719280082ac6bd9aa7becb3938dc9f9cbd57fac7d2871717b1feb0902ab6", size = 436687, upload-time = "2024-09-04T20:43:40.084Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/fb/4da72871d177d63649ac449aec2e8a29efe0274035880c7af59101ca2232/cffi-1.17.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2bb1a08b8008b281856e5971307cc386a8e9c5b625ac297e853d36da6efe9c17", size = 446211, upload-time = "2024-09-04T20:43:41.526Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/a0/62f00bcb411332106c02b663b26f3545a9ef136f80d5df746c05878f8c4b/cffi-1.17.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:045d61c734659cc045141be4bae381a41d89b741f795af1dd018bfb532fd0df8", size = 461325, upload-time = "2024-09-04T20:43:43.117Z" },
-    { url = "https://files.pythonhosted.org/packages/36/83/76127035ed2e7e27b0787604d99da630ac3123bfb02d8e80c633f218a11d/cffi-1.17.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:6883e737d7d9e4899a8a695e00ec36bd4e5e4f18fabe0aca0efe0a4b44cdb13e", size = 438784, upload-time = "2024-09-04T20:43:45.256Z" },
-    { url = "https://files.pythonhosted.org/packages/21/81/a6cd025db2f08ac88b901b745c163d884641909641f9b826e8cb87645942/cffi-1.17.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:6b8b4a92e1c65048ff98cfe1f735ef8f1ceb72e3d5f0c25fdb12087a23da22be", size = 461564, upload-time = "2024-09-04T20:43:46.779Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/fe/4d41c2f200c4a457933dbd98d3cf4e911870877bd94d9656cc0fcb390681/cffi-1.17.1-cp310-cp310-win32.whl", hash = "sha256:c9c3d058ebabb74db66e431095118094d06abf53284d9c81f27300d0e0d8bc7c", size = 171804, upload-time = "2024-09-04T20:43:48.186Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/b6/0b0f5ab93b0df4acc49cae758c81fe4e5ef26c3ae2e10cc69249dfd8b3ab/cffi-1.17.1-cp310-cp310-win_amd64.whl", hash = "sha256:0f048dcf80db46f0098ccac01132761580d28e28bc0f78ae0d58048063317e15", size = 181299, upload-time = "2024-09-04T20:43:49.812Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/f4/927e3a8899e52a27fa57a48607ff7dc91a9ebe97399b357b85a0c7892e00/cffi-1.17.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a45e3c6913c5b87b3ff120dcdc03f6131fa0065027d0ed7ee6190736a74cd401", size = 182264, upload-time = "2024-09-04T20:43:51.124Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/f5/6c3a8efe5f503175aaddcbea6ad0d2c96dad6f5abb205750d1b3df44ef29/cffi-1.17.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:30c5e0cb5ae493c04c8b42916e52ca38079f1b235c2f8ae5f4527b963c401caf", size = 178651, upload-time = "2024-09-04T20:43:52.872Z" },
-    { url = "https://files.pythonhosted.org/packages/94/dd/a3f0118e688d1b1a57553da23b16bdade96d2f9bcda4d32e7d2838047ff7/cffi-1.17.1-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f75c7ab1f9e4aca5414ed4d8e5c0e303a34f4421f8a0d47a4d019ceff0ab6af4", size = 445259, upload-time = "2024-09-04T20:43:56.123Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/ea/70ce63780f096e16ce8588efe039d3c4f91deb1dc01e9c73a287939c79a6/cffi-1.17.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a1ed2dd2972641495a3ec98445e09766f077aee98a1c896dcb4ad0d303628e41", size = 469200, upload-time = "2024-09-04T20:43:57.891Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/a0/a4fa9f4f781bda074c3ddd57a572b060fa0df7655d2a4247bbe277200146/cffi-1.17.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:46bf43160c1a35f7ec506d254e5c890f3c03648a4dbac12d624e4490a7046cd1", size = 477235, upload-time = "2024-09-04T20:44:00.18Z" },
-    { url = "https://files.pythonhosted.org/packages/62/12/ce8710b5b8affbcdd5c6e367217c242524ad17a02fe5beec3ee339f69f85/cffi-1.17.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a24ed04c8ffd54b0729c07cee15a81d964e6fee0e3d4d342a27b020d22959dc6", size = 459721, upload-time = "2024-09-04T20:44:01.585Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/6b/d45873c5e0242196f042d555526f92aa9e0c32355a1be1ff8c27f077fd37/cffi-1.17.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:610faea79c43e44c71e1ec53a554553fa22321b65fae24889706c0a84d4ad86d", size = 467242, upload-time = "2024-09-04T20:44:03.467Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/52/d9a0e523a572fbccf2955f5abe883cfa8bcc570d7faeee06336fbd50c9fc/cffi-1.17.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:a9b15d491f3ad5d692e11f6b71f7857e7835eb677955c00cc0aefcd0669adaf6", size = 477999, upload-time = "2024-09-04T20:44:05.023Z" },
-    { url = "https://files.pythonhosted.org/packages/44/74/f2a2460684a1a2d00ca799ad880d54652841a780c4c97b87754f660c7603/cffi-1.17.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:de2ea4b5833625383e464549fec1bc395c1bdeeb5f25c4a3a82b5a8c756ec22f", size = 454242, upload-time = "2024-09-04T20:44:06.444Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/4a/34599cac7dfcd888ff54e801afe06a19c17787dfd94495ab0c8d35fe99fb/cffi-1.17.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:fc48c783f9c87e60831201f2cce7f3b2e4846bf4d8728eabe54d60700b318a0b", size = 478604, upload-time = "2024-09-04T20:44:08.206Z" },
-    { url = "https://files.pythonhosted.org/packages/34/33/e1b8a1ba29025adbdcda5fb3a36f94c03d771c1b7b12f726ff7fef2ebe36/cffi-1.17.1-cp311-cp311-win32.whl", hash = "sha256:85a950a4ac9c359340d5963966e3e0a94a676bd6245a4b55bc43949eee26a655", size = 171727, upload-time = "2024-09-04T20:44:09.481Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/97/50228be003bb2802627d28ec0627837ac0bf35c90cf769812056f235b2d1/cffi-1.17.1-cp311-cp311-win_amd64.whl", hash = "sha256:caaf0640ef5f5517f49bc275eca1406b0ffa6aa184892812030f04c2abf589a0", size = 181400, upload-time = "2024-09-04T20:44:10.873Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/84/e94227139ee5fb4d600a7a4927f322e1d4aea6fdc50bd3fca8493caba23f/cffi-1.17.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:805b4371bf7197c329fcb3ead37e710d1bca9da5d583f5073b799d5c5bd1eee4", size = 183178, upload-time = "2024-09-04T20:44:12.232Z" },
-    { url = "https://files.pythonhosted.org/packages/da/ee/fb72c2b48656111c4ef27f0f91da355e130a923473bf5ee75c5643d00cca/cffi-1.17.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:733e99bc2df47476e3848417c5a4540522f234dfd4ef3ab7fafdf555b082ec0c", size = 178840, upload-time = "2024-09-04T20:44:13.739Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/b6/db007700f67d151abadf508cbfd6a1884f57eab90b1bb985c4c8c02b0f28/cffi-1.17.1-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1257bdabf294dceb59f5e70c64a3e2f462c30c7ad68092d01bbbfb1c16b1ba36", size = 454803, upload-time = "2024-09-04T20:44:15.231Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/df/f8d151540d8c200eb1c6fba8cd0dfd40904f1b0682ea705c36e6c2e97ab3/cffi-1.17.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:da95af8214998d77a98cc14e3a3bd00aa191526343078b530ceb0bd710fb48a5", size = 478850, upload-time = "2024-09-04T20:44:17.188Z" },
-    { url = "https://files.pythonhosted.org/packages/28/c0/b31116332a547fd2677ae5b78a2ef662dfc8023d67f41b2a83f7c2aa78b1/cffi-1.17.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d63afe322132c194cf832bfec0dc69a99fb9bb6bbd550f161a49e9e855cc78ff", size = 485729, upload-time = "2024-09-04T20:44:18.688Z" },
-    { url = "https://files.pythonhosted.org/packages/91/2b/9a1ddfa5c7f13cab007a2c9cc295b70fbbda7cb10a286aa6810338e60ea1/cffi-1.17.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f79fc4fc25f1c8698ff97788206bb3c2598949bfe0fef03d299eb1b5356ada99", size = 471256, upload-time = "2024-09-04T20:44:20.248Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/d5/da47df7004cb17e4955df6a43d14b3b4ae77737dff8bf7f8f333196717bf/cffi-1.17.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b62ce867176a75d03a665bad002af8e6d54644fad99a3c70905c543130e39d93", size = 479424, upload-time = "2024-09-04T20:44:21.673Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/ac/2a28bcf513e93a219c8a4e8e125534f4f6db03e3179ba1c45e949b76212c/cffi-1.17.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:386c8bf53c502fff58903061338ce4f4950cbdcb23e2902d86c0f722b786bbe3", size = 484568, upload-time = "2024-09-04T20:44:23.245Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/38/ca8a4f639065f14ae0f1d9751e70447a261f1a30fa7547a828ae08142465/cffi-1.17.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:4ceb10419a9adf4460ea14cfd6bc43d08701f0835e979bf821052f1805850fe8", size = 488736, upload-time = "2024-09-04T20:44:24.757Z" },
-    { url = "https://files.pythonhosted.org/packages/86/c5/28b2d6f799ec0bdecf44dced2ec5ed43e0eb63097b0f58c293583b406582/cffi-1.17.1-cp312-cp312-win32.whl", hash = "sha256:a08d7e755f8ed21095a310a693525137cfe756ce62d066e53f502a83dc550f65", size = 172448, upload-time = "2024-09-04T20:44:26.208Z" },
-    { url = "https://files.pythonhosted.org/packages/50/b9/db34c4755a7bd1cb2d1603ac3863f22bcecbd1ba29e5ee841a4bc510b294/cffi-1.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:51392eae71afec0d0c8fb1a53b204dbb3bcabcb3c9b807eedf3e1e6ccf2de903", size = 181976, upload-time = "2024-09-04T20:44:27.578Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/f8/dd6c246b148639254dad4d6803eb6a54e8c85c6e11ec9df2cffa87571dbe/cffi-1.17.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f3a2b4222ce6b60e2e8b337bb9596923045681d71e5a082783484d845390938e", size = 182989, upload-time = "2024-09-04T20:44:28.956Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/f1/672d303ddf17c24fc83afd712316fda78dc6fce1cd53011b839483e1ecc8/cffi-1.17.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0984a4925a435b1da406122d4d7968dd861c1385afe3b45ba82b750f229811e2", size = 178802, upload-time = "2024-09-04T20:44:30.289Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/2d/eab2e858a91fdff70533cab61dcff4a1f55ec60425832ddfdc9cd36bc8af/cffi-1.17.1-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d01b12eeeb4427d3110de311e1774046ad344f5b1a7403101878976ecd7a10f3", size = 454792, upload-time = "2024-09-04T20:44:32.01Z" },
-    { url = "https://files.pythonhosted.org/packages/75/b2/fbaec7c4455c604e29388d55599b99ebcc250a60050610fadde58932b7ee/cffi-1.17.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:706510fe141c86a69c8ddc029c7910003a17353970cff3b904ff0686a5927683", size = 478893, upload-time = "2024-09-04T20:44:33.606Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/b7/6e4a2162178bf1935c336d4da8a9352cccab4d3a5d7914065490f08c0690/cffi-1.17.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:de55b766c7aa2e2a3092c51e0483d700341182f08e67c63630d5b6f200bb28e5", size = 485810, upload-time = "2024-09-04T20:44:35.191Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/8a/1d0e4a9c26e54746dc08c2c6c037889124d4f59dffd853a659fa545f1b40/cffi-1.17.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c59d6e989d07460165cc5ad3c61f9fd8f1b4796eacbd81cee78957842b834af4", size = 471200, upload-time = "2024-09-04T20:44:36.743Z" },
-    { url = "https://files.pythonhosted.org/packages/26/9f/1aab65a6c0db35f43c4d1b4f580e8df53914310afc10ae0397d29d697af4/cffi-1.17.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd398dbc6773384a17fe0d3e7eeb8d1a21c2200473ee6806bb5e6a8e62bb73dd", size = 479447, upload-time = "2024-09-04T20:44:38.492Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/e4/fb8b3dd8dc0e98edf1135ff067ae070bb32ef9d509d6cb0f538cd6f7483f/cffi-1.17.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:3edc8d958eb099c634dace3c7e16560ae474aa3803a5df240542b305d14e14ed", size = 484358, upload-time = "2024-09-04T20:44:40.046Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/47/d7145bf2dc04684935d57d67dff9d6d795b2ba2796806bb109864be3a151/cffi-1.17.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:72e72408cad3d5419375fc87d289076ee319835bdfa2caad331e377589aebba9", size = 488469, upload-time = "2024-09-04T20:44:41.616Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/ee/f94057fa6426481d663b88637a9a10e859e492c73d0384514a17d78ee205/cffi-1.17.1-cp313-cp313-win32.whl", hash = "sha256:e03eab0a8677fa80d646b5ddece1cbeaf556c313dcfac435ba11f107ba117b5d", size = 172475, upload-time = "2024-09-04T20:44:43.733Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/fc/6a8cb64e5f0324877d503c854da15d76c1e50eb722e320b15345c4d0c6de/cffi-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:f6a16c31041f09ead72d69f583767292f750d24913dadacf5756b966aacb3f1a", size = 182009, upload-time = "2024-09-04T20:44:45.309Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/ea/8bb50596b8ffbc49ddd7a1ad305035daa770202a6b782fc164647c2673ad/cffi-1.17.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b2ab587605f4ba0bf81dc0cb08a41bd1c0a5906bd59243d56bad7668a6fc6c16", size = 182220, upload-time = "2024-09-04T20:45:01.577Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/11/e77c8cd24f58285a82c23af484cf5b124a376b32644e445960d1a4654c3a/cffi-1.17.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:28b16024becceed8c6dfbc75629e27788d8a3f9030691a1dbf9821a128b22c36", size = 178605, upload-time = "2024-09-04T20:45:03.837Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/65/25a8dc32c53bf5b7b6c2686b42ae2ad58743f7ff644844af7cdb29b49361/cffi-1.17.1-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1d599671f396c4723d016dbddb72fe8e0397082b0a77a4fab8028923bec050e8", size = 424910, upload-time = "2024-09-04T20:45:05.315Z" },
-    { url = "https://files.pythonhosted.org/packages/42/7a/9d086fab7c66bd7c4d0f27c57a1b6b068ced810afc498cc8c49e0088661c/cffi-1.17.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca74b8dbe6e8e8263c0ffd60277de77dcee6c837a3d0881d8c1ead7268c9e576", size = 447200, upload-time = "2024-09-04T20:45:06.903Z" },
-    { url = "https://files.pythonhosted.org/packages/da/63/1785ced118ce92a993b0ec9e0d0ac8dc3e5dbfbcaa81135be56c69cabbb6/cffi-1.17.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f7f5baafcc48261359e14bcd6d9bff6d4b28d9103847c9e136694cb0501aef87", size = 454565, upload-time = "2024-09-04T20:45:08.975Z" },
-    { url = "https://files.pythonhosted.org/packages/74/06/90b8a44abf3556599cdec107f7290277ae8901a58f75e6fe8f970cd72418/cffi-1.17.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:98e3969bcff97cae1b2def8ba499ea3d6f31ddfdb7635374834cf89a1a08ecf0", size = 435635, upload-time = "2024-09-04T20:45:10.64Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/62/a1f468e5708a70b1d86ead5bab5520861d9c7eacce4a885ded9faa7729c3/cffi-1.17.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cdf5ce3acdfd1661132f2a9c19cac174758dc2352bfe37d98aa7512c6b7178b3", size = 445218, upload-time = "2024-09-04T20:45:12.366Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/95/b34462f3ccb09c2594aa782d90a90b045de4ff1f70148ee79c69d37a0a5a/cffi-1.17.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:9755e4345d1ec879e3849e62222a18c7174d65a6a92d5b346b1863912168b595", size = 460486, upload-time = "2024-09-04T20:45:13.935Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/fc/a1e4bebd8d680febd29cf6c8a40067182b64f00c7d105f8f26b5bc54317b/cffi-1.17.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:f1e22e8c4419538cb197e4dd60acc919d7696e5ef98ee4da4e01d3f8cfa4cc5a", size = 437911, upload-time = "2024-09-04T20:45:15.696Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/c3/21cab7a6154b6a5ea330ae80de386e7665254835b9e98ecc1340b3a7de9a/cffi-1.17.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:c03e868a0b3bc35839ba98e74211ed2b05d2119be4e8a0f224fba9384f1fe02e", size = 460632, upload-time = "2024-09-04T20:45:17.284Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/b5/fd9f8b5a84010ca169ee49f4e4ad6f8c05f4e3545b72ee041dbbcb159882/cffi-1.17.1-cp39-cp39-win32.whl", hash = "sha256:e31ae45bc2e29f6b2abd0de1cc3b9d5205aa847cafaecb8af1476a609a2f6eb7", size = 171820, upload-time = "2024-09-04T20:45:18.762Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/52/b08750ce0bce45c143e1b5d7357ee8c55341b52bdef4b0f081af1eb248c2/cffi-1.17.1-cp39-cp39-win_amd64.whl", hash = "sha256:d016c76bdd850f3c626af19b0542c9677ba156e4ee4fccfdd7848803533ef662", size = 181290, upload-time = "2024-09-04T20:45:20.226Z" },
+    { url = "https://files.pythonhosted.org/packages/93/d7/516d984057745a6cd96575eea814fe1edd6646ee6efd552fb7b0921dec83/cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44", size = 184283, upload-time = "2025-09-08T23:22:08.01Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/84/ad6a0b408daa859246f57c03efd28e5dd1b33c21737c2db84cae8c237aa5/cffi-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49", size = 180504, upload-time = "2025-09-08T23:22:10.637Z" },
+    { url = "https://files.pythonhosted.org/packages/50/bd/b1a6362b80628111e6653c961f987faa55262b4002fcec42308cad1db680/cffi-2.0.0-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:53f77cbe57044e88bbd5ed26ac1d0514d2acf0591dd6bb02a3ae37f76811b80c", size = 208811, upload-time = "2025-09-08T23:22:12.267Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/27/6933a8b2562d7bd1fb595074cf99cc81fc3789f6a6c05cdabb46284a3188/cffi-2.0.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3e837e369566884707ddaf85fc1744b47575005c0a229de3327f8f9a20f4efeb", size = 216402, upload-time = "2025-09-08T23:22:13.455Z" },
+    { url = "https://files.pythonhosted.org/packages/05/eb/b86f2a2645b62adcfff53b0dd97e8dfafb5c8aa864bd0d9a2c2049a0d551/cffi-2.0.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5eda85d6d1879e692d546a078b44251cdd08dd1cfb98dfb77b670c97cee49ea0", size = 203217, upload-time = "2025-09-08T23:22:14.596Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/e0/6cbe77a53acf5acc7c08cc186c9928864bd7c005f9efd0d126884858a5fe/cffi-2.0.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9332088d75dc3241c702d852d4671613136d90fa6881da7d770a483fd05248b4", size = 203079, upload-time = "2025-09-08T23:22:15.769Z" },
+    { url = "https://files.pythonhosted.org/packages/98/29/9b366e70e243eb3d14a5cb488dfd3a0b6b2f1fb001a203f653b93ccfac88/cffi-2.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc7de24befaeae77ba923797c7c87834c73648a05a4bde34b3b7e5588973a453", size = 216475, upload-time = "2025-09-08T23:22:17.427Z" },
+    { url = "https://files.pythonhosted.org/packages/21/7a/13b24e70d2f90a322f2900c5d8e1f14fa7e2a6b3332b7309ba7b2ba51a5a/cffi-2.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cf364028c016c03078a23b503f02058f1814320a56ad535686f90565636a9495", size = 218829, upload-time = "2025-09-08T23:22:19.069Z" },
+    { url = "https://files.pythonhosted.org/packages/60/99/c9dc110974c59cc981b1f5b66e1d8af8af764e00f0293266824d9c4254bc/cffi-2.0.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e11e82b744887154b182fd3e7e8512418446501191994dbf9c9fc1f32cc8efd5", size = 211211, upload-time = "2025-09-08T23:22:20.588Z" },
+    { url = "https://files.pythonhosted.org/packages/49/72/ff2d12dbf21aca1b32a40ed792ee6b40f6dc3a9cf1644bd7ef6e95e0ac5e/cffi-2.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8ea985900c5c95ce9db1745f7933eeef5d314f0565b27625d9a10ec9881e1bfb", size = 218036, upload-time = "2025-09-08T23:22:22.143Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/cc/027d7fb82e58c48ea717149b03bcadcbdc293553edb283af792bd4bcbb3f/cffi-2.0.0-cp310-cp310-win32.whl", hash = "sha256:1f72fb8906754ac8a2cc3f9f5aaa298070652a0ffae577e0ea9bd480dc3c931a", size = 172184, upload-time = "2025-09-08T23:22:23.328Z" },
+    { url = "https://files.pythonhosted.org/packages/33/fa/072dd15ae27fbb4e06b437eb6e944e75b068deb09e2a2826039e49ee2045/cffi-2.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:b18a3ed7d5b3bd8d9ef7a8cb226502c6bf8308df1525e1cc676c3680e7176739", size = 182790, upload-time = "2025-09-08T23:22:24.752Z" },
+    { url = "https://files.pythonhosted.org/packages/12/4a/3dfd5f7850cbf0d06dc84ba9aa00db766b52ca38d8b86e3a38314d52498c/cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe", size = 184344, upload-time = "2025-09-08T23:22:26.456Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/8b/f0e4c441227ba756aafbe78f117485b25bb26b1c059d01f137fa6d14896b/cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c", size = 180560, upload-time = "2025-09-08T23:22:28.197Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/b7/1200d354378ef52ec227395d95c2576330fd22a869f7a70e88e1447eb234/cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92", size = 209613, upload-time = "2025-09-08T23:22:29.475Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93", size = 216476, upload-time = "2025-09-08T23:22:31.063Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/7f/55fecd70f7ece178db2f26128ec41430d8720f2d12ca97bf8f0a628207d5/cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5", size = 203374, upload-time = "2025-09-08T23:22:32.507Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ef/a7b77c8bdc0f77adc3b46888f1ad54be8f3b7821697a7b89126e829e676a/cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664", size = 202597, upload-time = "2025-09-08T23:22:34.132Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26", size = 215574, upload-time = "2025-09-08T23:22:35.443Z" },
+    { url = "https://files.pythonhosted.org/packages/44/64/58f6255b62b101093d5df22dcb752596066c7e89dd725e0afaed242a61be/cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9", size = 218971, upload-time = "2025-09-08T23:22:36.805Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/49/fa72cebe2fd8a55fbe14956f9970fe8eb1ac59e5df042f603ef7c8ba0adc/cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414", size = 211972, upload-time = "2025-09-08T23:22:38.436Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/28/dd0967a76aab36731b6ebfe64dec4e981aff7e0608f60c2d46b46982607d/cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743", size = 217078, upload-time = "2025-09-08T23:22:39.776Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/c0/015b25184413d7ab0a410775fdb4a50fca20f5589b5dab1dbbfa3baad8ce/cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5", size = 172076, upload-time = "2025-09-08T23:22:40.95Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8f/dc5531155e7070361eb1b7e4c1a9d896d0cb21c49f807a6c03fd63fc877e/cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5", size = 182820, upload-time = "2025-09-08T23:22:42.463Z" },
+    { url = "https://files.pythonhosted.org/packages/95/5c/1b493356429f9aecfd56bc171285a4c4ac8697f76e9bbbbb105e537853a1/cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d", size = 177635, upload-time = "2025-09-08T23:22:43.623Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/cc/08ed5a43f2996a16b462f64a7055c6e962803534924b9b2f1371d8c00b7b/cffi-2.0.0-cp39-cp39-macosx_10_13_x86_64.whl", hash = "sha256:fe562eb1a64e67dd297ccc4f5addea2501664954f2692b69a76449ec7913ecbf", size = 184288, upload-time = "2025-09-08T23:23:48.404Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/de/38d9726324e127f727b4ecc376bc85e505bfe61ef130eaf3f290c6847dd4/cffi-2.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:de8dad4425a6ca6e4e5e297b27b5c824ecc7581910bf9aee86cb6835e6812aa7", size = 180509, upload-time = "2025-09-08T23:23:49.73Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/13/c92e36358fbcc39cf0962e83223c9522154ee8630e1df7c0b3a39a8124e2/cffi-2.0.0-cp39-cp39-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:4647afc2f90d1ddd33441e5b0e85b16b12ddec4fca55f0d9671fef036ecca27c", size = 208813, upload-time = "2025-09-08T23:23:51.263Z" },
+    { url = "https://files.pythonhosted.org/packages/15/12/a7a79bd0df4c3bff744b2d7e52cc1b68d5e7e427b384252c42366dc1ecbc/cffi-2.0.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3f4d46d8b35698056ec29bca21546e1551a205058ae1a181d871e278b0b28165", size = 216498, upload-time = "2025-09-08T23:23:52.494Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ad/5c51c1c7600bdd7ed9a24a203ec255dccdd0ebf4527f7b922a0bde2fb6ed/cffi-2.0.0-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:e6e73b9e02893c764e7e8d5bb5ce277f1a009cd5243f8228f75f842bf937c534", size = 203243, upload-time = "2025-09-08T23:23:53.836Z" },
+    { url = "https://files.pythonhosted.org/packages/32/f2/81b63e288295928739d715d00952c8c6034cb6c6a516b17d37e0c8be5600/cffi-2.0.0-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:cb527a79772e5ef98fb1d700678fe031e353e765d1ca2d409c92263c6d43e09f", size = 203158, upload-time = "2025-09-08T23:23:55.169Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/74/cc4096ce66f5939042ae094e2e96f53426a979864aa1f96a621ad128be27/cffi-2.0.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:61d028e90346df14fedc3d1e5441df818d095f3b87d286825dfcbd6459b7ef63", size = 216548, upload-time = "2025-09-08T23:23:56.506Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/be/f6424d1dc46b1091ffcc8964fa7c0ab0cd36839dd2761b49c90481a6ba1b/cffi-2.0.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:0f6084a0ea23d05d20c3edcda20c3d006f9b6f3fefeac38f59262e10cef47ee2", size = 218897, upload-time = "2025-09-08T23:23:57.825Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/e0/dda537c2309817edf60109e39265f24f24aa7f050767e22c98c53fe7f48b/cffi-2.0.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:1cd13c99ce269b3ed80b417dcd591415d3372bcac067009b6e0f59c7d4015e65", size = 211249, upload-time = "2025-09-08T23:23:59.139Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/e7/7c769804eb75e4c4b35e658dba01de1640a351a9653c3d49ca89d16ccc91/cffi-2.0.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:89472c9762729b5ae1ad974b777416bfda4ac5642423fa93bd57a09204712322", size = 218041, upload-time = "2025-09-08T23:24:00.496Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/d9/6218d78f920dcd7507fc16a766b5ef8f3b913cc7aa938e7fc80b9978d089/cffi-2.0.0-cp39-cp39-win32.whl", hash = "sha256:2081580ebb843f759b9f617314a24ed5738c51d2aee65d31e02f6f7a2b97707a", size = 172138, upload-time = "2025-09-08T23:24:01.7Z" },
+    { url = "https://files.pythonhosted.org/packages/54/8f/a1e836f82d8e32a97e6b29cc8f641779181ac7363734f12df27db803ebda/cffi-2.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:b882b3df248017dba09d6b16defe9b5c407fe32fc7c65a9c69798e6175601be9", size = 182794, upload-time = "2025-09-08T23:24:02.943Z" },
 ]
 
 [[package]]
@@ -611,6 +645,55 @@ wheels = [
 [package.optional-dependencies]
 toml = [
     { name = "tomli", marker = "python_full_version <= '3.11'" },
+]
+
+[[package]]
+name = "cryptography"
+version = "47.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ef/b2/7ffa7fe8207a8c42147ffe70c3e360b228160c1d85dc3faff16aaa3244c0/cryptography-47.0.0.tar.gz", hash = "sha256:9f8e55fe4e63613a5e1cc5819030f27b97742d720203a087802ce4ce9ceb52bb", size = 830863, upload-time = "2026-04-24T19:54:57.056Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/c6/2733531243fba725f58611b918056b277692f1033373dcc8bd01af1c05d4/cryptography-47.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b9a8943e359b7615db1a3ba587994618e094ff3d6fa5a390c73d079ce18b3973", size = 4644617, upload-time = "2026-04-24T19:53:06.909Z" },
+    { url = "https://files.pythonhosted.org/packages/00/e3/b27be1a670a9b87f855d211cf0e1174a5d721216b7616bd52d8581d912ed/cryptography-47.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f5c15764f261394b22aef6b00252f5195f46f2ca300bec57149474e2538b31f8", size = 4668186, upload-time = "2026-04-24T19:53:09.053Z" },
+    { url = "https://files.pythonhosted.org/packages/81/b9/8443cfe5d17d482d348cee7048acf502bb89a51b6382f06240fd290d4ca3/cryptography-47.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:9c59ab0e0fa3a180a5a9c59f3a5abe3ef90d474bc56d7fadfbe80359491b615b", size = 4651244, upload-time = "2026-04-24T19:53:11.217Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/5e/13ed0cdd0eb88ba159d6dd5ebfece8cb901dbcf1ae5ac4072e28b55d3153/cryptography-47.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:34b4358b925a5ea3e14384ca781a2c0ef7ac219b57bb9eacc4457078e2b19f92", size = 5252906, upload-time = "2026-04-24T19:53:13.532Z" },
+    { url = "https://files.pythonhosted.org/packages/64/16/ed058e1df0f33d440217cd120d41d5dda9dd215a80b8187f68483185af82/cryptography-47.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0024b87d47ae2399165a6bfb20d24888881eeab83ae2566d62467c5ff0030ce7", size = 4701842, upload-time = "2026-04-24T19:53:15.618Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3d30986b30fdbd9e969abbdf8ba00ed0618615144341faeb57f395a084fe/cryptography-47.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:1e47422b5557bb82d3fff997e8d92cff4e28b9789576984f08c248d2b3535d93", size = 4289313, upload-time = "2026-04-24T19:53:17.755Z" },
+    { url = "https://files.pythonhosted.org/packages/df/fd/32db38e3ad0cb331f0691cb4c7a8a6f176f679124dee746b3af6633db4d9/cryptography-47.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:6f29f36582e6151d9686235e586dd35bb67491f024767d10b842e520dc6a07ac", size = 4650964, upload-time = "2026-04-24T19:53:20.062Z" },
+    { url = "https://files.pythonhosted.org/packages/86/53/5395d944dfd48cb1f67917f533c609c34347185ef15eb4308024c876f274/cryptography-47.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:a9b761f012a943b7de0e828843c5688d0de94a0578d44d6c85a1bae32f87791f", size = 5207817, upload-time = "2026-04-24T19:53:22.498Z" },
+    { url = "https://files.pythonhosted.org/packages/34/4f/e5711b28e1901f7d480a2b1b688b645aa4c77c73f10731ed17e7f7db3f0d/cryptography-47.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:4e1de79e047e25d6e9f8cea71c86b4a53aced64134f0f003bbcbf3655fd172c8", size = 4701544, upload-time = "2026-04-24T19:53:24.356Z" },
+    { url = "https://files.pythonhosted.org/packages/22/22/c8ddc25de3010fc8da447648f5a092c40e7a8fadf01dd6d255d9c0b9373d/cryptography-47.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ef6b3634087f18d2155b1e8ce264e5345a753da2c5fa9815e7d41315c90f8318", size = 4783536, upload-time = "2026-04-24T19:53:26.665Z" },
+    { url = "https://files.pythonhosted.org/packages/66/b6/d4a68f4ea999c6d89e8498579cba1c5fcba4276284de7773b17e4fa69293/cryptography-47.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:11dbb9f50a0f1bb9757b3d8c27c1101780efb8f0bdecfb12439c22a74d64c001", size = 4926106, upload-time = "2026-04-24T19:53:28.686Z" },
+    { url = "https://files.pythonhosted.org/packages/07/55/c18f75724544872f234678fdedc871391722cb34a2aee19faa9f63100bb2/cryptography-47.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2ebd84adf0728c039a3be2700289378e1c164afc6748df1a5ed456767bef9ba7", size = 4631180, upload-time = "2026-04-24T19:53:37.517Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/65/31a5cc0eaca99cec5bafffe155d407115d96136bb161e8b49e0ef73f09a7/cryptography-47.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f68d6fbc7fbbcfb0939fea72c3b96a9f9a6edfc0e1b1d29778a2066030418b1", size = 4653529, upload-time = "2026-04-24T19:53:39.775Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/bc/641c0519a495f3bfd0421b48d7cd325c4336578523ccd76ea322b6c29c7a/cryptography-47.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:6651d32eff255423503aa276739da98c30f26c40cbeffcc6048e0d54ef704c0c", size = 4638570, upload-time = "2026-04-24T19:53:42.129Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f2/300327b0a47f6dc94dd8b71b57052aefe178bb51745073d73d80604f11ab/cryptography-47.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:3fb8fa48075fad7193f2e5496135c6a76ac4b2aa5a38433df0a539296b377829", size = 5238019, upload-time = "2026-04-24T19:53:44.577Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/5a/5b5cf994391d4bf9d9c7efd4c66aabe4d95227256627f8fea6cff7dfadbd/cryptography-47.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:11438c7518132d95f354fa01a4aa2f806d172a061a7bed18cf18cbdacdb204d7", size = 4686832, upload-time = "2026-04-24T19:53:47.015Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/2c/ae950e28fd6475c852fc21a44db3e6b5bcc1261d1e370f2b6e42fa800fef/cryptography-47.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:8c1a736bbb3288005796c3f7ccb9453360d7fed483b13b9f468aea5171432923", size = 4269301, upload-time = "2026-04-24T19:53:48.97Z" },
+    { url = "https://files.pythonhosted.org/packages/67/fb/6a39782e150ffe5cc1b0018cb6ddc48bf7ca62b498d7539ffc8a758e977d/cryptography-47.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:f1557695e5c2b86e204f6ce9470497848634100787935ab7adc5397c54abd7ab", size = 4638110, upload-time = "2026-04-24T19:53:51.011Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/d7/0b3c71090a76e5c203164a47688b697635ece006dcd2499ab3a4dbd3f0bd/cryptography-47.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:f9a034b642b960767fb343766ae5ba6ad653f2e890ddd82955aef288ffea8736", size = 5194988, upload-time = "2026-04-24T19:53:52.962Z" },
+    { url = "https://files.pythonhosted.org/packages/63/33/63a961498a9df51721ab578c5a2622661411fc520e00bd83b0cc64eb20c4/cryptography-47.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:b1c76fca783aa7698eb21eb14f9c4aa09452248ee54a627d125025a43f83e7a7", size = 4686563, upload-time = "2026-04-24T19:53:55.274Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/bf/5ee5b145248f92250de86145d1c1d6edebbd57a7fe7caa4dedb5d4cf06a1/cryptography-47.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4f7722c97826770bab8ae92959a2e7b20a5e9e9bf4deae68fd86c3ca457bab52", size = 4770094, upload-time = "2026-04-24T19:53:57.753Z" },
+    { url = "https://files.pythonhosted.org/packages/92/43/21d220b2da5d517773894dacdcdb5c682c28d3fffce65548cb06e87d5501/cryptography-47.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:09f6d7bf6724f8db8b32f11eccf23efc8e759924bc5603800335cf8859a3ddbd", size = 4913811, upload-time = "2026-04-24T19:54:00.236Z" },
+    { url = "https://files.pythonhosted.org/packages/01/64/d7b1e54fdb69f22d24a64bb3e88dc718b31c7fb10ef0b9691a3cf7eeea6e/cryptography-47.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:07efe86201817e7d3c18781ca9770bc0db04e1e48c994be384e4602bc38f8f27", size = 4635767, upload-time = "2026-04-24T19:54:08.519Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/7b/cca826391fb2a94efdcdfe4631eb69306ee1cff0b22f664a412c90713877/cryptography-47.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b45761c6ec22b7c726d6a829558777e32d0f1c8be7c3f3480f9c912d5ee8a10", size = 4654350, upload-time = "2026-04-24T19:54:10.795Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/65/4b57bcc823f42a991627c51c2f68c9fd6eb1393c1756aac876cba2accae2/cryptography-47.0.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:edd4da498015da5b9f26d38d3bfc2e90257bfa9cbed1f6767c282a0025ae649b", size = 4643394, upload-time = "2026-04-24T19:54:13.275Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/c4/2c5fbeea70adbbca2bbae865e1d605d6a4a7f8dbd9d33eaf69645087f06c/cryptography-47.0.0-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9af828c0d5a65c70ec729cd7495a4bf1a67ecb66417b8f02ff125ab8a6326a74", size = 5225777, upload-time = "2026-04-24T19:54:15.18Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/b8/ac57107ef32749d2b244e36069bb688792a363aaaa3acc9e3cf84c130315/cryptography-47.0.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:256d07c78a04d6b276f5df935a9923275f53bd1522f214447fdf365494e2d515", size = 4688771, upload-time = "2026-04-24T19:54:17.835Z" },
+    { url = "https://files.pythonhosted.org/packages/56/fc/9f1de22ff8be99d991f240a46863c52d475404c408886c5a38d2b5c3bb26/cryptography-47.0.0-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:5d0e362ff51041b0c0d219cc7d6924d7b8996f57ce5712bdcef71eb3c65a59cc", size = 4270753, upload-time = "2026-04-24T19:54:19.963Z" },
+    { url = "https://files.pythonhosted.org/packages/00/68/d70c852797aa68e8e48d12e5a87170c43f67bb4a59403627259dd57d15de/cryptography-47.0.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:1581aef4219f7ca2849d0250edaa3866212fb74bf5667284f46aa92f9e65c1ca", size = 4642911, upload-time = "2026-04-24T19:54:21.818Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/51/661cbee74f594c5d97ff82d34f10d5551c085ca4668645f4606ebd22bd5d/cryptography-47.0.0-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:a49a3eb5341b9503fa3000a9a0db033161db90d47285291f53c2a9d2cd1b7f76", size = 5181411, upload-time = "2026-04-24T19:54:24.376Z" },
+    { url = "https://files.pythonhosted.org/packages/94/87/f2b6c374a82cf076cfa1416992ac8e8ec94d79facc37aec87c1a5cb72352/cryptography-47.0.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2207a498b03275d0051589e326b79d4cf59985c99031b05bb292ac52631c37fe", size = 4688262, upload-time = "2026-04-24T19:54:26.946Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e2/8b7462f4acf21ec509616f0245018bb197194ab0b65c2ea21a0bdd53c0eb/cryptography-47.0.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7a02675e2fabd0c0fc04c868b8781863cbf1967691543c22f5470500ff840b31", size = 4775506, upload-time = "2026-04-24T19:54:28.926Z" },
+    { url = "https://files.pythonhosted.org/packages/70/75/158e494e4c08dc05e039da5bb48553826bd26c23930cf8d3cd5f21fa8921/cryptography-47.0.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:80887c5cbd1774683cb126f0ab4184567f080071d5acf62205acb354b4b753b7", size = 4912060, upload-time = "2026-04-24T19:54:30.869Z" },
+    { url = "https://files.pythonhosted.org/packages/81/75/d691e284750df5d9569f2b1ce4a00a71e1d79566da83b2b3e5549c84917f/cryptography-47.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:1a405c08857258c11016777e11c02bacbe7ef596faf259305d282272a3a05cbe", size = 4587867, upload-time = "2026-04-24T19:54:40.619Z" },
+    { url = "https://files.pythonhosted.org/packages/07/d6/1b90f1a4e453009730b4545286f0b39bb348d805c11181fc31544e4f9a65/cryptography-47.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:20fdbe3e38fb67c385d233c89371fa27f9909f6ebca1cecc20c13518dae65475", size = 4627192, upload-time = "2026-04-24T19:54:42.849Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/53/cb358a80e9e359529f496870dd08c102aa8a4b5b9f9064f00f0d6ed5b527/cryptography-47.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:f7db373287273d8af1414cf95dc4118b13ffdc62be521997b0f2b270771fef50", size = 4587486, upload-time = "2026-04-24T19:54:44.908Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/57/aaa3d53876467a226f9a7a82fd14dd48058ad2de1948493442dfa16e2ffd/cryptography-47.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:9fe6b7c64926c765f9dff301f9c1b867febcda5768868ca084e18589113732ab", size = 4626327, upload-time = "2026-04-24T19:54:47.813Z" },
 ]
 
 [[package]]
@@ -1251,6 +1334,64 @@ wheels = [
 ]
 
 [[package]]
+name = "jaraco-classes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools", version = "10.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "more-itertools", version = "11.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload-time = "2024-03-31T07:27:36.643Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790", size = 6777, upload-time = "2024-03-31T07:27:34.792Z" },
+]
+
+[[package]]
+name = "jaraco-context"
+version = "6.1.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+dependencies = [
+    { name = "backports-tarfile", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/7b/c3081ff1af947915503121c649f26a778e1a2101fd525f74aef997d75b7e/jaraco_context-6.1.1.tar.gz", hash = "sha256:bc046b2dc94f1e5532bd02402684414575cc11f565d929b6563125deb0a6e581", size = 15832, upload-time = "2026-03-07T15:46:04.63Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/49/c152890d49102b280ecf86ba5f80a8c111c3a155dafa3bd24aeb64fde9e1/jaraco_context-6.1.1-py3-none-any.whl", hash = "sha256:0df6a0287258f3e364072c3e40d5411b20cafa30cb28c4839d24319cecf9f808", size = 7005, upload-time = "2026-03-07T15:46:03.515Z" },
+]
+
+[[package]]
+name = "jaraco-context"
+version = "6.1.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13'",
+    "python_full_version >= '3.11' and python_full_version < '3.13'",
+    "python_full_version == '3.10.*'",
+]
+dependencies = [
+    { name = "backports-tarfile", marker = "python_full_version >= '3.10' and python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/50/4763cd07e722bb6285316d390a164bc7e479db9d90daa769f22578f698b4/jaraco_context-6.1.2.tar.gz", hash = "sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3", size = 16801, upload-time = "2026-03-20T22:13:33.922Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl", hash = "sha256:bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535", size = 7871, upload-time = "2026-03-20T22:13:32.808Z" },
+]
+
+[[package]]
+name = "jaraco-functools"
+version = "4.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools", version = "10.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "more-itertools", version = "11.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0f/27/056e0638a86749374d6f57d0b0db39f29509cce9313cf91bdc0ac4d91084/jaraco_functools-4.4.0.tar.gz", hash = "sha256:da21933b0417b89515562656547a77b4931f98176eb173644c0d35032a33d6bb", size = 19943, upload-time = "2025-12-21T09:29:43.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/c4/813bb09f0985cb21e959f21f2464169eca882656849adf727ac7bb7e1767/jaraco_functools-4.4.0-py3-none-any.whl", hash = "sha256:9eec1e36f45c818d9bf307c8948eb03b2b56cd44087b3cdc989abca1f20b9176", size = 10481, upload-time = "2025-12-21T09:29:42.27Z" },
+]
+
+[[package]]
 name = "jedi"
 version = "0.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1260,6 +1401,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/72/3a/79a912fbd4d8dd6fbb02bf69afd3bb72cf0c729bb3063c6f4498603db17a/jedi-0.19.2.tar.gz", hash = "sha256:4770dc3de41bde3966b02eb84fbcf557fb33cce26ad23da12c742fb50ecb11f0", size = 1231287, upload-time = "2024-11-11T01:41:42.873Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c0/5a/9cac0c82afec3d09ccd97c8b6502d48f165f9124db81b4bcb90b4af974ee/jedi-0.19.2-py2.py3-none-any.whl", hash = "sha256:a8ef22bde8490f57fe5c7681a3c83cb58874daf72b4784de3cce5b6ef6edb5b9", size = 1572278, upload-time = "2024-11-11T01:41:40.175Z" },
+]
+
+[[package]]
+name = "jeepney"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
 ]
 
 [[package]]
@@ -1348,6 +1498,26 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/90/51/9187be60d989df97f5f0aba133fa54e7300f17616e065d1ada7d7646b6d6/jupyterlab_pygments-0.3.0.tar.gz", hash = "sha256:721aca4d9029252b11cfa9d185e5b5af4d54772bb8072f9b7036f4170054d35d", size = 512900, upload-time = "2023-11-23T09:26:37.44Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b1/dd/ead9d8ea85bf202d90cc513b533f9c363121c7792674f78e0d8a854b63b4/jupyterlab_pygments-0.3.0-py3-none-any.whl", hash = "sha256:841a89020971da1d8693f1a99997aefc5dc424bb1b251fd6322462a1b8842780", size = 15884, upload-time = "2023-11-23T09:26:34.325Z" },
+]
+
+[[package]]
+name = "keyring"
+version = "25.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata", marker = "python_full_version < '3.12'" },
+    { name = "jaraco-classes" },
+    { name = "jaraco-context", version = "6.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "jaraco-context", version = "6.1.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "jaraco-functools" },
+    { name = "jeepney", marker = "sys_platform == 'linux'" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "secretstorage", version = "3.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' and sys_platform == 'linux'" },
+    { name = "secretstorage", version = "3.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160, upload-time = "2025-11-16T16:26:08.402Z" },
 ]
 
 [[package]]
@@ -1567,6 +1737,32 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c4/79/bda47f7dd7c3c55770478d6d02c9960c430b0cf1773b72366ff89126ea31/mistune-3.1.3.tar.gz", hash = "sha256:a7035c21782b2becb6be62f8f25d3df81ccb4d6fa477a6525b15af06539f02a0", size = 94347, upload-time = "2025-03-19T14:27:24.955Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/01/4d/23c4e4f09da849e127e9f123241946c23c1e30f45a88366879e064211815/mistune-3.1.3-py3-none-any.whl", hash = "sha256:1a32314113cff28aa6432e99e522677c8587fd83e3d51c29b82a52409c842bd9", size = 53410, upload-time = "2025-03-19T14:27:23.451Z" },
+]
+
+[[package]]
+name = "more-itertools"
+version = "10.8.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ea/5d/38b681d3fce7a266dd9ab73c66959406d565b3e85f21d5e66e1181d93721/more_itertools-10.8.0.tar.gz", hash = "sha256:f638ddf8a1a0d134181275fb5d58b086ead7c6a72429ad725c67503f13ba30bd", size = 137431, upload-time = "2025-09-02T15:23:11.018Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl", hash = "sha256:52d4362373dcf7c52546bc4af9a86ee7c4579df9a8dc268be0a2f949d376cc9b", size = 69667, upload-time = "2025-09-02T15:23:09.635Z" },
+]
+
+[[package]]
+name = "more-itertools"
+version = "11.0.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13'",
+    "python_full_version >= '3.11' and python_full_version < '3.13'",
+    "python_full_version == '3.10.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a2/f7/139d22fef48ac78127d18e01d80cf1be40236ae489769d17f35c3d425293/more_itertools-11.0.2.tar.gz", hash = "sha256:392a9e1e362cbc106a2457d37cabf9b36e5e12efd4ebff1654630e76597df804", size = 144659, upload-time = "2026-04-09T15:01:33.297Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/98/6af411189d9413534c3eb691182bff1f5c6d44ed2f93f2edfe52a1bbceb8/more_itertools-11.0.2-py3-none-any.whl", hash = "sha256:6e35b35f818b01f691643c6c611bc0902f2e92b46c18fffa77ae1e7c46e912e4", size = 71939, upload-time = "2026-04-09T15:01:32.21Z" },
 ]
 
 [[package]]
@@ -2786,6 +2982,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3234,6 +3439,40 @@ wheels = [
 ]
 
 [[package]]
+name = "secretstorage"
+version = "3.3.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+dependencies = [
+    { name = "cryptography", marker = "python_full_version < '3.10'" },
+    { name = "jeepney", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/a4/f48c9d79cb507ed1373477dbceaba7401fd8a23af63b837fa61f1dcd3691/SecretStorage-3.3.3.tar.gz", hash = "sha256:2403533ef369eca6d2ba81718576c5e0f564d5cca1b58f73a8b23e7d4eeebd77", size = 19739, upload-time = "2022-08-13T16:22:46.976Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/24/b4293291fa1dd830f353d2cb163295742fa87f179fcc8a20a306a81978b7/SecretStorage-3.3.3-py3-none-any.whl", hash = "sha256:f356e6628222568e3af06f2eba8df495efa13b3b63081dafd4f7d9a7b7bc9f99", size = 15221, upload-time = "2022-08-13T16:22:44.457Z" },
+]
+
+[[package]]
+name = "secretstorage"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13'",
+    "python_full_version >= '3.11' and python_full_version < '3.13'",
+    "python_full_version == '3.10.*'",
+]
+dependencies = [
+    { name = "cryptography", marker = "python_full_version >= '3.10'" },
+    { name = "jeepney", marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
+]
+
+[[package]]
 name = "setuptools"
 version = "80.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3407,6 +3646,7 @@ dependencies = [
     { name = "huggingface-hub" },
     { name = "inquirerpy" },
     { name = "jinja2" },
+    { name = "keyring" },
     { name = "libcst" },
     { name = "loguru" },
     { name = "packaging" },
@@ -3479,6 +3719,7 @@ requires-dist = [
     { name = "huggingface-hub", specifier = ">=0.25.0" },
     { name = "inquirerpy", specifier = ">=0.3.4,<0.4" },
     { name = "jinja2", specifier = ">=3.1.2,<4" },
+    { name = "keyring", specifier = ">=25,<26" },
     { name = "libcst", specifier = ">=1.1.2" },
     { name = "loguru", specifier = ">=0.7.2" },
     { name = "packaging", specifier = ">=20.9" },


### PR DESCRIPTION
## :rocket: What

- Adds OAuth 2.0 device-flow login to truss as an alternative to API keys. Care was taken not to overly disturb existing auth paths.
- New commands: `truss auth login [--browser | --api-key K] [--remote N]`, `truss auth logout [--remote N]`, `truss auth status [--remote N]`. `truss login` is preserved as an alias and gains `--browser` and `--remote`.
- Secrets (api_key OR oauth tokens) are stored in the OS keyring under service `baseten-truss`. Falls back to inline trussrc with a one-line warning when no usable backend exists. `BASETEN_TRUSS_AUTH_KEYRING_DISABLED=1` forces the inline path silently.
- OAuth access tokens are refreshed proactively (60s leeway) before each request and persisted back to the keyring/trussrc on refresh.
- `--remote N` on `truss login` lets users create/update a non-default remote (previously `truss login` always wrote to a remote literally named `baseten`).
- Existing plaintext `[remote] api_key = ...` configs continue to work unchanged. No auto-migration.

### Warnings

⚠️ macOS users may see a one-time Keychain prompt the first time truss writes/reads the keyring entry; clicking "Always Allow" makes subsequent calls silent (until the Python interpreter is upgraded).

⚠️ This adds a new `keyring` dependency for all Truss library users. This should be mostly harmless unless it has transitive version constraint conflicts with other uses of this library. This was decided to be the best approach over using an optional "extra" and making everyone change their install to `pip install truss[cli]`.

## :computer: How

- New `truss/remote/baseten/oauth.py`: RFC 8628 device flow primitives (`request_device_authorization`, `poll_device_token`, `refresh`, `revoke`) targeting `/v1/users/auth/device/authorize|token` and `/v1/users/auth/logout` with `client_id=baseten-cli` (reuses the existing allowlisted client).
- Auth endpoints hit the REST API host (`api.baseten.co`), resolved from the `app.*` `remote_url` via a new `resolve_rest_api_url` helper in `api.py` - same mapping the rest of truss already uses for REST calls. Callers translate before invoking `oauth.*`; the oauth module takes `api_url` directly.
- `AuthService` (`auth.py`) gets a second creation mode for OAuth (`api_url`, `oauth_credential`, `on_token_refresh`); `auth_header()` returns a fresh header per request, refreshing in-place when within leeway. `RestAPIClient` / `BasetenApi` / `BasetenService` consume a `header_provider` callable rather than caching a key.
- `BasetenRemote` exposes a public `auth_header()` and persists refreshed credentials back through `RemoteFactory.update_remote_config`.
- Keyring offload helpers in `remote_factory.py` round-trip secret keys based on `auth_type` (`_INLINE_SECRET_KEYS_BY_AUTH_TYPE`); `remove_remote_config` clears keyring + trussrc for `truss auth logout`.
- `inquire_remote_config` (used on lazy add-remote from `push`/`predict` etc.) now offers an api-key vs. browser select, so any code path that lazily creates a remote gets OAuth for free.
- Minor: the device-flow prompt no longer auto-opens a browser (matches baseten-cli; avoids `xdg-open` stderr noise in headless Linux/SSH/dev-container envs); the success message follows the existing `👋 Logged out` pattern with `🔓 Logged in to remote ...`.

## :microscope: Testing

Many new unit tests and manual end to end testing