### PR TITLE
Auto-open browser for OAuth device flow login

### DIFF
--- a/truss/remote/baseten/oauth.py
+++ b/truss/remote/baseten/oauth.py
@@ -6,10 +6,13 @@ Tokens are returned as :class:`OAuthCredential` with an absolute Unix
 
 import logging
 import time
+import webbrowser
 from typing import Optional
 
 import pydantic
 import requests
+
+from truss.cli.utils.output import console
 
 logger = logging.getLogger(__name__)
 
@@ -127,11 +130,21 @@ def poll_device_token(
 
 
 def run_device_flow(api_url: str) -> OAuthCredential:
-    """Drive the full device flow: authorize, prompt, poll, return credential."""
+    """Drive the full device flow: authorize, open browser, poll, return credential."""
     authorization = request_device_authorization(api_url)
-    logger.info(
-        "Enter code %s at %s", authorization.user_code, authorization.verification_uri
-    )
+    target = authorization.verification_uri_complete or authorization.verification_uri
+    try:
+        webbrowser.open(target, new=2)
+    except Exception:
+        pass
+    console.print("Browser opened to authenticate...")
+    console.print()
+    console.print("If it didn't open, visit:")
+    console.print(f"  {target}")
+    console.print()
+    console.print(f"Verification code: {authorization.user_code}")
+    console.print()
+    console.print("Waiting...")
     return poll_device_token(api_url, authorization)
 
 

--- a/truss/tests/remote/baseten/test_oauth.py
+++ b/truss/tests/remote/baseten/test_oauth.py
@@ -195,7 +195,11 @@ def test_revoke_swallows_errors(caplog):
     assert any("revoke" in r.message.lower() for r in caplog.records)
 
 
-def test_run_device_flow_end_to_end():
+def test_run_device_flow_end_to_end(monkeypatch, capsys):
+    opened = []
+    monkeypatch.setattr(
+        oauth.webbrowser, "open", lambda url, new=0: opened.append(url) or True
+    )
     with requests_mock.Mocker() as m:
         m.post(DEVICE_AUTHORIZE_URL, json=_device_authorize_body())
         m.post(
@@ -204,3 +208,25 @@ def test_run_device_flow_end_to_end():
         )
         cred = oauth.run_device_flow(API_URL)
     assert cred.access_token == "at"
+    assert opened == ["https://login.baseten.co/device?user_code=USER"]
+    out = capsys.readouterr().out
+    assert "https://login.baseten.co/device?user_code=USER" in out
+    assert "USER" in out
+
+
+def test_run_device_flow_browser_open_failure_still_prints(monkeypatch, capsys):
+    def _raise(url, new=0):
+        raise RuntimeError("no browser")
+
+    monkeypatch.setattr(oauth.webbrowser, "open", _raise)
+    with requests_mock.Mocker() as m:
+        m.post(DEVICE_AUTHORIZE_URL, json=_device_authorize_body())
+        m.post(
+            DEVICE_TOKEN_URL,
+            json={"access_token": "at", "refresh_token": "rt", "expires_in": 3600},
+        )
+        cred = oauth.run_device_flow(API_URL)
+    assert cred.access_token == "at"
+    out = capsys.readouterr().out
+    assert "https://login.baseten.co/device?user_code=USER" in out
+    assert "USER" in out


### PR DESCRIPTION
## :rocket: What

Auto open browser to URL w/ verify code already present

## :computer: How

Just use `webbrowser` package and use `verification_uri_complete` instead of just `verification_uri`

## :microscope: Testing

Updated mocked unit tests and manually verified
