### PR TITLE
fix(truss): rewrite apt sources to US.txt mirror by default (RUN-340)

### DIFF
--- a/truss/contexts/image_builder/serving_image_builder.py
+++ b/truss/contexts/image_builder/serving_image_builder.py
@@ -105,6 +105,12 @@ CLOUD_BUCKET_CACHE = MODEL_CACHE_PATH
 HF_SOURCE_DIR = Path("./root/.cache/huggingface/hub/")
 HF_CACHE_DIR = Path("/root/.cache/huggingface/hub/")
 
+_DEFAULT_APT_MIRROR_URL = "mirror://mirrors.ubuntu.com/US.txt"
+
+
+def _resolve_apt_mirror_url() -> str:
+    return os.getenv("BT_APT_MIRROR_URL") or _DEFAULT_APT_MIRROR_URL
+
 
 class RemoteCache(ABC):
     def __init__(self, repo_name, data_dir, revision=None):
@@ -962,6 +968,7 @@ class ServingImageBuilder(ImageBuilder):
             use_local_src=config.use_local_src,
             passthrough_environment_variables=passthrough_environment_variables,
             run_as_user_id=run_as_user_id,
+            apt_mirror_url=_resolve_apt_mirror_url(),
             **FILENAME_CONSTANTS_MAP,
         )
         # Consolidate repeated empty lines to single empty lines.

--- a/truss/templates/base.Dockerfile.jinja
+++ b/truss/templates/base.Dockerfile.jinja
@@ -76,12 +76,12 @@ RUN {{ python_exec_path }} -c "import sys; \
     || { echo "ERROR: Supplied base image does not have {{ min_supported_python_version_in_custom_base_image }} <= python <= {{ max_supported_python_version_in_custom_base_image }}"; exit 1; }
 {% endblock %}
 
-{# Use apt's mirror method on Canonical's US country list. mirrors.txt is a stale fallback. #}
+{# Rewrite apt sources to a multi-mirror list. Default is Canonical's US country list; override with BT_APT_MIRROR_URL. #}
 {# Handle old format (Ubuntu 22.04 and earlier): /etc/apt/sources.list, and new format (Ubuntu 24.04+): /etc/apt/sources.list.d/ubuntu.sources #}
 {%- set ubuntu_sources_list_files = ["/etc/apt/sources.list", "/etc/apt/sources.list.d/ubuntu.sources"] %}
 {%- for ubuntu_sources_list_file in ubuntu_sources_list_files %}
 RUN if [ -f {{ ubuntu_sources_list_file }} ]; then \
-    sed -i.bak 's|http://archive.ubuntu.com/ubuntu/|mirror://mirrors.ubuntu.com/US.txt|g' {{ ubuntu_sources_list_file }}; \
+    sed -i.bak 's|http://archive.ubuntu.com/ubuntu/|{{ apt_mirror_url }}|g' {{ ubuntu_sources_list_file }}; \
 fi
 {%- endfor %}
 

--- a/truss/templates/base.Dockerfile.jinja
+++ b/truss/templates/base.Dockerfile.jinja
@@ -76,7 +76,7 @@ RUN {{ python_exec_path }} -c "import sys; \
     || { echo "ERROR: Supplied base image does not have {{ min_supported_python_version_in_custom_base_image }} <= python <= {{ max_supported_python_version_in_custom_base_image }}"; exit 1; }
 {% endblock %}
 
-{# Rewrite apt sources to a multi-mirror list. Default is Canonical's US country list; override with BT_APT_MIRROR_URL. #}
+{# Rewrite apt sources. Default uses apt's mirror method on Canonical's US country list. Override with BT_APT_MIRROR_URL: must end in '/ubuntu/' for a single mirror (e.g. https://mirrors.kernel.org/ubuntu/) or be a 'mirror://...' URL. #}
 {# Handle old format (Ubuntu 22.04 and earlier): /etc/apt/sources.list, and new format (Ubuntu 24.04+): /etc/apt/sources.list.d/ubuntu.sources #}
 {%- set ubuntu_sources_list_files = ["/etc/apt/sources.list", "/etc/apt/sources.list.d/ubuntu.sources"] %}
 {%- for ubuntu_sources_list_file in ubuntu_sources_list_files %}

--- a/truss/templates/base.Dockerfile.jinja
+++ b/truss/templates/base.Dockerfile.jinja
@@ -76,12 +76,12 @@ RUN {{ python_exec_path }} -c "import sys; \
     || { echo "ERROR: Supplied base image does not have {{ min_supported_python_version_in_custom_base_image }} <= python <= {{ max_supported_python_version_in_custom_base_image }}"; exit 1; }
 {% endblock %}
 
-{# mirrors.ubuntu.com is a redirector service (uses mirrors.txt) that provides the best mirror based on location #}
+{# Use apt's mirror method on Canonical's US country list. mirrors.txt is a stale fallback. #}
 {# Handle old format (Ubuntu 22.04 and earlier): /etc/apt/sources.list, and new format (Ubuntu 24.04+): /etc/apt/sources.list.d/ubuntu.sources #}
 {%- set ubuntu_sources_list_files = ["/etc/apt/sources.list", "/etc/apt/sources.list.d/ubuntu.sources"] %}
 {%- for ubuntu_sources_list_file in ubuntu_sources_list_files %}
 RUN if [ -f {{ ubuntu_sources_list_file }} ]; then \
-    sed -i.bak 's|http://archive.ubuntu.com/ubuntu/|mirror://mirrors.ubuntu.com/mirrors.txt|g' {{ ubuntu_sources_list_file }}; \
+    sed -i.bak 's|http://archive.ubuntu.com/ubuntu/|mirror://mirrors.ubuntu.com/US.txt|g' {{ ubuntu_sources_list_file }}; \
 fi
 {%- endfor %}
 

--- a/truss/tests/contexts/image_builder/test_serving_image_builder.py
+++ b/truss/tests/contexts/image_builder/test_serving_image_builder.py
@@ -54,6 +54,45 @@ def test_serving_image_dockerfile_from_user_base_image(
         assert gen_docker_lines == server_docker_lines
 
 
+@patch("platform.machine", return_value="amd")
+def test_apt_mirror_url_override(mock_machine, custom_model_truss_dir, monkeypatch):
+    monkeypatch.setenv("BT_APT_MIRROR_URL", "mirror://mirrors.ubuntu.com/JP.txt")
+    th = TrussHandle(custom_model_truss_dir)
+    th.update_python_version("py313")
+    th.set_base_image("baseten/truss-server-base:3.13-v0.4.3", "/usr/local/bin/python3")
+    image_builder = ServingImageBuilderContext.run(th.spec.truss_dir)
+
+    with TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir)
+        image_builder.prepare_image_build_dir(tmp_path)
+        dockerfile = (tmp_path / "Dockerfile").read_text()
+
+    assert "mirror://mirrors.ubuntu.com/JP.txt" in dockerfile
+    assert "mirror://mirrors.ubuntu.com/US.txt" not in dockerfile
+
+
+@pytest.mark.parametrize("env_value", [None, ""])
+@patch("platform.machine", return_value="amd")
+def test_apt_mirror_url_default(
+    mock_machine, custom_model_truss_dir, monkeypatch, env_value
+):
+    if env_value is None:
+        monkeypatch.delenv("BT_APT_MIRROR_URL", raising=False)
+    else:
+        monkeypatch.setenv("BT_APT_MIRROR_URL", env_value)
+    th = TrussHandle(custom_model_truss_dir)
+    th.update_python_version("py313")
+    th.set_base_image("baseten/truss-server-base:3.13-v0.4.3", "/usr/local/bin/python3")
+    image_builder = ServingImageBuilderContext.run(th.spec.truss_dir)
+
+    with TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir)
+        image_builder.prepare_image_build_dir(tmp_path)
+        dockerfile = (tmp_path / "Dockerfile").read_text()
+
+    assert "mirror://mirrors.ubuntu.com/US.txt" in dockerfile
+
+
 def test_requirements_setup_in_build_dir(custom_model_truss_dir):
     th = TrussHandle(custom_model_truss_dir)
     th.add_python_requirement("numpy")

--- a/truss/tests/test_data/server.Dockerfile
+++ b/truss/tests/test_data/server.Dockerfile
@@ -17,10 +17,10 @@ RUN /usr/local/bin/python3 -c "import sys; \
     else sys.exit(1)" \
     || { echo "ERROR: Supplied base image does not have 3.9 <= python <= 3.14"; exit 1; }
 RUN if [ -f /etc/apt/sources.list ]; then \
-    sed -i.bak 's|http://archive.ubuntu.com/ubuntu/|mirror://mirrors.ubuntu.com/mirrors.txt|g' /etc/apt/sources.list; \
+    sed -i.bak 's|http://archive.ubuntu.com/ubuntu/|mirror://mirrors.ubuntu.com/US.txt|g' /etc/apt/sources.list; \
 fi
 RUN if [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then \
-    sed -i.bak 's|http://archive.ubuntu.com/ubuntu/|mirror://mirrors.ubuntu.com/mirrors.txt|g' /etc/apt/sources.list.d/ubuntu.sources; \
+    sed -i.bak 's|http://archive.ubuntu.com/ubuntu/|mirror://mirrors.ubuntu.com/US.txt|g' /etc/apt/sources.list.d/ubuntu.sources; \
 fi
 RUN command -v curl >/dev/null 2>&1 || (apt update && apt install -y curl)
 RUN if ! command -v uv >/dev/null 2>&1; then \


### PR DESCRIPTION
## Why

`mirrors.ubuntu.com/mirrors.txt` is a stale 34-byte file (Last-Modified 2023-03-30) containing only `http://archive.ubuntu.com/ubuntu/`. The apt mirror method using that URL has no real failover.

## What

- Default: rewrite apt sources to `mirror://mirrors.ubuntu.com/US.txt`, Canonical's regenerated US country list (~80 entries with `archive.ubuntu.com` as final fallback).
- Override: read `BT_APT_MIRROR_URL` at image-build time and substitute that value in the rewrite. Empty/unset preserves the US.txt default.

## Verified

Docker build from `nvidia/cuda:12.8.1-base-ubuntu22.04`: `apt-get update` fetches `http://mirrors.ubuntu.com/US.txt`, packages pull from a mix of US mirrors with apt's automatic fallthrough on per-mirror errors, `apt-get install curl` succeeds. Unit tests cover override and default render paths.