### PR TITLE
Improve control server error logging and shutdown safety

### DIFF
--- a/truss/templates/control/control/application.py
+++ b/truss/templates/control/control/application.py
@@ -7,7 +7,7 @@ import re
 import traceback
 from collections.abc import Awaitable
 from pathlib import Path
-from typing import Callable
+from typing import Callable, Optional
 
 import httpx
 from endpoints import control_app
@@ -25,10 +25,11 @@ from starlette.middleware.base import BaseHTTPMiddleware
 SANITIZED_EXCEPTION_FRAMES = 2
 
 
-# NB(nikhil): SanitizedExceptionMiddleware will reduce the noise of control server stack frames, since
-# users often complain about the verbosity. Now, if any exceptions are explicitly raised during a proxied
-# request, we'll log the last two stack frames which should be sufficient for debugging while significantly
-# cutting down the volume.
+# NB(nikhil): SanitizedExceptionMiddleware reduces the noise of control server
+# stack frames, since users often complain about the verbosity. The headline
+# line carries the request, exception type, and message, so the actual error
+# is visible without a wall of frames. A small number of trailing frames from
+# the full exception chain (so __cause__ is preserved) follow.
 class SanitizedExceptionMiddleware(BaseHTTPMiddleware):
     def __init__(self, app, num_frames: int = SANITIZED_EXCEPTION_FRAMES):
         super().__init__(app)
@@ -47,8 +48,14 @@ class SanitizedExceptionMiddleware(BaseHTTPMiddleware):
                     {"error": str(exc)}, status_code=http.HTTPStatus.BAD_GATEWAY.value
                 )
 
-            sanitized_traceback = self._create_sanitized_traceback(exc)
-            request.app.state.logger.error(sanitized_traceback)
+            # Defensive: the error handler itself must not crash. _format_error
+            # touches str(exc) and the traceback chain, both of which can in
+            # principle raise on pathological exceptions.
+            try:
+                formatted = self._format_error(request, exc)
+            except Exception:
+                formatted = f"Unhandled control server exception: {type(exc).__name__}"
+            request.app.state.logger.error(formatted)
 
             if isinstance(exc, PatchApplicatonError):
                 error_type = _camel_to_snake_case(type(exc).__name__)
@@ -59,11 +66,39 @@ class SanitizedExceptionMiddleware(BaseHTTPMiddleware):
                     status_code=http.HTTPStatus.INTERNAL_SERVER_ERROR.value,
                 )
 
-    def _create_sanitized_traceback(self, error: Exception) -> str:
-        tb_lines = traceback.format_tb(error.__traceback__)
-        if tb_lines and self.num_frames > 0:
-            return "".join(tb_lines[-self.num_frames :])
-        return f"{type(error).__name__}: {error}"
+    def _format_error(self, request: Request, error: Exception) -> str:
+        lines = [
+            f"{request.method} {request.url.path}: {type(error).__name__}: {error}"
+        ]
+        seen: set[int] = set()
+        current: Optional[BaseException] = error
+        is_root = True
+        while current is not None and id(current) not in seen:
+            seen.add(id(current))
+            if not is_root:
+                lines.append(f"Caused by: {type(current).__name__}: {current}")
+            lines.extend(self._format_frames(current.__traceback__))
+            # Mirror Python's own rules: prefer __cause__; otherwise __context__
+            # is shown unless explicitly suppressed (raise X from None).
+            if current.__cause__ is not None:
+                current = current.__cause__
+            elif not current.__suppress_context__:
+                current = current.__context__
+            else:
+                current = None
+            is_root = False
+        return "\n".join(lines)
+
+    def _format_frames(self, tb) -> list[str]:
+        if self.num_frames <= 0 or tb is None:
+            return []
+        # Manual formatting avoids PEP 657 caret/squiggle markers that
+        # traceback.format_list adds in Python 3.11+.
+        frames = traceback.extract_tb(tb)[-self.num_frames :]
+        out: list[str] = []
+        for f in frames:
+            out.append(f'  File "{f.filename}", line {f.lineno}, in {f.name}')
+        return out
 
 
 def create_app(base_config: dict):
@@ -105,6 +140,9 @@ def create_app(base_config: dict):
 
     @contextlib.asynccontextmanager
     async def lifespan(app):
+        # Fire-and-forget: async_inference_server_startup_flow catches and logs
+        # its own exceptions, so the task will never raise into asyncio's
+        # "Task exception was never retrieved" handler.
         asyncio.create_task(
             async_inference_server_startup_flow(
                 app_state.inference_server_controller, app_logger

--- a/truss/templates/control/control/application.py
+++ b/truss/templates/control/control/application.py
@@ -67,6 +67,14 @@ class SanitizedExceptionMiddleware(BaseHTTPMiddleware):
                 )
 
     def _format_error(self, request: Request, error: Exception) -> str:
+        # Walk the exception chain outermost-to-innermost, emitting one
+        # "Caused by:" headline per cause plus a few frames each. This
+        # preserves the root-cause type and message (which Python would
+        # otherwise bury at the top of a many-screen traceback) while keeping
+        # the log entry compact. The walk is iterative so we don't hit
+        # Python's recursion limit, and `seen` cuts cycles by exception
+        # identity. Like Python's traceback module, chain depth itself is
+        # unbounded in principle; in practice real chains are <5 deep.
         lines = [
             f"{request.method} {request.url.path}: {type(error).__name__}: {error}"
         ]

--- a/truss/templates/control/control/helpers/inference_server_process_controller.py
+++ b/truss/templates/control/control/helpers/inference_server_process_controller.py
@@ -64,10 +64,12 @@ class InferenceServerProcessController:
         self._inference_server_started = False
 
     def terminate_with_wait(self) -> None:
+        # Always flip the terminated flag so the non-daemon overseer thread in
+        # InferenceServerController can exit, even when no process was started.
+        self._inference_server_terminated = True
         if self._inference_server_process is None:
             return
         self._terminate_children_and_process()
-        self._inference_server_terminated = True
         termination_check_attempts = int(
             TERMINATION_TIMEOUT_SECS / TERMINATION_CHECK_INTERVAL_SECS
         )

--- a/truss/templates/control/control/helpers/inference_server_process_controller.py
+++ b/truss/templates/control/control/helpers/inference_server_process_controller.py
@@ -47,8 +47,10 @@ class InferenceServerProcessController:
             self._inference_server_ever_started = True
             self._logged_unrecoverable_since_last_restart = False
 
-    def _terminate_children_and_process(self):
+    def _terminate_children_and_process(self) -> None:
         """Kill child processes first, then parent. Prevents port binding conflicts."""
+        if self._inference_server_process is None:
+            return
         # Use a shorter timeout than the truss patch read timeout (=120s):
         # see remote/baseten/api.py:_post_graphql_query()
         kill_child_processes(self._inference_server_process.pid, timeout_seconds=30)
@@ -61,7 +63,9 @@ class InferenceServerProcessController:
 
         self._inference_server_started = False
 
-    def terminate_with_wait(self):
+    def terminate_with_wait(self) -> None:
+        if self._inference_server_process is None:
+            return
         self._terminate_children_and_process()
         self._inference_server_terminated = True
         termination_check_attempts = int(

--- a/truss/templates/control/control/helpers/inference_server_starter.py
+++ b/truss/templates/control/control/helpers/inference_server_starter.py
@@ -6,6 +6,19 @@ from anyio import to_thread
 from helpers.inference_server_controller import InferenceServerController
 from tenacity import Retrying, stop_after_attempt, wait_exponential
 
+PATCH_PING_MAX_ATTEMPTS = 15
+NETWORK_EXCEPTIONS = (
+    requests.exceptions.ConnectionError,
+    requests.exceptions.ProxyError,
+    requests.exceptions.Timeout,
+)
+
+
+def _classify_error(exc: BaseException) -> str:
+    if isinstance(exc, NETWORK_EXCEPTIONS):
+        return "network error"
+    return "error"
+
 
 def inference_server_startup_flow(
     inference_server_controller: InferenceServerController, logger: Logger
@@ -28,6 +41,12 @@ def inference_server_startup_flow(
     Example responses:
     {"is_current": true}
     {"accepted": true}
+
+    Exceptions are caught and logged here rather than propagated. This is
+    invoked via asyncio.create_task() with no awaiter, so a raised exception
+    would only surface as Python's "Task exception was never retrieved"
+    warning at GC time. Logging a clear summary line at the failure boundary
+    is more actionable than that warning.
     """
     patch_ping_url = os.environ.get("PATCH_PING_URL_TRUSS")
     if patch_ping_url is None:
@@ -36,32 +55,53 @@ def inference_server_startup_flow(
 
     truss_hash = inference_server_controller.truss_hash()
     payload = {"truss_hash": truss_hash}
+    logger.info(f"Pinging {patch_ping_url} for patch with hash {truss_hash}")
 
-    for attempt in Retrying(
-        stop=stop_after_attempt(15), wait=wait_exponential(multiplier=2, min=1, max=4)
-    ):
-        with attempt:
-            try:
-                logger.info(
-                    f"Pinging {patch_ping_url} for patch with hash {truss_hash}"
-                )
-                resp = requests.post(patch_ping_url, json=payload)
-                resp.raise_for_status()
-                resp_body = resp.json()
+    try:
+        for attempt in Retrying(
+            stop=stop_after_attempt(PATCH_PING_MAX_ATTEMPTS),
+            wait=wait_exponential(multiplier=2, min=1, max=4),
+            reraise=True,
+        ):
+            with attempt:
+                try:
+                    resp = requests.post(patch_ping_url, json=payload)
+                    resp.raise_for_status()
+                    resp_body = resp.json()
 
-                # If hash is current start inference server, otherwise delay that
-                # for when patch is applied.
-                if "is_current" in resp_body and resp_body["is_current"] is True:
-                    logger.info("Hash is current, starting inference server")
-                    inference_server_controller.start()
-            except Exception as exc:  # noqa
-                logger.warning(f"Patch ping attempt failed with error {exc}")
-                raise exc
+                    # If hash is current start inference server, otherwise delay
+                    # that for when patch is applied.
+                    if "is_current" in resp_body and resp_body["is_current"] is True:
+                        logger.info("Hash is current, starting inference server")
+                        inference_server_controller.start()
+                except Exception as exc:
+                    attempt_number = attempt.retry_state.attempt_number
+                    if attempt_number == 1:
+                        logger.warning(
+                            f"Patch ping {_classify_error(exc)}: "
+                            f"{type(exc).__name__}: {exc}"
+                        )
+                    else:
+                        logger.info(
+                            f"Patch ping retry "
+                            f"{attempt_number}/{PATCH_PING_MAX_ATTEMPTS}: "
+                            f"{type(exc).__name__}"
+                        )
+                    raise
+    except Exception as exc:
+        logger.error(
+            f"Patch ping failed after {PATCH_PING_MAX_ATTEMPTS} attempts; "
+            f"inference server will not start. "
+            f"Last {_classify_error(exc)} reaching {patch_ping_url}: "
+            f"{type(exc).__name__}: {exc}"
+        )
 
 
 async def async_inference_server_startup_flow(
     inference_server_controller: InferenceServerController, logger: Logger
 ) -> None:
+    # Exceptions from the patch ping flow are caught and logged inside
+    # inference_server_startup_flow; this coroutine never raises from that path.
     return await to_thread.run_sync(
         inference_server_startup_flow, inference_server_controller, logger
     )

--- a/truss/tests/templates/control/control/helpers/test_inference_server_starter.py
+++ b/truss/tests/templates/control/control/helpers/test_inference_server_starter.py
@@ -1,0 +1,84 @@
+import logging
+from unittest import mock
+
+import pytest
+import requests
+import tenacity
+
+from truss.tests.templates.control.control.conftest import setup_control_imports
+
+setup_control_imports()
+
+from helpers import inference_server_starter  # noqa: E402
+
+
+@pytest.fixture
+def fast_retry(monkeypatch):
+    monkeypatch.setattr(inference_server_starter, "PATCH_PING_MAX_ATTEMPTS", 3)
+    monkeypatch.setattr(
+        inference_server_starter, "wait_exponential", lambda **_: tenacity.wait_none()
+    )
+
+
+@pytest.fixture
+def patch_ping_env(monkeypatch):
+    monkeypatch.setenv("PATCH_PING_URL_TRUSS", "http://patch-ping.example/ping")
+
+
+@pytest.fixture
+def controller():
+    c = mock.Mock()
+    c.truss_hash.return_value = "abc123"
+    return c
+
+
+def test_logs_classified_summary_after_retry_exhaustion_does_not_raise(
+    fast_retry, patch_ping_env, controller, caplog
+):
+    err = requests.exceptions.ProxyError("Unable to connect to proxy")
+    with mock.patch.object(requests, "post", side_effect=err):
+        with caplog.at_level(logging.INFO):
+            inference_server_starter.inference_server_startup_flow(
+                controller, logging.getLogger("test")
+            )
+
+    messages = [r.getMessage() for r in caplog.records]
+    levels = [r.levelname for r in caplog.records]
+
+    # First failure logged at WARNING with full type+message and network classification.
+    assert any(
+        m.startswith("Patch ping network error: ProxyError:") for m in messages
+    ), messages
+    # Subsequent attempts logged terse at INFO.
+    assert any("Patch ping retry 2/3: ProxyError" == m for m in messages), messages
+    # Final summary at ERROR mentioning the URL.
+    assert "ERROR" in levels
+    assert any(
+        "Patch ping failed after 3 attempts" in m
+        and "http://patch-ping.example/ping" in m
+        for m in messages
+    ), messages
+    controller.start.assert_not_called()
+
+
+def test_unclassified_error_logged_as_generic(
+    fast_retry, patch_ping_env, controller, caplog
+):
+    with mock.patch.object(requests, "post", side_effect=ValueError("boom")):
+        with caplog.at_level(logging.WARNING):
+            inference_server_starter.inference_server_startup_flow(
+                controller, logging.getLogger("test")
+            )
+
+    messages = [r.getMessage() for r in caplog.records]
+    assert any(m.startswith("Patch ping error: ValueError:") for m in messages), (
+        messages
+    )
+
+
+def test_no_patch_ping_url_starts_immediately(monkeypatch, controller):
+    monkeypatch.delenv("PATCH_PING_URL_TRUSS", raising=False)
+    inference_server_starter.inference_server_startup_flow(
+        controller, logging.getLogger("test")
+    )
+    controller.start.assert_called_once()

--- a/truss/tests/templates/control/control/test_sanitized_exception_middleware.py
+++ b/truss/tests/templates/control/control/test_sanitized_exception_middleware.py
@@ -1,0 +1,132 @@
+from unittest import mock
+
+import pytest
+
+from truss.tests.templates.control.control.conftest import setup_control_imports
+
+setup_control_imports()
+
+from truss.templates.control.control.application import (  # noqa: E402
+    SanitizedExceptionMiddleware,
+)
+
+
+@pytest.fixture
+def middleware():
+    return SanitizedExceptionMiddleware(app=mock.Mock(), num_frames=2)
+
+
+def _request(method: str = "GET", path: str = "/v1/models/model/loaded"):
+    req = mock.Mock()
+    req.method = method
+    req.url.path = path
+    return req
+
+
+def _raise_chain():
+    """Raise a 3-level cause chain: ConnectError -> ProtocolError -> RuntimeError."""
+    try:
+        try:
+            raise ConnectionError("dns failed")
+        except ConnectionError as inner:
+            raise OSError("protocol error") from inner
+    except OSError as middle:
+        raise RuntimeError("outer") from middle
+
+
+def test_format_simple_exception_no_chain(middleware):
+    try:
+        raise ValueError("bad input")
+    except ValueError as exc:
+        out = middleware._format_error(_request("POST", "/control/patch"), exc)
+
+    lines = out.splitlines()
+    assert lines[0] == "POST /control/patch: ValueError: bad input"
+    # No "Caused by:" lines for a single-exception chain.
+    assert not any(line.startswith("Caused by:") for line in lines)
+    # Frame lines have no caret/squiggle markers (PEP 657).
+    assert "^" not in out
+
+
+def test_format_walks_cause_chain(middleware):
+    try:
+        _raise_chain()
+    except RuntimeError as exc:
+        out = middleware._format_error(_request(), exc)
+
+    assert out.startswith("GET /v1/models/model/loaded: RuntimeError: outer")
+    # All three causes appear with their type and message.
+    assert "Caused by: OSError: protocol error" in out
+    assert "Caused by: ConnectionError: dns failed" in out
+    # Headlines are listed outermost-to-innermost.
+    assert out.index("OSError") < out.index("ConnectionError")
+    # No carets.
+    assert "^" not in out
+
+
+def test_frame_count_bounded_per_exception(middleware):
+    try:
+        _raise_chain()
+    except RuntimeError as exc:
+        out = middleware._format_error(_request(), exc)
+
+    frame_lines = [
+        line for line in out.splitlines() if line.lstrip().startswith("File ")
+    ]
+    # 3 exceptions in chain * num_frames(=2) = at most 6 frame lines. The
+    # innermost frames may have fewer (single-statement raises), so allow <=.
+    assert 1 <= len(frame_lines) <= 6
+
+
+def test_cycle_detection_terminates(middleware):
+    a = RuntimeError("a")
+    b = RuntimeError("b")
+    a.__cause__ = b
+    b.__cause__ = a  # cycle
+    a.__traceback__ = None
+    b.__traceback__ = None
+
+    out = middleware._format_error(_request(), a)
+    # Each appears exactly once despite the cycle.
+    assert out.count("RuntimeError: a") == 1
+    assert out.count("RuntimeError: b") == 1
+
+
+def test_self_referential_cause_terminates(middleware):
+    e = RuntimeError("self")
+    e.__cause__ = e
+    out = middleware._format_error(_request(), e)
+    assert out.count("RuntimeError: self") == 1
+
+
+def test_suppress_context_skips_context(middleware):
+    # `raise X from None` sets __suppress_context__=True; the implicit context
+    # should not be walked.
+    try:
+        try:
+            raise ValueError("hidden")
+        except ValueError:
+            raise RuntimeError("outer") from None
+    except RuntimeError as exc:
+        out = middleware._format_error(_request(), exc)
+
+    assert "RuntimeError: outer" in out
+    assert "ValueError: hidden" not in out
+    assert "Caused by:" not in out
+
+
+def test_num_frames_zero_disables_frames(middleware):
+    middleware.num_frames = 0
+    try:
+        _raise_chain()
+    except RuntimeError as exc:
+        out = middleware._format_error(_request(), exc)
+
+    frame_lines = [
+        line for line in out.splitlines() if line.lstrip().startswith("File ")
+    ]
+    assert frame_lines == []
+    # Headlines for all exceptions still present.
+    assert "RuntimeError: outer" in out
+    assert "OSError: protocol error" in out
+    assert "ConnectionError: dns failed" in out

--- a/truss/tests/templates/control/control/test_sanitized_exception_middleware.py
+++ b/truss/tests/templates/control/control/test_sanitized_exception_middleware.py
@@ -1,3 +1,4 @@
+import traceback
 from unittest import mock
 
 import pytest
@@ -24,7 +25,7 @@ def _request(method: str = "GET", path: str = "/v1/models/model/loaded"):
 
 
 def _raise_chain():
-    """Raise a 3-level cause chain: ConnectError -> ProtocolError -> RuntimeError."""
+    """Raise a 3-level cause chain: ConnectionError -> OSError -> RuntimeError."""
     try:
         try:
             raise ConnectionError("dns failed")
@@ -46,6 +47,31 @@ def test_format_simple_exception_no_chain(middleware):
     assert not any(line.startswith("Caused by:") for line in lines)
     # Frame lines have no caret/squiggle markers (PEP 657).
     assert "^" not in out
+
+
+def test_format_full_output_snapshot(middleware):
+    # Snapshot the exact output an end user would see. Line numbers are pulled
+    # from the actual traceback so edits above the chain don't break this. If
+    # the *shape* of the output ever changes (frame format, "Caused by:"
+    # prefix, ordering), this test fails loudly.
+    try:
+        _raise_chain()
+    except RuntimeError as exc:
+        out = middleware._format_error(_request(), exc)
+        outer = traceback.extract_tb(exc.__traceback__)[-2:]
+        middle = traceback.extract_tb(exc.__cause__.__traceback__)[-2:]
+        inner = traceback.extract_tb(exc.__cause__.__cause__.__traceback__)[-2:]
+
+    expected = (
+        f"GET /v1/models/model/loaded: RuntimeError: outer\n"
+        f'  File "{outer[0].filename}", line {outer[0].lineno}, in {outer[0].name}\n'
+        f'  File "{outer[1].filename}", line {outer[1].lineno}, in {outer[1].name}\n'
+        f"Caused by: OSError: protocol error\n"
+        f'  File "{middle[0].filename}", line {middle[0].lineno}, in {middle[0].name}\n'
+        f"Caused by: ConnectionError: dns failed\n"
+        f'  File "{inner[0].filename}", line {inner[0].lineno}, in {inner[0].name}'
+    )
+    assert out == expected, f"\nGOT:\n{out}\n\nEXPECTED:\n{expected}"
 
 
 def test_format_walks_cause_chain(middleware):


### PR DESCRIPTION
## :rocket: What

- Surface real exception type/message + cause chain in the control server's sanitized error log instead of two useless httpx frames
- Replace silent patch-ping retry exhaustion (asyncio "Task exception was never retrieved") with a single classified ERROR line
- Stop crashing shutdown with `AttributeError: 'NoneType' object has no attribute 'pid'` when the inference server never started

## :computer: How

- `SanitizedExceptionMiddleware`: walk `__cause__`/`__context__` with cycle detection, emit headline + `Caused by:` lines with manually formatted frames (no PEP 657 carets); wrap in try/except as a last-resort guard
- `inference_server_starter`: `reraise=True` on the retry loop, full classified WARNING on first failure, terse INFO retries, single ERROR summary on exhaustion; doc the swallow at both the function and the `create_task` call site
- `inference_server_process_controller`: None-guard `_terminate_children_and_process` and `terminate_with_wait`; add return annotations so mypy can actually see the optional access

## :microscope: Testing

- New unit tests for the middleware (chain walk, cycle, `__suppress_context__`, frame bound, `num_frames=0`) and the starter (network classification, retry log shape, exhaustion summary, no-URL early return)