### PR TITLE
Add --slurm-node-count to workstation command for multi-node SLURM clusters

### DIFF
--- a/truss/base/constants.py
+++ b/truss/base/constants.py
@@ -19,6 +19,7 @@ CONTROL_SERVER_CODE_DIR: pathlib.Path = TEMPLATES_DIR / "control"
 CHAINS_CODE_DIR: pathlib.Path = _TRUSS_ROOT.parent / "truss-chains" / "truss_chains"
 TRUSS_CODE_DIR: pathlib.Path = _TRUSS_ROOT.parent / "truss"
 TRAINING_TEMPLATE_DIR = TEMPLATES_DIR / "train"
+WORKSTATION_TEMPLATE_DIR = TEMPLATES_DIR / "workstation"
 # Must be sorted ascendingly.
 SUPPORTED_PYTHON_VERSIONS = ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 

--- a/truss/cli/train/workstation.py
+++ b/truss/cli/train/workstation.py
@@ -1,6 +1,9 @@
+import shutil
+from pathlib import Path
 from typing import Optional
 
 from truss.base import truss_config
+from truss.base.constants import WORKSTATION_TEMPLATE_DIR
 from truss_train.definitions import (
     BasetenCheckpoint,
     CacheConfig,
@@ -19,11 +22,21 @@ from truss_train.definitions import (
 DEFAULT_BASE_IMAGE = "nvidia/cuda:12.8.1-devel-ubuntu24.04"
 
 
+def copy_workstation_templates(target_dir: Path) -> None:
+    """Copy workstation SLURM setup scripts to the target directory."""
+    for script in WORKSTATION_TEMPLATE_DIR.iterdir():
+        if script.is_file() and script.suffix == ".sh":
+            dest = target_dir / script.name
+            shutil.copy2(str(script), str(dest))
+            dest.chmod(0o755)
+
+
 def build_workstation_project(
     accelerator: str,
     gpu_count: int,
     project_id: str,
     base_image: str = DEFAULT_BASE_IMAGE,
+    node_count: int = 1,
     enable_checkpointing: bool = False,
     checkpoint_path: Optional[str] = None,
     checkpoint_volume_size: Optional[int] = None,
@@ -32,7 +45,7 @@ def build_workstation_project(
     accel_enum = truss_config.Accelerator(accelerator)
 
     compute = Compute(
-        node_count=1,
+        node_count=node_count,
         accelerator=truss_config.AcceleratorSpec(
             accelerator=accel_enum, count=gpu_count
         ),
@@ -47,8 +60,13 @@ def build_workstation_project(
             ],
         )
 
+    if node_count > 1:
+        start_commands = ["bash /b10/workspace/setup_slurm.sh"]
+    else:
+        start_commands = ["sleep infinity"]
+
     runtime = Runtime(
-        start_commands=["sleep infinity"],
+        start_commands=start_commands,
         cache_config=CacheConfig(enabled=True, require_cache_affinity=False),
         checkpointing_config=CheckpointingConfig(
             enabled=enable_checkpointing,

--- a/truss/cli/train_commands.py
+++ b/truss/cli/train_commands.py
@@ -1134,14 +1134,21 @@ def capacity(remote: Optional[str]):
 @click.option(
     "--gpu-count",
     type=click.IntRange(1, 8),
-    default=1,
-    help="Number of GPUs (1-8, default: 1).",
+    default=None,
+    help="Number of GPUs (1-8, default: 1). Mutually exclusive with --slurm-node-count.",
 )
 @click.option(
     "--project-id",
     type=str,
     required=False,
     help="Project name (default: workstation-<accelerator>).",
+)
+@click.option(
+    "--slurm-node-count",
+    "node_count",
+    type=click.IntRange(1, 16),
+    default=None,
+    help="Number of SLURM nodes (each with 8 GPUs). Mutually exclusive with --gpu-count.",
 )
 @click.option(
     "--image",
@@ -1178,8 +1185,9 @@ def capacity(remote: Optional[str]):
 @common.common_options()
 def workstation(
     accelerator: str,
-    gpu_count: int,
+    gpu_count: Optional[int],
     project_id: Optional[str],
+    node_count: Optional[int],
     image: Optional[str],
     enable_checkpointing: bool,
     checkpoint_path: Optional[str],
@@ -1194,8 +1202,22 @@ def workstation(
     from truss.cli.train.workstation import (
         DEFAULT_BASE_IMAGE,
         build_workstation_project,
+        copy_workstation_templates,
     )
     from truss_train.public_api import push
+
+    if gpu_count is not None and node_count is not None:
+        raise click.UsageError(
+            "--gpu-count and --slurm-node-count are mutually exclusive."
+        )
+
+    if node_count is not None:
+        # SLURM mode: each node gets 8 GPUs
+        gpu_count = 8
+    else:
+        # Single-node mode
+        gpu_count = gpu_count or 1
+        node_count = 1
 
     accelerator = accelerator.upper()
     if not project_id:
@@ -1210,32 +1232,54 @@ def workstation(
         gpu_count=gpu_count,
         project_id=project_id,
         base_image=base_image,
+        node_count=node_count,
         enable_checkpointing=enable_checkpointing,
         checkpoint_path=checkpoint_path,
         checkpoint_volume_size=checkpoint_volume_size,
         checkpoint_from_job=checkpoint_from_job,
     )
 
+    node_str = f"{node_count}x " if node_count > 1 else ""
     console.print(
         f"Launching workstation [cyan]{project_id}[/cyan] "
-        f"with [cyan]{gpu_count}x {accelerator}[/cyan]..."
+        f"with [cyan]{node_str}{gpu_count}x {accelerator}[/cyan]..."
     )
 
-    # Use an empty temp dir as source so we don't upload the user's cwd.
-    with tempfile.TemporaryDirectory() as empty_dir:
+    # Use a temp dir as source so we don't upload the user's cwd.
+    # For multi-node, copy the SLURM setup scripts into it.
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        if node_count > 1:
+            copy_workstation_templates(Path(tmp_dir))
         job_resp = push(
-            config=training_project, remote=remote, source_dir=Path(empty_dir)
+            config=training_project, remote=remote, source_dir=Path(tmp_dir)
         )
 
     job_id = job_resp["id"]
+    ssh_lines = f"  [cyan]ssh training-job-{job_id}-0.ssh.baseten.co[/cyan]"
+    if node_count > 1:
+        ssh_lines += " (leader)"
+        for i in range(1, node_count):
+            ssh_lines += (
+                f"\n  [cyan]ssh training-job-{job_id}-{i}.ssh.baseten.co[/cyan]"
+            )
+
+    multi_node_hint = ""
+    if node_count > 1:
+        multi_node_hint = (
+            "\n"
+            "Multi-node env vars available on each node:\n"
+            "  BT_LEADER_ADDR, BT_NODE_RANK, BT_GROUP_SIZE\n"
+        )
+
     console.print(
         f"\n[green]Workstation created![/green]\n"
         f"\n"
         f"Once the job is running, SSH in with:\n"
-        f"  [cyan]ssh training-job-{job_id}-0.ssh.baseten.co[/cyan]\n"
+        f"{ssh_lines}\n"
         f"\n"
         f"If you haven't set up SSH yet, run:\n"
         f"  [cyan]truss ssh setup[/cyan]\n"
+        f"{multi_node_hint}"
         f"\n"
         f"View logs:\n"
         f"  [cyan]truss train logs --job-id {job_id} --tail[/cyan]\n"

--- a/truss/templates/workstation/install_slurm.sh
+++ b/truss/templates/workstation/install_slurm.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Common SLURM + munge installation for all workstation nodes.
+# This script is sourced (not executed) by setup_slurm.sh.
+
+SLURM_DIR="${BT_PROJECT_CACHE_DIR}/slurm_workstation"
+mkdir -p "$SLURM_DIR"
+
+export DEBIAN_FRONTEND=noninteractive
+echo "Installing SLURM packages..."
+apt-get update -qq 2>&1
+apt-get install -y -qq slurm-wlm slurm-client munge 2>&1
+
+# Setup munge directories
+mkdir -p /etc/munge /var/log/munge /var/lib/munge /run/munge
+chown -R munge:munge /etc/munge /var/log/munge /var/lib/munge /run/munge
+chmod 700 /etc/munge
+chmod 711 /run/munge
+pkill -9 munged 2>/dev/null || true
+rm -f /etc/munge/munge.key
+
+# Detect GPUs
+ACTUAL_GPUS=0
+for dev in /dev/nvidia[0-9]*; do
+    [ -e "$dev" ] && ACTUAL_GPUS=$((ACTUAL_GPUS + 1))
+done
+
+WORKER_IP=$(hostname -I | awk '{print $1}')
+WORKER_HOSTNAME=$(hostname -s)
+
+echo "SLURM installed on ${WORKER_HOSTNAME} (${WORKER_IP}, ${ACTUAL_GPUS} GPUs)"
+
+# Shared helper: configure gres.conf and cgroup.conf.
+# Called by both controller and worker setup scripts.
+configure_gres_and_cgroup() {
+    mkdir -p /etc/slurm
+    cat > /etc/slurm/gres.conf <<GRESCONF
+GRESCONF
+    for dev in /dev/nvidia[0-9]*; do
+        [ -e "$dev" ] && echo "Name=gpu File=${dev}" >> /etc/slurm/gres.conf
+    done
+
+    # Use cgroup/v1 — containers have cgroup2 mounted read-only,
+    # so the v2 plugin cannot create scopes.
+    cat > /etc/slurm/cgroup.conf <<CGROUPCONF
+CgroupPlugin=cgroup/v1
+CGROUPCONF
+}

--- a/truss/templates/workstation/setup_controller.sh
+++ b/truss/templates/workstation/setup_controller.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+# Controller node (rank 0) setup.
+# Runs slurmctld + slurmd, generates slurm.conf, then idles.
+# This script is sourced by setup_slurm.sh after install_slurm.sh.
+#
+# Expected variables from install_slurm.sh:
+#   SLURM_DIR, ACTUAL_GPUS, WORKER_IP, WORKER_HOSTNAME
+
+# Clean stale state from previous runs before any workers register
+rm -rf "$SLURM_DIR/nodes"
+rm -f "$SLURM_DIR/slurm.conf" "$SLURM_DIR/munge.key"
+mkdir -p "$SLURM_DIR/nodes"
+# Signal that cleanup is done and workers can register
+touch "$SLURM_DIR/ready_for_registration"
+
+# Register this node
+echo "$WORKER_IP" > "$SLURM_DIR/nodes/node_${BT_NODE_RANK}_ip"
+echo "$WORKER_HOSTNAME" > "$SLURM_DIR/nodes/node_${BT_NODE_RANK}_hostname"
+echo "$ACTUAL_GPUS" > "$SLURM_DIR/nodes/node_${BT_NODE_RANK}_gpus"
+grep -c ^processor /proc/cpuinfo > "$SLURM_DIR/nodes/node_${BT_NODE_RANK}_cpus"
+echo "Node ${BT_NODE_RANK}: registered (${WORKER_HOSTNAME}, ${WORKER_IP}, ${ACTUAL_GPUS} GPUs)"
+
+# Generate and share munge key
+dd if=/dev/urandom bs=1 count=1024 > /etc/munge/munge.key 2>/dev/null
+chown munge:munge /etc/munge/munge.key
+chmod 400 /etc/munge/munge.key
+cp /etc/munge/munge.key "$SLURM_DIR/munge.key.tmp"
+mv "$SLURM_DIR/munge.key.tmp" "$SLURM_DIR/munge.key"
+
+# Start munge
+service munge start || munged --force
+
+# Wait for all nodes to register
+echo "Waiting for ${BT_GROUP_SIZE} nodes to register..."
+while true; do
+    REGISTERED=$(ls "$SLURM_DIR/nodes"/node_*_ip 2>/dev/null | wc -l)
+    [ "$REGISTERED" -ge "$BT_GROUP_SIZE" ] && break
+    echo "  ${REGISTERED}/${BT_GROUP_SIZE} nodes registered..."
+    sleep 3
+done
+echo "All ${BT_GROUP_SIZE} nodes registered."
+
+# Build /etc/hosts and slurm.conf
+CONTROLLER_IP="$WORKER_IP"
+CONTROLLER_HOSTNAME="$WORKER_HOSTNAME"
+
+mkdir -p /var/spool/slurmctld /var/spool/slurmd /var/log/slurm /etc/slurm
+chmod 755 /var/spool/slurmctld /var/spool/slurmd
+
+cat > /etc/slurm/slurm.conf <<SLURMCONF
+ClusterName=workstation
+SlurmctldHost=${CONTROLLER_HOSTNAME}(${CONTROLLER_IP})
+SlurmUser=root
+MpiDefault=none
+ProctrackType=proctrack/linuxproc
+ReturnToService=2
+SlurmctldPidFile=/run/slurmctld.pid
+SlurmdPidFile=/run/slurmd.pid
+SlurmdSpoolDir=/var/spool/slurmd
+SlurmctldLogFile=/var/log/slurm/slurmctld.log
+SlurmdLogFile=/var/log/slurm/slurmd.log
+StateSaveLocation=/var/spool/slurmctld
+SchedulerType=sched/builtin
+SelectType=select/cons_tres
+SelectTypeParameters=CR_Core_Memory
+TaskPlugin=task/none
+SlurmctldDebug=info
+SlurmdDebug=info
+SlurmdParameters=config_overrides
+SlurmdTimeout=300
+InactiveLimit=0
+MinJobAge=300
+SlurmctldTimeout=120
+WaitTime=0
+GresTypes=gpu
+SLURMCONF
+
+ALL_NODES=""
+for i in $(seq 0 $((BT_GROUP_SIZE - 1))); do
+    NODE_IP=$(cat "$SLURM_DIR/nodes/node_${i}_ip")
+    NODE_HOST=$(cat "$SLURM_DIR/nodes/node_${i}_hostname")
+    NODE_GPUS=$(cat "$SLURM_DIR/nodes/node_${i}_gpus")
+    NODE_CPUS=$(cat "$SLURM_DIR/nodes/node_${i}_cpus")
+
+    # Add to /etc/hosts
+    sed -i "/ ${NODE_HOST}$/d" /etc/hosts 2>/dev/null || true
+    echo "${NODE_IP} ${NODE_HOST}" >> /etc/hosts
+
+    echo "NodeName=${NODE_HOST} NodeAddr=${NODE_IP} CPUs=${NODE_CPUS} RealMemory=100000 Gres=gpu:${NODE_GPUS} State=UNKNOWN" >> /etc/slurm/slurm.conf
+
+    [ -z "$ALL_NODES" ] && ALL_NODES="$NODE_HOST" || ALL_NODES="${ALL_NODES},${NODE_HOST}"
+done
+
+echo "PartitionName=gpu Nodes=${ALL_NODES} Default=YES MaxTime=INFINITE State=UP" >> /etc/slurm/slurm.conf
+
+# Share slurm.conf with workers
+cp /etc/slurm/slurm.conf "$SLURM_DIR/slurm.conf"
+
+configure_gres_and_cgroup
+
+# Clear stale state and start slurmctld
+rm -f /var/spool/slurmctld/node_state /var/spool/slurmctld/node_state.old
+rm -f /var/spool/slurmctld/job_state /var/spool/slurmctld/job_state.old
+slurmctld -D &
+sleep 3
+echo "slurmctld started."
+
+# Also run slurmd on node 0 (it's a worker too)
+slurmd -D &
+sleep 2
+echo "slurmd started on controller node."
+
+# Wait for all workers to show up in sinfo
+echo "Waiting for all ${BT_GROUP_SIZE} nodes in SLURM..."
+WAITED=0
+while true; do
+    READY=$(sinfo -N --noheader 2>/dev/null | grep -cE "idle|mixed|alloc" || true)
+    [ "$READY" -ge "$BT_GROUP_SIZE" ] && break
+    sleep 5
+    WAITED=$((WAITED + 5))
+    [ "$WAITED" -ge 300 ] && echo "WARNING: timeout waiting for SLURM nodes" && break
+    echo "  SLURM nodes ready: ${READY}/${BT_GROUP_SIZE}"
+done
+
+echo ""
+echo "============================================"
+echo "  SLURM CLUSTER READY"
+echo "  Nodes: ${BT_GROUP_SIZE}"
+echo "  GPUs per node: ${ACTUAL_GPUS}"
+echo "  Total GPUs: $((BT_GROUP_SIZE * ACTUAL_GPUS))"
+echo "============================================"
+echo ""
+sinfo
+echo ""
+
+sleep infinity

--- a/truss/templates/workstation/setup_slurm.sh
+++ b/truss/templates/workstation/setup_slurm.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Entry point for multi-node workstation SLURM setup.
+# Dispatches to controller or worker based on BT_NODE_RANK.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Common setup: install SLURM, munge, detect GPUs
+source "${SCRIPT_DIR}/install_slurm.sh"
+
+if [ "${BT_NODE_RANK}" = "0" ]; then
+    source "${SCRIPT_DIR}/setup_controller.sh"
+else
+    source "${SCRIPT_DIR}/setup_worker.sh"
+fi

--- a/truss/templates/workstation/setup_worker.sh
+++ b/truss/templates/workstation/setup_worker.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Worker node (rank > 0) setup.
+# Registers with the controller, starts slurmd, then idles.
+# This script is sourced by setup_slurm.sh after install_slurm.sh.
+#
+# Expected variables from install_slurm.sh:
+#   SLURM_DIR, ACTUAL_GPUS, WORKER_IP, WORKER_HOSTNAME
+
+# Wait for controller to clean stale state
+echo "Waiting for controller to initialize..."
+while [ ! -f "$SLURM_DIR/ready_for_registration" ]; do sleep 2; done
+
+# Register this node
+mkdir -p "$SLURM_DIR/nodes"
+echo "$WORKER_IP" > "$SLURM_DIR/nodes/node_${BT_NODE_RANK}_ip"
+echo "$WORKER_HOSTNAME" > "$SLURM_DIR/nodes/node_${BT_NODE_RANK}_hostname"
+echo "$ACTUAL_GPUS" > "$SLURM_DIR/nodes/node_${BT_NODE_RANK}_gpus"
+grep -c ^processor /proc/cpuinfo > "$SLURM_DIR/nodes/node_${BT_NODE_RANK}_cpus"
+echo "Node ${BT_NODE_RANK}: registered (${WORKER_HOSTNAME}, ${WORKER_IP}, ${ACTUAL_GPUS} GPUs)"
+
+# Wait for munge key
+echo "Waiting for munge key from controller..."
+while [ ! -f "$SLURM_DIR/munge.key" ]; do sleep 2; done
+cp "$SLURM_DIR/munge.key" /etc/munge/munge.key
+chown munge:munge /etc/munge/munge.key
+chmod 400 /etc/munge/munge.key
+service munge start || munged --force
+
+# Wait for slurm.conf containing our hostname
+echo "Waiting for slurm.conf..."
+while true; do
+    [ -f "$SLURM_DIR/slurm.conf" ] \
+        && grep -q "$WORKER_HOSTNAME" "$SLURM_DIR/slurm.conf" 2>/dev/null \
+        && break
+    sleep 2
+done
+
+mkdir -p /var/spool/slurmd /var/log/slurm /etc/slurm
+chmod 755 /var/spool/slurmd
+cp "$SLURM_DIR/slurm.conf" /etc/slurm/slurm.conf
+
+# Add all nodes to /etc/hosts
+for i in $(seq 0 $((BT_GROUP_SIZE - 1))); do
+    [ "$i" = "${BT_NODE_RANK}" ] && continue
+    if [ -f "$SLURM_DIR/nodes/node_${i}_ip" ]; then
+        OTHER_IP=$(cat "$SLURM_DIR/nodes/node_${i}_ip")
+        OTHER_HOST=$(cat "$SLURM_DIR/nodes/node_${i}_hostname")
+        echo "${OTHER_IP} ${OTHER_HOST}" >> /etc/hosts
+    fi
+done
+
+configure_gres_and_cgroup
+
+# Start slurmd
+slurmd -D &
+sleep 2
+echo "Worker ${BT_NODE_RANK} slurmd started."
+
+sleep infinity

--- a/truss/tests/cli/train/test_workstation.py
+++ b/truss/tests/cli/train/test_workstation.py
@@ -1,10 +1,24 @@
+import os
+import tempfile
+from pathlib import Path
+
 import pytest
 
-from truss.cli.train.workstation import build_workstation_project
+from truss.cli.train.workstation import (
+    build_workstation_project,
+    copy_workstation_templates,
+)
 from truss_train.definitions import (
     InteractiveSessionProvider,
     InteractiveSessionTrigger,
 )
+
+EXPECTED_TEMPLATE_FILES = [
+    "setup_slurm.sh",
+    "install_slurm.sh",
+    "setup_controller.sh",
+    "setup_worker.sh",
+]
 
 
 def test_build_workstation_project_defaults():
@@ -37,3 +51,29 @@ def test_build_workstation_project_h200_multi_gpu():
 def test_build_workstation_project_invalid_accelerator():
     with pytest.raises(ValueError):
         build_workstation_project(accelerator="INVALID", gpu_count=1, project_id="test")
+
+
+def test_build_workstation_project_multinode_uses_slurm():
+    project = build_workstation_project(
+        accelerator="H100", gpu_count=8, project_id="test", node_count=4
+    )
+    job = project.job
+    assert job.compute.node_count == 4
+    assert job.runtime.start_commands == ["bash /b10/workspace/setup_slurm.sh"]
+
+
+def test_copy_workstation_templates():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        copy_workstation_templates(Path(tmp_dir))
+        for name in EXPECTED_TEMPLATE_FILES:
+            script = Path(tmp_dir) / name
+            assert script.exists(), f"Missing {name}"
+            assert os.access(script, os.X_OK), f"{name} is not executable"
+
+
+def test_workstation_template_dir_exists():
+    from truss.base.constants import WORKSTATION_TEMPLATE_DIR
+
+    assert WORKSTATION_TEMPLATE_DIR.exists()
+    for name in EXPECTED_TEMPLATE_FILES:
+        assert (WORKSTATION_TEMPLATE_DIR / name).exists(), f"Missing template {name}"


### PR DESCRIPTION
## Summary
Adds `--slurm-node-count` to `truss train workstation` for spinning up multi-node SLURM clusters.

- `--slurm-node-count N` provisions N nodes as a SLURM cluster (each with 8 GPUs, mutually exclusive with `--gpu-count`). Node 0 runs slurmctld + slurmd, others run slurmd. SSH into node 0 and use `srun`/`sbatch`.
- SLURM setup scripts live in `truss/templates/workstation/` as modular shell scripts (install, controller, worker).
- Uses cgroup/v1 and TaskPlugin=task/none for container compatibility.

## Usage
```bash
# Single node, 2 GPUs (existing behavior)
truss train workstation --accelerator H200 --gpu-count 2

# 4-node SLURM cluster (32 GPUs total)
truss train workstation --accelerator H200 --slurm-node-count 4
```

## Test plan
- [x] 6 unit tests pass
- [x] Manually tested 4-node H200 SLURM cluster — `srun --nodes=4 --ntasks=4 hostname` across all nodes