### PR TITLE
feat(docker_server): slim build branch (no in-image proxy)

### DIFF
--- a/truss/contexts/image_builder/serving_image_builder.py
+++ b/truss/contexts/image_builder/serving_image_builder.py
@@ -175,9 +175,11 @@ def _build_cache_mount_template_vars(cache_mount_id: Optional[str]) -> Dict[str,
 
 
 def _should_use_docker_server_slim(config: TrussConfig) -> bool:
-    if not os.getenv("BT_USE_DOCKER_SERVER_SLIM", False):
+    if os.getenv("BT_USE_DOCKER_SERVER_SLIM", "").strip().lower() != "true":
         return False
     if config.docker_server is None:
+        return False
+    if config.docker_server.no_build:
         return False
     return True
 

--- a/truss/contexts/image_builder/serving_image_builder.py
+++ b/truss/contexts/image_builder/serving_image_builder.py
@@ -174,14 +174,16 @@ def _build_cache_mount_template_vars(cache_mount_id: Optional[str]) -> Dict[str,
     }
 
 
+def _is_docker_server_build(config: TrussConfig) -> bool:
+    return config.docker_server is not None and not config.docker_server.no_build
+
+
+def _docker_server_slim_enabled() -> bool:
+    return os.getenv("BT_USE_DOCKER_SERVER_SLIM", "").strip().lower() == "true"
+
+
 def _should_use_docker_server_slim(config: TrussConfig) -> bool:
-    if os.getenv("BT_USE_DOCKER_SERVER_SLIM", "").strip().lower() != "true":
-        return False
-    if config.docker_server is None:
-        return False
-    if config.docker_server.no_build:
-        return False
-    return True
+    return _is_docker_server_build(config) and _docker_server_slim_enabled()
 
 
 class RemoteCache(ABC):
@@ -726,10 +728,8 @@ class ServingImageBuilder(ImageBuilder):
                 else:
                     self.prepare_trtllm_decoder_build_dir(build_dir=build_dir)
 
-        if (
-            config.docker_server is not None
-            and config.docker_server.no_build is not True
-            and not _should_use_docker_server_slim(config)
+        if _is_docker_server_build(config) and not _should_use_docker_server_slim(
+            config
         ):
             self._copy_into_build_dir(
                 TEMPLATES_DIR / "docker_server_requirements.txt",

--- a/truss/contexts/image_builder/serving_image_builder.py
+++ b/truss/contexts/image_builder/serving_image_builder.py
@@ -174,6 +174,14 @@ def _build_cache_mount_template_vars(cache_mount_id: Optional[str]) -> Dict[str,
     }
 
 
+def _should_use_docker_server_slim(config: TrussConfig) -> bool:
+    if not os.getenv("BT_USE_DOCKER_SERVER_SLIM", False):
+        return False
+    if config.docker_server is None:
+        return False
+    return True
+
+
 class RemoteCache(ABC):
     def __init__(self, repo_name, data_dir, revision=None):
         self.repo_name = repo_name
@@ -719,6 +727,7 @@ class ServingImageBuilder(ImageBuilder):
         if (
             config.docker_server is not None
             and config.docker_server.no_build is not True
+            and not _should_use_docker_server_slim(config)
         ):
             self._copy_into_build_dir(
                 TEMPLATES_DIR / "docker_server_requirements.txt",
@@ -730,7 +739,6 @@ class ServingImageBuilder(ImageBuilder):
 
             generate_docker_server_supervisord_config(build_dir, config)
 
-            # Copy event listener script
             event_listener_script = (
                 TEMPLATES_DIR / "docker_server" / "event_listener.py"
             )
@@ -1035,6 +1043,7 @@ class ServingImageBuilder(ImageBuilder):
             apt_mirror_url=_resolve_apt_mirror_url(),
             cache_mount_id=cache_mount_id,
             **_build_cache_mount_template_vars(cache_mount_id),
+            docker_server_slim=_should_use_docker_server_slim(config),
             **FILENAME_CONSTANTS_MAP,
         )
         # Consolidate repeated empty lines to single empty lines.

--- a/truss/templates/server.Dockerfile.jinja
+++ b/truss/templates/server.Dockerfile.jinja
@@ -117,6 +117,13 @@ RUN {% for secret,path in config.build.secret_to_path_mapping.items() %} --mount
 {%- endif %} {#- endif build_commands #}
 
 {%- if config.docker_server %}
+{%- if docker_server_slim %}
+ENV DOCKER_SERVER_SLIM="true"
+ENV SERVER_START_CMD={{ config.docker_server.start_command | tojson }}
+{{ chown_and_switch_to_regular_user_if_enabled() }}
+ENTRYPOINT ["sh", "-c"]
+CMD [{{ config.docker_server.start_command | tojson }}]
+{%- else %}
 RUN {{ apt_cache_mount }}apt-get update -y && apt-get install -y --no-install-recommends \
         curl nginx{% if not cache_mount_id %} && rm -rf /var/lib/apt/lists/*{% endif %}
 COPY --chown={{ default_owner }} ./docker_server_requirements.txt ${APP_HOME}/docker_server_requirements.txt
@@ -139,6 +146,7 @@ RUN mkdir -p /dev/shm
 {#- nginx writes to /var/lib/nginx, /var/log/nginx, /dev/shm, and /run directories #}
 {{ chown_and_switch_to_regular_user_if_enabled(["/var/lib/nginx", "/var/log/nginx", "/run", "/dev/shm"]) }}
 ENTRYPOINT ["/docker_server/.venv/bin/supervisord", "-c", "{{ supervisor_config_path }}"]
+{%- endif %} {#- endif docker_server_slim #}
 
 {%- elif requires_live_reload %} {#- elif requires_live_reload #}
 ENV HASH_TRUSS="{{ truss_hash }}"

--- a/truss/templates/server.Dockerfile.jinja
+++ b/truss/templates/server.Dockerfile.jinja
@@ -118,7 +118,6 @@ RUN {% for secret,path in config.build.secret_to_path_mapping.items() %} --mount
 
 {%- if config.docker_server %}
 {%- if docker_server_slim %}
-ENV DOCKER_SERVER_SLIM="true"
 ENV SERVER_START_CMD={{ config.docker_server.start_command | tojson }}
 {{ chown_and_switch_to_regular_user_if_enabled() }}
 ENTRYPOINT ["sh", "-c"]

--- a/truss/tests/contexts/image_builder/test_serving_image_builder.py
+++ b/truss/tests/contexts/image_builder/test_serving_image_builder.py
@@ -1118,10 +1118,6 @@ class TestDockerServerSlimBuild:
 
     @pytest.mark.parametrize("env_value", ["", "false", "False", "0", "no", "1"])
     def test_legacy_dockerfile_when_flag_value_is_not_true(self, tmp_path, env_value):
-        # only the literal string "true" should enable slim; anything else (including
-        # truthy-looking but non-"true" values like "1" or "no") falls back to legacy.
-        # This pins the parsing against the previous os.getenv(..., False) bug where
-        # any non-empty string was treated as truthy.
         truss_dir = self._make_docker_server_truss(tmp_path)
         with patch.dict(os.environ, {"BT_USE_DOCKER_SERVER_SLIM": env_value}):
             builder = ServingImageBuilderContext.run(truss_dir)
@@ -1133,9 +1129,6 @@ class TestDockerServerSlimBuild:
         assert "nginx" in dockerfile
 
     def test_no_build_skips_slim_branch_even_with_flag_on(self, tmp_path):
-        # no_build images ship with a customer-supplied ENTRYPOINT/CMD; the slim
-        # branch overrides those, so we must not enter it for no_build regardless of
-        # the slim flag.
         truss_dir = self._make_docker_server_truss(tmp_path)
         config_path = truss_dir / "config.yaml"
         with config_path.open() as f:
@@ -1150,9 +1143,6 @@ class TestDockerServerSlimBuild:
             builder.prepare_image_build_dir(build_dir)
 
         dockerfile = (build_dir / "Dockerfile").read_text()
-        # no_build template signature: short FROM-only dockerfile with no
-        # SERVER_START_CMD env, no nginx, no supervisord. Both slim and legacy
-        # branches of server.Dockerfile.jinja set SERVER_START_CMD; no_build does not.
         assert "SERVER_START_CMD" not in dockerfile
         assert "nginx" not in dockerfile.lower()
         assert "supervisord" not in dockerfile.lower()

--- a/truss/tests/contexts/image_builder/test_serving_image_builder.py
+++ b/truss/tests/contexts/image_builder/test_serving_image_builder.py
@@ -25,6 +25,7 @@ from truss.contexts.image_builder.serving_image_builder import (
     get_files_to_model_cache_v1,
 )
 from truss.tests.test_testing_utilities_for_other_tests import ensure_kill_all
+from truss.truss_handle.build import init_directory
 from truss.truss_handle.truss_handle import TrussHandle
 
 BASE_DIR = Path(__file__).parent
@@ -1060,3 +1061,58 @@ def test_nginx_config_disables_disk_writes(tmp_path):
     assert "fastcgi_temp_path /dev/shm/nginx_fastcgi_temp;" in nginx_config
     assert "uwsgi_temp_path /dev/shm/nginx_uwsgi_temp;" in nginx_config
     assert "scgi_temp_path /dev/shm/nginx_scgi_temp;" in nginx_config
+
+
+class TestDockerServerSlimBuild:
+    def _make_docker_server_truss(self, tmp_path, transport_kind="http"):
+        truss_dir = tmp_path / f"docker_server_truss_{transport_kind}"
+        th = TrussHandle(init_directory(truss_dir))
+        th.update_python_version("py311")
+        th.set_base_image("python:3.11-slim", "/usr/local/bin/python3")
+        config = th.spec.config
+        config.docker_server = DockerServer(
+            start_command="python main.py --port 8000",
+            server_port=8000,
+            predict_endpoint="/predict",
+            readiness_endpoint="/health",
+            liveness_endpoint="/health",
+        )
+        config.runtime.transport = {"kind": transport_kind}
+        with (truss_dir / "config.yaml").open("w") as f:
+            yaml.dump(config.to_dict(verbose=True), f)
+        return truss_dir
+
+    @pytest.mark.parametrize("transport_kind", ["http", "grpc"])
+    def test_slim_dockerfile_omits_nginx_and_supervisord(
+        self, tmp_path, transport_kind
+    ):
+        truss_dir = self._make_docker_server_truss(
+            tmp_path, transport_kind=transport_kind
+        )
+        with patch.dict(os.environ, {"BT_USE_DOCKER_SERVER_SLIM": "true"}):
+            builder = ServingImageBuilderContext.run(truss_dir)
+            build_dir = tmp_path / f"build_{transport_kind}"
+            builder.prepare_image_build_dir(build_dir)
+
+        dockerfile = (build_dir / "Dockerfile").read_text()
+        assert "DOCKER_SERVER_SLIM" in dockerfile
+        assert 'ENTRYPOINT ["sh", "-c"]' in dockerfile
+        assert "nginx" not in dockerfile.lower()
+        assert "supervisord" not in dockerfile.lower()
+        assert not (build_dir / "proxy.conf").exists()
+        assert not (build_dir / "supervisord.conf").exists()
+        assert not (build_dir / "docker_server_requirements.txt").exists()
+
+    def test_legacy_dockerfile_unchanged_when_flag_off(self, tmp_path):
+        truss_dir = self._make_docker_server_truss(tmp_path)
+        builder = ServingImageBuilderContext.run(truss_dir)
+        build_dir = tmp_path / "build"
+        builder.prepare_image_build_dir(build_dir)
+
+        dockerfile = (build_dir / "Dockerfile").read_text()
+        assert "DOCKER_SERVER_SLIM" not in dockerfile
+        assert "supervisord" in dockerfile
+        assert "nginx" in dockerfile
+        assert (build_dir / "proxy.conf").exists()
+        assert (build_dir / "supervisord.conf").exists()
+        assert (build_dir / "docker_server_requirements.txt").exists()

--- a/truss/tests/contexts/image_builder/test_serving_image_builder.py
+++ b/truss/tests/contexts/image_builder/test_serving_image_builder.py
@@ -1095,7 +1095,7 @@ class TestDockerServerSlimBuild:
             builder.prepare_image_build_dir(build_dir)
 
         dockerfile = (build_dir / "Dockerfile").read_text()
-        assert "DOCKER_SERVER_SLIM" in dockerfile
+        assert "SERVER_START_CMD" in dockerfile
         assert 'ENTRYPOINT ["sh", "-c"]' in dockerfile
         assert "nginx" not in dockerfile.lower()
         assert "supervisord" not in dockerfile.lower()
@@ -1110,9 +1110,49 @@ class TestDockerServerSlimBuild:
         builder.prepare_image_build_dir(build_dir)
 
         dockerfile = (build_dir / "Dockerfile").read_text()
-        assert "DOCKER_SERVER_SLIM" not in dockerfile
         assert "supervisord" in dockerfile
         assert "nginx" in dockerfile
         assert (build_dir / "proxy.conf").exists()
         assert (build_dir / "supervisord.conf").exists()
         assert (build_dir / "docker_server_requirements.txt").exists()
+
+    @pytest.mark.parametrize("env_value", ["", "false", "False", "0", "no", "1"])
+    def test_legacy_dockerfile_when_flag_value_is_not_true(self, tmp_path, env_value):
+        # only the literal string "true" should enable slim; anything else (including
+        # truthy-looking but non-"true" values like "1" or "no") falls back to legacy.
+        # This pins the parsing against the previous os.getenv(..., False) bug where
+        # any non-empty string was treated as truthy.
+        truss_dir = self._make_docker_server_truss(tmp_path)
+        with patch.dict(os.environ, {"BT_USE_DOCKER_SERVER_SLIM": env_value}):
+            builder = ServingImageBuilderContext.run(truss_dir)
+            build_dir = tmp_path / f"build_{env_value or 'empty'}"
+            builder.prepare_image_build_dir(build_dir)
+
+        dockerfile = (build_dir / "Dockerfile").read_text()
+        assert "supervisord" in dockerfile
+        assert "nginx" in dockerfile
+
+    def test_no_build_skips_slim_branch_even_with_flag_on(self, tmp_path):
+        # no_build images ship with a customer-supplied ENTRYPOINT/CMD; the slim
+        # branch overrides those, so we must not enter it for no_build regardless of
+        # the slim flag.
+        truss_dir = self._make_docker_server_truss(tmp_path)
+        config_path = truss_dir / "config.yaml"
+        with config_path.open() as f:
+            cfg = yaml.safe_load(f)
+        cfg["docker_server"]["no_build"] = True
+        with config_path.open("w") as f:
+            yaml.dump(cfg, f)
+
+        with patch.dict(os.environ, {"BT_USE_DOCKER_SERVER_SLIM": "true"}):
+            builder = ServingImageBuilderContext.run(truss_dir)
+            build_dir = tmp_path / "build_no_build_slim"
+            builder.prepare_image_build_dir(build_dir)
+
+        dockerfile = (build_dir / "Dockerfile").read_text()
+        # no_build template signature: short FROM-only dockerfile with no
+        # SERVER_START_CMD env, no nginx, no supervisord. Both slim and legacy
+        # branches of server.Dockerfile.jinja set SERVER_START_CMD; no_build does not.
+        assert "SERVER_START_CMD" not in dockerfile
+        assert "nginx" not in dockerfile.lower()
+        assert "supervisord" not in dockerfile.lower()


### PR DESCRIPTION
## What

Adds a `docker_server` build that omits nginx and supervisord. Triggered by `BT_USE_DOCKER_SERVER_SLIM=true`. Customer's `start_command` runs as PID 1. Routing and probes are the deploying platform's responsibility.

Distinct from #2357: that PR keeps an external nginx in the pod (sidecar). This one assumes no nginx anywhere (in-image or sidecar). Both gates are separate env vars and can coexist.

## How

- `_should_use_docker_server_slim(config)` predicate gates the slim path.
- `serving_image_builder.prepare_image_build_dir` skips nginx/supervisord scaffolding for slim builds.
- `server.Dockerfile.jinja` adds a slim branch under `config.docker_server`: sets `DOCKER_SERVER_SLIM` and `SERVER_START_CMD`, switches users, runs `ENTRYPOINT ["sh", "-c"]` + `CMD [start_command]`.

Transport-agnostic; the customer's start_command runs PID 1 regardless of HTTP or gRPC.

## Testing

[Integration tests](https://github.com/basetenlabs/truss/actions/runs/27835333322)

`uv run pytest truss/tests/contexts/image_builder/test_serving_image_builder.py::TestDockerServerSlimBuild` covers slim path (parametrized over http and grpc) and legacy fallback when env var unset.

## Release requirements

- Pre-release: none. Env var is not set by default; no-op until the platform enables it.
- Post-release: none.
- External communication: none.