### PR TITLE
refactor(loops): clean up _get_loop_run_model_name and stray trainer refs

### DIFF
--- a/truss/cli/train/deploy_checkpoints/deploy_checkpoints.py
+++ b/truss/cli/train/deploy_checkpoints/deploy_checkpoints.py
@@ -259,19 +259,19 @@ def _get_model_name(
     ).execute()
 
 
-def _get_loop_run_model_name(base_model_id: Optional[str]) -> str:
-    """Prompt for a model name in Loops-checkpoint deploys.
+def _model_name_from_checkpoint_model_ref(checkpoint_model_ref: str) -> str:
+    """Derive a default model name from a checkpoint's model reference.
 
-    The CLI doesn't need to know the weight format — the server reads it
-    off the Loops-checkpoint row. We just prompt for a name with the
-    base model as a sensible default.
+    Checkpoint rows store the underlying model as a HuggingFace-style
+    identifier in their ``base_model`` field. The trailing path segment
+    is a sensible default model name to suggest to the user.
+
+    Examples:
+        "meta-llama/Llama-3.1-8B-Instruct" -> "Llama-3.1-8B-Instruct"
+        "openai/whisper-large-v3"          -> "whisper-large-v3"
+        "Llama-3.1-8B-Instruct"            -> "Llama-3.1-8B-Instruct"
     """
-    default = base_model_id.split("/")[-1] if base_model_id else ""
-    return inquirer.text(
-        message="Enter the model name.",
-        validate=lambda s: s and s.strip(),
-        default=default,
-    ).execute()
+    return checkpoint_model_ref.split("/")[-1]
 
 
 def _hydrate_deploy_config(
@@ -309,7 +309,17 @@ def _hydrate_deploy_config(
         if deploy_config.model_name:
             model_name = deploy_config.model_name
         else:
-            model_name = _get_loop_run_model_name(checkpoint_details.base_model_id)
+            checkpoint_model_ref = checkpoint_details.base_model_id
+            default = (
+                _model_name_from_checkpoint_model_ref(checkpoint_model_ref)
+                if checkpoint_model_ref
+                else ""
+            )
+            model_name = inquirer.text(
+                message="Enter the model name.",
+                validate=lambda s: s and s.strip(),
+                default=default,
+            ).execute()
     else:
         checkpoint_details = _ensure_checkpoint_details(
             remote_provider, deploy_config.checkpoint_details, project_id, job_id

--- a/truss/tests/cli/test_loops_cli.py
+++ b/truss/tests/cli/test_loops_cli.py
@@ -15,7 +15,7 @@ def mock_remote():
     remote.create_loop_session.return_value = {"id": "session_abc123"}
     remote.create_loop_run.return_value = {
         "id": "abc123",
-        "base_url": "https://trainer-xyz456.api.baseten.co/loops",
+        "base_url": "https://trainer-xyz456.api.baseten.co/trainer",
         "sampler": {
             "id": "sampler_def789",
             "base_url": "https://model-def789.api.baseten.co/deployment/v1/sync",
@@ -238,7 +238,7 @@ def test_view_lists_active_deployments(mock_remote):
         {
             "id": "dep_abc",
             "base_model": "Qwen/Qwen3-8B",
-            "base_url": "https://trainer-abc.api.baseten.co/loops",
+            "base_url": "https://trainer-abc.api.baseten.co/trainer",
             "status": {"name": "RUNNING"},
         }
     ]

--- a/truss/tests/cli/test_loops_cli.py
+++ b/truss/tests/cli/test_loops_cli.py
@@ -14,8 +14,8 @@ def mock_remote():
     remote = Mock()
     remote.create_loop_session.return_value = {"id": "session_abc123"}
     remote.create_loop_run.return_value = {
-        "id": "trainer_xyz456",
-        "base_url": "https://trainer-xyz456.api.baseten.co/trainer",
+        "id": "abc123",
+        "base_url": "https://trainer-xyz456.api.baseten.co/loops",
         "sampler": {
             "id": "sampler_def789",
             "base_url": "https://model-def789.api.baseten.co/deployment/v1/sync",
@@ -238,7 +238,7 @@ def test_view_lists_active_deployments(mock_remote):
         {
             "id": "dep_abc",
             "base_model": "Qwen/Qwen3-8B",
-            "base_url": "https://trainer-abc.api.baseten.co/trainer",
+            "base_url": "https://trainer-abc.api.baseten.co/loops",
             "status": {"name": "RUNNING"},
         }
     ]

--- a/truss/tests/test_config.py
+++ b/truss/tests/test_config.py
@@ -1807,7 +1807,7 @@ class TestTrussConfigWeights:
 
 
 class TestCheckpointListNoMixing:
-    """CheckpointList rejects mixing training-job and trainer checkpoint sources."""
+    """CheckpointList rejects mixing training-job and loops checkpoint sources."""
 
     def test_artifact_references_only_accepted(self):
         ckpt_list = CheckpointList(


### PR DESCRIPTION
## Summary
- Split the misleadingly-named `_get_loop_run_model_name` into a pure parser, `_model_name_from_checkpoint_model_ref`, that takes a required `str` and documents the input format with three concrete examples. The `Optional` handling and the `inquirer` prompt now live at the only call site, so the function and its caller stop trading off optionality.
- Renames the function arg to `checkpoint_model_ref` (per review feedback — the input is a checkpoint's model reference, not a trainer-flow concept).
- Cleans up the last two stray "trainer" references that should now read "loops" (a test docstring in `test_config.py`). The mocked Loops `base_url`s in `test_loops_cli.py` keep both the `trainer-XXX.api.baseten.co` CNAME and the `/trainer` path because that's what the server actually returns today.

## Test plan
- [x] `uv run ruff check` / `uv run ruff format` clean on touched files
- [x] `uv run pytest truss/tests/cli/test_loops_cli.py truss/tests/test_config.py::TestCheckpointListNoMixing` — 26 passed
- [ ] Manual smoke of the `truss train deploy_checkpoints` Loops flow (model-name prompt + default still appears, `Optional` base_model_id still handled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)