### PR TITLE
Add CustomEngineBuilderLLMChainlet

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "truss"
-version = "0.16.2"
+version = "0.16.3rc002"
 description = "A seamless bridge from model development to model delivery"
 authors = [
     { name = "Pankaj Gupta", email = "no-reply@baseten.co" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "truss"
-version = "0.16.3rc002"
+version = "0.16.3rc003"
 description = "A seamless bridge from model development to model delivery"
 authors = [
     { name = "Pankaj Gupta", email = "no-reply@baseten.co" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "truss"
-version = "0.16.3rc003"
+version = "0.16.3rc004"
 description = "A seamless bridge from model development to model delivery"
 authors = [
     { name = "Pankaj Gupta", email = "no-reply@baseten.co" },

--- a/truss-chains/tests/test_framework.py
+++ b/truss-chains/tests/test_framework.py
@@ -10,7 +10,9 @@ import pytest
 
 import truss_chains as chains
 from truss.base import trt_llm_config, truss_config
-from truss_chains import framework, public_api, public_types, utils
+from truss_chains import framework, private_types, public_api, public_types, utils
+from truss_chains.deployment import code_gen
+from truss_chains.remote_chainlet import model_skeleton
 
 utils.setup_dev_logging(logging.DEBUG)
 
@@ -918,6 +920,147 @@ def test_custom_engine_builder_can_depend_on_other_chainlets():
                 self, llm_input: chains.EngineBuilderLLMInput
             ) -> AsyncIterator[str]:
                 yield await self._helper.run_remote()
+
+
+# Generated `load()` for the custom variant must wire `trt_llm` onto the chainlet,
+# and the wrapper at runtime must propagate it so `run_remote` can use the engine.
+########################################################################################
+
+
+class _FakeLazyDataResolver:
+    """Mimics the subset of LazyDataResolverV2 that ``TrussChainletModel.__init__``
+    invokes (just `block_until_download_complete`)."""
+
+    def block_until_download_complete(self) -> None:
+        return None
+
+
+def _new_truss_chainlet_model(
+    chainlet_cls: type, trt_llm: object
+) -> model_skeleton.TrussChainletModel:
+    """Construct a `TrussChainletModel` plumbed exactly like the deployed wrapper.
+
+    The chains-generated `model.py` calls `TrussChainletModel.__init__(...)`
+    with a `trt_llm` kwarg when the truss server has populated it. We replicate
+    that here without firing up the full code-gen pipeline."""
+    truss_metadata = private_types.TrussMetadata(chainlet_to_service={}).model_dump()
+    config = {"model_metadata": {private_types.TRUSS_CONFIG_CHAINS_KEY: truss_metadata}}
+    instance = model_skeleton.TrussChainletModel(
+        config=config,
+        data_dir=pathlib.Path("/tmp"),
+        secrets={},  # type: ignore[arg-type] -- behaves like a dict mapping for tests
+        lazy_data_resolver=_FakeLazyDataResolver(),  # type: ignore[arg-type]
+        environment=None,
+        trt_llm=trt_llm,
+    )
+    # Mirror what `_gen_load_src` emits for a custom engine-builder chainlet:
+    # build the user chainlet, then graft `trt_llm` onto it.
+    instance._chainlet = chainlet_cls()
+    if framework.is_custom_engine_builder_chainlet(chainlet_cls):
+        instance._chainlet.trt_llm = instance._trt_llm
+    return instance
+
+
+def test_gen_load_src_injects_trt_llm_for_custom_variant():
+    """Codegen must emit `self._chainlet.trt_llm = self._trt_llm` for the
+    custom variant so user `run_remote` can reach the engine, and must NOT
+    emit it for plain chainlets (where there is no `_trt_llm` to forward)."""
+    with _raise_errors():
+
+        class CustomLLMLoadSrc(chains.CustomEngineBuilderLLMChainlet):
+            remote_config = chains.RemoteConfig(
+                compute=chains.Compute(gpu=truss_config.Accelerator.H100),
+                assets=chains.Assets(secret_keys=["hf_access_token"]),
+            )
+            engine_builder_config = _make_trtllm_config()
+
+            async def run_remote(
+                self, llm_input: chains.EngineBuilderLLMInput
+            ) -> AsyncIterator[str]:
+                yield "ok"
+
+        class PlainChainlet(chains.ChainletBase):
+            async def run_remote(self) -> str:
+                return "plain"
+
+        custom_descr = framework._global_chainlet_registry.get_descriptor(
+            CustomLLMLoadSrc
+        )
+        plain_descr = framework._global_chainlet_registry.get_descriptor(PlainChainlet)
+
+        custom_load = code_gen._gen_load_src(custom_descr).src
+        plain_load = code_gen._gen_load_src(plain_descr).src
+
+        assert "self._chainlet.trt_llm = self._trt_llm" in custom_load
+        assert "self._chainlet.trt_llm = self._trt_llm" not in plain_load
+
+
+def test_run_remote_can_access_trt_llm_engine_via_wrapper():
+    """End-to-end-ish: a fake `trt_llm` injected into the model wrapper must
+    reach the chainlet's `run_remote` as `self.trt_llm["engine"]`. Exercises
+    the model_skeleton + the wiring `_gen_load_src` is responsible for."""
+
+    engine_calls: list[dict] = []
+
+    class _FakeBritonEngine:
+        async def completions(self, *, request, model_input):
+            engine_calls.append({"request": request, "model_input": model_input})
+            return f"hello {model_input['prompt']}"
+
+    fake_trt_llm = {"engine": _FakeBritonEngine()}
+
+    with _raise_errors():
+
+        class EngineUsingChainlet(chains.CustomEngineBuilderLLMChainlet):
+            remote_config = chains.RemoteConfig(
+                compute=chains.Compute(gpu=truss_config.Accelerator.H100),
+                assets=chains.Assets(secret_keys=["hf_access_token"]),
+            )
+            engine_builder_config = _make_trtllm_config()
+
+            async def run_remote(
+                self, llm_input: chains.EngineBuilderLLMInput
+            ) -> AsyncIterator[str]:
+                # The whole point of the custom variant: read self.trt_llm.
+                engine = self.trt_llm["engine"]
+                result = await engine.completions(
+                    request=None, model_input={"prompt": llm_input.prompt}
+                )
+                yield result
+
+        wrapper = _new_truss_chainlet_model(EngineUsingChainlet, fake_trt_llm)
+
+        # Wrapper-level plumbing: __init__ stashes the kwarg and load propagates it.
+        assert wrapper._trt_llm is fake_trt_llm
+        assert wrapper._chainlet.trt_llm is fake_trt_llm
+
+        async def _drive():
+            chunks: list[str] = []
+            async for chunk in wrapper._chainlet.run_remote(
+                public_types.EngineBuilderLLMInput(prompt="world")
+            ):
+                chunks.append(chunk)
+            return chunks
+
+        chunks = asyncio.run(_drive())
+        assert chunks == ["hello world"]
+        assert engine_calls == [{"request": None, "model_input": {"prompt": "world"}}]
+
+
+def test_run_remote_trt_llm_is_none_for_plain_chainlet_wrapper():
+    """When the truss server does not pass `trt_llm` (regular chainlet path),
+    the wrapper must not blow up: `_trt_llm` defaults to `None` and the user
+    chainlet is unaffected."""
+    with _raise_errors():
+
+        class PlainNoTrtLLM(chains.ChainletBase):
+            async def run_remote(self) -> str:
+                return "ok"
+
+        wrapper = _new_truss_chainlet_model(PlainNoTrtLLM, trt_llm=None)
+        assert wrapper._trt_llm is None
+        # The plain chainlet must not have had `trt_llm` grafted on by load().
+        assert not hasattr(wrapper._chainlet, "trt_llm")
 
 
 def test_raises_invalid_display_name():

--- a/truss-chains/tests/test_framework.py
+++ b/truss-chains/tests/test_framework.py
@@ -9,7 +9,7 @@ import pydantic
 import pytest
 
 import truss_chains as chains
-from truss.base import truss_config
+from truss.base import trt_llm_config, truss_config
 from truss_chains import framework, public_api, public_types, utils
 
 utils.setup_dev_logging(logging.DEBUG)
@@ -793,6 +793,131 @@ def test_raises_engine_builder_validation():
                 assets=chains.Assets(secret_keys=["hf_access_token"]),
             )
             engine_builder_config = 123
+
+
+def _make_trtllm_config() -> trt_llm_config.TRTLLMConfiguration:
+    return trt_llm_config.TRTLLMConfiguration(
+        build=trt_llm_config.TrussTRTLLMBuildConfiguration(
+            base_model="decoder",
+            max_seq_len=2048,
+            max_batch_size=8,
+            checkpoint_repository={"source": "HF", "repo": "meta-llama/Llama-2-7b"},
+        ),
+        runtime=trt_llm_config.TrussTRTLLMRuntimeConfiguration(),
+    )
+
+
+def test_custom_engine_builder_registers_and_allows_run_remote_override():
+    """The custom variant has no `@final` run_remote, so user overrides must work,
+    and the framework config should mark it as engine-builder with dependency
+    support enabled."""
+    with _raise_errors():
+
+        class CustomLLM(chains.CustomEngineBuilderLLMChainlet):
+            remote_config = chains.RemoteConfig(
+                compute=chains.Compute(gpu=truss_config.Accelerator.H100),
+                assets=chains.Assets(secret_keys=["hf_access_token"]),
+            )
+            engine_builder_config = _make_trtllm_config()
+
+            async def run_remote(
+                self, llm_input: chains.EngineBuilderLLMInput
+            ) -> AsyncIterator[str]:
+                yield "hello"
+
+        assert framework.is_engine_builder_chainlet(CustomLLM)
+        assert framework.is_custom_engine_builder_chainlet(CustomLLM)
+        assert CustomLLM._framework_config.supports_dependencies is True
+        # Regular engine-builder chainlets must *not* be treated as the custom
+        # variant.
+        assert not framework.is_custom_engine_builder_chainlet(
+            chains.EngineBuilderLLMChainlet
+        )
+
+
+def test_custom_engine_builder_allows_relaxed_remote_config():
+    """The strict field restrictions for briton-only engine builders do not apply
+    to the custom variant, which runs real user code and may need e.g. custom
+    health checks. Concretely: `options.health_checks` would be rejected on the
+    briton-only variant, but must be accepted here."""
+    with _raise_errors():
+
+        class CustomLLMRelaxed(chains.CustomEngineBuilderLLMChainlet):
+            remote_config = chains.RemoteConfig(
+                compute=chains.Compute(gpu=truss_config.Accelerator.H100),
+                assets=chains.Assets(secret_keys=["hf_access_token"]),
+                options=chains.ChainletOptions(
+                    health_checks=truss_config.HealthChecks(
+                        restart_threshold_seconds=60
+                    )
+                ),
+            )
+            engine_builder_config = _make_trtllm_config()
+
+            async def run_remote(
+                self, llm_input: chains.EngineBuilderLLMInput
+            ) -> AsyncIterator[str]:
+                yield "ok"
+
+
+def test_custom_engine_builder_rejects_inference_stack_v2():
+    """The image-builder's v2 path replaces `model.py` with a briton docker
+    server, so custom Python would silently never run. We surface that as an
+    explicit validation error."""
+    match = (
+        rf"{TEST_FILE}:\d+ \(CustomLLMv2\) \[kind: INVALID_CONFIG_ERROR\].*"
+        r"CustomEngineBuilderLLMChainlet only supports TRT-LLM `inference_stack='v1'`"
+    )
+    with pytest.raises(public_types.ChainsUsageError, match=match), _raise_errors():
+
+        class CustomLLMv2(chains.CustomEngineBuilderLLMChainlet):
+            remote_config = chains.RemoteConfig(
+                compute=chains.Compute(gpu=truss_config.Accelerator.H100),
+                assets=chains.Assets(secret_keys=["hf_access_token"]),
+            )
+            engine_builder_config = trt_llm_config.TRTLLMConfiguration(
+                build=trt_llm_config.TrussTRTLLMBuildConfiguration(
+                    checkpoint_repository={
+                        "source": "HF",
+                        "repo": "meta-llama/Llama-2-7b",
+                    }
+                ),
+                runtime=trt_llm_config.TRTLLMRuntimeConfigurationV2(
+                    max_seq_len=2048, max_batch_size=8
+                ),
+                inference_stack="v2",
+            )
+
+            async def run_remote(
+                self, llm_input: chains.EngineBuilderLLMInput
+            ) -> AsyncIterator[str]:
+                yield "nope"
+
+
+def test_custom_engine_builder_can_depend_on_other_chainlets():
+    """Unlike the briton-only variant, the custom engine-builder chainlet may
+    declare `chains.depends(...)` on peer chainlets so it can orchestrate
+    additional calls from inside the briton handler."""
+    with _raise_errors():
+
+        class Helper(chains.ChainletBase):
+            async def run_remote(self) -> str:
+                return "helper"
+
+        class CustomLLMWithDeps(chains.CustomEngineBuilderLLMChainlet):
+            remote_config = chains.RemoteConfig(
+                compute=chains.Compute(gpu=truss_config.Accelerator.H100),
+                assets=chains.Assets(secret_keys=["hf_access_token"]),
+            )
+            engine_builder_config = _make_trtllm_config()
+
+            def __init__(self, helper=chains.depends(Helper)):
+                self._helper = helper
+
+            async def run_remote(
+                self, llm_input: chains.EngineBuilderLLMInput
+            ) -> AsyncIterator[str]:
+                yield await self._helper.run_remote()
 
 
 def test_raises_invalid_display_name():

--- a/truss-chains/truss_chains/__init__.py
+++ b/truss-chains/truss_chains/__init__.py
@@ -1,5 +1,10 @@
 from truss.base.truss_config import WeightsSource
-from truss_chains.framework import ChainletBase, EngineBuilderLLMChainlet, ModelBase
+from truss_chains.framework import (
+    ChainletBase,
+    CustomEngineBuilderLLMChainlet,
+    EngineBuilderLLMChainlet,
+    ModelBase,
+)
 from truss_chains.public_api import (
     depends,
     depends_context,
@@ -32,6 +37,7 @@ from truss_chains.utils import make_abs_path_here
 __all__ = [
     "Assets",
     "BasetenImage",
+    "CustomEngineBuilderLLMChainlet",
     "EngineBuilderLLMChainlet",
     "ChainletBase",
     "ChainletOptions",

--- a/truss-chains/truss_chains/deployment/code_gen.py
+++ b/truss-chains/truss_chains/deployment/code_gen.py
@@ -990,7 +990,15 @@ def gen_truss_chainlet(
     config.write_to_yaml_file(
         chainlet_dir / serving_image_builder.CONFIG_FILE, verbose=True
     )
-    if engine_builder_config:
+    # Briton-only engine-builder chainlets emit a pure-briton truss with no
+    # user ``model.py`` and no bundled packages. The custom variant ships real
+    # user code, so it must fall through to ``_gen_truss_chainlet_file`` and
+    # the ``copy_tree_path`` below; the chains-generated ``TrussChainletModel``
+    # is what receives ``trt_llm`` injection from the truss server and routes
+    # requests to ``run_remote``.
+    if engine_builder_config and not framework.is_custom_engine_builder_chainlet(
+        chainlet_descriptor.chainlet_cls
+    ):
         return chainlet_dir
 
     # This assumes all imports are absolute w.r.t chain root (or site-packages).

--- a/truss-chains/truss_chains/deployment/code_gen.py
+++ b/truss-chains/truss_chains/deployment/code_gen.py
@@ -465,12 +465,17 @@ def _gen_load_src(chainlet_descriptor: private_types.ChainletAPIDescriptor) -> _
 
     user_chainlet_ref = _gen_chainlet_import_and_ref(chainlet_descriptor)
     imports.update(user_chainlet_ref.imports)
-    body = _indent(
-        "\n".join(
-            [f"logging.info(f'Loading Chainlet `{chainlet_descriptor.name}`.')"]
-            + [f"self._chainlet = {user_chainlet_ref.src}({init_args})"]
-        )
-    )
+    body_lines = [
+        f"logging.info(f'Loading Chainlet `{chainlet_descriptor.name}`.')",
+        f"self._chainlet = {user_chainlet_ref.src}({init_args})",
+    ]
+    # Custom engine-builder chainlets get the briton ``trt_llm`` dict injected
+    # onto the chainlet instance so user code can access ``self.trt_llm`` in
+    # ``run_remote``. Regular chainlets leave ``_trt_llm`` as ``None`` and this
+    # assignment is skipped.
+    if framework.is_custom_engine_builder_chainlet(chainlet_descriptor.chainlet_cls):
+        body_lines.append("self._chainlet.trt_llm = self._trt_llm")
+    body = _indent("\n".join(body_lines))
     src = "\n".join(["def load(self) -> None:", body])
     return _Source(src=src, imports=imports)
 
@@ -867,8 +872,20 @@ def _gen_truss_config(
 
     if issubclass(chainlet_descriptor.chainlet_cls, framework.EngineBuilderChainlet):
         config.trt_llm = chainlet_descriptor.chainlet_cls.engine_builder_config
-        truss_config.TrussConfig.model_validate(config)
-        return config
+        # Enables BDN weight mirroring for engine builder checkpoints.
+        if assets.weights:
+            config.weights = truss_config.Weights(assets.weights)
+        # Pure (non-custom) engine-builder chainlets produce a briton-only
+        # truss; no user ``model.py`` is generated and the rest of this
+        # function (requirements / image / model-class wiring) is skipped.
+        # Custom engine-builder chainlets fall through so they emit both the
+        # TRT-LLM config *and* the chain-generated ``model.py`` that receives
+        # ``trt_llm`` injection from the truss server.
+        if not framework.is_custom_engine_builder_chainlet(
+            chainlet_descriptor.chainlet_cls
+        ):
+            truss_config.TrussConfig.model_validate(config)
+            return config
 
     config.model_class_filename = _MODEL_FILENAME
     config.model_class_name = _MODEL_CLS_NAME

--- a/truss-chains/truss_chains/deployment/code_gen.py
+++ b/truss-chains/truss_chains/deployment/code_gen.py
@@ -858,6 +858,7 @@ def _gen_truss_config(
     config.runtime.streaming_read_timeout = remote_config.options.streaming_read_timeout
     config.model_metadata = cast(dict[str, Any], remote_config.options.metadata) or {}
     config.environment_variables = dict(remote_config.options.env_variables)
+    config.build_commands = list(remote_config.build_commands)
 
     if remote_config.docker_image.truss_server_version_override:
         config.runtime.truss_server_version_override = (

--- a/truss-chains/truss_chains/framework.py
+++ b/truss-chains/truss_chains/framework.py
@@ -876,6 +876,32 @@ def _validate_engine_builder_fields(
         )
 
 
+def _validate_custom_engine_builder_config(
+    cls: Type[private_types.ABCChainlet], location: _ErrorLocation
+) -> None:
+    """Additional sanity checks for `CustomEngineBuilderLLMChainlet` subclasses.
+
+    The image-builder path for TRT-LLM ``inference_stack="v2"`` unconditionally
+    replaces the user's ``model.py`` with briton as a docker_server, which would
+    silently drop the custom Python code. Surface this as an explicit error
+    instead of debugging a no-op at runtime.
+    """
+    engine_cfg = getattr(cls, private_types.ENGINE_BUILDER_CONFIG_NAME, None)
+    if not isinstance(engine_cfg, trt_llm_config.TRTLLMConfiguration):
+        # Type errors are already reported by `_validate_config_class_variable`.
+        return
+    if engine_cfg.inference_stack == "v2":
+        _collect_error(
+            "CustomEngineBuilderLLMChainlet only supports TRT-LLM "
+            "`inference_stack='v1'` today; the v2 image builder replaces the "
+            "user `model.py` with a briton docker_server, so custom Python "
+            "would never run. Use a v1 engine_builder_config or switch to "
+            "`EngineBuilderLLMChainlet` (briton-only).",
+            _ErrorKind.INVALID_CONFIG_ERROR,
+            location,
+        )
+
+
 def _validate_health_check(
     cls: Type[private_types.ABCChainlet], location: _ErrorLocation
 ) -> Optional[private_types.HealthCheckAPIDescriptor]:
@@ -974,6 +1000,7 @@ def validate_and_register_cls(cls: Type[private_types.ABCChainlet]) -> None:
         "ModelBase",
         "EngineBuilderChainlet",
         "EngineBuilderLLMChainlet",
+        "CustomEngineBuilderLLMChainlet",
     ]
     if cls.__name__ in _skip_class_name:
         logging.debug(f"Skipping chainlet class validation for `{cls}`.")
@@ -994,7 +1021,14 @@ def validate_and_register_cls(cls: Type[private_types.ABCChainlet]) -> None:
             private_types.ENGINE_BUILDER_CONFIG_NAME,
             trt_llm_config.TRTLLMConfiguration,
         )
-        _validate_engine_builder_fields(cls.remote_config, location)
+        # The custom variant ships real user code, so the strict "everything
+        # in remote_config must be unset" rule of the briton-only variant
+        # doesn't apply: users may need docker_image (for extra pip deps),
+        # cached assets, health checks, etc.
+        if not is_custom_engine_builder_chainlet(cls):
+            _validate_engine_builder_fields(cls.remote_config, location)
+        else:
+            _validate_custom_engine_builder_config(cls, location)
 
     init_validator = _ChainletInitValidator(cls, location)
     chainlet_descriptor = private_types.ChainletAPIDescriptor(
@@ -1672,12 +1706,49 @@ class EngineBuilderChainlet(private_types.ABCChainlet, metaclass=abc.ABCMeta):
 
     def __init_subclass__(cls, **kwargs) -> None:
         super().__init_subclass__(**kwargs)
+        # Custom engine-builder chainlets run real user Python in front of
+        # briton, so they may call out to other chainlets. The briton-only
+        # variant does not support dependencies. Since this runs while
+        # ``CustomEngineBuilderLLMChainlet`` itself is being defined we probe
+        # by class-name to avoid a forward-reference ``NameError``.
+        supports_dependencies = any(
+            base.__name__ == "CustomEngineBuilderLLMChainlet" for base in cls.__mro__
+        )
         cls._framework_config = private_types.FrameworkConfig(
             entity_type=private_types.EntityType.ENGINE_BUILDER_MODEL,
-            supports_dependencies=False,
+            supports_dependencies=supports_dependencies,
             endpoint_method_name=private_types.RUN_REMOTE_METHOD_NAME,
         )
         validate_and_register_cls(cls)
+
+
+class CustomEngineBuilderLLMChainlet(EngineBuilderChainlet, metaclass=abc.ABCMeta):
+    """An engine-builder chainlet that runs user-defined Python in front of briton.
+
+    Unlike :class:`EngineBuilderLLMChainlet`, which produces a pure-briton truss,
+    this variant emits a truss with **both** ``config.trt_llm`` (so briton is
+    built into the container) **and** a generated ``model.py`` that instantiates
+    the user's chainlet class. The briton engine object is exposed to the
+    chainlet via the :attr:`trt_llm` instance attribute *before* ``run_remote``
+    is invoked, mirroring the standalone custom engine builder pattern:
+    https://docs.baseten.co/engines/engine-builder-llm/custom-engine-builder
+
+    Subclasses override ``run_remote`` to implement business logic, fan-out,
+    custom routing, etc., and may call briton in-process via::
+
+        await self.trt_llm["engine"].chat_completions(
+            request=request, model_input=payload
+        )
+
+    Subclasses may also declare dependencies on other chainlets, e.g. to
+    orchestrate additional models inside the custom engine-builder handler.
+    """
+
+    engine_builder_config: ClassVar[trt_llm_config.TRTLLMConfiguration]
+    # Populated by the generated ``model.py`` wrapper at load time, before any
+    # request is served. Typed as ``Any`` because the concrete briton object is
+    # only importable at runtime inside the deployed image.
+    trt_llm: Any = None
 
 
 class EngineBuilderLLMChainlet(EngineBuilderChainlet, metaclass=abc.ABCMeta):
@@ -1691,3 +1762,7 @@ class EngineBuilderLLMChainlet(EngineBuilderChainlet, metaclass=abc.ABCMeta):
 
 def is_engine_builder_chainlet(cls: Type[private_types.ABCChainlet]):
     return issubclass(cls, EngineBuilderChainlet)
+
+
+def is_custom_engine_builder_chainlet(cls: Type[private_types.ABCChainlet]):
+    return issubclass(cls, CustomEngineBuilderLLMChainlet)

--- a/truss-chains/truss_chains/public_types.py
+++ b/truss-chains/truss_chains/public_types.py
@@ -492,6 +492,11 @@ class RemoteConfig(custom_types.SafeModelNonSerializable):
     assets: Assets = Assets()
     name: Optional[str] = None
     options: ChainletOptions = ChainletOptions()
+    build_commands: list[str] = pydantic.Field(
+        default_factory=list,
+        description="Shell commands run during the Docker image build, after system "
+        "packages and before chain code (same as Truss `config.yaml` `build_commands`).",
+    )
 
     def get_compute_spec(self) -> ComputeSpec:
         return self.compute.get_spec()

--- a/truss-chains/truss_chains/remote_chainlet/model_skeleton.py
+++ b/truss-chains/truss_chains/remote_chainlet/model_skeleton.py
@@ -1,5 +1,5 @@
 import pathlib
-from typing import Optional
+from typing import Any, Optional
 
 from truss.templates.shared import lazy_data_resolver, secrets_resolver
 from truss_chains import private_types, public_types
@@ -9,6 +9,11 @@ from truss_chains.remote_chainlet import utils
 class TrussChainletModel:
     _context: public_types.DeploymentContext
     _chainlet: private_types.ABCChainlet
+    # Populated only for chainlets derived from ``CustomEngineBuilderLLMChainlet``;
+    # ``None`` for regular chainlets. The value is the ``trt_llm`` dict the truss
+    # server injects when ``config.trt_llm`` is set and the model class declares a
+    # ``trt_llm`` kwarg (see ``truss/trt_llm/validation.py``).
+    _trt_llm: Optional[Any]
 
     def __init__(
         self,
@@ -18,6 +23,10 @@ class TrussChainletModel:
         lazy_data_resolver: lazy_data_resolver.LazyDataResolverV2,
         # TODO: Remove the default value once all truss versions are synced up.
         environment: Optional[dict] = None,
+        # Optional — only supplied by the truss server when the chainlet was
+        # generated from a ``CustomEngineBuilderLLMChainlet`` (i.e. the truss
+        # config has ``trt_llm`` set and the model-class declares this kwarg).
+        trt_llm: Optional[Any] = None,
     ) -> None:
         truss_metadata: private_types.TrussMetadata = (
             private_types.TrussMetadata.model_validate(
@@ -39,6 +48,7 @@ class TrussChainletModel:
             data_dir=data_dir,
             environment=deployment_environment,
         )
+        self._trt_llm = trt_llm
         lazy_data_resolver.block_until_download_complete()
 
     # Below illustrated code will be added by code generation.

--- a/truss/tests/trt_llm/test_validation.py
+++ b/truss/tests/trt_llm/test_validation.py
@@ -62,6 +62,41 @@ class Model:
             "foo",
             False,
         ),
+        # Class with class-level annotated assignments before __init__ (mirrors
+        # the chains-generated ``TrussChainletModel``). Should not crash on
+        # accessing ``.name`` of an ``ast.AnnAssign`` node.
+        (
+            """
+from typing import Any, Optional
+
+
+class TrussChainletModel:
+    _context: Any
+    _chainlet: Any
+    _trt_llm: Optional[Any]
+
+    def __init__(self, config, trt_llm=None):
+        pass
+            """,
+            "TrussChainletModel",
+            "trt_llm",
+            False,
+        ),
+        # Same shape, but missing the ``trt_llm`` arg -- should raise the
+        # normal "missing arg" ValidationError, not an AttributeError.
+        (
+            """
+class TrussChainletModel:
+    _context: object
+    _chainlet: object
+
+    def __init__(self, config):
+        pass
+            """,
+            "TrussChainletModel",
+            "trt_llm",
+            True,
+        ),
     ],
 )
 def test_has_class_init_arg(src, expected_arg, class_name, expected_to_raise):

--- a/truss/trt_llm/validation.py
+++ b/truss/trt_llm/validation.py
@@ -21,10 +21,17 @@ def _verify_has_class_init_arg(source: str, class_name: str, arg_name: str):
     for node in tree.body:
         if isinstance(node, ast.ClassDef) and node.name == class_name:
             for child in node.body:
-                if child.name == "__init__":  # type: ignore[attr-defined]
+                # The class body can contain class-level annotated assignments
+                # (``ast.AnnAssign``), docstrings, etc. Only ``FunctionDef`` /
+                # ``AsyncFunctionDef`` carry a ``.name``; skip everything else
+                # so we don't trip on e.g. ``_chainlet: ABCChainlet`` declared
+                # in the chains-generated ``TrussChainletModel``.
+                if not isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    continue
+                if child.name == "__init__":
                     model_class_init_found = True
                     arg_found = False
-                    for arg in child.args.args:  # type: ignore[attr-defined]
+                    for arg in child.args.args:
                         if arg.arg == arg_name:
                             arg_found = True
                     if not arg_found:


### PR DESCRIPTION
## Summary

Introduces `CustomEngineBuilderLLMChainlet`, a new chains base class that combines the engine-builder TRT-LLM container with user-defined Python in front of briton — bridging the gap between the briton-only `EngineBuilderLLMChainlet` and standalone custom-engine-builder trusses (https://docs.baseten.co/engines/engine-builder-llm/custom-engine-builder).

- **New chainlet base class** (`truss_chains/framework.py`, exposed via `truss_chains.__init__`): subclasses set `engine_builder_config`, override `run_remote`, and access the briton engine through `self.trt_llm` (injected at load time).
- **Code-gen** (`deployment/code_gen.py`): when the chainlet is the custom variant, fall through to emit a real `model.py` plus the TRT-LLM config (instead of short-circuiting to a briton-only truss), and inject `self._trt_llm` onto the user chainlet inside the generated `load()`.
- **Model skeleton** (`remote_chainlet/model_skeleton.py`): `TrussChainletModel.__init__` now accepts an optional `trt_llm` kwarg, which the truss server passes when `config.trt_llm` is set; stored on `self._trt_llm` for the generated `load()` to forward.
- **Validation** (`framework.py`): relaxes the strict \"everything in `remote_config` must be unset\" rule for the custom variant (so users can declare compute, secrets, health checks, custom docker image, dependencies on other chainlets, etc.), and adds an explicit error if `inference_stack='v2'` is used (the v2 image builder unconditionally replaces `model.py` with a briton docker_server, which would silently drop user code).
- **TRT-LLM AST validation fix** (`truss/trt_llm/validation.py`): the existing `_verify_has_class_init_arg` walked every node in the class body and called `.name` on it, which crashes on class-level `AnnAssign` (e.g. `_chainlet: ABCChainlet` in the chains-generated `TrussChainletModel`). Now skips non-function nodes.
- **Tests**: covers registration, `run_remote` override, relaxed `remote_config`, the v2 rejection, the AST-validation fix on a class with annotated assignments, and the code-gen / model-skeleton injection path.
- **Version**: bumps `pyproject.toml` to `0.16.3rc004` for an RC release.

## Test plan

- [ ] `uv run pytest truss-chains/tests/test_framework.py -v`
- [ ] `uv run pytest truss/tests/trt_llm/test_validation.py -v`
- [ ] `uv run ruff check . && uv run ruff format --check .`
- [ ] Build + deploy a sample `CustomEngineBuilderLLMChainlet` end-to-end and confirm `self.trt_llm[\"engine\"].chat_completions(...)` works inside `run_remote`.
- [ ] Confirm a v2 `inference_stack` config raises `INVALID_CONFIG_ERROR` at validation time.


Made with [Cursor](https://cursor.com)