### PR TITLE
feat(trainers): support deploying trainer checkpoints via deploy_checkpoints

### DIFF
--- a/truss-train/tests/test_definitions.py
+++ b/truss-train/tests/test_definitions.py
@@ -115,8 +115,7 @@ class TestCheckpointListTrainerCheckpoints:
 
     def test_trainer_checkpoint_ids_round_trip_to_truss_config(self):
         ckpt_list = CheckpointList(
-            base_model_id="Qwen/Qwen3-8B",
-            trainer_checkpoint_ids=["tcp_a", "tcp_b"],
+            base_model_id="Qwen/Qwen3-8B", trainer_checkpoint_ids=["tcp_a", "tcp_b"]
         )
         truss_ckpt_list = ckpt_list.to_truss_config()
         assert truss_ckpt_list.artifact_references == []

--- a/truss-train/tests/test_definitions.py
+++ b/truss-train/tests/test_definitions.py
@@ -100,3 +100,53 @@ class TestTrainingJobWeightsAuthValidation:
         )
         assert len(job.weights) == 1
         assert job.weights[0].auth is None
+
+
+from truss_train.definitions import (
+    CheckpointList,
+    LoRACheckpoint,
+    ModelWeightsFormat,
+)
+
+
+class TestCheckpointListTrainerCheckpoints:
+    """truss-train CheckpointList: trainer_checkpoint_ids field, validator, to_truss_config."""
+
+    def test_trainer_checkpoint_ids_round_trip_to_truss_config(self):
+        ckpt_list = CheckpointList(
+            base_model_id="Qwen/Qwen3-8B",
+            trainer_checkpoint_ids=["tcp_a", "tcp_b"],
+        )
+        truss_ckpt_list = ckpt_list.to_truss_config()
+        assert truss_ckpt_list.artifact_references == []
+        assert truss_ckpt_list.trainer_checkpoint_ids == ["tcp_a", "tcp_b"]
+        assert truss_ckpt_list.download_folder == ckpt_list.download_folder
+
+    def test_artifact_references_round_trip_to_truss_config(self):
+        ckpt_list = CheckpointList(
+            base_model_id="Qwen/Qwen3-8B",
+            checkpoints=[
+                LoRACheckpoint(
+                    training_job_id="tj_abc",
+                    checkpoint_name="step-1",
+                    model_weight_format=ModelWeightsFormat.LORA,
+                )
+            ],
+        )
+        truss_ckpt_list = ckpt_list.to_truss_config()
+        assert len(truss_ckpt_list.artifact_references) == 1
+        assert truss_ckpt_list.artifact_references[0].training_job_id == "tj_abc"
+        assert truss_ckpt_list.trainer_checkpoint_ids == []
+
+    def test_mixing_checkpoints_and_trainer_ids_raises(self):
+        with pytest.raises(ValidationError, match="cannot mix"):
+            CheckpointList(
+                checkpoints=[
+                    LoRACheckpoint(
+                        training_job_id="tj_abc",
+                        checkpoint_name="step-1",
+                        model_weight_format=ModelWeightsFormat.LORA,
+                    )
+                ],
+                trainer_checkpoint_ids=["tcp_xyz"],
+            )

--- a/truss-train/tests/test_definitions.py
+++ b/truss-train/tests/test_definitions.py
@@ -2,7 +2,15 @@ import pytest
 from pydantic import ValidationError
 
 from truss.base import truss_config
-from truss_train.definitions import Compute, Image, Runtime, TrainingJob
+from truss_train.definitions import (
+    CheckpointList,
+    Compute,
+    Image,
+    LoRACheckpoint,
+    ModelWeightsFormat,
+    Runtime,
+    TrainingJob,
+)
 
 
 def _minimal_job(**kwargs):
@@ -100,13 +108,6 @@ class TestTrainingJobWeightsAuthValidation:
         )
         assert len(job.weights) == 1
         assert job.weights[0].auth is None
-
-
-from truss_train.definitions import (
-    CheckpointList,
-    LoRACheckpoint,
-    ModelWeightsFormat,
-)
 
 
 class TestCheckpointListTrainerCheckpoints:

--- a/truss-train/truss_train/definitions.py
+++ b/truss-train/truss_train/definitions.py
@@ -274,6 +274,16 @@ class CheckpointList(custom_types.SafeModelNoExtra):
     download_folder: str = truss_config.DEFAULT_TRAINING_CHECKPOINT_FOLDER
     base_model_id: Optional[str] = None
     checkpoints: List[Checkpoint] = []
+    trainer_checkpoint_ids: List[str] = []
+
+    @model_validator(mode="after")
+    def _no_mixing(self) -> "CheckpointList":
+        if self.checkpoints and self.trainer_checkpoint_ids:
+            raise ValueError(
+                "checkpoint_details cannot mix checkpoints (training-job checkpoints) "
+                "and trainer_checkpoint_ids (trainer checkpoints) in the same deploy"
+            )
+        return self
 
     def to_truss_config(self) -> truss_config.CheckpointList:
         artifact_references: List[truss_config.TrainingArtifactReference] = [
@@ -282,6 +292,7 @@ class CheckpointList(custom_types.SafeModelNoExtra):
         return truss_config.CheckpointList(
             download_folder=self.download_folder,
             artifact_references=artifact_references,
+            trainer_checkpoint_ids=self.trainer_checkpoint_ids,
         )
 
 

--- a/truss-train/truss_train/definitions.py
+++ b/truss-train/truss_train/definitions.py
@@ -280,8 +280,9 @@ class CheckpointList(custom_types.SafeModelNoExtra):
     def _no_mixing(self) -> "CheckpointList":
         if self.checkpoints and self.trainer_checkpoint_ids:
             raise ValueError(
-                "checkpoint_details cannot mix checkpoints (training-job checkpoints) "
-                "and trainer_checkpoint_ids (trainer checkpoints) in the same deploy"
+                "checkpoint_details cannot mix checkpoints (training job "
+                "checkpoints) and trainer_checkpoint_ids (trainer checkpoints) "
+                "in the same deploy"
             )
         return self
 

--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -1095,8 +1095,9 @@ class CheckpointList(custom_types.ConfigModel):
     def _no_mixing(self) -> "CheckpointList":
         if self.artifact_references and self.trainer_checkpoint_ids:
             raise ValueError(
-                "training_checkpoints cannot mix artifact_references (training-job checkpoints) "
-                "and trainer_checkpoint_ids (trainer checkpoints) in the same deploy"
+                "training_checkpoints cannot mix artifact_references (training "
+                "job checkpoints) and trainer_checkpoint_ids (trainer checkpoints) "
+                "in the same deploy"
             )
         return self
 

--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -1084,6 +1084,21 @@ class CheckpointList(custom_types.ConfigModel):
     artifact_references: list[TrainingArtifactReference] = pydantic.Field(
         default_factory=list
     )
+    trainer_checkpoint_ids: list[str] = pydantic.Field(
+        default_factory=list,
+        description=(
+            "Trainer checkpoint IDs to deploy. Mutually exclusive with artifact_references."
+        ),
+    )
+
+    @pydantic.model_validator(mode="after")
+    def _no_mixing(self) -> "CheckpointList":
+        if self.artifact_references and self.trainer_checkpoint_ids:
+            raise ValueError(
+                "training_checkpoints cannot mix artifact_references (training-job checkpoints) "
+                "and trainer_checkpoint_ids (trainer checkpoints) in the same deploy"
+            )
+        return self
 
 
 # TODO: remove just use normal python version instead of this.

--- a/truss/cli/train/core.py
+++ b/truss/cli/train/core.py
@@ -348,7 +348,7 @@ def print_deploy_checkpoints_success_message(
 ):
     checkpoint_names = _get_checkpoint_names(checkpoint_deploy_config)
     if not checkpoint_names:
-        # Trainer-checkpoint deploys reference checkpoints by TSC PK; the
+        # Trainer-checkpoint deploys reference checkpoints by ID; the
         # client doesn't know each name without an extra API call. Skip the
         # name-specific guidance.
         console.print(

--- a/truss/cli/train/core.py
+++ b/truss/cli/train/core.py
@@ -337,21 +337,25 @@ def create_model_version_from_inference_template(
 def _get_checkpoint_names(
     checkpoint_deploy_config: DeployCheckpointsConfigComplete,
 ) -> list[str]:
-    names = [
+    return [
         checkpoint.checkpoint_name
         for checkpoint in checkpoint_deploy_config.checkpoint_details.checkpoints
     ]
-    # Trainer checkpoints are referenced by TSC PK; server resolves the
-    # name. Print the PK for now — refining this would require a second
-    # API call to resolve PK → name on the client.
-    names.extend(checkpoint_deploy_config.checkpoint_details.trainer_checkpoint_ids)
-    return names
 
 
 def print_deploy_checkpoints_success_message(
     checkpoint_deploy_config: DeployCheckpointsConfigComplete,
 ):
     checkpoint_names = _get_checkpoint_names(checkpoint_deploy_config)
+    if not checkpoint_names:
+        # Trainer-checkpoint deploys reference checkpoints by TSC PK; the
+        # client doesn't know each name without an extra API call. Skip the
+        # name-specific guidance.
+        console.print(
+            Text("\nDeployment succeeded. Set the `model` parameter on each "),
+            Text("request to the trainer checkpoint name (e.g. `step-100`)."),
+        )
+        return
     console.print(
         Text("\nTo run the model"),
         Text("ensure your `model` parameter is set to one of"),

--- a/truss/cli/train/core.py
+++ b/truss/cli/train/core.py
@@ -317,6 +317,7 @@ def create_model_version_from_inference_template(
             DeployCheckpointsConfig(),
             args.project_id,
             args.job_id,
+            args.trainer_id,
             args.dry_run,
         )
     # User provided a checkpoint deploy config file
@@ -328,6 +329,7 @@ def create_model_version_from_inference_template(
             checkpoint_deploy,
             args.project_id,
             args.job_id,
+            args.trainer_id,
             args.dry_run,
         )
 
@@ -335,10 +337,15 @@ def create_model_version_from_inference_template(
 def _get_checkpoint_names(
     checkpoint_deploy_config: DeployCheckpointsConfigComplete,
 ) -> list[str]:
-    return [
+    names = [
         checkpoint.checkpoint_name
         for checkpoint in checkpoint_deploy_config.checkpoint_details.checkpoints
     ]
+    # Trainer checkpoints are referenced by TSC PK; server resolves the
+    # name. Print the PK for now — refining this would require a second
+    # API call to resolve PK → name on the client.
+    names.extend(checkpoint_deploy_config.checkpoint_details.trainer_checkpoint_ids)
+    return names
 
 
 def print_deploy_checkpoints_success_message(

--- a/truss/cli/train/deploy_checkpoints/deploy_checkpoints.py
+++ b/truss/cli/train/deploy_checkpoints/deploy_checkpoints.py
@@ -363,9 +363,9 @@ def _ensure_trainer_checkpoint_details(
     CLI doesn't need to know it.
     """
     if checkpoint_details and checkpoint_details.trainer_checkpoint_ids:
-        return _process_user_provided_trainer_checkpoint_ids(
-            checkpoint_details, remote_provider
-        )
+        # User-authored trainer-checkpoint IDs in --config — server
+        # resolves and validates on deploy; nothing for the CLI to enrich.
+        return checkpoint_details
     if not trainer_id:
         raise click.UsageError(
             "--trainer-id is required to deploy trainer checkpoints."
@@ -412,13 +412,6 @@ def _prompt_user_for_trainer_checkpoint_details(
         checkpoint_details.base_model_id = trainer.get("base_model") or first_selected.get(
             "base_model"
         )
-    return checkpoint_details
-
-
-def _process_user_provided_trainer_checkpoint_ids(
-    checkpoint_details: CheckpointList, remote_provider: BasetenRemote
-) -> CheckpointList:
-    """User-authored trainer-checkpoint ID list — server resolves and validates on deploy."""
     return checkpoint_details
 
 

--- a/truss/cli/train/deploy_checkpoints/deploy_checkpoints.py
+++ b/truss/cli/train/deploy_checkpoints/deploy_checkpoints.py
@@ -126,21 +126,12 @@ def _build_inference_template_request(
             },
         }
         weights_sources.append(weights_source)
-    for composite in checkpoint_deploy_config.checkpoint_details.trainer_checkpoint_ids:
-        if "/" not in composite:
-            raise ValueError(
-                f"trainer_checkpoint_ids entry {composite!r} must be in the format "
-                "'<trainer_id>/<checkpoint_name>'"
-            )
-        trainer_id, checkpoint_name = composite.split("/", 1)
+    for trainer_checkpoint_id in checkpoint_deploy_config.checkpoint_details.trainer_checkpoint_ids:
         weights_sources.append(
             {
                 "weight_source_type": "B10_TRAINER_CHECKPOINTING",
                 "b10_trainer_checkpoint_weights_source": {
-                    "checkpoint": {
-                        "trainer_id": trainer_id,
-                        "checkpoint_name": checkpoint_name,
-                    }
+                    "checkpoint": {"trainer_checkpoint_id": trainer_checkpoint_id}
                 },
             }
         )
@@ -393,24 +384,28 @@ def _prompt_user_for_trainer_checkpoint_details(
     response = remote_provider.api.list_trainer_checkpoints(
         trainer["session_id"], trainer["id"]
     )
+    # Pick by checkpoint_name in the UI; map back to trainer-checkpoint
+    # database IDs for the wire so the server doesn't need to re-resolve names.
+    name_to_pk = OrderedDict(
+        (checkpoint["checkpoint_id"], checkpoint["id"])
+        for checkpoint in response["checkpoints"]
+    )
+    if not name_to_pk:
+        raise click.UsageError(
+            f"No checkpoints found for trainer {trainer['id']}."
+        )
     response_checkpoints = OrderedDict(
         (checkpoint["checkpoint_id"], checkpoint)
         for checkpoint in response["checkpoints"]
     )
-    if not response_checkpoints:
-        raise click.UsageError(
-            f"No checkpoints found for trainer {trainer['id']}."
-        )
     selected_names = _get_checkpoint_ids_to_deploy(
-        list(response_checkpoints.keys()), response_checkpoints
+        list(name_to_pk.keys()), response_checkpoints
     )
 
     if not checkpoint_details:
         checkpoint_details = CheckpointList()
-    # Composite "trainer_id/checkpoint_name" — same shape as the
-    # bt://trainers@<trainer_id>/<name> URI body.
     checkpoint_details.trainer_checkpoint_ids = [
-        f"{trainer['id']}/{name}" for name in selected_names
+        name_to_pk[name] for name in selected_names
     ]
     first_selected = response_checkpoints[selected_names[0]]
     if checkpoint_details.base_model_id is None:

--- a/truss/cli/train/deploy_checkpoints/deploy_checkpoints.py
+++ b/truss/cli/train/deploy_checkpoints/deploy_checkpoints.py
@@ -281,10 +281,26 @@ def _hydrate_deploy_config(
     job_id: Optional[str],
     trainer_id: Optional[str],
 ) -> DeployCheckpointsConfigComplete:
-    is_trainer_flow = trainer_id is not None or (
+    config_has_training_job_checkpoints = (
+        deploy_config.checkpoint_details is not None
+        and bool(deploy_config.checkpoint_details.checkpoints)
+    )
+    config_has_trainer_checkpoints = (
         deploy_config.checkpoint_details is not None
         and bool(deploy_config.checkpoint_details.trainer_checkpoint_ids)
     )
+    if trainer_id is not None and config_has_training_job_checkpoints:
+        raise click.UsageError(
+            "--trainer-id cannot be combined with checkpoint_details.checkpoints "
+            "from --config (training job checkpoints). Pick one source."
+        )
+    if (project_id or job_id) and config_has_trainer_checkpoints:
+        raise click.UsageError(
+            "--project-id / --job-id cannot be combined with "
+            "checkpoint_details.trainer_checkpoint_ids from --config. Pick one source."
+        )
+
+    is_trainer_flow = trainer_id is not None or config_has_trainer_checkpoints
     if is_trainer_flow:
         checkpoint_details = _ensure_trainer_checkpoint_details(
             remote_provider, deploy_config.checkpoint_details, trainer_id

--- a/truss/cli/train/deploy_checkpoints/deploy_checkpoints.py
+++ b/truss/cli/train/deploy_checkpoints/deploy_checkpoints.py
@@ -40,10 +40,11 @@ def create_model_version_from_inference_template(
     checkpoint_deploy_config: DeployCheckpointsConfig,
     project_id: Optional[str],
     job_id: Optional[str],
+    trainer_id: Optional[str],
     dry_run: bool,
 ) -> DeploySuccessResult:
     checkpoint_deploy_config = _hydrate_deploy_config(
-        checkpoint_deploy_config, remote_provider, project_id, job_id
+        checkpoint_deploy_config, remote_provider, project_id, job_id, trainer_id
     )
 
     request_data = _build_inference_template_request(
@@ -125,6 +126,15 @@ def _build_inference_template_request(
             },
         }
         weights_sources.append(weights_source)
+    for trainer_checkpoint_id in checkpoint_deploy_config.checkpoint_details.trainer_checkpoint_ids:
+        weights_sources.append(
+            {
+                "weight_source_type": "B10_TRAINER_CHECKPOINTING",
+                "b10_trainer_checkpoint_weights_source": {
+                    "checkpoint": {"trainer_checkpoint_id": trainer_checkpoint_id}
+                },
+            }
+        )
 
     # Build environment variables
     environment_variables = []
@@ -252,11 +262,23 @@ def _hydrate_deploy_config(
     remote_provider: BasetenRemote,
     project_id: Optional[str],
     job_id: Optional[str],
+    trainer_id: Optional[str],
 ) -> DeployCheckpointsConfigComplete:
-    checkpoint_details = _ensure_checkpoint_details(
-        remote_provider, deploy_config.checkpoint_details, project_id, job_id
+    is_trainer_flow = trainer_id is not None or (
+        deploy_config.checkpoint_details is not None
+        and bool(deploy_config.checkpoint_details.trainer_checkpoint_ids)
     )
-    model_weight_format = checkpoint_details.checkpoints[0].model_weight_format
+    if is_trainer_flow:
+        checkpoint_details = _ensure_trainer_checkpoint_details(
+            remote_provider, deploy_config.checkpoint_details, trainer_id
+        )
+        # All R.1 trainer outputs are LoRA today.
+        model_weight_format = ModelWeightsFormat.LORA
+    else:
+        checkpoint_details = _ensure_checkpoint_details(
+            remote_provider, deploy_config.checkpoint_details, project_id, job_id
+        )
+        model_weight_format = checkpoint_details.checkpoints[0].model_weight_format
 
     base_model_id = checkpoint_details.base_model_id
     if deploy_config.model_name:
@@ -309,6 +331,81 @@ def _ensure_checkpoint_details(
         return _prompt_user_for_checkpoint_details(
             remote_provider, checkpoint_details, project_id, job_id
         )
+
+
+def _ensure_trainer_checkpoint_details(
+    remote_provider: BasetenRemote,
+    checkpoint_details: Optional[CheckpointList],
+    trainer_id: Optional[str],
+) -> CheckpointList:
+    """Resolve a trainer checkpoint flow into a CheckpointList.
+
+    Each entry in ``trainer_checkpoint_ids`` is a TrainerServerCheckpoint PK.
+    The server resolves it to its trainer + checkpoint_name on deploy.
+    """
+    if checkpoint_details and checkpoint_details.trainer_checkpoint_ids:
+        return _process_user_provided_trainer_checkpoint_ids(
+            checkpoint_details, remote_provider
+        )
+    if not trainer_id:
+        raise click.UsageError(
+            "--trainer-id is required to deploy trainer checkpoints."
+        )
+    return _prompt_user_for_trainer_checkpoint_details(
+        remote_provider, checkpoint_details, trainer_id
+    )
+
+
+def _prompt_user_for_trainer_checkpoint_details(
+    remote_provider: BasetenRemote,
+    checkpoint_details: Optional[CheckpointList],
+    trainer_id: str,
+) -> CheckpointList:
+    trainer = _resolve_trainer(remote_provider, trainer_id)
+    response = remote_provider.api.list_trainer_checkpoints(
+        trainer["session_id"], trainer["id"]
+    )
+    # Pick by checkpoint_name in the UI; map back to TSC PKs for the wire.
+    name_to_pk = OrderedDict(
+        (checkpoint["checkpoint_id"], checkpoint["id"])
+        for checkpoint in response["checkpoints"]
+    )
+    if not name_to_pk:
+        raise click.UsageError(
+            f"No checkpoints found for trainer {trainer['id']}."
+        )
+    response_checkpoints = OrderedDict(
+        (checkpoint["checkpoint_id"], checkpoint)
+        for checkpoint in response["checkpoints"]
+    )
+    selected_names = _get_checkpoint_ids_to_deploy(
+        list(name_to_pk.keys()), response_checkpoints
+    )
+
+    if not checkpoint_details:
+        checkpoint_details = CheckpointList()
+    checkpoint_details.trainer_checkpoint_ids = [
+        name_to_pk[name] for name in selected_names
+    ]
+    if checkpoint_details.base_model_id is None:
+        checkpoint_details.base_model_id = trainer.get("base_model") or response_checkpoints[
+            selected_names[0]
+        ].get("base_model")
+    return checkpoint_details
+
+
+def _process_user_provided_trainer_checkpoint_ids(
+    checkpoint_details: CheckpointList, remote_provider: BasetenRemote
+) -> CheckpointList:
+    """User-authored TSC PK list — server resolves and validates on deploy."""
+    return checkpoint_details
+
+
+def _resolve_trainer(remote_provider: BasetenRemote, trainer_id: str) -> dict:
+    matches = remote_provider.api.search_trainers(trainer_id=trainer_id)
+    if not matches:
+        raise click.UsageError(f"Trainer {trainer_id} not found.")
+    return matches[0]
 
 
 def _prompt_user_for_checkpoint_details(

--- a/truss/cli/train/deploy_checkpoints/deploy_checkpoints.py
+++ b/truss/cli/train/deploy_checkpoints/deploy_checkpoints.py
@@ -126,7 +126,9 @@ def _build_inference_template_request(
             },
         }
         weights_sources.append(weights_source)
-    for trainer_checkpoint_id in checkpoint_deploy_config.checkpoint_details.trainer_checkpoint_ids:
+    for (
+        trainer_checkpoint_id
+    ) in checkpoint_deploy_config.checkpoint_details.trainer_checkpoint_ids:
         weights_sources.append(
             {
                 "weight_source_type": "B10_TRAINER_CHECKPOINTING",

--- a/truss/cli/train/deploy_checkpoints/deploy_checkpoints.py
+++ b/truss/cli/train/deploy_checkpoints/deploy_checkpoints.py
@@ -126,12 +126,21 @@ def _build_inference_template_request(
             },
         }
         weights_sources.append(weights_source)
-    for trainer_checkpoint_id in checkpoint_deploy_config.checkpoint_details.trainer_checkpoint_ids:
+    for composite in checkpoint_deploy_config.checkpoint_details.trainer_checkpoint_ids:
+        if "/" not in composite:
+            raise ValueError(
+                f"trainer_checkpoint_ids entry {composite!r} must be in the format "
+                "'<trainer_id>/<checkpoint_name>'"
+            )
+        trainer_id, checkpoint_name = composite.split("/", 1)
         weights_sources.append(
             {
                 "weight_source_type": "B10_TRAINER_CHECKPOINTING",
                 "b10_trainer_checkpoint_weights_source": {
-                    "checkpoint": {"trainer_checkpoint_id": trainer_checkpoint_id}
+                    "checkpoint": {
+                        "trainer_id": trainer_id,
+                        "checkpoint_name": checkpoint_name,
+                    }
                 },
             }
         )
@@ -384,28 +393,24 @@ def _prompt_user_for_trainer_checkpoint_details(
     response = remote_provider.api.list_trainer_checkpoints(
         trainer["session_id"], trainer["id"]
     )
-    # Pick by checkpoint_name in the UI; send the trainer checkpoint IDs
-    # on the wire so the server doesn't need to re-resolve names.
-    name_to_pk = OrderedDict(
-        (checkpoint["checkpoint_id"], checkpoint["id"])
-        for checkpoint in response["checkpoints"]
-    )
-    if not name_to_pk:
-        raise click.UsageError(
-            f"No checkpoints found for trainer {trainer['id']}."
-        )
     response_checkpoints = OrderedDict(
         (checkpoint["checkpoint_id"], checkpoint)
         for checkpoint in response["checkpoints"]
     )
+    if not response_checkpoints:
+        raise click.UsageError(
+            f"No checkpoints found for trainer {trainer['id']}."
+        )
     selected_names = _get_checkpoint_ids_to_deploy(
-        list(name_to_pk.keys()), response_checkpoints
+        list(response_checkpoints.keys()), response_checkpoints
     )
 
     if not checkpoint_details:
         checkpoint_details = CheckpointList()
+    # Composite "trainer_id/checkpoint_name" — same shape as the
+    # bt://trainers@<trainer_id>/<name> URI body.
     checkpoint_details.trainer_checkpoint_ids = [
-        name_to_pk[name] for name in selected_names
+        f"{trainer['id']}/{name}" for name in selected_names
     ]
     first_selected = response_checkpoints[selected_names[0]]
     if checkpoint_details.base_model_id is None:

--- a/truss/cli/train/deploy_checkpoints/deploy_checkpoints.py
+++ b/truss/cli/train/deploy_checkpoints/deploy_checkpoints.py
@@ -382,7 +382,7 @@ def _prompt_user_for_trainer_checkpoint_details(
 ) -> CheckpointList:
     trainer = _resolve_trainer(remote_provider, trainer_id)
     response = remote_provider.api.list_trainer_checkpoints(
-        trainer["session_id"], trainer["id"]
+        trainer["session_id"], trainer["trainer_id"]
     )
     # Pick by checkpoint_name in the UI; map back to trainer-checkpoint
     # database IDs for the wire so the server doesn't need to re-resolve names.
@@ -392,7 +392,7 @@ def _prompt_user_for_trainer_checkpoint_details(
     )
     if not name_to_pk:
         raise click.UsageError(
-            f"No checkpoints found for trainer {trainer['id']}."
+            f"No checkpoints found for trainer {trainer['trainer_id']}."
         )
     response_checkpoints = OrderedDict(
         (checkpoint["checkpoint_id"], checkpoint)

--- a/truss/cli/train/deploy_checkpoints/deploy_checkpoints.py
+++ b/truss/cli/train/deploy_checkpoints/deploy_checkpoints.py
@@ -281,6 +281,8 @@ def _hydrate_deploy_config(
     job_id: Optional[str],
     trainer_id: Optional[str],
 ) -> DeployCheckpointsConfigComplete:
+    trainer_id_provided = trainer_id is not None
+    job_flag_provided = bool(project_id or job_id)
     config_has_training_job_checkpoints = (
         deploy_config.checkpoint_details is not None
         and bool(deploy_config.checkpoint_details.checkpoints)
@@ -289,18 +291,18 @@ def _hydrate_deploy_config(
         deploy_config.checkpoint_details is not None
         and bool(deploy_config.checkpoint_details.trainer_checkpoint_ids)
     )
-    if trainer_id is not None and config_has_training_job_checkpoints:
+    if trainer_id_provided and config_has_training_job_checkpoints:
         raise click.UsageError(
             "--trainer-id cannot be combined with checkpoint_details.checkpoints "
             "from --config (training job checkpoints). Pick one source."
         )
-    if (project_id or job_id) and config_has_trainer_checkpoints:
+    if job_flag_provided and config_has_trainer_checkpoints:
         raise click.UsageError(
             "--project-id / --job-id cannot be combined with "
             "checkpoint_details.trainer_checkpoint_ids from --config. Pick one source."
         )
 
-    is_trainer_flow = trainer_id is not None or config_has_trainer_checkpoints
+    is_trainer_flow = trainer_id_provided or config_has_trainer_checkpoints
     if is_trainer_flow:
         checkpoint_details = _ensure_trainer_checkpoint_details(
             remote_provider, deploy_config.checkpoint_details, trainer_id

--- a/truss/cli/train/deploy_checkpoints/deploy_checkpoints.py
+++ b/truss/cli/train/deploy_checkpoints/deploy_checkpoints.py
@@ -407,11 +407,8 @@ def _prompt_user_for_trainer_checkpoint_details(
     checkpoint_details.trainer_checkpoint_ids = [
         name_to_pk[name] for name in selected_names
     ]
-    first_selected = response_checkpoints[selected_names[0]]
     if checkpoint_details.base_model_id is None:
-        checkpoint_details.base_model_id = trainer.get("base_model") or first_selected.get(
-            "base_model"
-        )
+        checkpoint_details.base_model_id = trainer["base_model"]
     return checkpoint_details
 
 

--- a/truss/cli/train/deploy_checkpoints/deploy_checkpoints.py
+++ b/truss/cli/train/deploy_checkpoints/deploy_checkpoints.py
@@ -257,6 +257,21 @@ def _get_model_name(
     ).execute()
 
 
+def _get_trainer_model_name(base_model_id: Optional[str]) -> str:
+    """Prompt for a model name in trainer-checkpoint deploys.
+
+    The CLI doesn't need to know the weight format — the server reads it
+    off the TSC row. We just prompt for a name with the base model as a
+    sensible default.
+    """
+    default = base_model_id.split("/")[-1] if base_model_id else ""
+    return inquirer.text(
+        message="Enter the model name.",
+        validate=lambda s: s and s.strip(),
+        default=default,
+    ).execute()
+
+
 def _hydrate_deploy_config(
     deploy_config: DeployCheckpointsConfig,
     remote_provider: BasetenRemote,
@@ -272,19 +287,21 @@ def _hydrate_deploy_config(
         checkpoint_details = _ensure_trainer_checkpoint_details(
             remote_provider, deploy_config.checkpoint_details, trainer_id
         )
-        # All R.1 trainer outputs are LoRA today.
-        model_weight_format = ModelWeightsFormat.LORA
+        if deploy_config.model_name:
+            model_name = deploy_config.model_name
+        else:
+            model_name = _get_trainer_model_name(checkpoint_details.base_model_id)
     else:
         checkpoint_details = _ensure_checkpoint_details(
             remote_provider, deploy_config.checkpoint_details, project_id, job_id
         )
-        model_weight_format = checkpoint_details.checkpoints[0].model_weight_format
-
-    base_model_id = checkpoint_details.base_model_id
-    if deploy_config.model_name:
-        model_name = deploy_config.model_name
-    else:
-        model_name = _get_model_name(model_weight_format, base_model_id)
+        if deploy_config.model_name:
+            model_name = deploy_config.model_name
+        else:
+            model_weight_format = checkpoint_details.checkpoints[0].model_weight_format
+            model_name = _get_model_name(
+                model_weight_format, checkpoint_details.base_model_id
+            )
 
     compute = _ensure_compute_spec(deploy_config.compute, remote_provider)
 
@@ -341,7 +358,9 @@ def _ensure_trainer_checkpoint_details(
     """Resolve a trainer checkpoint flow into a CheckpointList.
 
     Each entry in ``trainer_checkpoint_ids`` is a TrainerServerCheckpoint PK.
-    The server resolves it to its trainer + checkpoint_name on deploy.
+    The server resolves it to its trainer + checkpoint_name on deploy and
+    reads the actual weight format off the TSC row — the CLI doesn't need
+    to know it.
     """
     if checkpoint_details and checkpoint_details.trainer_checkpoint_ids:
         return _process_user_provided_trainer_checkpoint_ids(
@@ -387,10 +406,11 @@ def _prompt_user_for_trainer_checkpoint_details(
     checkpoint_details.trainer_checkpoint_ids = [
         name_to_pk[name] for name in selected_names
     ]
+    first_selected = response_checkpoints[selected_names[0]]
     if checkpoint_details.base_model_id is None:
-        checkpoint_details.base_model_id = trainer.get("base_model") or response_checkpoints[
-            selected_names[0]
-        ].get("base_model")
+        checkpoint_details.base_model_id = trainer.get("base_model") or first_selected.get(
+            "base_model"
+        )
     return checkpoint_details
 
 

--- a/truss/cli/train/deploy_checkpoints/deploy_checkpoints.py
+++ b/truss/cli/train/deploy_checkpoints/deploy_checkpoints.py
@@ -261,8 +261,8 @@ def _get_trainer_model_name(base_model_id: Optional[str]) -> str:
     """Prompt for a model name in trainer-checkpoint deploys.
 
     The CLI doesn't need to know the weight format — the server reads it
-    off the TSC row. We just prompt for a name with the base model as a
-    sensible default.
+    off the trainer-checkpoint row. We just prompt for a name with the
+    base model as a sensible default.
     """
     default = base_model_id.split("/")[-1] if base_model_id else ""
     return inquirer.text(
@@ -359,8 +359,8 @@ def _ensure_trainer_checkpoint_details(
 
     Each entry in ``trainer_checkpoint_ids`` is a TrainerServerCheckpoint PK.
     The server resolves it to its trainer + checkpoint_name on deploy and
-    reads the actual weight format off the TSC row — the CLI doesn't need
-    to know it.
+    reads the actual weight format off the trainer-checkpoint row — the
+    CLI doesn't need to know it.
     """
     if checkpoint_details and checkpoint_details.trainer_checkpoint_ids:
         return _process_user_provided_trainer_checkpoint_ids(
@@ -384,7 +384,8 @@ def _prompt_user_for_trainer_checkpoint_details(
     response = remote_provider.api.list_trainer_checkpoints(
         trainer["session_id"], trainer["id"]
     )
-    # Pick by checkpoint_name in the UI; map back to TSC PKs for the wire.
+    # Pick by checkpoint_name in the UI; send the trainer checkpoint IDs
+    # on the wire so the server doesn't need to re-resolve names.
     name_to_pk = OrderedDict(
         (checkpoint["checkpoint_id"], checkpoint["id"])
         for checkpoint in response["checkpoints"]
@@ -417,7 +418,7 @@ def _prompt_user_for_trainer_checkpoint_details(
 def _process_user_provided_trainer_checkpoint_ids(
     checkpoint_details: CheckpointList, remote_provider: BasetenRemote
 ) -> CheckpointList:
-    """User-authored TSC PK list — server resolves and validates on deploy."""
+    """User-authored trainer-checkpoint ID list — server resolves and validates on deploy."""
     return checkpoint_details
 
 

--- a/truss/cli/train/types.py
+++ b/truss/cli/train/types.py
@@ -17,6 +17,7 @@ class DeployCheckpointArgs:
     dry_run: bool
     project_id: Optional[str]
     job_id: Optional[str]
+    trainer_id: Optional[str]
     deploy_config_path: Optional[str]
 
 

--- a/truss/cli/train_commands.py
+++ b/truss/cli/train_commands.py
@@ -505,6 +505,12 @@ def get_job_metrics(
 @click.option("--project", type=str, required=False, help="Project name or project id.")
 @click.option("--job-id", type=str, required=False, help="Job ID.")
 @click.option(
+    "--trainer-id",
+    type=str,
+    required=False,
+    help="Trainer ID. Use to deploy checkpoints from a trainer (R.1) flow instead of a training job.",
+)
+@click.option(
     "--config",
     type=str,
     required=False,
@@ -525,6 +531,7 @@ def deploy_checkpoints(
     project_id: Optional[str],
     project: Optional[str],
     job_id: Optional[str],
+    trainer_id: Optional[str],
     config: Optional[str],
     remote: Optional[str],
     dry_run: bool,
@@ -540,14 +547,20 @@ def deploy_checkpoints(
     remote_provider: BasetenRemote = cast(
         BasetenRemote, RemoteFactory.create(remote=remote)
     )
-    project_id = _maybe_resolve_project_id_from_id_or_name(
-        remote_provider, project_id=project_id, project=project
-    )
+    if trainer_id and (project_id or project or job_id):
+        raise click.UsageError(
+            "--trainer-id cannot be combined with --project, --project-id, or --job-id."
+        )
+    if not trainer_id:
+        project_id = _maybe_resolve_project_id_from_id_or_name(
+            remote_provider, project_id=project_id, project=project
+        )
     result = train_cli.create_model_version_from_inference_template(
         remote_provider,
         train_cli.DeployCheckpointArgs(
             project_id=project_id,
             job_id=job_id,
+            trainer_id=trainer_id,
             deploy_config_path=config,
             dry_run=dry_run,
         ),

--- a/truss/cli/train_commands.py
+++ b/truss/cli/train_commands.py
@@ -508,7 +508,7 @@ def get_job_metrics(
     "--trainer-id",
     type=str,
     required=False,
-    help="Trainer ID. Use to deploy checkpoints from a trainer (R.1) flow instead of a training job.",
+    help="Trainer ID. Use to deploy checkpoints from a trainer instead of a training job.",
 )
 @click.option(
     "--config",

--- a/truss/config.schema.json
+++ b/truss/config.schema.json
@@ -180,6 +180,14 @@
           },
           "title": "Artifact References",
           "type": "array"
+        },
+        "trainer_checkpoint_ids": {
+          "description": "Trainer checkpoint IDs to deploy. Mutually exclusive with artifact_references.",
+          "items": {
+            "type": "string"
+          },
+          "title": "Trainer Checkpoint Ids",
+          "type": "array"
         }
       },
       "title": "CheckpointList",

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -875,6 +875,18 @@ class BasetenApi:
         )
         return resp_json
 
+    def search_trainers(self, trainer_id: Optional[str] = None):
+        resp_json = self._rest_api_client.post(
+            "v1/trainers/search", body={"trainer_id": trainer_id}
+        )
+        return resp_json["trainers"]
+
+    def list_trainer_checkpoints(self, session_id: str, trainer_id: str):
+        resp_json = self._rest_api_client.get(
+            f"v1/trainer_sessions/{session_id}/trainers/{trainer_id}/checkpoints"
+        )
+        return resp_json
+
     def get_training_job_isession(self, project_id: str, job_id: str):
         resp_json = self._rest_api_client.get(
             f"v1/training_projects/{project_id}/jobs/{job_id}/auth_codes"

--- a/truss/tests/cli/train/test_deploy_checkpoints.py
+++ b/truss/tests/cli/train/test_deploy_checkpoints.py
@@ -286,7 +286,7 @@ def test_hydrate_whisper_checkpoint():
 def mock_trainer_remote():
     mock = MagicMock()
     mock.api.search_trainers.return_value = [
-        {"id": "trnr_xyz", "session_id": "sess_abc", "base_model": "Qwen/Qwen3-8B"}
+        {"trainer_id": "trnr_xyz", "session_id": "sess_abc", "base_model": "Qwen/Qwen3-8B"}
     ]
     mock.api.list_trainer_checkpoints.return_value = {
         "trainer_id": "trnr_xyz",
@@ -306,7 +306,7 @@ def mock_trainer_remote():
 
 def test_resolve_trainer_returns_first_match(mock_trainer_remote):
     result = _resolve_trainer(mock_trainer_remote, "trnr_xyz")
-    assert result["id"] == "trnr_xyz"
+    assert result["trainer_id"] == "trnr_xyz"
     assert result["session_id"] == "sess_abc"
     mock_trainer_remote.api.search_trainers.assert_called_once_with(trainer_id="trnr_xyz")
 

--- a/truss/tests/cli/train/test_deploy_checkpoints.py
+++ b/truss/tests/cli/train/test_deploy_checkpoints.py
@@ -286,7 +286,11 @@ def test_hydrate_whisper_checkpoint():
 def mock_trainer_remote():
     mock = MagicMock()
     mock.api.search_trainers.return_value = [
-        {"trainer_id": "trnr_xyz", "session_id": "sess_abc", "base_model": "Qwen/Qwen3-8B"}
+        {
+            "trainer_id": "trnr_xyz",
+            "session_id": "sess_abc",
+            "base_model": "Qwen/Qwen3-8B",
+        }
     ]
     mock.api.list_trainer_checkpoints.return_value = {
         "trainer_id": "trnr_xyz",
@@ -308,7 +312,9 @@ def test_resolve_trainer_returns_first_match(mock_trainer_remote):
     result = _resolve_trainer(mock_trainer_remote, "trnr_xyz")
     assert result["trainer_id"] == "trnr_xyz"
     assert result["session_id"] == "sess_abc"
-    mock_trainer_remote.api.search_trainers.assert_called_once_with(trainer_id="trnr_xyz")
+    mock_trainer_remote.api.search_trainers.assert_called_once_with(
+        trainer_id="trnr_xyz"
+    )
 
 
 def test_resolve_trainer_raises_when_not_found(mock_trainer_remote):
@@ -349,9 +355,7 @@ def test_ensure_trainer_checkpoint_details_picker_emits_ids_and_base_model(
     so no prompt mock is needed for this case.
     """
     result = _ensure_trainer_checkpoint_details(
-        mock_trainer_remote,
-        checkpoint_details=None,
-        trainer_id="trnr_xyz",
+        mock_trainer_remote, checkpoint_details=None, trainer_id="trnr_xyz"
     )
     assert result.trainer_checkpoint_ids == ["tcp_step100"]
     assert result.base_model_id == "Qwen/Qwen3-8B"

--- a/truss/tests/cli/train/test_deploy_checkpoints.py
+++ b/truss/tests/cli/train/test_deploy_checkpoints.py
@@ -7,6 +7,7 @@ import truss_train.definitions as definitions
 from truss.cli.train.deploy_checkpoints.deploy_checkpoints import (
     _ensure_trainer_checkpoint_details,
     _get_checkpoint_ids_to_deploy,
+    _hydrate_deploy_config,
     _resolve_trainer,
     hydrate_checkpoint,
 )
@@ -362,3 +363,49 @@ def test_ensure_trainer_checkpoint_details_picker_emits_ids_and_base_model(
     mock_trainer_remote.api.list_trainer_checkpoints.assert_called_once_with(
         "sess_abc", "trnr_xyz"
     )
+
+
+def test_hydrate_deploy_config_rejects_trainer_id_with_config_checkpoints(
+    mock_trainer_remote,
+):
+    """--trainer-id + --config that has training-job checkpoints should error."""
+    deploy_config = definitions.DeployCheckpointsConfig(
+        checkpoint_details=definitions.CheckpointList(
+            checkpoints=[
+                definitions.LoRACheckpoint(
+                    training_job_id="tj_abc",
+                    checkpoint_name="step-1",
+                    model_weight_format=definitions.ModelWeightsFormat.LORA,
+                )
+            ]
+        )
+    )
+    with pytest.raises(click.UsageError, match="--trainer-id cannot be combined"):
+        _hydrate_deploy_config(
+            deploy_config,
+            mock_trainer_remote,
+            project_id=None,
+            job_id=None,
+            trainer_id="trnr_xyz",
+        )
+
+
+def test_hydrate_deploy_config_rejects_job_id_with_config_trainer_checkpoint_ids(
+    mock_trainer_remote,
+):
+    """--job-id + --config that has trainer_checkpoint_ids should error."""
+    deploy_config = definitions.DeployCheckpointsConfig(
+        checkpoint_details=definitions.CheckpointList(
+            trainer_checkpoint_ids=["tcp_xyz"]
+        )
+    )
+    with pytest.raises(
+        click.UsageError, match="--project-id / --job-id cannot be combined"
+    ):
+        _hydrate_deploy_config(
+            deploy_config,
+            mock_trainer_remote,
+            project_id=None,
+            job_id="tj_abc",
+            trainer_id=None,
+        )

--- a/truss/tests/cli/train/test_deploy_checkpoints.py
+++ b/truss/tests/cli/train/test_deploy_checkpoints.py
@@ -1,10 +1,13 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+import rich_click as click
 
 import truss_train.definitions as definitions
 from truss.cli.train.deploy_checkpoints.deploy_checkpoints import (
+    _ensure_trainer_checkpoint_details,
     _get_checkpoint_ids_to_deploy,
+    _resolve_trainer,
     hydrate_checkpoint,
 )
 from truss.cli.train.deploy_checkpoints.deploy_full_checkpoints import (
@@ -279,13 +282,6 @@ def test_hydrate_whisper_checkpoint():
     assert isinstance(result, definitions.WhisperCheckpoint)
 
 
-from truss.cli.train.deploy_checkpoints.deploy_checkpoints import (
-    _ensure_trainer_checkpoint_details,
-    _resolve_trainer,
-)
-import rich_click as click
-
-
 @pytest.fixture
 def mock_trainer_remote():
     mock = MagicMock()
@@ -293,15 +289,16 @@ def mock_trainer_remote():
         {"id": "trnr_xyz", "session_id": "sess_abc", "base_model": "Qwen/Qwen3-8B"}
     ]
     mock.api.list_trainer_checkpoints.return_value = {
+        "trainer_id": "trnr_xyz",
         "checkpoints": [
             {
-                "id": "tcp_step100",
+                "trainer_id": "trnr_xyz",
                 "checkpoint_id": "step-100",
                 "base_model": "Qwen/Qwen3-8B",
                 "checkpoint_type": "lora",
                 "lora_adapter_config": {"r": 16},
             }
-        ]
+        ],
     }
     return mock
 
@@ -323,7 +320,9 @@ def test_ensure_trainer_checkpoint_details_user_provided_passes_through(
     mock_trainer_remote,
 ):
     """When the user authored trainer_checkpoint_ids in --config, return as-is."""
-    user_config = definitions.CheckpointList(trainer_checkpoint_ids=["tcp_step100"])
+    user_config = definitions.CheckpointList(
+        trainer_checkpoint_ids=["trnr_xyz/step-100"]
+    )
     result = _ensure_trainer_checkpoint_details(
         mock_trainer_remote, user_config, trainer_id=None
     )
@@ -355,7 +354,7 @@ def test_ensure_trainer_checkpoint_details_picker_emits_ids_and_base_model(
         checkpoint_details=None,
         trainer_id="trnr_xyz",
     )
-    assert result.trainer_checkpoint_ids == ["tcp_step100"]
+    assert result.trainer_checkpoint_ids == ["trnr_xyz/step-100"]
     assert result.base_model_id == "Qwen/Qwen3-8B"
     mock_trainer_remote.api.list_trainer_checkpoints.assert_called_once_with(
         "sess_abc", "trnr_xyz"

--- a/truss/tests/cli/train/test_deploy_checkpoints.py
+++ b/truss/tests/cli/train/test_deploy_checkpoints.py
@@ -277,3 +277,86 @@ def test_hydrate_whisper_checkpoint():
     assert result.checkpoint_name == checkpoint_id
     assert result.model_weight_format == definitions.ModelWeightsFormat.WHISPER
     assert isinstance(result, definitions.WhisperCheckpoint)
+
+
+from truss.cli.train.deploy_checkpoints.deploy_checkpoints import (
+    _ensure_trainer_checkpoint_details,
+    _resolve_trainer,
+)
+import rich_click as click
+
+
+@pytest.fixture
+def mock_trainer_remote():
+    mock = MagicMock()
+    mock.api.search_trainers.return_value = [
+        {"id": "trnr_xyz", "session_id": "sess_abc", "base_model": "Qwen/Qwen3-8B"}
+    ]
+    mock.api.list_trainer_checkpoints.return_value = {
+        "checkpoints": [
+            {
+                "id": "tcp_step100",
+                "checkpoint_id": "step-100",
+                "base_model": "Qwen/Qwen3-8B",
+                "checkpoint_type": "lora",
+                "lora_adapter_config": {"r": 16},
+            }
+        ]
+    }
+    return mock
+
+
+def test_resolve_trainer_returns_first_match(mock_trainer_remote):
+    result = _resolve_trainer(mock_trainer_remote, "trnr_xyz")
+    assert result["id"] == "trnr_xyz"
+    assert result["session_id"] == "sess_abc"
+    mock_trainer_remote.api.search_trainers.assert_called_once_with(trainer_id="trnr_xyz")
+
+
+def test_resolve_trainer_raises_when_not_found(mock_trainer_remote):
+    mock_trainer_remote.api.search_trainers.return_value = []
+    with pytest.raises(click.UsageError, match="Trainer trnr_missing not found"):
+        _resolve_trainer(mock_trainer_remote, "trnr_missing")
+
+
+def test_ensure_trainer_checkpoint_details_user_provided_passes_through(
+    mock_trainer_remote,
+):
+    """When the user authored trainer_checkpoint_ids in --config, return as-is."""
+    user_config = definitions.CheckpointList(trainer_checkpoint_ids=["tcp_step100"])
+    result = _ensure_trainer_checkpoint_details(
+        mock_trainer_remote, user_config, trainer_id=None
+    )
+    assert result is user_config
+    # Did not hit the API since user authored the IDs.
+    mock_trainer_remote.api.search_trainers.assert_not_called()
+    mock_trainer_remote.api.list_trainer_checkpoints.assert_not_called()
+
+
+def test_ensure_trainer_checkpoint_details_requires_trainer_id_when_unprovided(
+    mock_trainer_remote,
+):
+    with pytest.raises(click.UsageError, match="--trainer-id is required"):
+        _ensure_trainer_checkpoint_details(
+            mock_trainer_remote, checkpoint_details=None, trainer_id=None
+        )
+
+
+def test_ensure_trainer_checkpoint_details_picker_emits_ids_and_base_model(
+    mock_trainer_remote,
+):
+    """With --trainer-id set, picker selects checkpoints and we send IDs on the wire.
+
+    Single checkpoint short-circuits the inquirer prompt (mirroring TJC behavior),
+    so no prompt mock is needed for this case.
+    """
+    result = _ensure_trainer_checkpoint_details(
+        mock_trainer_remote,
+        checkpoint_details=None,
+        trainer_id="trnr_xyz",
+    )
+    assert result.trainer_checkpoint_ids == ["tcp_step100"]
+    assert result.base_model_id == "Qwen/Qwen3-8B"
+    mock_trainer_remote.api.list_trainer_checkpoints.assert_called_once_with(
+        "sess_abc", "trnr_xyz"
+    )

--- a/truss/tests/cli/train/test_deploy_checkpoints.py
+++ b/truss/tests/cli/train/test_deploy_checkpoints.py
@@ -292,6 +292,7 @@ def mock_trainer_remote():
         "trainer_id": "trnr_xyz",
         "checkpoints": [
             {
+                "id": "tcp_step100",
                 "trainer_id": "trnr_xyz",
                 "checkpoint_id": "step-100",
                 "base_model": "Qwen/Qwen3-8B",
@@ -320,9 +321,7 @@ def test_ensure_trainer_checkpoint_details_user_provided_passes_through(
     mock_trainer_remote,
 ):
     """When the user authored trainer_checkpoint_ids in --config, return as-is."""
-    user_config = definitions.CheckpointList(
-        trainer_checkpoint_ids=["trnr_xyz/step-100"]
-    )
+    user_config = definitions.CheckpointList(trainer_checkpoint_ids=["tcp_step100"])
     result = _ensure_trainer_checkpoint_details(
         mock_trainer_remote, user_config, trainer_id=None
     )
@@ -354,7 +353,7 @@ def test_ensure_trainer_checkpoint_details_picker_emits_ids_and_base_model(
         checkpoint_details=None,
         trainer_id="trnr_xyz",
     )
-    assert result.trainer_checkpoint_ids == ["trnr_xyz/step-100"]
+    assert result.trainer_checkpoint_ids == ["tcp_step100"]
     assert result.base_model_id == "Qwen/Qwen3-8B"
     mock_trainer_remote.api.list_trainer_checkpoints.assert_called_once_with(
         "sess_abc", "trnr_xyz"

--- a/truss/tests/test_config.py
+++ b/truss/tests/test_config.py
@@ -1808,7 +1808,9 @@ class TestCheckpointListNoMixing:
     def test_artifact_references_only_accepted(self):
         ckpt_list = CheckpointList(
             artifact_references=[
-                TrainingArtifactReference(training_job_id="tj_abc", paths=["rank-0/step-1/"])
+                TrainingArtifactReference(
+                    training_job_id="tj_abc", paths=["rank-0/step-1/"]
+                )
             ]
         )
         assert ckpt_list.artifact_references[0].training_job_id == "tj_abc"
@@ -1823,7 +1825,9 @@ class TestCheckpointListNoMixing:
         with pytest.raises(pydantic.ValidationError, match="cannot mix"):
             CheckpointList(
                 artifact_references=[
-                    TrainingArtifactReference(training_job_id="tj_abc", paths=["rank-0/step-1/"])
+                    TrainingArtifactReference(
+                        training_job_id="tj_abc", paths=["rank-0/step-1/"]
+                    )
                 ],
                 trainer_checkpoint_ids=["tcp_xyz"],
             )

--- a/truss/tests/test_config.py
+++ b/truss/tests/test_config.py
@@ -27,6 +27,7 @@ from truss.base.truss_config import (
     ModelRepoCacheInternal,
     Resources,
     Runtime,
+    TrainingArtifactReference,
     TransportKind,
     TrussConfig,
     WebsocketOptions,
@@ -1799,3 +1800,35 @@ class TestTrussConfigWeights:
         assert config_new.weights.sources[0].source == "hf://meta-llama/Llama-2-7b@main"
         assert config_new.weights.sources[0].mount_location == "/models/llama"
         assert config_new.weights.sources[0].allow_patterns == ["*.safetensors"]
+
+
+class TestCheckpointListNoMixing:
+    """CheckpointList rejects mixing training-job and trainer checkpoint sources."""
+
+    def test_artifact_references_only_accepted(self):
+        ckpt_list = CheckpointList(
+            artifact_references=[
+                TrainingArtifactReference(training_job_id="tj_abc", paths=["rank-0/step-1/"])
+            ]
+        )
+        assert ckpt_list.artifact_references[0].training_job_id == "tj_abc"
+        assert ckpt_list.trainer_checkpoint_ids == []
+
+    def test_trainer_checkpoint_ids_only_accepted(self):
+        ckpt_list = CheckpointList(trainer_checkpoint_ids=["tcp_xyz"])
+        assert ckpt_list.trainer_checkpoint_ids == ["tcp_xyz"]
+        assert ckpt_list.artifact_references == []
+
+    def test_mixing_raises(self):
+        with pytest.raises(pydantic.ValidationError, match="cannot mix"):
+            CheckpointList(
+                artifact_references=[
+                    TrainingArtifactReference(training_job_id="tj_abc", paths=["rank-0/step-1/"])
+                ],
+                trainer_checkpoint_ids=["tcp_xyz"],
+            )
+
+    def test_empty_lists_accepted(self):
+        ckpt_list = CheckpointList()
+        assert ckpt_list.artifact_references == []
+        assert ckpt_list.trainer_checkpoint_ids == []


### PR DESCRIPTION
## Summary

Adds plumbing for `truss train deploy_checkpoints --trainer-id <id>`, mirroring the existing training-job (TJC) flow for trainer-server checkpoints (TSC) produced by the R.1 RL trainer.

- `CheckpointList.trainer_checkpoint_ids` (truss + truss-train) — list of TrainerServerCheckpoint PKs. Mutually exclusive with `artifact_references` / `checkpoints` via `_no_mixing` validators.
- New `--trainer-id` CLI flag; mutually exclusive with TJC selectors.
- New API methods: `search_trainers` (POST `/v1/trainers/search`) and `list_trainer_checkpoints` (GET `/v1/trainer_sessions/.../checkpoints`).
- Interactive picker over checkpoint_name; emits TSC PKs on the wire.
- Inference template request gains `B10_TRAINER_CHECKPOINTING` weight-source entries carrying `trainer_checkpoint_id`.

Server-side wiring (monorepo) is a separate set of PRs and includes:
- `POST /v1/trainers/search` endpoint
- Exposing TSC PK in the existing `GetTrainerServerCheckpointsResponseV1`
- `WeightSourceType.B10_TRAINER_CHECKPOINTING` graphql + pydantic
- Bundle creation, `bt://trainers@...` URI emission, BDN resolver dispatch

## Test plan

- [x] Existing 588 unit tests still pass after the rename + new types
- [x] Add unit tests for `_ensure_trainer_checkpoint_details` dispatch (--trainer-id vs config.trainer_checkpoint_ids)
- [x] Add unit tests for `_no_mixing` validators on both `CheckpointList`s
- [ ] End-to-end smoke once monorepo PR lands: deploy from `--trainer-id <real-id>` against staging