### PR TITLE
fix(truss-transfer): fail manifest creation when cloud weights resolve to zero files

### DIFF
--- a/truss-transfer/src/create/common_metadata.rs
+++ b/truss-transfer/src/create/common_metadata.rs
@@ -65,12 +65,19 @@ pub async fn extract_cloud_metadata<T: CloudMetadataProvider>(
 
         let mut list_stream = object_store.list(Some(&prefix_path));
 
+        // Track per-model object counts so we can fail fast on misconfigured
+        // weights sources (bad URI/prefix or filters that match nothing) instead
+        // of silently producing an empty manifest and starting the container.
+        let mut listed_count: usize = 0;
+        let mut kept_for_model: usize = 0;
+
         while let Some(meta) = list_stream
             .next()
             .await
             .transpose()
-            .map_err(|e| anyhow!("Failed to list objects: {}", e))?
+            .map_err(|e| anyhow!("Failed to list objects under '{}': {}", model.repo_id, e))?
         {
+            listed_count += 1;
             let object_path = meta.location.to_string();
 
             // Extract relative path from the prefix (for file naming)
@@ -120,6 +127,25 @@ pub async fn extract_cloud_metadata<T: CloudMetadataProvider>(
             };
 
             basetenpointers.push(pointer);
+            kept_for_model += 1;
+        }
+
+        if listed_count == 0 {
+            return Err(anyhow!(
+                "No objects found at '{}'. Verify the URI/prefix exists and that the provided \
+                 credentials ('{}') have list access to it.",
+                model.repo_id,
+                model.runtime_secret_name
+            ));
+        }
+        if kept_for_model == 0 {
+            return Err(anyhow!(
+                "No files at '{}' matched the configured allow_patterns={:?} / \
+                 ignore_patterns={:?}. Adjust the patterns or remove them to include files.",
+                model.repo_id,
+                model.allow_patterns,
+                model.ignore_patterns
+            ));
         }
     }
 
@@ -134,4 +160,169 @@ pub async fn create_single_cloud_basetenpointers<T: CloudMetadataProvider>(
     model_path: &String,
 ) -> Result<Vec<BasetenPointer>> {
     extract_cloud_metadata(provider, vec![repo], model_path.clone()).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{GcsResolution, ResolutionType};
+    use bytes::Bytes;
+    use object_store::memory::InMemory;
+    use object_store::path::Path as ObjPath;
+    use std::sync::Arc;
+
+    /// Test provider that wraps an in-memory ObjectStore so we can drive
+    /// extract_cloud_metadata without hitting the network. Holds an
+    /// Arc<dyn ObjectStore> (which has a blanket ObjectStore impl in the
+    /// crate) so we can hand out shared, pre-populated stores via
+    /// create_object_store while keeping the trait's Box<dyn ObjectStore>
+    /// return type.
+    struct TestProvider {
+        store: Arc<dyn ObjectStore>,
+        prefix: String,
+    }
+
+    #[async_trait::async_trait]
+    impl CloudMetadataProvider for TestProvider {
+        fn parse_uri(&self, _uri: &str) -> Result<(String, String)> {
+            Ok(("test-bucket".to_string(), self.prefix.clone()))
+        }
+
+        fn create_object_store(
+            &self,
+            _bucket: &str,
+            _runtime_secret_name: &str,
+        ) -> Result<Box<dyn ObjectStore>> {
+            Ok(Box::new(Arc::clone(&self.store)))
+        }
+
+        fn create_resolution(&self, bucket: &str, object_path: &str) -> Resolution {
+            Resolution::Gcs(GcsResolution::new(
+                object_path.to_string(),
+                bucket.to_string(),
+            ))
+        }
+
+        fn hash_type(&self) -> &'static str {
+            "etag"
+        }
+
+        fn extract_hash(&self, meta: &object_store::ObjectMeta) -> String {
+            meta.e_tag
+                .clone()
+                .unwrap_or_else(|| "test-etag".to_string())
+        }
+
+        fn generate_uid(&self, bucket: &str, object_path: &str, _hash: &str) -> String {
+            format!("test:{bucket}:{object_path}")
+        }
+    }
+
+    fn make_repo(allow: Option<Vec<String>>, ignore: Option<Vec<String>>) -> ModelRepo {
+        ModelRepo {
+            repo_id: "s3://test-bucket/missing/prefix".to_string(),
+            revision: "".to_string(),
+            allow_patterns: allow,
+            ignore_patterns: ignore,
+            volume_folder: "test_vol".to_string(),
+            runtime_secret_name: "aws-secret-json".to_string(),
+            kind: ResolutionType::S3,
+        }
+    }
+
+    #[tokio::test]
+    async fn errors_when_listing_returns_zero_objects() {
+        // Empty in-memory store -> `list` yields nothing.
+        let provider = TestProvider {
+            store: Arc::new(InMemory::new()),
+            prefix: "missing/prefix".to_string(),
+        };
+        let repo = make_repo(None, None);
+
+        let err = extract_cloud_metadata(&provider, vec![&repo], "/app/model_cache".to_string())
+            .await
+            .expect_err("expected an error when no objects are listed");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("No objects found"),
+            "unexpected error message: {msg}"
+        );
+        assert!(
+            msg.contains(&repo.repo_id),
+            "error should reference repo_id, got: {msg}"
+        );
+        assert!(
+            msg.contains(&repo.runtime_secret_name),
+            "error should reference runtime secret name, got: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn errors_when_all_files_filtered_out() {
+        // Populate the store with two real objects under the prefix.
+        let store = InMemory::new();
+        for name in &["model.bin", "config.json"] {
+            store
+                .put(
+                    &ObjPath::from(format!("data/{name}")),
+                    Bytes::from_static(b"hello").into(),
+                )
+                .await
+                .unwrap();
+        }
+        let provider = TestProvider {
+            store: Arc::new(store),
+            prefix: "data".to_string(),
+        };
+
+        // allow_patterns matches none of the listed objects -> all filtered out.
+        let repo = make_repo(Some(vec!["*.zzz".to_string()]), None);
+
+        let err = extract_cloud_metadata(&provider, vec![&repo], "/app/model_cache".to_string())
+            .await
+            .expect_err("expected an error when filters drop every object");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("No files at"),
+            "unexpected error message: {msg}"
+        );
+        assert!(
+            msg.contains("*.zzz"),
+            "error message should mention the failing allow_pattern, got: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn succeeds_when_at_least_one_file_matches() {
+        let store = InMemory::new();
+        store
+            .put(
+                &ObjPath::from("data/model.safetensors"),
+                Bytes::from_static(b"weights").into(),
+            )
+            .await
+            .unwrap();
+        store
+            .put(
+                &ObjPath::from("data/README.md"),
+                Bytes::from_static(b"docs").into(),
+            )
+            .await
+            .unwrap();
+        let provider = TestProvider {
+            store: Arc::new(store),
+            prefix: "data".to_string(),
+        };
+
+        let repo = make_repo(Some(vec!["*.safetensors".to_string()]), None);
+
+        let pointers =
+            extract_cloud_metadata(&provider, vec![&repo], "/app/model_cache".to_string())
+                .await
+                .expect("expected success when at least one file matches");
+        assert_eq!(pointers.len(), 1);
+        assert!(pointers[0].file_name.ends_with("model.safetensors"));
+    }
 }

--- a/truss-transfer/src/create/hf_metadata.rs
+++ b/truss-transfer/src/create/hf_metadata.rs
@@ -134,6 +134,17 @@ pub async fn metadata_hf_repo(
         .collect();
     let filtered_files = filter_repo_files(files, allow_patterns, ignore_patterns)?;
 
+    // Fail fast if the configured patterns excluded every file in the repo,
+    // otherwise the runtime would silently sync zero files and start the
+    // container with no weights.
+    if filtered_files.is_empty() {
+        return Err(HfError::Pattern(format!(
+            "No files in HuggingFace repo '{repo_id}' (revision '{revision}') matched the configured \
+             allow_patterns={allow_patterns:?} / ignore_patterns={ignore_patterns:?}. \
+             Adjust the patterns or remove them to include files."
+        )));
+    }
+
     // Use semaphore to limit concurrent metadata requests (max 20 concurrent)
     let semaphore = Arc::new(Semaphore::new(20));
     let mut tasks = FuturesUnordered::new();
@@ -302,5 +313,49 @@ mod tests {
         assert_eq!(model_repo.revision, "main");
         assert_eq!(model_repo.volume_folder, "test");
         assert_eq!(model_repo.runtime_secret_name, "hf_access_token");
+    }
+
+    /// Network-dependent test: ensures that when allow_patterns matches no
+    /// files in a real HuggingFace repo, metadata_hf_repo errors out instead
+    /// of silently returning an empty manifest. Mirrors the style of
+    /// `test_create_basetenpointer_hf_julien_dummy` in basetenpointer.rs which
+    /// already requires network access to HuggingFace.
+    #[tokio::test]
+    async fn metadata_hf_repo_errors_when_patterns_match_nothing() {
+        const HF_REPO: &str = "julien-c/dummy-unknown";
+        const HF_REVISION: &str = "60b8d3fe22aebb024b573f1cca224db3126d10f3";
+
+        let allow_patterns = vec!["*.this_extension_will_never_exist".to_string()];
+
+        let result = metadata_hf_repo(
+            HF_REPO,
+            HF_REVISION,
+            Some(&allow_patterns),
+            None,
+            None,
+        )
+        .await;
+
+        match result {
+            Err(HfError::Pattern(msg)) => {
+                assert!(
+                    msg.contains("matched the configured"),
+                    "unexpected error message: {msg}"
+                );
+                assert!(
+                    msg.contains("this_extension_will_never_exist"),
+                    "error should reference the failing pattern, got: {msg}"
+                );
+            }
+            Err(HfError::InvalidMetadata(msg))
+                if msg.contains("Failed to get repo info")
+                    || msg.contains("Failed to build HuggingFace API") =>
+            {
+                // No network access in this environment - skip the assertion.
+                eprintln!("Skipping network-dependent assertion: {msg}");
+            }
+            Ok(_) => panic!("expected an error when allow_patterns match nothing"),
+            Err(other) => panic!("unexpected error variant: {other:?}"),
+        }
     }
 }

--- a/truss-transfer/tests/test_create_bptr_with_aws.py
+++ b/truss-transfer/tests/test_create_bptr_with_aws.py
@@ -105,3 +105,52 @@ def test_dolly_with_download():
     assert Path(
         "/app/model_cache/julien_dummy/rank-0/checkpoint-24/tokenizer_config.json"
     ).exists()
+
+
+def test_nonexistent_s3_prefix_errors():
+    """Issue #2354: a misconfigured S3 URI/prefix must fail manifest creation
+    rather than silently producing an empty manifest and starting the
+    container with no weights synced."""
+    if not Path("/secrets/aws-secret-json").exists():
+        pytest.skip(
+            "Skipping test_nonexistent_s3_prefix_errors because AWS secret is not available."
+        )
+
+    models = [
+        truss_transfer.PyModelRepo(
+            repo_id="s3://bt-training-dev-org-b68c04fe47d34c85bfa91515bc9d5e2d/this/prefix/does/not/exist/",
+            revision="",
+            runtime_secret_name="aws-secret-json",
+            volume_folder="bogus_prefix",
+            kind="s3",
+            allow_patterns=None,
+            ignore_patterns=None,
+        )
+    ]
+
+    with pytest.raises(Exception, match="No objects found"):
+        truss_transfer.create_basetenpointer_from_models(models)
+
+
+def test_allow_pattern_matches_nothing_errors():
+    """Issue #2354: a real S3 prefix with an allow_pattern that matches no
+    files must fail manifest creation."""
+    if not Path("/secrets/aws-secret-json").exists():
+        pytest.skip(
+            "Skipping test_allow_pattern_matches_nothing_errors because AWS secret is not available."
+        )
+
+    models = [
+        truss_transfer.PyModelRepo(
+            repo_id="s3://bt-training-dev-org-b68c04fe47d34c85bfa91515bc9d5e2d/training_projects/n4q95w5/jobs/prwny3y/",
+            revision="",
+            runtime_secret_name="aws-secret-json",
+            volume_folder="julien_dummy",
+            kind="s3",
+            allow_patterns=["*.this_extension_will_never_exist"],
+            ignore_patterns=None,
+        )
+    ]
+
+    with pytest.raises(Exception, match="No files at"):
+        truss_transfer.create_basetenpointer_from_models(models)


### PR DESCRIPTION
Fixes: #2354

<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What

Fixes [issue #2354](https://github.com/basetenlabs/truss/issues/2354): when a weights / `model_cache` entry pointed at a cloud URI with **no matching objects** (bad S3/GCS/Azure prefix or no list access) or **`allow_patterns` / `ignore_patterns` excluded every file**, **truss-transfer** used to build an **empty Baseten pointer manifest** so the container could **start with zero weights synced**. Manifest creation now **fails fast** with clear errors instead of succeeding silently.

Also applies the same “no files after filtering” guard to **Hugging Face** repos when patterns remove every sibling file.

<!--
  How was the change described above implemented?
-->
## :computer: How

- **`truss-transfer` / `extract_cloud_metadata`** ([`truss-transfer/src/create/common_metadata.rs`](truss-transfer/src/create/common_metadata.rs)): per `ModelRepo`, count listed objects vs objects kept after glob filters; `Err` if **zero listed** (prefix / credentials / list) vs **zero kept** (patterns).
- **`truss-transfer` / `metadata_hf_repo`** ([`truss-transfer/src/create/hf_metadata.rs`](truss-transfer/src/create/hf_metadata.rs)): after `filter_repo_files`, `Err` if the filtered file list is empty, with `allow_patterns` / `ignore_patterns` in the message.
- **Tests**: in-memory `ObjectStore` unit tests for both cloud failure modes + success path; HF network smoke for empty allow list; optional **pytest** cases on real S3 (same secret path as existing `test_create_bptr_with_aws` tests) for bogus prefix and non-matching `allow_patterns`.

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing

- `cargo test --lib` in **`truss-transfer/`** (all lib tests, including new ones).
- `cargo clippy --tests --no-deps` in **`truss-transfer/`** (pre-existing warnings elsewhere; no new issues required for this change).
- `uv run ruff check` / format check on **`truss-transfer/tests/test_create_bptr_with_aws.py`**.
- **`truss-transfer/tests/test_create_bptr_with_aws.py`**: new cases **skip** without `/secrets/aws-secret-json` (same as existing AWS tests in that file).
- Full **`uv run pytest truss/tests`**: many failures are **Docker-dependent** (`python_on_whales` / `docker buildx`); not required to validate this Rust-only behavior. CI is the right place for the full matrix if Docker is not available locally.