### PR TITLE
fix(truss): Add missing weights block to BIS LLM Deploys

### DIFF
--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -218,6 +218,8 @@ class BasetenRemote(TrussRemote):
             body["name"] = model_name
         if config.environment_variables:
             body["environment_variables"] = config.environment_variables
+        if config.weights:
+            body["weights"] = config.weights.model_dump(exclude_none=True)
         if labels is not None:
             body["metadata"] = labels
 

--- a/truss/tests/remote/baseten/test_remote.py
+++ b/truss/tests/remote/baseten/test_remote.py
@@ -6,7 +6,7 @@ import pydantic
 import pytest
 import requests_mock
 
-from truss.base.truss_config import BISLLM
+from truss.base.truss_config import BISLLM, Weights, WeightsSource
 from truss.remote.baseten import custom_types as b10_types
 from truss.remote.baseten.core import (
     ModelId,
@@ -656,6 +656,12 @@ def test_push_uses_bis_llm_service_for_bis_llm(
         config={"model": "test-llm"}, version="v1"
     )
     mock_truss_handle.spec.config.environment_variables = {"HF_TOKEN": "secret"}
+    mock_truss_handle.spec.config.weights = Weights(
+        [
+            WeightsSource(source="hf://model-1", mount_location="/models/base"),
+            WeightsSource(source="hf://model-2", mount_location="/models/adapter"),
+        ]
+    )
 
     bis_llm_handle = mock.Mock(
         version_id="bis-llm-deployment-id",
@@ -694,6 +700,10 @@ def test_push_uses_bis_llm_service_for_bis_llm(
     assert kwargs["team_id"] is None
     assert kwargs["body"]["llm_config"] == {"model": "test-llm"}
     assert kwargs["body"]["llm_version"] == "v1"
+    assert kwargs["body"]["weights"] == [
+        {"source": "hf://model-1", "mount_location": "/models/base"},
+        {"source": "hf://model-2", "mount_location": "/models/adapter"},
+    ]
     assert kwargs["body"]["environment_variables"] == {"HF_TOKEN": "secret"}
     assert kwargs["body"]["metadata"] == {
         "git_sha": "abc123",


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
The BDN integration with BIS was not being leveraged because the weights block was not passed on from the config to the REST API call.

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
