### PR TITLE
Add User-Agent header to Baseten REST, GraphQL, OAuth, and inference calls

### DIFF
--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -43,6 +43,7 @@ from truss.remote.baseten.core import (
 )
 from truss.remote.baseten.remote import BasetenRemote
 from truss.remote.baseten.service import BasetenService, URLConfig
+from truss.remote.baseten.user_agent import set_client_name
 from truss.remote.remote_factory import USER_TRUSSRC_PATH, RemoteFactory
 from truss.trt_llm.config_checks import (
     has_no_tags_trt_llm_builder,
@@ -163,6 +164,7 @@ def _start_watch_mode(
 @common.common_options(add_middleware=False)
 def truss_cli(ctx) -> None:
     """truss: The simplest way to serve models in production"""
+    set_client_name("truss-cli")
     # Click "stacks" the root command and group/subcommands, to avoid running the
     # middleware twice, we don't add it via decorator to the root command, but instead
     # selective run it here inline.

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -13,6 +13,7 @@ from truss.remote.baseten.auth import AuthService
 from truss.remote.baseten.custom_types import APIKeyCategory, TeamType
 from truss.remote.baseten.error import ApiError
 from truss.remote.baseten.rest_client import RestAPIClient
+from truss.remote.baseten.user_agent import with_user_agent
 from truss.remote.baseten.utils.transfer import base64_encoded_json_str
 
 logger = logging.getLogger(__name__)
@@ -159,7 +160,7 @@ class BasetenApi:
         self._rest_api_client.suppress_error_print = value
 
     def _post_graphql_query(self, query: str, variables: Optional[dict] = None) -> dict:
-        headers = self._auth_service.fetch_auth_header()
+        headers = with_user_agent(self._auth_service.fetch_auth_header())
         payload: Dict[str, Any] = {"query": query}
         if variables is not None:
             payload["variables"] = variables

--- a/truss/remote/baseten/oauth.py
+++ b/truss/remote/baseten/oauth.py
@@ -11,6 +11,8 @@ from typing import Optional
 import pydantic
 import requests
 
+from truss.remote.baseten.user_agent import user_agent_header
+
 logger = logging.getLogger(__name__)
 
 CLIENT_ID = "baseten-cli"
@@ -68,6 +70,7 @@ def request_device_authorization(api_url: str) -> DeviceAuthorization:
     resp = requests.post(
         api_url.rstrip("/") + DEVICE_AUTHORIZE_PATH,
         data={"client_id": CLIENT_ID},
+        headers={"User-Agent": user_agent_header()},
         timeout=30,
     )
     if not resp.ok:
@@ -101,6 +104,7 @@ def poll_device_token(
                 "device_code": authorization.device_code,
                 "client_id": CLIENT_ID,
             },
+            headers={"User-Agent": user_agent_header()},
             timeout=30,
         )
         if resp.ok:
@@ -143,6 +147,7 @@ def refresh(api_url: str, credential: OAuthCredential) -> OAuthCredential:
             "refresh_token": credential.refresh_token,
             "client_id": CLIENT_ID,
         },
+        headers={"User-Agent": user_agent_header()},
         timeout=30,
     )
     if not resp.ok:
@@ -157,7 +162,10 @@ def revoke(api_url: str, credential: OAuthCredential) -> None:
     try:
         resp = requests.post(
             api_url.rstrip("/") + LOGOUT_PATH,
-            headers={"Authorization": f"Bearer {credential.access_token}"},
+            headers={
+                "Authorization": f"Bearer {credential.access_token}",
+                "User-Agent": user_agent_header(),
+            },
             timeout=30,
         )
     except requests.RequestException as exc:

--- a/truss/remote/baseten/rest_client.py
+++ b/truss/remote/baseten/rest_client.py
@@ -1,15 +1,20 @@
-from typing import Any, Callable, Dict
+from typing import Any, Callable
 
 import requests
+
+from truss.remote.baseten.user_agent import with_user_agent
 
 
 class RestAPIClient:
     base_url: str
 
-    def __init__(self, base_url: str, header_provider: Callable[[], Dict[str, str]]):
+    def __init__(self, base_url: str, header_provider: Callable[[], dict[str, str]]):
         self.base_url = base_url
         self._header_provider = header_provider
         self.suppress_error_print = False
+
+    def _headers(self) -> dict[str, str]:
+        return with_user_agent(self._header_provider())
 
     def _handle_error(self, resp: requests.Response):
         if 400 <= resp.status_code < 500:
@@ -21,32 +26,28 @@ class RestAPIClient:
                 pass
         resp.raise_for_status()
 
-    def get(self, path: str, url_params: Dict[str, str] = {}):
+    def get(self, path: str, url_params: dict[str, str] = {}):
         resp = requests.get(
-            f"{self.base_url}/{path}",
-            headers=self._header_provider(),
-            params=url_params,
+            f"{self.base_url}/{path}", headers=self._headers(), params=url_params
         )
         self._handle_error(resp)
         return resp.json()
 
     def post(self, path: str, body: Any):
         resp = requests.post(
-            f"{self.base_url}/{path}", headers=self._header_provider(), json=body
+            f"{self.base_url}/{path}", headers=self._headers(), json=body
         )
         self._handle_error(resp)
         return resp.json()
 
     def delete(self, path: str):
-        resp = requests.delete(
-            f"{self.base_url}/{path}", headers=self._header_provider()
-        )
+        resp = requests.delete(f"{self.base_url}/{path}", headers=self._headers())
         self._handle_error(resp)
         return resp.json()
 
     def patch(self, path: str, body: Any):
         resp = requests.patch(
-            f"{self.base_url}/{path}", headers=self._header_provider(), json=body
+            f"{self.base_url}/{path}", headers=self._headers(), json=body
         )
         self._handle_error(resp)
         return resp.json()

--- a/truss/remote/baseten/user_agent.py
+++ b/truss/remote/baseten/user_agent.py
@@ -1,0 +1,29 @@
+"""User-Agent header for outbound calls to Baseten services."""
+
+import platform
+from collections.abc import Mapping
+
+import truss
+
+_client_name = "truss-sdk"
+
+
+def set_client_name(name: str) -> None:
+    """Set the client name used in the User-Agent header (e.g. ``truss-cli``)."""
+    global _client_name
+    _client_name = name
+
+
+def user_agent_header() -> str:
+    """Build a User-Agent value like ``truss-cli/0.17.2 (Python/3.13.2; Linux)``."""
+    return (
+        f"{_client_name}/{truss.__version__} "
+        f"(Python/{platform.python_version()}; {platform.system()})"
+    )
+
+
+def with_user_agent(headers: Mapping[str, str]) -> dict[str, str]:
+    """Return a copy of ``headers`` with our User-Agent set, unless one is already present."""
+    if any(key.lower() == "user-agent" for key in headers):
+        return dict(headers)
+    return {**headers, "User-Agent": user_agent_header()}

--- a/truss/remote/truss_remote.py
+++ b/truss/remote/truss_remote.py
@@ -6,6 +6,7 @@ import requests
 
 if TYPE_CHECKING:
     from rich import console as rich_console
+from truss.remote.baseten.user_agent import with_user_agent
 from truss.truss_handle.truss_handle import TrussHandle
 
 
@@ -70,7 +71,7 @@ class TrussService(ABC):
             headers = {}
 
         auth_header = self.authenticate()
-        headers = {**headers, **auth_header}
+        headers = with_user_agent({**headers, **auth_header})
         if method == "GET":
             response = requests.request(method, url, headers=headers, stream=stream)
         elif method == "POST":

--- a/truss/tests/remote/baseten/conftest.py
+++ b/truss/tests/remote/baseten/conftest.py
@@ -10,6 +10,7 @@ def mock_auth_service():
     auth_service = mock.Mock()
     auth_token = mock.Mock(headers=lambda: {"Authorization": "Api-Key token"})
     auth_service.authenticate.return_value = auth_token
+    auth_service.fetch_auth_header.return_value = {"Authorization": "Api-Key token"}
     return auth_service
 
 

--- a/truss/tests/remote/baseten/test_user_agent.py
+++ b/truss/tests/remote/baseten/test_user_agent.py
@@ -1,0 +1,39 @@
+import re
+
+import truss
+from truss.remote.baseten import user_agent
+
+
+def test_user_agent_header_format():
+    header = user_agent.user_agent_header()
+    assert re.fullmatch(
+        rf"truss-(cli|sdk)/{re.escape(truss.__version__)} \(Python/[\d.]+; \w+\)",
+        header,
+    )
+
+
+def test_set_client_name_changes_product_token():
+    original = user_agent._client_name
+    try:
+        user_agent.set_client_name("truss-cli")
+        assert user_agent.user_agent_header().startswith("truss-cli/")
+        user_agent.set_client_name("truss-sdk")
+        assert user_agent.user_agent_header().startswith("truss-sdk/")
+    finally:
+        user_agent.set_client_name(original)
+
+
+def test_with_user_agent_injects_when_absent():
+    out = user_agent.with_user_agent({"Authorization": "Api-Key token"})
+    assert out["Authorization"] == "Api-Key token"
+    assert out["User-Agent"] == user_agent.user_agent_header()
+
+
+def test_with_user_agent_does_not_clobber_existing():
+    out = user_agent.with_user_agent({"User-Agent": "custom/1.0"})
+    assert out == {"User-Agent": "custom/1.0"}
+
+
+def test_with_user_agent_does_not_clobber_case_insensitive():
+    out = user_agent.with_user_agent({"user-agent": "custom/1.0"})
+    assert out == {"user-agent": "custom/1.0"}


### PR DESCRIPTION
## :rocket: What

Adds `User-Agent` header that looks like `truss-cli/0.17.2 (Python/3.13.2; Linux)` to Baseten calls made by Truss HTTP clients

## :computer: How

Updated the few places to add this header

## :microscope: Testing

Minimal unit tests