### PR TITLE
refactor: rename `trainer_checkpoint_ids` to `loop_checkpoint_ids`

### DIFF
--- a/truss-train/tests/test_definitions.py
+++ b/truss-train/tests/test_definitions.py
@@ -110,16 +110,16 @@ class TestTrainingJobWeightsAuthValidation:
         assert job.weights[0].auth is None
 
 
-class TestCheckpointListTrainerCheckpoints:
-    """truss-train CheckpointList: trainer_checkpoint_ids field, validator, to_truss_config."""
+class TestCheckpointListLoopCheckpoints:
+    """truss-train CheckpointList: loop_checkpoint_ids field, validator, to_truss_config."""
 
-    def test_trainer_checkpoint_ids_round_trip_to_truss_config(self):
+    def test_loop_checkpoint_ids_round_trip_to_truss_config(self):
         ckpt_list = CheckpointList(
-            base_model_id="Qwen/Qwen3-8B", trainer_checkpoint_ids=["tcp_a", "tcp_b"]
+            base_model_id="Qwen/Qwen3-8B", loop_checkpoint_ids=["tcp_a", "tcp_b"]
         )
         truss_ckpt_list = ckpt_list.to_truss_config()
         assert truss_ckpt_list.artifact_references == []
-        assert truss_ckpt_list.trainer_checkpoint_ids == ["tcp_a", "tcp_b"]
+        assert truss_ckpt_list.loop_checkpoint_ids == ["tcp_a", "tcp_b"]
         assert truss_ckpt_list.download_folder == ckpt_list.download_folder
 
     def test_artifact_references_round_trip_to_truss_config(self):
@@ -136,9 +136,9 @@ class TestCheckpointListTrainerCheckpoints:
         truss_ckpt_list = ckpt_list.to_truss_config()
         assert len(truss_ckpt_list.artifact_references) == 1
         assert truss_ckpt_list.artifact_references[0].training_job_id == "tj_abc"
-        assert truss_ckpt_list.trainer_checkpoint_ids == []
+        assert truss_ckpt_list.loop_checkpoint_ids == []
 
-    def test_mixing_checkpoints_and_trainer_ids_raises(self):
+    def test_mixing_checkpoints_and_loop_ids_raises(self):
         with pytest.raises(ValidationError, match="cannot mix"):
             CheckpointList(
                 checkpoints=[
@@ -148,5 +148,5 @@ class TestCheckpointListTrainerCheckpoints:
                         model_weight_format=ModelWeightsFormat.LORA,
                     )
                 ],
-                trainer_checkpoint_ids=["tcp_xyz"],
+                loop_checkpoint_ids=["tcp_xyz"],
             )

--- a/truss-train/truss_train/definitions.py
+++ b/truss-train/truss_train/definitions.py
@@ -281,7 +281,7 @@ class CheckpointList(custom_types.SafeModelNoExtra):
         if self.checkpoints and self.loop_checkpoint_ids:
             raise ValueError(
                 "checkpoint_details cannot mix checkpoints (training job "
-                "checkpoints) and loop_checkpoint_ids (trainer checkpoints) "
+                "checkpoints) and loop_checkpoint_ids (Loop checkpoints) "
                 "in the same deploy"
             )
         return self

--- a/truss-train/truss_train/definitions.py
+++ b/truss-train/truss_train/definitions.py
@@ -274,14 +274,14 @@ class CheckpointList(custom_types.SafeModelNoExtra):
     download_folder: str = truss_config.DEFAULT_TRAINING_CHECKPOINT_FOLDER
     base_model_id: Optional[str] = None
     checkpoints: List[Checkpoint] = []
-    trainer_checkpoint_ids: List[str] = []
+    loop_checkpoint_ids: List[str] = []
 
     @model_validator(mode="after")
     def _no_mixing(self) -> "CheckpointList":
-        if self.checkpoints and self.trainer_checkpoint_ids:
+        if self.checkpoints and self.loop_checkpoint_ids:
             raise ValueError(
                 "checkpoint_details cannot mix checkpoints (training job "
-                "checkpoints) and trainer_checkpoint_ids (trainer checkpoints) "
+                "checkpoints) and loop_checkpoint_ids (trainer checkpoints) "
                 "in the same deploy"
             )
         return self
@@ -293,7 +293,7 @@ class CheckpointList(custom_types.SafeModelNoExtra):
         return truss_config.CheckpointList(
             download_folder=self.download_folder,
             artifact_references=artifact_references,
-            trainer_checkpoint_ids=self.trainer_checkpoint_ids,
+            loop_checkpoint_ids=self.loop_checkpoint_ids,
         )
 
 

--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -1088,7 +1088,7 @@ class CheckpointList(custom_types.ConfigModel):
     loop_checkpoint_ids: list[str] = pydantic.Field(
         default_factory=list,
         description=(
-            "Trainer checkpoint IDs to deploy. Mutually exclusive with artifact_references."
+            "Loop checkpoint IDs to deploy. Mutually exclusive with artifact_references."
         ),
     )
 
@@ -1097,7 +1097,7 @@ class CheckpointList(custom_types.ConfigModel):
         if self.artifact_references and self.loop_checkpoint_ids:
             raise ValueError(
                 "training_checkpoints cannot mix artifact_references (training "
-                "job checkpoints) and loop_checkpoint_ids (trainer checkpoints) "
+                "job checkpoints) and loop_checkpoint_ids (Loop checkpoints) "
                 "in the same deploy"
             )
         return self

--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -1085,7 +1085,7 @@ class CheckpointList(custom_types.ConfigModel):
     artifact_references: list[TrainingArtifactReference] = pydantic.Field(
         default_factory=list
     )
-    trainer_checkpoint_ids: list[str] = pydantic.Field(
+    loop_checkpoint_ids: list[str] = pydantic.Field(
         default_factory=list,
         description=(
             "Trainer checkpoint IDs to deploy. Mutually exclusive with artifact_references."
@@ -1094,10 +1094,10 @@ class CheckpointList(custom_types.ConfigModel):
 
     @pydantic.model_validator(mode="after")
     def _no_mixing(self) -> "CheckpointList":
-        if self.artifact_references and self.trainer_checkpoint_ids:
+        if self.artifact_references and self.loop_checkpoint_ids:
             raise ValueError(
                 "training_checkpoints cannot mix artifact_references (training "
-                "job checkpoints) and trainer_checkpoint_ids (trainer checkpoints) "
+                "job checkpoints) and loop_checkpoint_ids (trainer checkpoints) "
                 "in the same deploy"
             )
         return self

--- a/truss/cli/train/deploy_checkpoints/deploy_checkpoints.py
+++ b/truss/cli/train/deploy_checkpoints/deploy_checkpoints.py
@@ -127,13 +127,13 @@ def _build_inference_template_request(
         }
         weights_sources.append(weights_source)
     for (
-        trainer_checkpoint_id
-    ) in checkpoint_deploy_config.checkpoint_details.trainer_checkpoint_ids:
+        loop_checkpoint_id
+    ) in checkpoint_deploy_config.checkpoint_details.loop_checkpoint_ids:
         weights_sources.append(
             {
-                "weight_source_type": "B10_TRAINER_CHECKPOINTING",
-                "b10_trainer_checkpoint_weights_source": {
-                    "checkpoint": {"trainer_checkpoint_id": trainer_checkpoint_id}
+                "weight_source_type": "B10_LOOP_CHECKPOINTING",
+                "b10_loop_checkpoint_weights_source": {
+                    "checkpoint": {"loop_checkpoint_id": loop_checkpoint_id}
                 },
             }
         )
@@ -288,7 +288,7 @@ def _hydrate_deploy_config(
         and bool(deploy_config.checkpoint_details.checkpoints)
     )
     config_has_loop_checkpoints = deploy_config.checkpoint_details is not None and bool(
-        deploy_config.checkpoint_details.trainer_checkpoint_ids
+        deploy_config.checkpoint_details.loop_checkpoint_ids
     )
     if run_id_provided and config_has_training_job_checkpoints:
         raise click.UsageError(
@@ -298,7 +298,7 @@ def _hydrate_deploy_config(
     if job_flag_provided and config_has_loop_checkpoints:
         raise click.UsageError(
             "--project-id / --job-id cannot be combined with "
-            "checkpoint_details.trainer_checkpoint_ids from --config. Pick one source."
+            "checkpoint_details.loop_checkpoint_ids from --config. Pick one source."
         )
 
     is_loop_flow = run_id_provided or config_has_loop_checkpoints
@@ -376,13 +376,11 @@ def _ensure_loop_checkpoint_details(
 ) -> CheckpointList:
     """Resolve a Loops-checkpoint flow into a CheckpointList.
 
-    Each entry in ``trainer_checkpoint_ids`` is a Loops-checkpoint PK
-    (the field name is preserved for backwards-compat with existing
-    ``--config`` files). The server resolves it to its run +
-    checkpoint_name on deploy and reads the actual weight format off
-    the row — the CLI doesn't need to know it.
+    Each entry in ``loop_checkpoint_ids`` is a Loops-checkpoint PK. The
+    server resolves it to its run + checkpoint_name on deploy and reads
+    the actual weight format off the row — the CLI doesn't need to know it.
     """
-    if checkpoint_details and checkpoint_details.trainer_checkpoint_ids:
+    if checkpoint_details and checkpoint_details.loop_checkpoint_ids:
         # User-authored Loops-checkpoint IDs in --config — server
         # resolves and validates on deploy; nothing for the CLI to enrich.
         return checkpoint_details
@@ -418,7 +416,7 @@ def _prompt_user_for_loop_checkpoint_details(
 
     if not checkpoint_details:
         checkpoint_details = CheckpointList()
-    checkpoint_details.trainer_checkpoint_ids = [
+    checkpoint_details.loop_checkpoint_ids = [
         name_to_pk[name] for name in selected_names
     ]
     if checkpoint_details.base_model_id is None:

--- a/truss/config.schema.json
+++ b/truss/config.schema.json
@@ -181,7 +181,7 @@
           "title": "Artifact References",
           "type": "array"
         },
-        "trainer_checkpoint_ids": {
+        "loop_checkpoint_ids": {
           "description": "Trainer checkpoint IDs to deploy. Mutually exclusive with artifact_references.",
           "items": {
             "type": "string"

--- a/truss/config.schema.json
+++ b/truss/config.schema.json
@@ -182,7 +182,7 @@
           "type": "array"
         },
         "loop_checkpoint_ids": {
-          "description": "Trainer checkpoint IDs to deploy. Mutually exclusive with artifact_references.",
+          "description": "Loop checkpoint IDs to deploy. Mutually exclusive with artifact_references.",
           "items": {
             "type": "string"
           },

--- a/truss/config.schema.json
+++ b/truss/config.schema.json
@@ -186,7 +186,7 @@
           "items": {
             "type": "string"
           },
-          "title": "Trainer Checkpoint Ids",
+          "title": "Loop Checkpoint Ids",
           "type": "array"
         }
       },

--- a/truss/tests/cli/train/test_deploy_checkpoints.py
+++ b/truss/tests/cli/train/test_deploy_checkpoints.py
@@ -317,8 +317,8 @@ def test_resolve_loop_run_raises_when_not_found(mock_loop_remote):
 
 
 def test_ensure_loop_checkpoint_details_user_provided_passes_through(mock_loop_remote):
-    """When the user authored trainer_checkpoint_ids in --config, return as-is."""
-    user_config = definitions.CheckpointList(trainer_checkpoint_ids=["tcp_step100"])
+    """When the user authored loop_checkpoint_ids in --config, return as-is."""
+    user_config = definitions.CheckpointList(loop_checkpoint_ids=["tcp_step100"])
     result = _ensure_loop_checkpoint_details(mock_loop_remote, user_config, run_id=None)
     assert result is user_config
     # Did not hit the API since user authored the IDs.
@@ -346,7 +346,7 @@ def test_ensure_loop_checkpoint_details_picker_emits_ids_and_base_model(
     result = _ensure_loop_checkpoint_details(
         mock_loop_remote, checkpoint_details=None, run_id="trnr_xyz"
     )
-    assert result.trainer_checkpoint_ids == ["tcp_step100"]
+    assert result.loop_checkpoint_ids == ["tcp_step100"]
     assert result.base_model_id == "Qwen/Qwen3-8B"
     mock_loop_remote.api.list_loop_checkpoints.assert_called_once_with(
         run_id="trnr_xyz"
@@ -376,13 +376,13 @@ def test_hydrate_deploy_config_rejects_run_id_with_config_checkpoints(mock_loop_
         )
 
 
-def test_hydrate_deploy_config_rejects_job_id_with_config_trainer_checkpoint_ids(
+def test_hydrate_deploy_config_rejects_job_id_with_config_loop_checkpoint_ids(
     mock_loop_remote,
 ):
-    """--job-id + --config that has trainer_checkpoint_ids should error."""
+    """--job-id + --config that has loop_checkpoint_ids should error."""
     deploy_config = definitions.DeployCheckpointsConfig(
         checkpoint_details=definitions.CheckpointList(
-            trainer_checkpoint_ids=["tcp_xyz"]
+            loop_checkpoint_ids=["tcp_xyz"]
         )
     )
     with pytest.raises(

--- a/truss/tests/cli/train/test_deploy_checkpoints.py
+++ b/truss/tests/cli/train/test_deploy_checkpoints.py
@@ -381,9 +381,7 @@ def test_hydrate_deploy_config_rejects_job_id_with_config_loop_checkpoint_ids(
 ):
     """--job-id + --config that has loop_checkpoint_ids should error."""
     deploy_config = definitions.DeployCheckpointsConfig(
-        checkpoint_details=definitions.CheckpointList(
-            loop_checkpoint_ids=["tcp_xyz"]
-        )
+        checkpoint_details=definitions.CheckpointList(loop_checkpoint_ids=["tcp_xyz"])
     )
     with pytest.raises(
         click.UsageError, match="--project-id / --job-id cannot be combined"

--- a/truss/tests/test_config.py
+++ b/truss/tests/test_config.py
@@ -1818,11 +1818,11 @@ class TestCheckpointListNoMixing:
             ]
         )
         assert ckpt_list.artifact_references[0].training_job_id == "tj_abc"
-        assert ckpt_list.trainer_checkpoint_ids == []
+        assert ckpt_list.loop_checkpoint_ids == []
 
-    def test_trainer_checkpoint_ids_only_accepted(self):
-        ckpt_list = CheckpointList(trainer_checkpoint_ids=["tcp_xyz"])
-        assert ckpt_list.trainer_checkpoint_ids == ["tcp_xyz"]
+    def test_loop_checkpoint_ids_only_accepted(self):
+        ckpt_list = CheckpointList(loop_checkpoint_ids=["tcp_xyz"])
+        assert ckpt_list.loop_checkpoint_ids == ["tcp_xyz"]
         assert ckpt_list.artifact_references == []
 
     def test_mixing_raises(self):
@@ -1833,10 +1833,10 @@ class TestCheckpointListNoMixing:
                         training_job_id="tj_abc", paths=["rank-0/step-1/"]
                     )
                 ],
-                trainer_checkpoint_ids=["tcp_xyz"],
+                loop_checkpoint_ids=["tcp_xyz"],
             )
 
     def test_empty_lists_accepted(self):
         ckpt_list = CheckpointList()
         assert ckpt_list.artifact_references == []
-        assert ckpt_list.trainer_checkpoint_ids == []
+        assert ckpt_list.loop_checkpoint_ids == []


### PR DESCRIPTION
## Summary

- Renames `CheckpointList.trainer_checkpoint_ids` → `loop_checkpoint_ids` on both `truss.base.truss_config.CheckpointList` and `truss_train.definitions.CheckpointList`.
- Renames the deploy-checkpoints wire payload: `B10_TRAINER_CHECKPOINTING` → `B10_LOOP_CHECKPOINTING`, `b10_trainer_checkpoint_weights_source` → `b10_loop_checkpoint_weights_source`, `trainer_checkpoint_id` → `loop_checkpoint_id` (sent to Django).
- Regenerates `truss/config.schema.json` (title field updated to "Loop Checkpoint Ids").
- Hard cutover — no aliases. Existing user `--config` files with `trainer_checkpoint_ids:` will fail validation against the new `truss_train.CheckpointList` (uses `SafeModelNoExtra` with `extra="forbid"`).

## Context

[TRN-765](https://linear.app/baseten/issue/TRN-765/use-loop-checkpoint-ids-in-deploy-checkpoints). Companion to baseten#19694, which renames the matching Python types, GraphQL types, and wire keys on the Django side.

## Release ordering

**Land baseten#19694 first.** Until Django parses `loop_checkpoint_ids` / `B10_LOOP_CHECKPOINTING`, this truss client emitting the new keys would be rejected with 400 on every deploy.

**Out of scope (kept as `trainer_*` for now):** `_ensure_trainer_checkpoint_details`, `_prompt_user_for_trainer_checkpoint_details`, `list_trainer_checkpoints` API method, `_resolve_trainer` — those reference the TrainerServer concept (still named `trainer` on the Django side) rather than the checkpoint-id field.

## Test plan

- [x] `pytest truss/tests/test_config.py truss/tests/cli/train/test_deploy_checkpoints.py truss-train/tests/test_definitions.py` — 217 passed locally.
- [x] `truss/config.schema.json` regenerated via `uv run bin/generate_truss_config_schema.py`; pre-commit `check-truss-config-schema` clean.
- [ ] After Django#19694 deploys, smoke-test `truss train deploy_checkpoints --trainer-id ...` end-to-end and confirm the request payload uses the new keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
