### PR TITLE
feat(loops): add `truss loops push` CLI command (TRN-730)

### DIFF
--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -77,6 +77,11 @@ click.rich_click.COMMAND_GROUPS = {
             "commands": ["train"],
             "table_styles": {"row_styles": ["magenta"]},  # type: ignore
         },
+        {
+            "name": "Loops",
+            "commands": ["loops"],
+            "table_styles": {"row_styles": ["cyan"]},  # type: ignore
+        },
     ]
 }
 
@@ -1497,6 +1502,7 @@ def kill_all() -> None:
 # These imports are needed to register the subcommands
 from truss.cli import (  # noqa: F401
     chains_commands,
+    loops_commands,
     migrate_commands,
     ssh_commands,
     train_commands,

--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -1,0 +1,84 @@
+from typing import Optional, cast
+
+import rich_click as click
+
+from truss.cli import remote_cli
+from truss.cli.cli import truss_cli
+from truss.cli.utils import common
+from truss.cli.utils.output import console
+from truss.remote.baseten.remote import BasetenRemote
+from truss.remote.remote_factory import RemoteFactory
+
+
+@click.group()
+def loops():
+    """Subcommands for truss loops"""
+
+
+truss_cli.add_command(loops)
+
+
+@loops.command(name="push")
+@click.argument("base_model_id", type=str)
+@click.option(
+    "--training-project-id",
+    type=str,
+    required=False,
+    help="Training project ID to associate the deployment with.",
+)
+@click.option(
+    "--sampler-checkpoint",
+    type=str,
+    required=False,
+    help="Checkpoint ID to use for the sampling server.",
+)
+@click.option(
+    "--trainer-checkpoint",
+    type=str,
+    required=False,
+    help="Checkpoint ID to use for the trainer server.",
+)
+@click.option("--remote", type=str, required=False, help="Remote to use.")
+@common.common_options()
+def push_trainer_deployment(
+    base_model_id: str,
+    training_project_id: Optional[str],
+    sampler_checkpoint: Optional[str],
+    trainer_checkpoint: Optional[str],
+    remote: Optional[str],
+) -> None:
+    """Deploy training infrastructure for a base model.
+
+    Creates a trainer session, trainer server, and sampling server for
+    BASE_MODEL_ID. If a training project already has an active trainer
+    deployment, this command will fail with a validation error.
+    """
+    if not remote:
+        remote = remote_cli.inquire_remote_name()
+
+    remote_provider: BasetenRemote = cast(
+        BasetenRemote, RemoteFactory.create(remote=remote)
+    )
+
+    with console.status("Creating trainer session...", spinner="dots"):
+        session = remote_provider.create_trainer_session(
+            training_project_id=training_project_id
+        )
+    session_id = session["id"]
+
+    with console.status(
+        f"Deploying trainer and sampling servers for [cyan]{base_model_id}[/cyan]...",
+        spinner="dots",
+    ):
+        remote_provider.create_trainer_server(
+            session_id=session_id,
+            model=base_model_id,
+            sampler_checkpoint_id=sampler_checkpoint,
+            trainer_checkpoint_id=trainer_checkpoint,
+        )
+
+    console.print(
+        f"✨ Trainer deployment for [cyan]{base_model_id}[/cyan] is ready.\n"
+        f"   Trainer server and sampling server have been provisioned.",
+        style="green",
+    )

--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -32,12 +32,6 @@ truss_cli.add_command(loops)
     help="Training project ID to associate the deployment with.",
 )
 @click.option(
-    "--sampler",
-    type=str,
-    required=False,
-    help="Base model ID for additional samplers to include in the deployment.",
-)
-@click.option(
     "--max-seq-len",
     type=int,
     default=4096,
@@ -49,7 +43,6 @@ truss_cli.add_command(loops)
 def push_trainer_deployment(
     base_model: str,
     project_id: Optional[str],
-    sampler: Optional[str],
     max_seq_len: int,
     remote: Optional[str],
 ) -> None:

--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -1,3 +1,4 @@
+import time
 from typing import Optional, cast
 
 import rich_click as click
@@ -9,6 +10,11 @@ from truss.cli.utils.output import console
 from truss.remote.baseten.remote import BasetenRemote
 from truss.remote.remote_factory import RemoteFactory
 
+_POLL_INTERVAL_SECONDS = 10
+_READY_TIMEOUT_SECONDS = (
+    600  # ~10 minutes; trainer cold-start typically takes ~5 minutes
+)
+
 
 @click.group()
 def loops():
@@ -19,24 +25,18 @@ truss_cli.add_command(loops)
 
 
 @loops.command(name="push")
-@click.argument("base_model_id", type=str)
+@click.argument("base_model", type=str)
 @click.option(
-    "--training-project-id",
+    "--project-id",
     type=str,
     required=False,
     help="Training project ID to associate the deployment with.",
 )
 @click.option(
-    "--sampler-checkpoint",
+    "--sampler",
     type=str,
     required=False,
-    help="Checkpoint ID to use for the sampling server.",
-)
-@click.option(
-    "--trainer-checkpoint",
-    type=str,
-    required=False,
-    help="Checkpoint ID to use for the trainer server.",
+    help="Base model ID for additional samplers to include in the deployment.",
 )
 @click.option(
     "--max-seq-len",
@@ -48,17 +48,16 @@ truss_cli.add_command(loops)
 @click.option("--remote", type=str, required=False, help="Remote to use.")
 @common.common_options()
 def push_trainer_deployment(
-    base_model_id: str,
-    training_project_id: Optional[str],
-    sampler_checkpoint: Optional[str],
-    trainer_checkpoint: Optional[str],
+    base_model: str,
+    project_id: Optional[str],
+    sampler: Optional[str],
     max_seq_len: int,
     remote: Optional[str],
 ) -> None:
     """Deploy training infrastructure for a base model.
 
     Creates a trainer session, trainer server, and sampling server for
-    BASE_MODEL_ID. If a training project already has an active trainer
+    BASE_MODEL. If a training project already has an active trainer
     deployment, this command will fail with a validation error.
     """
     if not remote:
@@ -69,25 +68,42 @@ def push_trainer_deployment(
     )
 
     with console.status("Creating trainer session...", spinner="dots"):
-        session = remote_provider.create_trainer_session(
-            training_project_id=training_project_id
-        )
+        session = remote_provider.create_trainer_session(training_project_id=project_id)
     session_id = session["id"]
 
     with console.status(
-        f"Deploying trainer and sampling servers for [cyan]{base_model_id}[/cyan]...",
+        # Trainer cold-start typically takes ~5 minutes.
+        f"Deploying trainer and sampling servers for [cyan]{base_model}[/cyan]"
+        f" (this may take ~5 minutes)...",
         spinner="dots",
     ):
         remote_provider.create_trainer_server(
-            session_id=session_id,
-            model=base_model_id,
-            max_seq_len=max_seq_len,
-            sampler_checkpoint_id=sampler_checkpoint,
-            trainer_checkpoint_id=trainer_checkpoint,
+            session_id=session_id, model=base_model, max_seq_len=max_seq_len
         )
+        _poll_until_running(remote_provider, session_id)
 
     console.print(
-        f"✨ Trainer deployment for [cyan]{base_model_id}[/cyan] is ready.\n"
+        f"✨ Trainer deployment for [cyan]{base_model}[/cyan] is ready.\n"
         f"   Trainer server and sampling server have been provisioned.",
         style="green",
+    )
+
+
+def _poll_until_running(remote_provider: BasetenRemote, session_id: str) -> None:
+    """Poll GET /v1/trainers/sessions/{session_id} until all trainer servers are RUNNING."""
+    deadline = time.monotonic() + _READY_TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        session_overview = remote_provider.get_trainer_session(session_id)
+        trainer_servers = session_overview.get("trainer_servers", [])
+        statuses = [ts.get("status") for ts in trainer_servers]
+        if statuses and all(s == "running" for s in statuses):
+            return
+        if any(s == "failed" for s in statuses):
+            raise click.ClickException(
+                "Trainer deployment failed. Check the Baseten dashboard for details."
+            )
+        time.sleep(_POLL_INTERVAL_SECONDS)
+    raise click.ClickException(
+        f"Timed out waiting for trainer deployment to become ready after"
+        f" {_READY_TIMEOUT_SECONDS}s."
     )

--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -41,10 +41,7 @@ truss_cli.add_command(loops)
 @click.option("--remote", type=str, required=False, help="Remote to use.")
 @common.common_options()
 def push_trainer_deployment(
-    base_model: str,
-    project_id: Optional[str],
-    max_seq_len: int,
-    remote: Optional[str],
+    base_model: str, project_id: Optional[str], max_seq_len: int, remote: Optional[str]
 ) -> None:
     """Deploy training infrastructure for a base model.
 

--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -38,6 +38,13 @@ truss_cli.add_command(loops)
     required=False,
     help="Checkpoint ID to use for the trainer server.",
 )
+@click.option(
+    "--max-seq-len",
+    type=int,
+    default=4096,
+    show_default=True,
+    help="Maximum sequence length for training.",
+)
 @click.option("--remote", type=str, required=False, help="Remote to use.")
 @common.common_options()
 def push_trainer_deployment(
@@ -45,6 +52,7 @@ def push_trainer_deployment(
     training_project_id: Optional[str],
     sampler_checkpoint: Optional[str],
     trainer_checkpoint: Optional[str],
+    max_seq_len: int,
     remote: Optional[str],
 ) -> None:
     """Deploy training infrastructure for a base model.
@@ -73,6 +81,7 @@ def push_trainer_deployment(
         remote_provider.create_trainer_server(
             session_id=session_id,
             model=base_model_id,
+            max_seq_len=max_seq_len,
             sampler_checkpoint_id=sampler_checkpoint,
             trainer_checkpoint_id=trainer_checkpoint,
         )

--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -1,6 +1,7 @@
 import time
 from typing import Optional, cast
 
+import requests
 import rich_click as click
 
 from truss.cli import remote_cli
@@ -10,10 +11,8 @@ from truss.cli.utils.output import console
 from truss.remote.baseten.remote import BasetenRemote
 from truss.remote.remote_factory import RemoteFactory
 
+_READY_TIMEOUT_SECONDS = 600
 _POLL_INTERVAL_SECONDS = 10
-_READY_TIMEOUT_SECONDS = (
-    600  # ~10 minutes; trainer cold-start typically takes ~5 minutes
-)
 
 
 @click.group()
@@ -77,10 +76,11 @@ def push_trainer_deployment(
         f" (this may take ~5 minutes)...",
         spinner="dots",
     ):
-        remote_provider.create_trainer_server(
+        trainer_server = remote_provider.create_trainer_server(
             session_id=session_id, model=base_model, max_seq_len=max_seq_len
         )
-        _poll_until_running(remote_provider, session_id)
+        trainer_base_url = trainer_server["base_url"]
+        _poll_until_running(remote_provider, trainer_base_url)
 
     console.print(
         f"✨ Trainer deployment for [cyan]{base_model}[/cyan] is ready.\n"
@@ -89,19 +89,18 @@ def push_trainer_deployment(
     )
 
 
-def _poll_until_running(remote_provider: BasetenRemote, session_id: str) -> None:
-    """Poll GET /v1/trainers/sessions/{session_id} until all trainer servers are RUNNING."""
+def _poll_until_running(remote_provider: BasetenRemote, trainer_base_url: str) -> None:
+    """Poll GET {trainer_base_url}/health until the trainer server is up."""
+    health_url = f"{trainer_base_url}/health"
+    auth_header = remote_provider.fetch_auth_header()
     deadline = time.monotonic() + _READY_TIMEOUT_SECONDS
     while time.monotonic() < deadline:
-        session_overview = remote_provider.get_trainer_session(session_id)
-        trainer_servers = session_overview.get("trainer_servers", [])
-        statuses = [ts.get("status") for ts in trainer_servers]
-        if statuses and all(s == "running" for s in statuses):
-            return
-        if any(s == "failed" for s in statuses):
-            raise click.ClickException(
-                "Trainer deployment failed. Check the Baseten dashboard for details."
-            )
+        try:
+            resp = requests.get(health_url, headers=auth_header, timeout=10)
+            if resp.status_code == 200:
+                return
+        except requests.RequestException:
+            pass
         time.sleep(_POLL_INTERVAL_SECONDS)
     raise click.ClickException(
         f"Timed out waiting for trainer deployment to become ready after"

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -1195,8 +1195,6 @@ class BasetenApi:
         lora_rank: int = 16,
         max_seq_len: int = 4096,
         seed: Optional[int] = None,
-        sampler_checkpoint_id: Optional[str] = None,
-        trainer_checkpoint_id: Optional[str] = None,
     ) -> dict:
         body: Dict[str, Any] = {
             "model": model,
@@ -1205,10 +1203,6 @@ class BasetenApi:
         }
         if seed is not None:
             body["seed"] = seed
-        if sampler_checkpoint_id is not None:
-            body["sampler_checkpoint_id"] = sampler_checkpoint_id
-        if trainer_checkpoint_id is not None:
-            body["trainer_checkpoint_id"] = trainer_checkpoint_id
         resp_json = self._rest_api_client.post(
             f"v1/trainers/sessions/{session_id}/trainers", body=body
         )

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -1176,3 +1176,36 @@ class BasetenApi:
         return self._rest_api_client.post(
             f"v1/llm_models/{model_id}/deployments", body=body
         )
+
+    def create_trainer_session(self, training_project_id: Optional[str] = None) -> dict:
+        body: Dict[str, Any] = {}
+        if training_project_id is not None:
+            body["training_project_id"] = training_project_id
+        resp_json = self._rest_api_client.post("v1/trainers/sessions", body=body)
+        return resp_json["session"]
+
+    def create_trainer_server(
+        self,
+        session_id: str,
+        model: str,
+        lora_rank: int = 16,
+        max_seq_len: int = 32768,
+        seed: Optional[int] = None,
+        sampler_checkpoint_id: Optional[str] = None,
+        trainer_checkpoint_id: Optional[str] = None,
+    ) -> dict:
+        body: Dict[str, Any] = {
+            "model": model,
+            "lora_rank": lora_rank,
+            "max_seq_len": max_seq_len,
+        }
+        if seed is not None:
+            body["seed"] = seed
+        if sampler_checkpoint_id is not None:
+            body["sampler_checkpoint_id"] = sampler_checkpoint_id
+        if trainer_checkpoint_id is not None:
+            body["trainer_checkpoint_id"] = trainer_checkpoint_id
+        resp_json = self._rest_api_client.post(
+            f"v1/trainers/sessions/{session_id}/trainers", body=body
+        )
+        return resp_json["trainer_server"]

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -1177,6 +1177,10 @@ class BasetenApi:
             f"v1/llm_models/{model_id}/deployments", body=body
         )
 
+    def get_trainer_session(self, session_id: str) -> dict:
+        resp_json = self._rest_api_client.get(f"v1/trainers/sessions/{session_id}")
+        return resp_json["session"]
+
     def create_trainer_session(self, training_project_id: Optional[str] = None) -> dict:
         body: Dict[str, Any] = {}
         if training_project_id is not None:

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -1189,7 +1189,7 @@ class BasetenApi:
         session_id: str,
         model: str,
         lora_rank: int = 16,
-        max_seq_len: int = 32768,
+        max_seq_len: int = 4096,
         seed: Optional[int] = None,
         sampler_checkpoint_id: Optional[str] = None,
         trainer_checkpoint_id: Optional[str] = None,

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -1022,3 +1022,26 @@ class BasetenRemote(TrussRemote):
 
     def upsert_training_project(self, training_project, team_id=None):
         return self._api.upsert_training_project(training_project, team_id=team_id)
+
+    def create_trainer_session(self, training_project_id=None):
+        return self._api.create_trainer_session(training_project_id=training_project_id)
+
+    def create_trainer_server(
+        self,
+        session_id,
+        model,
+        lora_rank=16,
+        max_seq_len=32768,
+        seed=None,
+        sampler_checkpoint_id=None,
+        trainer_checkpoint_id=None,
+    ):
+        return self._api.create_trainer_server(
+            session_id=session_id,
+            model=model,
+            lora_rank=lora_rank,
+            max_seq_len=max_seq_len,
+            seed=seed,
+            sampler_checkpoint_id=sampler_checkpoint_id,
+            trainer_checkpoint_id=trainer_checkpoint_id,
+        )

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -1031,7 +1031,7 @@ class BasetenRemote(TrussRemote):
         session_id,
         model,
         lora_rank=16,
-        max_seq_len=32768,
+        max_seq_len=4096,
         seed=None,
         sampler_checkpoint_id=None,
         trainer_checkpoint_id=None,

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -1023,6 +1023,9 @@ class BasetenRemote(TrussRemote):
     def upsert_training_project(self, training_project, team_id=None):
         return self._api.upsert_training_project(training_project, team_id=team_id)
 
+    def get_trainer_session(self, session_id):
+        return self._api.get_trainer_session(session_id)
+
     def create_trainer_session(self, training_project_id=None):
         return self._api.create_trainer_session(training_project_id=training_project_id)
 

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -1036,8 +1036,6 @@ class BasetenRemote(TrussRemote):
         lora_rank=16,
         max_seq_len=4096,
         seed=None,
-        sampler_checkpoint_id=None,
-        trainer_checkpoint_id=None,
     ):
         return self._api.create_trainer_server(
             session_id=session_id,
@@ -1045,6 +1043,4 @@ class BasetenRemote(TrussRemote):
             lora_rank=lora_rank,
             max_seq_len=max_seq_len,
             seed=seed,
-            sampler_checkpoint_id=sampler_checkpoint_id,
-            trainer_checkpoint_id=trainer_checkpoint_id,
         )

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -1030,12 +1030,7 @@ class BasetenRemote(TrussRemote):
         return self._api.create_trainer_session(training_project_id=training_project_id)
 
     def create_trainer_server(
-        self,
-        session_id,
-        model,
-        lora_rank=16,
-        max_seq_len=4096,
-        seed=None,
+        self, session_id, model, lora_rank=16, max_seq_len=4096, seed=None
     ):
         return self._api.create_trainer_server(
             session_id=session_id,

--- a/truss/tests/cli/test_loops_cli.py
+++ b/truss/tests/cli/test_loops_cli.py
@@ -21,10 +21,7 @@ def mock_remote():
             "base_url": "https://model-def789.api.baseten.co/deployment/v1/sync",
         },
     }
-    remote.get_trainer_session.return_value = {
-        "id": "session_abc123",
-        "trainer_servers": [{"id": "trainer_xyz456", "status": "running"}],
-    }
+    remote.fetch_auth_header.return_value = {"Authorization": "Api-Key test_key"}
     return remote
 
 
@@ -33,7 +30,9 @@ def _invoke_loops_push(args, mock_remote):
     with patch(
         "truss.remote.remote_factory.RemoteFactory.create", return_value=mock_remote
     ):
-        return runner.invoke(truss_cli, ["loops", "push"] + args)
+        with patch("requests.get") as mock_get:
+            mock_get.return_value = Mock(status_code=200)
+            return runner.invoke(truss_cli, ["loops", "push"] + args)
 
 
 def test_push_basic(mock_remote):
@@ -83,43 +82,39 @@ def test_push_with_max_seq_len(mock_remote):
 
 
 def test_push_polls_until_running(mock_remote):
-    # First two polls return deploying, third returns running.
-    mock_remote.get_trainer_session.side_effect = [
-        {
-            "id": "session_abc123",
-            "trainer_servers": [{"id": "t1", "status": "deploying"}],
-        },
-        {
-            "id": "session_abc123",
-            "trainer_servers": [{"id": "t1", "status": "deploying"}],
-        },
-        {
-            "id": "session_abc123",
-            "trainer_servers": [{"id": "t1", "status": "running"}],
-        },
-    ]
+    # First two polls return 503, third returns 200.
+    responses = [Mock(status_code=503), Mock(status_code=503), Mock(status_code=200)]
 
-    with patch("truss.cli.loops_commands.time.sleep"):
-        result = _invoke_loops_push(
-            ["Qwen/Qwen3-8B", "--remote", "test_remote"], mock_remote
-        )
+    runner = CliRunner()
+    with patch(
+        "truss.remote.remote_factory.RemoteFactory.create", return_value=mock_remote
+    ):
+        with patch("requests.get", side_effect=responses):
+            with patch("truss.cli.loops_commands.time.sleep"):
+                result = runner.invoke(
+                    truss_cli, ["loops", "push", "Qwen/Qwen3-8B", "--remote", "test_remote"]
+                )
 
     assert result.exit_code == 0, result.output
-    assert mock_remote.get_trainer_session.call_count == 3
 
 
-def test_push_fails_on_failed_status(mock_remote):
-    mock_remote.get_trainer_session.return_value = {
-        "id": "session_abc123",
-        "trainer_servers": [{"id": "t1", "status": "failed"}],
-    }
-
-    result = _invoke_loops_push(
-        ["Qwen/Qwen3-8B", "--remote", "test_remote"], mock_remote
-    )
+def test_push_times_out_waiting_for_health(mock_remote):
+    runner = CliRunner()
+    with patch(
+        "truss.remote.remote_factory.RemoteFactory.create", return_value=mock_remote
+    ):
+        with patch("requests.get", return_value=Mock(status_code=503)):
+            with patch("truss.cli.loops_commands.time.sleep"):
+                with patch(
+                    "truss.cli.loops_commands.time.monotonic", side_effect=[0, 0, 700]
+                ):
+                    result = runner.invoke(
+                        truss_cli,
+                        ["loops", "push", "Qwen/Qwen3-8B", "--remote", "test_remote"],
+                    )
 
     assert result.exit_code != 0
-    assert "failed" in result.output.lower()
+    assert "Timed out" in result.output
 
 
 def test_push_uses_inquire_when_remote_not_provided(mock_remote):
@@ -130,7 +125,9 @@ def test_push_uses_inquire_when_remote_not_provided(mock_remote):
         with patch(
             "truss.cli.remote_cli.inquire_remote_name", return_value="inquired_remote"
         ) as mock_inquire:
-            result = runner.invoke(truss_cli, ["loops", "push", "Qwen/Qwen3-8B"])
+            with patch("requests.get") as mock_get:
+                mock_get.return_value = Mock(status_code=200)
+                result = runner.invoke(truss_cli, ["loops", "push", "Qwen/Qwen3-8B"])
 
     assert result.exit_code == 0, result.output
     mock_inquire.assert_called_once()

--- a/truss/tests/cli/test_loops_cli.py
+++ b/truss/tests/cli/test_loops_cli.py
@@ -1,0 +1,194 @@
+"""Tests for truss loops CLI commands."""
+
+import os
+from unittest.mock import Mock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from truss.cli.cli import truss_cli
+
+
+@pytest.fixture
+def mock_remote():
+    remote = Mock()
+    remote.create_trainer_session.return_value = {"id": "session_abc123"}
+    remote.create_trainer_server.return_value = {
+        "id": "trainer_xyz456",
+        "base_url": "https://trainer-xyz456.api.baseten.co/trainer",
+        "sampling_server": {
+            "id": "sampler_def789",
+            "base_url": "https://model-def789.api.baseten.co/deployment/v1/sync",
+        },
+    }
+    return remote
+
+
+def _invoke_loops_push(args, mock_remote):
+    runner = CliRunner()
+    with patch(
+        "truss.remote.remote_factory.RemoteFactory.create", return_value=mock_remote
+    ):
+        return runner.invoke(truss_cli, ["loops", "push"] + args)
+
+
+def test_push_basic(mock_remote):
+    result = _invoke_loops_push(
+        ["Qwen/Qwen3-8B", "--remote", "test_remote"], mock_remote
+    )
+
+    assert result.exit_code == 0, result.output
+    mock_remote.create_trainer_session.assert_called_once_with(training_project_id=None)
+    mock_remote.create_trainer_server.assert_called_once_with(
+        session_id="session_abc123",
+        model="Qwen/Qwen3-8B",
+        sampler_checkpoint_id=None,
+        trainer_checkpoint_id=None,
+    )
+    assert "Qwen/Qwen3-8B" in result.output
+
+
+def test_push_with_training_project_id(mock_remote):
+    result = _invoke_loops_push(
+        [
+            "Qwen/Qwen3-8B",
+            "--remote",
+            "test_remote",
+            "--training-project-id",
+            "proj_abc",
+        ],
+        mock_remote,
+    )
+
+    assert result.exit_code == 0, result.output
+    mock_remote.create_trainer_session.assert_called_once_with(
+        training_project_id="proj_abc"
+    )
+
+
+def test_push_with_sampler_checkpoint(mock_remote):
+    result = _invoke_loops_push(
+        [
+            "Qwen/Qwen3-8B",
+            "--remote",
+            "test_remote",
+            "--sampler-checkpoint",
+            "ckpt_sampler",
+        ],
+        mock_remote,
+    )
+
+    assert result.exit_code == 0, result.output
+    mock_remote.create_trainer_server.assert_called_once_with(
+        session_id="session_abc123",
+        model="Qwen/Qwen3-8B",
+        sampler_checkpoint_id="ckpt_sampler",
+        trainer_checkpoint_id=None,
+    )
+
+
+def test_push_with_trainer_checkpoint(mock_remote):
+    result = _invoke_loops_push(
+        [
+            "Qwen/Qwen3-8B",
+            "--remote",
+            "test_remote",
+            "--trainer-checkpoint",
+            "ckpt_trainer",
+        ],
+        mock_remote,
+    )
+
+    assert result.exit_code == 0, result.output
+    mock_remote.create_trainer_server.assert_called_once_with(
+        session_id="session_abc123",
+        model="Qwen/Qwen3-8B",
+        sampler_checkpoint_id=None,
+        trainer_checkpoint_id="ckpt_trainer",
+    )
+
+
+def test_push_with_all_options(mock_remote):
+    result = _invoke_loops_push(
+        [
+            "Qwen/Qwen3-8B",
+            "--remote",
+            "test_remote",
+            "--training-project-id",
+            "proj_abc",
+            "--sampler-checkpoint",
+            "ckpt_sampler",
+            "--trainer-checkpoint",
+            "ckpt_trainer",
+        ],
+        mock_remote,
+    )
+
+    assert result.exit_code == 0, result.output
+    mock_remote.create_trainer_session.assert_called_once_with(
+        training_project_id="proj_abc"
+    )
+    mock_remote.create_trainer_server.assert_called_once_with(
+        session_id="session_abc123",
+        model="Qwen/Qwen3-8B",
+        sampler_checkpoint_id="ckpt_sampler",
+        trainer_checkpoint_id="ckpt_trainer",
+    )
+
+
+def test_push_uses_inquire_when_remote_not_provided(mock_remote):
+    runner = CliRunner()
+    with patch(
+        "truss.remote.remote_factory.RemoteFactory.create", return_value=mock_remote
+    ):
+        with patch(
+            "truss.cli.remote_cli.inquire_remote_name", return_value="inquired_remote"
+        ) as mock_inquire:
+            result = runner.invoke(truss_cli, ["loops", "push", "Qwen/Qwen3-8B"])
+
+    assert result.exit_code == 0, result.output
+    mock_inquire.assert_called_once()
+
+
+def test_push_fails_when_base_model_id_missing():
+    runner = CliRunner()
+    result = runner.invoke(truss_cli, ["loops", "push", "--remote", "test_remote"])
+
+    assert result.exit_code != 0
+    assert "Missing argument" in result.output
+
+
+def test_push_propagates_session_creation_error(mock_remote):
+    mock_remote.create_trainer_session.side_effect = RuntimeError(
+        "session creation failed"
+    )
+
+    result = _invoke_loops_push(
+        ["Qwen/Qwen3-8B", "--remote", "test_remote"], mock_remote
+    )
+
+    assert result.exit_code != 0
+
+
+def test_push_propagates_trainer_server_creation_error(mock_remote):
+    mock_remote.create_trainer_server.side_effect = RuntimeError(
+        "active TrainerDeployment already exists"
+    )
+
+    result = _invoke_loops_push(
+        ["Qwen/Qwen3-8B", "--remote", "test_remote"], mock_remote
+    )
+
+    assert result.exit_code != 0
+
+
+def test_push_help():
+    env = os.environ.copy()
+    env["COLUMNS"] = "200"
+    runner = CliRunner(env=env)
+    result = runner.invoke(truss_cli, ["loops", "push", "--help"])
+
+    assert result.exit_code == 0
+    assert "--training-project-id" in result.output
+    assert "--sampler-checkpoint" in result.output
+    assert "--trainer-checkpoint" in result.output

--- a/truss/tests/cli/test_loops_cli.py
+++ b/truss/tests/cli/test_loops_cli.py
@@ -21,6 +21,10 @@ def mock_remote():
             "base_url": "https://model-def789.api.baseten.co/deployment/v1/sync",
         },
     }
+    remote.get_trainer_session.return_value = {
+        "id": "session_abc123",
+        "trainer_servers": [{"id": "trainer_xyz456", "status": "running"}],
+    }
     return remote
 
 
@@ -40,24 +44,14 @@ def test_push_basic(mock_remote):
     assert result.exit_code == 0, result.output
     mock_remote.create_trainer_session.assert_called_once_with(training_project_id=None)
     mock_remote.create_trainer_server.assert_called_once_with(
-        session_id="session_abc123",
-        model="Qwen/Qwen3-8B",
-        max_seq_len=4096,
-        sampler_checkpoint_id=None,
-        trainer_checkpoint_id=None,
+        session_id="session_abc123", model="Qwen/Qwen3-8B", max_seq_len=4096
     )
     assert "Qwen/Qwen3-8B" in result.output
 
 
-def test_push_with_training_project_id(mock_remote):
+def test_push_with_project_id(mock_remote):
     result = _invoke_loops_push(
-        [
-            "Qwen/Qwen3-8B",
-            "--remote",
-            "test_remote",
-            "--training-project-id",
-            "proj_abc",
-        ],
+        ["Qwen/Qwen3-8B", "--remote", "test_remote", "--project-id", "proj_abc"],
         mock_remote,
     )
 
@@ -67,77 +61,13 @@ def test_push_with_training_project_id(mock_remote):
     )
 
 
-def test_push_with_sampler_checkpoint(mock_remote):
+def test_push_with_sampler(mock_remote):
     result = _invoke_loops_push(
-        [
-            "Qwen/Qwen3-8B",
-            "--remote",
-            "test_remote",
-            "--sampler-checkpoint",
-            "ckpt_sampler",
-        ],
+        ["Qwen/Qwen3-8B", "--remote", "test_remote", "--sampler", "Qwen/Qwen3-0.6B"],
         mock_remote,
     )
 
     assert result.exit_code == 0, result.output
-    mock_remote.create_trainer_server.assert_called_once_with(
-        session_id="session_abc123",
-        model="Qwen/Qwen3-8B",
-        max_seq_len=4096,
-        sampler_checkpoint_id="ckpt_sampler",
-        trainer_checkpoint_id=None,
-    )
-
-
-def test_push_with_trainer_checkpoint(mock_remote):
-    result = _invoke_loops_push(
-        [
-            "Qwen/Qwen3-8B",
-            "--remote",
-            "test_remote",
-            "--trainer-checkpoint",
-            "ckpt_trainer",
-        ],
-        mock_remote,
-    )
-
-    assert result.exit_code == 0, result.output
-    mock_remote.create_trainer_server.assert_called_once_with(
-        session_id="session_abc123",
-        model="Qwen/Qwen3-8B",
-        max_seq_len=4096,
-        sampler_checkpoint_id=None,
-        trainer_checkpoint_id="ckpt_trainer",
-    )
-
-
-def test_push_with_all_options(mock_remote):
-    result = _invoke_loops_push(
-        [
-            "Qwen/Qwen3-8B",
-            "--remote",
-            "test_remote",
-            "--training-project-id",
-            "proj_abc",
-            "--sampler-checkpoint",
-            "ckpt_sampler",
-            "--trainer-checkpoint",
-            "ckpt_trainer",
-        ],
-        mock_remote,
-    )
-
-    assert result.exit_code == 0, result.output
-    mock_remote.create_trainer_session.assert_called_once_with(
-        training_project_id="proj_abc"
-    )
-    mock_remote.create_trainer_server.assert_called_once_with(
-        session_id="session_abc123",
-        model="Qwen/Qwen3-8B",
-        max_seq_len=4096,
-        sampler_checkpoint_id="ckpt_sampler",
-        trainer_checkpoint_id="ckpt_trainer",
-    )
 
 
 def test_push_with_max_seq_len(mock_remote):
@@ -148,12 +78,48 @@ def test_push_with_max_seq_len(mock_remote):
 
     assert result.exit_code == 0, result.output
     mock_remote.create_trainer_server.assert_called_once_with(
-        session_id="session_abc123",
-        model="Qwen/Qwen3-8B",
-        max_seq_len=32768,
-        sampler_checkpoint_id=None,
-        trainer_checkpoint_id=None,
+        session_id="session_abc123", model="Qwen/Qwen3-8B", max_seq_len=32768
     )
+
+
+def test_push_polls_until_running(mock_remote):
+    # First two polls return deploying, third returns running.
+    mock_remote.get_trainer_session.side_effect = [
+        {
+            "id": "session_abc123",
+            "trainer_servers": [{"id": "t1", "status": "deploying"}],
+        },
+        {
+            "id": "session_abc123",
+            "trainer_servers": [{"id": "t1", "status": "deploying"}],
+        },
+        {
+            "id": "session_abc123",
+            "trainer_servers": [{"id": "t1", "status": "running"}],
+        },
+    ]
+
+    with patch("truss.cli.loops_commands.time.sleep"):
+        result = _invoke_loops_push(
+            ["Qwen/Qwen3-8B", "--remote", "test_remote"], mock_remote
+        )
+
+    assert result.exit_code == 0, result.output
+    assert mock_remote.get_trainer_session.call_count == 3
+
+
+def test_push_fails_on_failed_status(mock_remote):
+    mock_remote.get_trainer_session.return_value = {
+        "id": "session_abc123",
+        "trainer_servers": [{"id": "t1", "status": "failed"}],
+    }
+
+    result = _invoke_loops_push(
+        ["Qwen/Qwen3-8B", "--remote", "test_remote"], mock_remote
+    )
+
+    assert result.exit_code != 0
+    assert "failed" in result.output.lower()
 
 
 def test_push_uses_inquire_when_remote_not_provided(mock_remote):
@@ -170,7 +136,7 @@ def test_push_uses_inquire_when_remote_not_provided(mock_remote):
     mock_inquire.assert_called_once()
 
 
-def test_push_fails_when_base_model_id_missing():
+def test_push_fails_when_base_model_missing():
     runner = CliRunner()
     result = runner.invoke(truss_cli, ["loops", "push", "--remote", "test_remote"])
 
@@ -209,7 +175,6 @@ def test_push_help():
     result = runner.invoke(truss_cli, ["loops", "push", "--help"])
 
     assert result.exit_code == 0
-    assert "--training-project-id" in result.output
-    assert "--sampler-checkpoint" in result.output
-    assert "--trainer-checkpoint" in result.output
+    assert "--project-id" in result.output
+    assert "--sampler" in result.output
     assert "--max-seq-len" in result.output

--- a/truss/tests/cli/test_loops_cli.py
+++ b/truss/tests/cli/test_loops_cli.py
@@ -83,7 +83,8 @@ def test_push_polls_until_running(mock_remote):
         with patch("requests.get", side_effect=responses):
             with patch("truss.cli.loops_commands.time.sleep"):
                 result = runner.invoke(
-                    truss_cli, ["loops", "push", "Qwen/Qwen3-8B", "--remote", "test_remote"]
+                    truss_cli,
+                    ["loops", "push", "Qwen/Qwen3-8B", "--remote", "test_remote"],
                 )
 
     assert result.exit_code == 0, result.output

--- a/truss/tests/cli/test_loops_cli.py
+++ b/truss/tests/cli/test_loops_cli.py
@@ -42,6 +42,7 @@ def test_push_basic(mock_remote):
     mock_remote.create_trainer_server.assert_called_once_with(
         session_id="session_abc123",
         model="Qwen/Qwen3-8B",
+        max_seq_len=4096,
         sampler_checkpoint_id=None,
         trainer_checkpoint_id=None,
     )
@@ -82,6 +83,7 @@ def test_push_with_sampler_checkpoint(mock_remote):
     mock_remote.create_trainer_server.assert_called_once_with(
         session_id="session_abc123",
         model="Qwen/Qwen3-8B",
+        max_seq_len=4096,
         sampler_checkpoint_id="ckpt_sampler",
         trainer_checkpoint_id=None,
     )
@@ -103,6 +105,7 @@ def test_push_with_trainer_checkpoint(mock_remote):
     mock_remote.create_trainer_server.assert_called_once_with(
         session_id="session_abc123",
         model="Qwen/Qwen3-8B",
+        max_seq_len=4096,
         sampler_checkpoint_id=None,
         trainer_checkpoint_id="ckpt_trainer",
     )
@@ -131,8 +134,25 @@ def test_push_with_all_options(mock_remote):
     mock_remote.create_trainer_server.assert_called_once_with(
         session_id="session_abc123",
         model="Qwen/Qwen3-8B",
+        max_seq_len=4096,
         sampler_checkpoint_id="ckpt_sampler",
         trainer_checkpoint_id="ckpt_trainer",
+    )
+
+
+def test_push_with_max_seq_len(mock_remote):
+    result = _invoke_loops_push(
+        ["Qwen/Qwen3-8B", "--remote", "test_remote", "--max-seq-len", "32768"],
+        mock_remote,
+    )
+
+    assert result.exit_code == 0, result.output
+    mock_remote.create_trainer_server.assert_called_once_with(
+        session_id="session_abc123",
+        model="Qwen/Qwen3-8B",
+        max_seq_len=32768,
+        sampler_checkpoint_id=None,
+        trainer_checkpoint_id=None,
     )
 
 
@@ -192,3 +212,4 @@ def test_push_help():
     assert "--training-project-id" in result.output
     assert "--sampler-checkpoint" in result.output
     assert "--trainer-checkpoint" in result.output
+    assert "--max-seq-len" in result.output

--- a/truss/tests/cli/test_loops_cli.py
+++ b/truss/tests/cli/test_loops_cli.py
@@ -60,15 +60,6 @@ def test_push_with_project_id(mock_remote):
     )
 
 
-def test_push_with_sampler(mock_remote):
-    result = _invoke_loops_push(
-        ["Qwen/Qwen3-8B", "--remote", "test_remote", "--sampler", "Qwen/Qwen3-0.6B"],
-        mock_remote,
-    )
-
-    assert result.exit_code == 0, result.output
-
-
 def test_push_with_max_seq_len(mock_remote):
     result = _invoke_loops_push(
         ["Qwen/Qwen3-8B", "--remote", "test_remote", "--max-seq-len", "32768"],
@@ -173,5 +164,4 @@ def test_push_help():
 
     assert result.exit_code == 0
     assert "--project-id" in result.output
-    assert "--sampler" in result.output
     assert "--max-seq-len" in result.output


### PR DESCRIPTION
## :rocket: What

Adds `truss loops push <base-model-id>` — a new CLI command that deploys the training infrastructure (session, trainer server, and sampling server) needed for RL training loops on Baseten.

Part of [TRN-730](https://linear.app/baseten/issue/TRN-730).

## :computer: How

- **`truss/cli/loops_commands.py`**: New `loops` command group with a `push` subcommand. Takes `BASE_MODEL_ID` as a required argument plus optional `--training-project-id`, `--sampler-checkpoint`, and `--trainer-checkpoint`.
- **`truss/remote/baseten/api.py`**: Added `create_trainer_session` (`POST /v1/trainers/sessions`) and `create_trainer_server` (`POST /v1/trainers/sessions/{sid}/trainers`) API methods.
- **`truss/remote/baseten/remote.py`**: Added corresponding passthrough wrappers.
- **`truss/cli/cli.py`**: Registered `loops_commands` and added a `Loops` group to the help display.

The command flow:
1. Creates a `TrainerSession` (optionally tied to a training project)
2. Creates a `TrainerServer` + `SamplingServer` (the backend also creates the `TrainerDeployment` here)
3. If the user already has an active `TrainerDeployment`, the backend returns a validation error

Optional checkpoint args (`--sampler-checkpoint`, `--trainer-checkpoint`) are forwarded to the trainer server request to support resuming from a prior checkpoint once TRN-737 lands.

## :microscope: Testing

10 unit tests in `truss/tests/cli/test_loops_cli.py` covering:
- Happy path with required arg only
- Each optional flag (`--training-project-id`, `--sampler-checkpoint`, `--trainer-checkpoint`)
- All options together
- Remote inquiry fallback when `--remote` is omitted
- Missing required `BASE_MODEL_ID` exits with error
- Session creation error propagation
- Trainer server creation error propagation (e.g. active deployment already exists)
- Help output includes all option flags