### PR TITLE
Add `truss train workstation` CLI command

### DIFF
--- a/truss/cli/train/workstation.py
+++ b/truss/cli/train/workstation.py
@@ -1,11 +1,16 @@
+from typing import Optional
+
 from truss.base import truss_config
 from truss_train.definitions import (
+    BasetenCheckpoint,
     CacheConfig,
+    CheckpointingConfig,
     Compute,
     Image,
     InteractiveSession,
     InteractiveSessionProvider,
     InteractiveSessionTrigger,
+    LoadCheckpointConfig,
     Runtime,
     TrainingJob,
     TrainingProject,
@@ -19,6 +24,10 @@ def build_workstation_project(
     gpu_count: int,
     project_id: str,
     base_image: str = DEFAULT_BASE_IMAGE,
+    enable_checkpointing: bool = False,
+    checkpoint_path: Optional[str] = None,
+    checkpoint_volume_size: Optional[int] = None,
+    checkpoint_from_job: Optional[str] = None,
 ) -> TrainingProject:
     accel_enum = truss_config.Accelerator(accelerator)
 
@@ -29,9 +38,24 @@ def build_workstation_project(
         ),
     )
 
+    load_checkpoint_config = None
+    if checkpoint_from_job:
+        load_checkpoint_config = LoadCheckpointConfig(
+            enabled=True,
+            checkpoints=[
+                BasetenCheckpoint.from_latest_checkpoint(job_id=checkpoint_from_job)
+            ],
+        )
+
     runtime = Runtime(
         start_commands=["sleep infinity"],
         cache_config=CacheConfig(enabled=True, require_cache_affinity=False),
+        checkpointing_config=CheckpointingConfig(
+            enabled=enable_checkpointing,
+            checkpoint_path=checkpoint_path,
+            volume_size_gib=checkpoint_volume_size,
+        ),
+        load_checkpoint_config=load_checkpoint_config,
     )
 
     interactive_session = InteractiveSession(

--- a/truss/cli/train/workstation.py
+++ b/truss/cli/train/workstation.py
@@ -1,0 +1,45 @@
+from truss.base import truss_config
+from truss_train.definitions import (
+    Compute,
+    Image,
+    InteractiveSession,
+    InteractiveSessionProvider,
+    InteractiveSessionTrigger,
+    Runtime,
+    TrainingJob,
+    TrainingProject,
+)
+
+DEFAULT_BASE_IMAGE = "nvidia/cuda:12.8.1-devel-ubuntu24.04"
+
+
+def build_workstation_project(
+    accelerator: str,
+    gpu_count: int,
+    project_id: str,
+    base_image: str = DEFAULT_BASE_IMAGE,
+) -> TrainingProject:
+    accel_enum = truss_config.Accelerator(accelerator)
+
+    compute = Compute(
+        node_count=1,
+        accelerator=truss_config.AcceleratorSpec(
+            accelerator=accel_enum, count=gpu_count
+        ),
+    )
+
+    runtime = Runtime(start_commands=["sleep infinity"])
+
+    interactive_session = InteractiveSession(
+        trigger=InteractiveSessionTrigger.ON_STARTUP,
+        session_provider=InteractiveSessionProvider.SSH,
+    )
+
+    job = TrainingJob(
+        image=Image(base_image=base_image),
+        compute=compute,
+        runtime=runtime,
+        interactive_session=interactive_session,
+    )
+
+    return TrainingProject(name=project_id, job=job)

--- a/truss/cli/train/workstation.py
+++ b/truss/cli/train/workstation.py
@@ -1,5 +1,6 @@
 from truss.base import truss_config
 from truss_train.definitions import (
+    CacheConfig,
     Compute,
     Image,
     InteractiveSession,
@@ -28,7 +29,10 @@ def build_workstation_project(
         ),
     )
 
-    runtime = Runtime(start_commands=["sleep infinity"])
+    runtime = Runtime(
+        start_commands=["sleep infinity"],
+        cache_config=CacheConfig(enabled=True, require_cache_affinity=False),
+    )
 
     interactive_session = InteractiveSession(
         trigger=InteractiveSessionTrigger.ON_STARTUP,

--- a/truss/cli/train_commands.py
+++ b/truss/cli/train_commands.py
@@ -1148,6 +1148,8 @@ def workstation(
     tail: bool,
 ):
     """Spin up an SSH workstation on Baseten training infrastructure."""
+    import tempfile
+
     from truss.cli.train.workstation import (
         DEFAULT_BASE_IMAGE,
         build_workstation_project,
@@ -1174,7 +1176,11 @@ def workstation(
         f"with [cyan]{gpu_count}x {accelerator}[/cyan]..."
     )
 
-    job_resp = push(config=training_project, remote=remote)
+    # Use an empty temp dir as source so we don't upload the user's cwd.
+    with tempfile.TemporaryDirectory() as empty_dir:
+        job_resp = push(
+            config=training_project, remote=remote, source_dir=Path(empty_dir)
+        )
 
     job_id = job_resp["id"]
     console.print(

--- a/truss/cli/train_commands.py
+++ b/truss/cli/train_commands.py
@@ -1136,6 +1136,30 @@ def capacity(remote: Optional[str]):
     required=False,
     help="Custom Docker base image (default: nvidia/cuda:12.8.1-devel-ubuntu24.04).",
 )
+@click.option(
+    "--enable-checkpointing",
+    is_flag=True,
+    default=False,
+    help="Enable checkpoint storage.",
+)
+@click.option(
+    "--checkpoint-path",
+    type=str,
+    required=False,
+    help="Path inside the container to save checkpoints.",
+)
+@click.option(
+    "--checkpoint-volume-size",
+    type=int,
+    required=False,
+    help="Checkpoint volume size in GiB.",
+)
+@click.option(
+    "--checkpoint-from-job",
+    type=str,
+    required=False,
+    help="Job ID to load the latest checkpoint from.",
+)
 @click.option("--remote", type=str, required=False, help="Remote to use.")
 @click.option("--tail", is_flag=True, help="Tail for status + logs after push.")
 @common.common_options()
@@ -1144,6 +1168,10 @@ def workstation(
     gpu_count: int,
     project_id: Optional[str],
     image: Optional[str],
+    enable_checkpointing: bool,
+    checkpoint_path: Optional[str],
+    checkpoint_volume_size: Optional[int],
+    checkpoint_from_job: Optional[str],
     remote: Optional[str],
     tail: bool,
 ):
@@ -1169,6 +1197,10 @@ def workstation(
         gpu_count=gpu_count,
         project_id=project_id,
         base_image=base_image,
+        enable_checkpointing=enable_checkpointing,
+        checkpoint_path=checkpoint_path,
+        checkpoint_volume_size=checkpoint_volume_size,
+        checkpoint_from_job=checkpoint_from_job,
     )
 
     console.print(

--- a/truss/cli/train_commands.py
+++ b/truss/cli/train_commands.py
@@ -1109,3 +1109,95 @@ def capacity(remote: Optional[str]):
         BasetenRemote, RemoteFactory.create(remote=remote)
     )
     train_cli.display_training_capacity(remote_provider)
+
+
+@train.command(name="workstation")
+@click.option(
+    "--accelerator",
+    type=click.Choice(["H100", "H200"], case_sensitive=False),
+    default="H100",
+    help="GPU accelerator type (default: H100).",
+)
+@click.option(
+    "--gpu-count",
+    type=click.IntRange(1, 8),
+    default=1,
+    help="Number of GPUs (1-8, default: 1).",
+)
+@click.option(
+    "--project-id",
+    type=str,
+    required=False,
+    help="Project name (default: workstation-<accelerator>).",
+)
+@click.option(
+    "--image",
+    type=str,
+    required=False,
+    help="Custom Docker base image (default: nvidia/cuda:12.8.1-devel-ubuntu24.04).",
+)
+@click.option("--remote", type=str, required=False, help="Remote to use.")
+@click.option("--tail", is_flag=True, help="Tail for status + logs after push.")
+@common.common_options()
+def workstation(
+    accelerator: str,
+    gpu_count: int,
+    project_id: Optional[str],
+    image: Optional[str],
+    remote: Optional[str],
+    tail: bool,
+):
+    """Spin up an SSH workstation on Baseten training infrastructure."""
+    from truss.cli.train.workstation import (
+        DEFAULT_BASE_IMAGE,
+        build_workstation_project,
+    )
+    from truss_train.public_api import push
+
+    accelerator = accelerator.upper()
+    if not project_id:
+        project_id = f"workstation-{accelerator}"
+
+    if not remote:
+        remote = remote_cli.inquire_remote_name()
+
+    base_image = image or DEFAULT_BASE_IMAGE
+    training_project = build_workstation_project(
+        accelerator=accelerator,
+        gpu_count=gpu_count,
+        project_id=project_id,
+        base_image=base_image,
+    )
+
+    console.print(
+        f"Launching workstation [cyan]{project_id}[/cyan] "
+        f"with [cyan]{gpu_count}x {accelerator}[/cyan]..."
+    )
+
+    job_resp = push(config=training_project, remote=remote)
+
+    job_id = job_resp["id"]
+    console.print(
+        f"\n[green]Workstation created![/green]\n"
+        f"\n"
+        f"Once the job is running, SSH in with:\n"
+        f"  [cyan]ssh training-job-{job_id}-0.ssh.baseten.co[/cyan]\n"
+        f"\n"
+        f"If you haven't set up SSH yet, run:\n"
+        f"  [cyan]truss ssh setup[/cyan]\n"
+        f"\n"
+        f"View logs:\n"
+        f"  [cyan]truss train logs --job-id {job_id} --tail[/cyan]\n"
+        f"\n"
+        f"Stop the workstation:\n"
+        f"  [cyan]truss train stop --job-id {job_id}[/cyan]"
+    )
+
+    if tail:
+        remote_provider: BasetenRemote = cast(
+            BasetenRemote, RemoteFactory.create(remote=remote)
+        )
+        project_resp_id = job_resp["training_project"]["id"]
+        watcher = TrainingLogWatcher(remote_provider.api, project_resp_id, job_id)
+        for log in watcher.watch():
+            cli_log_utils.output_log(log)

--- a/truss/tests/cli/train/test_workstation.py
+++ b/truss/tests/cli/train/test_workstation.py
@@ -1,0 +1,39 @@
+import pytest
+
+from truss.cli.train.workstation import build_workstation_project
+from truss_train.definitions import (
+    InteractiveSessionProvider,
+    InteractiveSessionTrigger,
+)
+
+
+def test_build_workstation_project_defaults():
+    project = build_workstation_project(
+        accelerator="H100", gpu_count=1, project_id="workstation-H100"
+    )
+    assert project.name == "workstation-H100"
+
+    job = project.job
+    assert job.compute.accelerator.accelerator.value == "H100"
+    assert job.compute.accelerator.count == 1
+    assert job.compute.node_count == 1
+    assert job.runtime.start_commands == ["sleep infinity"]
+    assert job.interactive_session is not None
+    assert job.interactive_session.trigger == InteractiveSessionTrigger.ON_STARTUP
+    assert job.interactive_session.session_provider == InteractiveSessionProvider.SSH
+
+
+def test_build_workstation_project_h200_multi_gpu():
+    project = build_workstation_project(
+        accelerator="H200", gpu_count=4, project_id="my-workstation"
+    )
+    assert project.name == "my-workstation"
+
+    job = project.job
+    assert job.compute.accelerator.accelerator.value == "H200"
+    assert job.compute.accelerator.count == 4
+
+
+def test_build_workstation_project_invalid_accelerator():
+    with pytest.raises(ValueError):
+        build_workstation_project(accelerator="INVALID", gpu_count=1, project_id="test")


### PR DESCRIPTION
## Summary
- Adds `truss train workstation` command to spin up an SSH workstation on Baseten training infrastructure
- Supports `--accelerator` (H100/H200), `--gpu-count` (1-8), `--project-id`, `--image`, `--tail`
- Defaults to `nvidia/cuda:12.8.1-devel-ubuntu24.04` base image with SSH interactive session on startup

## Usage
```bash
# Default: 1x H100
truss train workstation

# 4x H200 with custom project name
truss train workstation --accelerator H200 --gpu-count 4 --project-id my-dev-box

# Custom base image
truss train workstation --image pytorch/pytorch:2.7.0-cuda12.8-cudnn9-runtime
```

## Test plan
- [x] Unit tests for `build_workstation_project` (accelerator types, GPU counts, invalid input)
- [ ] Manual test: `uv run truss train workstation --accelerator H100` and SSH in