### PR TITLE
feat(loops): add new `truss loops` cli commands

### DIFF
--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -169,7 +169,7 @@ def view_loop_runs(
     remote_provider: BasetenRemote = cast(
         BasetenRemote, RemoteFactory.create(remote=remote)
     )
-    runs = remote_provider.api.search_loop_runs(run_id=run_id, base_model=model_name)
+    runs = remote_provider.api.list_loop_runs(run_id=run_id, base_model=model_name)
     _render_loop_runs(runs)
 
 

--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -1,7 +1,8 @@
 import time
-from typing import Optional, cast
+from typing import Any, Dict, List, Optional, cast
 
 import requests
+import rich.table
 import rich_click as click
 
 from truss.cli import remote_cli
@@ -33,14 +34,14 @@ truss_cli.add_command(loops)
 )
 @click.option("--remote", type=str, required=False, help="Remote to use.")
 @common.common_options()
-def push_trainer_deployment(
+def push_loop_deployment(
     base_model: str, project_id: Optional[str], remote: Optional[str]
 ) -> None:
-    """Deploy training infrastructure for a base model.
+    """Deploy a Loops run + sampler for a base model.
 
-    Creates a trainer session, trainer server, and sampling server for
-    BASE_MODEL. If a training project already has an active trainer
-    deployment, this command will fail with a validation error.
+    Creates a Loops session, run, and paired sampler for BASE_MODEL. If
+    the project already has an active Loops deployment for this base
+    model, the command fails with a validation error.
     """
     if not remote:
         remote = remote_cli.inquire_remote_name()
@@ -49,25 +50,25 @@ def push_trainer_deployment(
         BasetenRemote, RemoteFactory.create(remote=remote)
     )
 
-    with console.status("Creating trainer session...", spinner="dots"):
-        session = remote_provider.create_trainer_session(training_project_id=project_id)
+    with console.status("Creating Loops session...", spinner="dots"):
+        session = remote_provider.create_loop_session(training_project_id=project_id)
     session_id = session["id"]
 
     with console.status(
-        # Trainer cold-start typically takes ~5 minutes.
-        f"Deploying trainer and sampling servers for [cyan]{base_model}[/cyan]"
+        # Loops run cold-start typically takes ~5 minutes.
+        f"Deploying Loops run and sampler for [cyan]{base_model}[/cyan]"
         f" (this may take ~5 minutes)...",
         spinner="dots",
     ):
-        trainer_server = remote_provider.create_trainer_server(
+        run = remote_provider.create_loop_run(
             session_id=session_id, base_model=base_model
         )
-        trainer_base_url = trainer_server["base_url"]
-        _poll_until_running(remote_provider, trainer_base_url)
+        run_base_url = run["base_url"]
+        _poll_until_running(remote_provider, run_base_url)
 
     console.print(
-        f"✨ Trainer deployment for [cyan]{base_model}[/cyan] is ready.\n"
-        f"   Trainer server and sampling server have been provisioned.",
+        f"✨ Loops deployment for [cyan]{base_model}[/cyan] is ready.\n"
+        f"   Run and sampler have been provisioned.",
         style="green",
     )
 
@@ -105,9 +106,9 @@ def deactivate_loop_deployment(
     console.print(f"Loop deployment for {base_model} deactivated.", style="green")
 
 
-def _poll_until_running(remote_provider: BasetenRemote, trainer_base_url: str) -> None:
-    """Poll GET {trainer_base_url}/health until the trainer server is up."""
-    health_url = f"{trainer_base_url}/health"
+def _poll_until_running(remote_provider: BasetenRemote, run_base_url: str) -> None:
+    """Poll GET {run_base_url}/health until the Loops run is up."""
+    health_url = f"{run_base_url}/health"
     auth_header = remote_provider.fetch_auth_header()
     deadline = time.monotonic() + _READY_TIMEOUT_SECONDS
     while time.monotonic() < deadline:
@@ -119,6 +120,139 @@ def _poll_until_running(remote_provider: BasetenRemote, trainer_base_url: str) -
             pass
         time.sleep(_POLL_INTERVAL_SECONDS)
     raise click.ClickException(
-        f"Timed out waiting for trainer deployment to become ready after"
+        f"Timed out waiting for Loops deployment to become ready after"
         f" {_READY_TIMEOUT_SECONDS}s."
     )
+
+
+@loops.command(name="view")
+@click.option("--remote", type=str, required=False, help="Remote to use.")
+@common.common_options()
+def view_loop_deployments(remote: Optional[str]) -> None:
+    """List the caller's active Loops deployments.
+
+    Excludes deployments whose latest status is STOPPED.
+    """
+    if not remote:
+        remote = remote_cli.inquire_remote_name()
+
+    remote_provider: BasetenRemote = cast(
+        BasetenRemote, RemoteFactory.create(remote=remote)
+    )
+    deployments = remote_provider.api.list_loop_deployments()
+    _render_loop_deployments(deployments)
+
+
+@loops.group(name="runs")
+def loop_runs() -> None:
+    """Subcommands for working with Loops runs."""
+
+
+@loop_runs.command(name="view")
+@click.option("--run-id", type=str, required=False, help="Filter by run ID.")
+@click.option(
+    "--model-name", type=str, required=False, help="Filter runs by base model name."
+)
+@click.option("--remote", type=str, required=False, help="Remote to use.")
+@common.common_options()
+def view_loop_runs(
+    run_id: Optional[str], model_name: Optional[str], remote: Optional[str]
+) -> None:
+    """List Loops runs visible to the caller.
+
+    Both filters are optional and can be combined; omit both to list all
+    runs visible to the caller.
+    """
+    if not remote:
+        remote = remote_cli.inquire_remote_name()
+
+    remote_provider: BasetenRemote = cast(
+        BasetenRemote, RemoteFactory.create(remote=remote)
+    )
+    runs = remote_provider.api.search_loop_runs(run_id=run_id, base_model=model_name)
+    _render_loop_runs(runs)
+
+
+@loops.group(name="samplers")
+def loop_samplers() -> None:
+    """Subcommands for working with Loops samplers."""
+
+
+@loop_samplers.command(name="view")
+@click.option("--remote", type=str, required=False, help="Remote to use.")
+@common.common_options()
+def view_loop_samplers(remote: Optional[str]) -> None:
+    """List Loops samplers visible to the caller."""
+    if not remote:
+        remote = remote_cli.inquire_remote_name()
+
+    remote_provider: BasetenRemote = cast(
+        BasetenRemote, RemoteFactory.create(remote=remote)
+    )
+    samplers = remote_provider.api.list_loop_samplers()
+    _render_loop_samplers(samplers)
+
+
+def _render_loop_deployments(deployments: List[Dict[str, Any]]) -> None:
+    if not deployments:
+        console.print("No active Loops deployments.", style="yellow")
+        return
+    table = rich.table.Table(
+        show_header=True,
+        header_style="bold magenta",
+        title="Loops Deployments",
+        box=rich.table.box.ROUNDED,
+        border_style="blue",
+    )
+    table.add_column("Deployment ID", style="cyan")
+    table.add_column("Base Model", style="green")
+    table.add_column("Status", style="yellow")
+    table.add_column("Base URL", style="dim")
+    for deployment in deployments:
+        status = deployment.get("status") or {}
+        table.add_row(
+            deployment.get("id", ""),
+            deployment.get("base_model", "") or "",
+            status.get("name", "") if isinstance(status, dict) else "",
+            deployment.get("base_url", ""),
+        )
+    console.print(table)
+
+
+def _render_loop_runs(runs: List[Dict[str, Any]]) -> None:
+    if not runs:
+        console.print("No Loops runs found.", style="yellow")
+        return
+    table = rich.table.Table(
+        show_header=True,
+        header_style="bold magenta",
+        title="Loops Runs",
+        box=rich.table.box.ROUNDED,
+        border_style="blue",
+    )
+    table.add_column("Run ID", style="cyan")
+    table.add_column("Session ID", style="cyan")
+    table.add_column("Base Model", style="green")
+    for run in runs:
+        table.add_row(
+            run.get("run_id", ""), run.get("session_id", ""), run.get("base_model", "")
+        )
+    console.print(table)
+
+
+def _render_loop_samplers(samplers: List[Dict[str, Any]]) -> None:
+    if not samplers:
+        console.print("No Loops samplers found.", style="yellow")
+        return
+    table = rich.table.Table(
+        show_header=True,
+        header_style="bold magenta",
+        title="Loops Samplers",
+        box=rich.table.box.ROUNDED,
+        border_style="blue",
+    )
+    table.add_column("Sampler ID", style="cyan")
+    table.add_column("Base URL", style="dim")
+    for sampler in samplers:
+        table.add_row(sampler.get("id", ""), sampler.get("base_url", ""))
+    console.print(table)

--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -131,7 +131,7 @@ def _poll_until_running(remote_provider: BasetenRemote, run_base_url: str) -> No
 def view_loop_deployments(remote: Optional[str]) -> None:
     """List the caller's active Loops deployments.
 
-    Excludes deployments whose latest status is STOPPED.
+    Excludes deployments whose latest status is STOPPED (filtered server-side).
     """
     if not remote:
         remote = remote_cli.inquire_remote_name()

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -1229,9 +1229,6 @@ class BasetenApi:
         return resp_json["deployment"]
 
     def list_loop_samplers(self) -> List[Dict[str, Any]]:
-        # NB: backend GET /v1/loops/samplers does not yet exist (TRN-762
-        # follow-up). The CLI surface is wired here so it lights up the
-        # moment the endpoint ships; until then, callers will hit a 404.
         resp_json = self._rest_api_client.get("v1/loops/samplers")
         return resp_json["samplers"]
 

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -1192,27 +1192,48 @@ class BasetenApi:
             f"v1/llm_models/{model_id}/deployments", body=body
         )
 
-    def get_trainer_session(self, session_id: str) -> dict:
-        resp_json = self._rest_api_client.get(f"v1/trainer_sessions/{session_id}")
-        return resp_json["session"]
-
-    def create_trainer_session(self, training_project_id: Optional[str] = None) -> dict:
+    def create_loop_session(self, training_project_id: Optional[str] = None) -> dict:
         body: Dict[str, Any] = {}
         if training_project_id is not None:
             body["training_project_id"] = training_project_id
-        resp_json = self._rest_api_client.post("v1/trainer_sessions", body=body)
+        resp_json = self._rest_api_client.post("v1/loops/sessions", body=body)
         return resp_json["session"]
 
-    def create_trainer_server(
+    def create_loop_run(
         self, session_id: str, base_model: str, seed: Optional[int] = None
     ) -> dict:
-        body: Dict[str, Any] = {"model": base_model}
+        body: Dict[str, Any] = {"session_id": session_id, "base_model": base_model}
         if seed is not None:
             body["seed"] = seed
-        resp_json = self._rest_api_client.post(
-            f"v1/trainer_sessions/{session_id}/trainers", body=body
-        )
-        return resp_json["trainer_server"]
+        resp_json = self._rest_api_client.post("v1/loops/runs", body=body)
+        return resp_json["run"]
+
+    def get_loop_session(self, session_id: str) -> dict:
+        resp_json = self._rest_api_client.get(f"v1/loops/sessions/{session_id}")
+        return resp_json["session"]
+
+    def get_loop_run(self, run_id: str) -> dict:
+        resp_json = self._rest_api_client.get(f"v1/loops/runs/{run_id}")
+        return resp_json["run"]
+
+    def get_loop_sampler(self, sampler_id: str) -> dict:
+        resp_json = self._rest_api_client.get(f"v1/loops/samplers/{sampler_id}")
+        return resp_json["sampler"]
+
+    def list_loop_deployments(self) -> List[Dict[str, Any]]:
+        resp_json = self._rest_api_client.get("v1/loops/deployments")
+        return resp_json["deployments"]
+
+    def get_loop_deployment(self, deployment_id: str) -> dict:
+        resp_json = self._rest_api_client.get(f"v1/loops/deployments/{deployment_id}")
+        return resp_json["deployment"]
+
+    def list_loop_samplers(self) -> List[Dict[str, Any]]:
+        # NB: backend GET /v1/loops/samplers does not yet exist (TRN-762
+        # follow-up). The CLI surface is wired here so it light up the
+        # moment the endpoint ships; until then, callers will hit a 404.
+        resp_json = self._rest_api_client.get("v1/loops/samplers")
+        return resp_json["samplers"]
 
     def list_loop_checkpoint_files(
         self, checkpoint_id: str, page_size: int = 1000

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -1230,7 +1230,7 @@ class BasetenApi:
 
     def list_loop_samplers(self) -> List[Dict[str, Any]]:
         # NB: backend GET /v1/loops/samplers does not yet exist (TRN-762
-        # follow-up). The CLI surface is wired here so it light up the
+        # follow-up). The CLI surface is wired here so it lights up the
         # moment the endpoint ships; until then, callers will hit a 404.
         resp_json = self._rest_api_client.get("v1/loops/samplers")
         return resp_json["samplers"]

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -1262,10 +1262,6 @@ class BasetenApi:
             )
         return all_presigned_urls
 
-    def list_loop_deployments(self):
-        resp_json = self._rest_api_client.get("v1/loops/deployments")
-        return resp_json["deployments"]
-
     def deactivate_loop_deployment(self, deployment_id: str) -> None:
         self._rest_api_client.post(
             f"v1/loops/deployments/{deployment_id}/deactivate", body={}

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -1023,14 +1023,11 @@ class BasetenRemote(TrussRemote):
     def upsert_training_project(self, training_project, team_id=None):
         return self._api.upsert_training_project(training_project, team_id=team_id)
 
-    def get_trainer_session(self, session_id):
-        return self._api.get_trainer_session(session_id)
+    def create_loop_session(self, training_project_id=None):
+        return self._api.create_loop_session(training_project_id=training_project_id)
 
-    def create_trainer_session(self, training_project_id=None):
-        return self._api.create_trainer_session(training_project_id=training_project_id)
-
-    def create_trainer_server(self, session_id, base_model, seed=None):
-        return self._api.create_trainer_server(
+    def create_loop_run(self, session_id, base_model, seed=None):
+        return self._api.create_loop_run(
             session_id=session_id, base_model=base_model, seed=seed
         )
 

--- a/truss/tests/cli/test_loops_cli.py
+++ b/truss/tests/cli/test_loops_cli.py
@@ -257,19 +257,17 @@ def test_view_with_no_deployments_prints_friendly_message(mock_remote):
 
 
 def test_runs_view_no_filters_calls_search_with_none(mock_remote):
-    mock_remote.api.search_loop_runs.return_value = [
+    mock_remote.api.list_loop_runs.return_value = [
         {"run_id": "trnr_xyz", "session_id": "sess_abc", "base_model": "Qwen/Qwen3-8B"}
     ]
     result = _invoke(["loops", "runs", "view", "--remote", "test_remote"], mock_remote)
     assert result.exit_code == 0, result.output
-    mock_remote.api.search_loop_runs.assert_called_once_with(
-        run_id=None, base_model=None
-    )
+    mock_remote.api.list_loop_runs.assert_called_once_with(run_id=None, base_model=None)
     assert "trnr_xyz" in result.output
 
 
 def test_runs_view_with_run_id_filter(mock_remote):
-    mock_remote.api.search_loop_runs.return_value = [
+    mock_remote.api.list_loop_runs.return_value = [
         {"run_id": "trnr_xyz", "session_id": "sess_abc", "base_model": "Qwen/Qwen3-8B"}
     ]
     result = _invoke(
@@ -277,13 +275,13 @@ def test_runs_view_with_run_id_filter(mock_remote):
         mock_remote,
     )
     assert result.exit_code == 0, result.output
-    mock_remote.api.search_loop_runs.assert_called_once_with(
+    mock_remote.api.list_loop_runs.assert_called_once_with(
         run_id="trnr_xyz", base_model=None
     )
 
 
 def test_runs_view_with_model_name_filter(mock_remote):
-    mock_remote.api.search_loop_runs.return_value = []
+    mock_remote.api.list_loop_runs.return_value = []
     result = _invoke(
         [
             "loops",
@@ -297,7 +295,7 @@ def test_runs_view_with_model_name_filter(mock_remote):
         mock_remote,
     )
     assert result.exit_code == 0, result.output
-    mock_remote.api.search_loop_runs.assert_called_once_with(
+    mock_remote.api.list_loop_runs.assert_called_once_with(
         run_id=None, base_model="Qwen/Qwen3-8B"
     )
     assert "No Loops runs found" in result.output

--- a/truss/tests/cli/test_loops_cli.py
+++ b/truss/tests/cli/test_loops_cli.py
@@ -12,11 +12,11 @@ from truss.cli.cli import truss_cli
 @pytest.fixture
 def mock_remote():
     remote = Mock()
-    remote.create_trainer_session.return_value = {"id": "session_abc123"}
-    remote.create_trainer_server.return_value = {
+    remote.create_loop_session.return_value = {"id": "session_abc123"}
+    remote.create_loop_run.return_value = {
         "id": "trainer_xyz456",
         "base_url": "https://trainer-xyz456.api.baseten.co/trainer",
-        "sampling_server": {
+        "sampler": {
             "id": "sampler_def789",
             "base_url": "https://model-def789.api.baseten.co/deployment/v1/sync",
         },
@@ -41,8 +41,8 @@ def test_push_basic(mock_remote):
     )
 
     assert result.exit_code == 0, result.output
-    mock_remote.create_trainer_session.assert_called_once_with(training_project_id=None)
-    mock_remote.create_trainer_server.assert_called_once_with(
+    mock_remote.create_loop_session.assert_called_once_with(training_project_id=None)
+    mock_remote.create_loop_run.assert_called_once_with(
         session_id="session_abc123", base_model="Qwen/Qwen3-8B"
     )
     assert "Qwen/Qwen3-8B" in result.output
@@ -55,7 +55,7 @@ def test_push_with_project_id(mock_remote):
     )
 
     assert result.exit_code == 0, result.output
-    mock_remote.create_trainer_session.assert_called_once_with(
+    mock_remote.create_loop_session.assert_called_once_with(
         training_project_id="proj_abc"
     )
 
@@ -122,7 +122,7 @@ def test_push_fails_when_base_model_missing():
 
 
 def test_push_propagates_session_creation_error(mock_remote):
-    mock_remote.create_trainer_session.side_effect = RuntimeError(
+    mock_remote.create_loop_session.side_effect = RuntimeError(
         "session creation failed"
     )
 
@@ -133,9 +133,9 @@ def test_push_propagates_session_creation_error(mock_remote):
     assert result.exit_code != 0
 
 
-def test_push_propagates_trainer_server_creation_error(mock_remote):
-    mock_remote.create_trainer_server.side_effect = RuntimeError(
-        "active TrainerDeployment already exists"
+def test_push_propagates_loop_run_creation_error(mock_remote):
+    mock_remote.create_loop_run.side_effect = RuntimeError(
+        "active loop deployment already exists"
     )
 
     result = _invoke_loops_push(
@@ -221,3 +221,107 @@ def test_deactivate_requires_base_model(mock_remote):
 
     assert result.exit_code != 0
     mock_remote.deactivate_loop_deployment.assert_not_called()
+
+
+def _invoke(args, mock_remote):
+    env = os.environ.copy()
+    env["COLUMNS"] = "200"
+    runner = CliRunner(env=env)
+    with patch(
+        "truss.remote.remote_factory.RemoteFactory.create", return_value=mock_remote
+    ):
+        return runner.invoke(truss_cli, args)
+
+
+def test_view_lists_active_deployments(mock_remote):
+    mock_remote.api.list_loop_deployments.return_value = [
+        {
+            "id": "dep_abc",
+            "base_model": "Qwen/Qwen3-8B",
+            "base_url": "https://trainer-abc.api.baseten.co/trainer",
+            "status": {"name": "RUNNING"},
+        }
+    ]
+    result = _invoke(["loops", "view", "--remote", "test_remote"], mock_remote)
+    assert result.exit_code == 0, result.output
+    assert "dep_abc" in result.output
+    assert "Qwen/Qwen3-8B" in result.output
+    assert "RUNNING" in result.output
+
+
+def test_view_with_no_deployments_prints_friendly_message(mock_remote):
+    mock_remote.api.list_loop_deployments.return_value = []
+    result = _invoke(["loops", "view", "--remote", "test_remote"], mock_remote)
+    assert result.exit_code == 0, result.output
+    assert "No active Loops deployments" in result.output
+
+
+def test_runs_view_no_filters_calls_search_with_none(mock_remote):
+    mock_remote.api.search_loop_runs.return_value = [
+        {"run_id": "trnr_xyz", "session_id": "sess_abc", "base_model": "Qwen/Qwen3-8B"}
+    ]
+    result = _invoke(["loops", "runs", "view", "--remote", "test_remote"], mock_remote)
+    assert result.exit_code == 0, result.output
+    mock_remote.api.search_loop_runs.assert_called_once_with(
+        run_id=None, base_model=None
+    )
+    assert "trnr_xyz" in result.output
+
+
+def test_runs_view_with_run_id_filter(mock_remote):
+    mock_remote.api.search_loop_runs.return_value = [
+        {"run_id": "trnr_xyz", "session_id": "sess_abc", "base_model": "Qwen/Qwen3-8B"}
+    ]
+    result = _invoke(
+        ["loops", "runs", "view", "--remote", "test_remote", "--run-id", "trnr_xyz"],
+        mock_remote,
+    )
+    assert result.exit_code == 0, result.output
+    mock_remote.api.search_loop_runs.assert_called_once_with(
+        run_id="trnr_xyz", base_model=None
+    )
+
+
+def test_runs_view_with_model_name_filter(mock_remote):
+    mock_remote.api.search_loop_runs.return_value = []
+    result = _invoke(
+        [
+            "loops",
+            "runs",
+            "view",
+            "--remote",
+            "test_remote",
+            "--model-name",
+            "Qwen/Qwen3-8B",
+        ],
+        mock_remote,
+    )
+    assert result.exit_code == 0, result.output
+    mock_remote.api.search_loop_runs.assert_called_once_with(
+        run_id=None, base_model="Qwen/Qwen3-8B"
+    )
+    assert "No Loops runs found" in result.output
+
+
+def test_samplers_view_lists_samplers(mock_remote):
+    mock_remote.api.list_loop_samplers.return_value = [
+        {
+            "id": "sampler_def",
+            "base_url": "https://model-def.api.baseten.co/deployment/v1/sync",
+        }
+    ]
+    result = _invoke(
+        ["loops", "samplers", "view", "--remote", "test_remote"], mock_remote
+    )
+    assert result.exit_code == 0, result.output
+    mock_remote.api.list_loop_samplers.assert_called_once_with()
+    assert "sampler_def" in result.output
+
+
+def test_samplers_view_no_samplers_prints_friendly_message(mock_remote):
+    mock_remote.api.list_loop_samplers.return_value = []
+    result = _invoke(
+        ["loops", "samplers", "view", "--remote", "test_remote"], mock_remote
+    )
+    assert result.exit_code == 0, result.output
+    assert "No Loops samplers found" in result.output


### PR DESCRIPTION
## :rocket: What

Linear: [TRN-753](https://linear.app/baseten-labs/issue/TRN-753).

**Stacked on #2427** (TRN-749). Rebased on top of #2427's deactivate-by-id refactor; auto-rebases to `main` after #2427 merges.

Repoints `truss loops push` from `/v1/trainer_sessions/*` to `/v1/loops/*` and adds three net-new commands.

- `truss loops view` — list the caller's active Loops deployments (excludes STOPPED).
- `truss loops runs view [--run-id <id>] [--model-name <name>]` — list Loops runs, optionally filtered. Filters can be combined; omit both to list all visible runs.
- `truss loops samplers view` — list the caller's Loops samplers.

Loops-language sweep on `truss loops push` user-facing strings ("Trainer session" → "Loops session", "trainer and sampling servers" → "Loops run and sampler", etc.). `truss loops deactivate` was already shipped (#2421) and was repointed in #2427; not touched here.

## :computer: How

- `BasetenApi`: rename `create_trainer_session` → `create_loop_session` (POST `/v1/loops/sessions`), `create_trainer_server` → `create_loop_run` (POST `/v1/loops/runs`, body `{session_id, base_model, seed?}`, returns `{id, base_url, sampler}` per `LoopRunV1`). Drops unused `get_trainer_session`. Adds `get_loop_session`, `get_loop_run`, `get_loop_sampler`, `get_loop_deployment`, `list_loop_samplers`. `list_loop_deployments` lives in #2427 — used here without modification.
- `BasetenRemote`: adds `create_loop_session` / `create_loop_run` wrappers; the new `view` commands call `remote.api.list_*` directly.
- `loops_commands.py`: push uses the renamed methods; new `view`, `runs view`, `samplers view` commands render via `rich.table`.

A small fix commit (`fix(loops): drop duplicate list_loop_deployments after TRN-749 rebase`) removes a duplicate definition produced by rebasing on top of #2427's deactivate refactor (which independently added the same method). Keeps the typed copy alongside the other Loops getters.

## :microscope: Testing

- Updated existing push tests for renamed mocks and the `LoopRunV1`-shape return value (`sampler` field instead of `sampling_server`).
- New tests cover `loops view` (with deployments / empty), `loops runs view` (no filter / `--run-id` / `--model-name`), and `loops samplers view` (with samplers / empty).
- `uv run ruff check .` clean; `uv run ruff format .` clean.
- `uv run pytest truss/tests/cli/` → **402 passed**.

## Dependencies

Depends on the following backend PRs (all merged):

- basetenlabs/baseten#19651 (TRN-750) — `/v1/loops/sessions` + `/v1/loops/runs` + `GET /v1/loops/deployments` + `POST /v1/loops/deployments/{id}/deactivate`.
- basetenlabs/baseten#19657 (TRN-762) — `GET /v1/loops/runs` with `?run_id=` / `?base_model=` URL params (used by `truss loops runs view`); single-resource GETs for sessions/runs/samplers/deployments; `GET /v1/loops/samplers` (used by `truss loops samplers view`).
