### PR TITLE
feat(loops): poll sampler /v1/models health during truss loops push

### DIFF
--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -53,6 +53,8 @@ def push_trainer_deployment(
         session = remote_provider.create_trainer_session(training_project_id=project_id)
     session_id = session["id"]
 
+    auth_header = remote_provider.fetch_auth_header()
+
     with console.status(
         # Trainer cold-start typically takes ~5 minutes.
         f"Deploying trainer and sampling servers for [cyan]{base_model}[/cyan]"
@@ -63,7 +65,10 @@ def push_trainer_deployment(
             session_id=session_id, base_model=base_model
         )
         trainer_base_url = trainer_server["base_url"]
-        _poll_until_running(remote_provider, trainer_base_url)
+        sampler_base_url = (trainer_server.get("sampling_server") or {}).get("base_url")
+        _poll_until_healthy(f"{trainer_base_url}/health", auth_header)
+        if sampler_base_url:
+            _poll_until_healthy(f"{sampler_base_url}/v1/models", auth_header)
 
     console.print(
         f"✨ Trainer deployment for [cyan]{base_model}[/cyan] is ready.\n"
@@ -105,20 +110,17 @@ def deactivate_loop_deployment(
     console.print(f"Loop deployment for {base_model} deactivated.", style="green")
 
 
-def _poll_until_running(remote_provider: BasetenRemote, trainer_base_url: str) -> None:
-    """Poll GET {trainer_base_url}/health until the trainer server is up."""
-    health_url = f"{trainer_base_url}/health"
-    auth_header = remote_provider.fetch_auth_header()
+def _poll_until_healthy(health_url: str, auth_header: dict) -> None:
+    """Poll health_url until it returns HTTP 200 or the timeout expires."""
     deadline = time.monotonic() + _READY_TIMEOUT_SECONDS
     while time.monotonic() < deadline:
         try:
-            resp = requests.get(health_url, headers=auth_header, timeout=10)
-            if resp.status_code == 200:
+            if requests.get(health_url, headers=auth_header, timeout=10).status_code == 200:
                 return
         except requests.RequestException:
             pass
         time.sleep(_POLL_INTERVAL_SECONDS)
     raise click.ClickException(
-        f"Timed out waiting for trainer deployment to become ready after"
+        f"Timed out waiting for {health_url} to become healthy after"
         f" {_READY_TIMEOUT_SECONDS}s."
     )

--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -110,7 +110,7 @@ def deactivate_loop_deployment(
     console.print(f"Loop deployment for {base_model} deactivated.", style="green")
 
 
-def _poll_until_healthy(health_url: str, auth_header: dict) -> None:
+def _poll_until_healthy(health_url: str, auth_header: dict[str, str]) -> None:
     """Poll health_url until it returns HTTP 200 or the timeout expires."""
     deadline = time.monotonic() + _READY_TIMEOUT_SECONDS
     while time.monotonic() < deadline:

--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -115,7 +115,10 @@ def _poll_until_healthy(health_url: str, auth_header: dict[str, str]) -> None:
     deadline = time.monotonic() + _READY_TIMEOUT_SECONDS
     while time.monotonic() < deadline:
         try:
-            if requests.get(health_url, headers=auth_header, timeout=10).status_code == 200:
+            if (
+                requests.get(health_url, headers=auth_header, timeout=10).status_code
+                == 200
+            ):
                 return
         except requests.RequestException:
             pass

--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -121,6 +121,6 @@ def _poll_until_healthy(health_url: str, auth_header: dict) -> None:
             pass
         time.sleep(_POLL_INTERVAL_SECONDS)
     raise click.ClickException(
-        f"Timed out waiting for {health_url} to become healthy after"
+        f"Timed out waiting for {health_url} to become ready after"
         f" {_READY_TIMEOUT_SECONDS}s."
     )

--- a/truss/tests/cli/test_loops_cli.py
+++ b/truss/tests/cli/test_loops_cli.py
@@ -60,15 +60,20 @@ def test_push_with_project_id(mock_remote):
     )
 
 
-def test_push_polls_until_running(mock_remote):
-    # First two polls return 503, third returns 200.
-    responses = [Mock(status_code=503), Mock(status_code=503), Mock(status_code=200)]
+def test_push_polls_trainer_health(mock_remote):
+    # Trainer: 503, 503, 200. Sampler: 200 immediately.
+    responses = [
+        Mock(status_code=503),  # trainer poll 1
+        Mock(status_code=503),  # trainer poll 2
+        Mock(status_code=200),  # trainer poll 3 — healthy
+        Mock(status_code=200),  # sampler poll 1 — healthy
+    ]
 
     runner = CliRunner()
     with patch(
         "truss.remote.remote_factory.RemoteFactory.create", return_value=mock_remote
     ):
-        with patch("requests.get", side_effect=responses):
+        with patch("requests.get", side_effect=responses) as mock_get:
             with patch("truss.cli.loops_commands.time.sleep"):
                 result = runner.invoke(
                     truss_cli,
@@ -76,6 +81,32 @@ def test_push_polls_until_running(mock_remote):
                 )
 
     assert result.exit_code == 0, result.output
+    urls = [call[0][0] for call in mock_get.call_args_list]
+    assert urls[0].endswith("/health")
+    assert urls[-1].endswith("/v1/models")
+
+
+def test_push_polls_sampler_health(mock_remote):
+    # Trainer healthy immediately; sampler: 503, 200.
+    responses = [
+        Mock(status_code=200),  # trainer — healthy
+        Mock(status_code=503),  # sampler poll 1
+        Mock(status_code=200),  # sampler poll 2 — healthy
+    ]
+
+    runner = CliRunner()
+    with patch(
+        "truss.remote.remote_factory.RemoteFactory.create", return_value=mock_remote
+    ):
+        with patch("requests.get", side_effect=responses) as mock_get:
+            with patch("truss.cli.loops_commands.time.sleep"):
+                result = runner.invoke(
+                    truss_cli,
+                    ["loops", "push", "Qwen/Qwen3-8B", "--remote", "test_remote"],
+                )
+
+    assert result.exit_code == 0, result.output
+    assert mock_get.call_count == 3
 
 
 def test_push_times_out_waiting_for_health(mock_remote):
@@ -95,6 +126,7 @@ def test_push_times_out_waiting_for_health(mock_remote):
 
     assert result.exit_code != 0
     assert "Timed out" in result.output
+    assert "healthy" in result.output
 
 
 def test_push_uses_inquire_when_remote_not_provided(mock_remote):

--- a/truss/tests/cli/test_loops_cli.py
+++ b/truss/tests/cli/test_loops_cli.py
@@ -126,7 +126,7 @@ def test_push_times_out_waiting_for_health(mock_remote):
 
     assert result.exit_code != 0
     assert "Timed out" in result.output
-    assert "healthy" in result.output
+    assert "ready" in result.output
 
 
 def test_push_uses_inquire_when_remote_not_provided(mock_remote):


### PR DESCRIPTION
## :rocket: What

`truss loops push` now waits for both the trainer server and the paired sampling server to be healthy before returning, instead of only waiting on the trainer.

## :computer: How

Replaced `_poll_until_running` with a generic `_poll_until_healthy(health_url, auth_header)` helper that polls any URL until it returns HTTP 200. The push command calls it sequentially:

1. `GET {trainer_base_url}/health` — trainer server readiness
2. `GET {sampler_base_url}/v1/models` — vLLM sampling server readiness (skipped if no sampler URL is returned)

Auth header is fetched once from `remote_provider.fetch_auth_header()` and reused for both polls.

## :microscope: Testing

- Added `test_push_polls_trainer_health` — verifies trainer `/health` is polled and retried until 200
- Added `test_push_polls_sampler_health` — verifies sampler `/v1/models` is polled after trainer is healthy
- All 16 existing tests pass