### PR TITLE
feat(truss): add BT_APT_MIRROR_URL_FALLBACKS for apt mirror retry

### DIFF
--- a/truss/contexts/image_builder/serving_image_builder.py
+++ b/truss/contexts/image_builder/serving_image_builder.py
@@ -105,11 +105,14 @@ CLOUD_BUCKET_CACHE = MODEL_CACHE_PATH
 HF_SOURCE_DIR = Path("./root/.cache/huggingface/hub/")
 HF_CACHE_DIR = Path("/root/.cache/huggingface/hub/")
 
-_DEFAULT_APT_MIRROR_URL = "mirror://mirrors.ubuntu.com/US.txt"
-
 
 def _resolve_apt_mirror_url() -> str:
-    return os.getenv("BT_APT_MIRROR_URL") or _DEFAULT_APT_MIRROR_URL
+    return os.getenv("BT_APT_MIRROR_URL", "")
+
+
+def _resolve_apt_mirror_url_fallbacks() -> List[str]:
+    raw = os.getenv("BT_APT_MIRROR_URL_FALLBACKS", "")
+    return [u for u in raw.split() if u]
 
 
 class RemoteCache(ABC):
@@ -969,6 +972,7 @@ class ServingImageBuilder(ImageBuilder):
             passthrough_environment_variables=passthrough_environment_variables,
             run_as_user_id=run_as_user_id,
             apt_mirror_url=_resolve_apt_mirror_url(),
+            apt_mirror_url_fallbacks=_resolve_apt_mirror_url_fallbacks(),
             **FILENAME_CONSTANTS_MAP,
         )
         # Consolidate repeated empty lines to single empty lines.

--- a/truss/templates/base.Dockerfile.jinja
+++ b/truss/templates/base.Dockerfile.jinja
@@ -76,14 +76,31 @@ RUN {{ python_exec_path }} -c "import sys; \
     || { echo "ERROR: Supplied base image does not have {{ min_supported_python_version_in_custom_base_image }} <= python <= {{ max_supported_python_version_in_custom_base_image }}"; exit 1; }
 {% endblock %}
 
-{# Rewrite apt sources. Default uses apt's mirror method on Canonical's US country list. Override with BT_APT_MIRROR_URL: must end in '/ubuntu/' for a single mirror (e.g. https://mirrors.kernel.org/ubuntu/) or be a 'mirror://...' URL. #}
-{# Handle old format (Ubuntu 22.04 and earlier): /etc/apt/sources.list, and new format (Ubuntu 24.04+): /etc/apt/sources.list.d/ubuntu.sources #}
+{# Set BT_APT_MIRROR_URL to rewrite apt sources to a single mirror; BT_APT_MIRROR_URL_FALLBACKS (whitespace-separated) retries other mirrors if apt-get update fails. Both unset = leave sources as-is. #}
+{# Source files: /etc/apt/sources.list (<=22.04), /etc/apt/sources.list.d/ubuntu.sources (24.04+). #}
 {%- set ubuntu_sources_list_files = ["/etc/apt/sources.list", "/etc/apt/sources.list.d/ubuntu.sources"] %}
+{%- if apt_mirror_url %}
 {%- for ubuntu_sources_list_file in ubuntu_sources_list_files %}
 RUN if [ -f {{ ubuntu_sources_list_file }} ]; then \
     sed -i.bak 's|http://archive.ubuntu.com/ubuntu/|{{ apt_mirror_url }}|g' {{ ubuntu_sources_list_file }}; \
 fi
 {%- endfor %}
+{%- if apt_mirror_url_fallbacks %}
+RUN current='{{ apt_mirror_url }}'; \
+    if apt-get update -qq; then :; else \
+        success=0; \
+        for fb in {{ apt_mirror_url_fallbacks | join(' ') }}; do \
+            echo "apt mirror $current failed; trying $fb" >&2; \
+            for sl in {{ ubuntu_sources_list_files | join(' ') }}; do \
+                [ -f "$sl" ] && sed -i "s|$current|$fb|g" "$sl"; \
+            done; \
+            current="$fb"; \
+            if apt-get update -qq; then success=1; break; fi; \
+        done; \
+        [ "$success" = "1" ] || { echo "all apt mirrors failed" >&2; exit 1; }; \
+    fi
+{%- endif %}
+{%- endif %}
 
 {% block install_tools %}
 {# Install curl if not already present. Required for uv installation and truss-transfer-cli. #}

--- a/truss/tests/contexts/image_builder/test_serving_image_builder.py
+++ b/truss/tests/contexts/image_builder/test_serving_image_builder.py
@@ -90,7 +90,32 @@ def test_apt_mirror_url_default(
         image_builder.prepare_image_build_dir(tmp_path)
         dockerfile = (tmp_path / "Dockerfile").read_text()
 
-    assert "mirror://mirrors.ubuntu.com/US.txt" in dockerfile
+    assert "sed -i.bak" not in dockerfile
+    assert "all apt mirrors failed" not in dockerfile
+
+
+@patch("platform.machine", return_value="amd")
+def test_apt_mirror_url_fallbacks(mock_machine, custom_model_truss_dir, monkeypatch):
+    monkeypatch.setenv("BT_APT_MIRROR_URL", "http://primary.example/ubuntu/")
+    monkeypatch.setenv(
+        "BT_APT_MIRROR_URL_FALLBACKS",
+        "http://fallback1.example/ubuntu/ http://fallback2.example/ubuntu/",
+    )
+    th = TrussHandle(custom_model_truss_dir)
+    th.update_python_version("py313")
+    th.set_base_image("baseten/truss-server-base:3.13-v0.4.3", "/usr/local/bin/python3")
+    image_builder = ServingImageBuilderContext.run(th.spec.truss_dir)
+
+    with TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir)
+        image_builder.prepare_image_build_dir(tmp_path)
+        dockerfile = (tmp_path / "Dockerfile").read_text()
+
+    assert "http://primary.example/ubuntu/" in dockerfile
+    assert "http://fallback1.example/ubuntu/" in dockerfile
+    assert "http://fallback2.example/ubuntu/" in dockerfile
+    assert "for fb in" in dockerfile
+    assert "all apt mirrors failed" in dockerfile
 
 
 def test_requirements_setup_in_build_dir(custom_model_truss_dir):

--- a/truss/tests/test_data/server.Dockerfile
+++ b/truss/tests/test_data/server.Dockerfile
@@ -16,12 +16,6 @@ RUN /usr/local/bin/python3 -c "import sys; \
     and sys.version_info.minor <= 14 \
     else sys.exit(1)" \
     || { echo "ERROR: Supplied base image does not have 3.9 <= python <= 3.14"; exit 1; }
-RUN if [ -f /etc/apt/sources.list ]; then \
-    sed -i.bak 's|http://archive.ubuntu.com/ubuntu/|mirror://mirrors.ubuntu.com/US.txt|g' /etc/apt/sources.list; \
-fi
-RUN if [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then \
-    sed -i.bak 's|http://archive.ubuntu.com/ubuntu/|mirror://mirrors.ubuntu.com/US.txt|g' /etc/apt/sources.list.d/ubuntu.sources; \
-fi
 RUN command -v curl >/dev/null 2>&1 || (apt update && apt install -y curl)
 RUN if ! command -v uv >/dev/null 2>&1; then \
     curl -LsSf --retry 5 --retry-delay 5 https://astral.sh/uv/0.10.0/install.sh | sh && \


### PR DESCRIPTION
Builds on top of [#2412](https://github.com/basetenlabs/truss/pull/2412) with two changes:

1. Adds `BT_APT_MIRROR_URL_FALLBACKS` (whitespace-separated URLs). When the primary mirror's `apt-get update` fails, the Dockerfile rewrites `sources.list` to each fallback in turn until one succeeds.
2. Drops the previous default of `mirror://mirrors.ubuntu.com/US.txt` introduced in #2412. The `mirror://` method picks a different mirror per build, breaking BuildKit cache stability across rebuilds. With this PR, leaving `BT_APT_MIRROR_URL` unset leaves `sources.list` untouched (i.e. vanilla `archive.ubuntu.com`); setting an explicit URL keeps the rendered RUN command constant.

Made with [Cursor](https://cursor.com)
