### PR TITLE
refactor: rename `loop_checkpoint_id[s]` to `loops_checkpoint_id[s]`

### DIFF
--- a/truss-train/tests/test_definitions.py
+++ b/truss-train/tests/test_definitions.py
@@ -111,15 +111,15 @@ class TestTrainingJobWeightsAuthValidation:
 
 
 class TestCheckpointListLoopCheckpoints:
-    """truss-train CheckpointList: loop_checkpoint_ids field, validator, to_truss_config."""
+    """truss-train CheckpointList: loops_checkpoint_ids field, validator, to_truss_config."""
 
-    def test_loop_checkpoint_ids_round_trip_to_truss_config(self):
+    def test_loops_checkpoint_ids_round_trip_to_truss_config(self):
         ckpt_list = CheckpointList(
-            base_model_id="Qwen/Qwen3-8B", loop_checkpoint_ids=["tcp_a", "tcp_b"]
+            base_model_id="Qwen/Qwen3-8B", loops_checkpoint_ids=["tcp_a", "tcp_b"]
         )
         truss_ckpt_list = ckpt_list.to_truss_config()
         assert truss_ckpt_list.artifact_references == []
-        assert truss_ckpt_list.loop_checkpoint_ids == ["tcp_a", "tcp_b"]
+        assert truss_ckpt_list.loops_checkpoint_ids == ["tcp_a", "tcp_b"]
         assert truss_ckpt_list.download_folder == ckpt_list.download_folder
 
     def test_artifact_references_round_trip_to_truss_config(self):
@@ -136,7 +136,7 @@ class TestCheckpointListLoopCheckpoints:
         truss_ckpt_list = ckpt_list.to_truss_config()
         assert len(truss_ckpt_list.artifact_references) == 1
         assert truss_ckpt_list.artifact_references[0].training_job_id == "tj_abc"
-        assert truss_ckpt_list.loop_checkpoint_ids == []
+        assert truss_ckpt_list.loops_checkpoint_ids == []
 
     def test_mixing_checkpoints_and_loop_ids_raises(self):
         with pytest.raises(ValidationError, match="cannot mix"):
@@ -148,5 +148,5 @@ class TestCheckpointListLoopCheckpoints:
                         model_weight_format=ModelWeightsFormat.LORA,
                     )
                 ],
-                loop_checkpoint_ids=["tcp_xyz"],
+                loops_checkpoint_ids=["tcp_xyz"],
             )

--- a/truss-train/truss_train/definitions.py
+++ b/truss-train/truss_train/definitions.py
@@ -274,14 +274,14 @@ class CheckpointList(custom_types.SafeModelNoExtra):
     download_folder: str = truss_config.DEFAULT_TRAINING_CHECKPOINT_FOLDER
     base_model_id: Optional[str] = None
     checkpoints: List[Checkpoint] = []
-    loop_checkpoint_ids: List[str] = []
+    loops_checkpoint_ids: List[str] = []
 
     @model_validator(mode="after")
     def _no_mixing(self) -> "CheckpointList":
-        if self.checkpoints and self.loop_checkpoint_ids:
+        if self.checkpoints and self.loops_checkpoint_ids:
             raise ValueError(
                 "checkpoint_details cannot mix checkpoints (training job "
-                "checkpoints) and loop_checkpoint_ids (Loop checkpoints) "
+                "checkpoints) and loops_checkpoint_ids (Loop checkpoints) "
                 "in the same deploy"
             )
         return self
@@ -293,7 +293,7 @@ class CheckpointList(custom_types.SafeModelNoExtra):
         return truss_config.CheckpointList(
             download_folder=self.download_folder,
             artifact_references=artifact_references,
-            loop_checkpoint_ids=self.loop_checkpoint_ids,
+            loops_checkpoint_ids=self.loops_checkpoint_ids,
         )
 
 

--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -1085,7 +1085,7 @@ class CheckpointList(custom_types.ConfigModel):
     artifact_references: list[TrainingArtifactReference] = pydantic.Field(
         default_factory=list
     )
-    loop_checkpoint_ids: list[str] = pydantic.Field(
+    loops_checkpoint_ids: list[str] = pydantic.Field(
         default_factory=list,
         description=(
             "Loop checkpoint IDs to deploy. Mutually exclusive with artifact_references."
@@ -1094,10 +1094,10 @@ class CheckpointList(custom_types.ConfigModel):
 
     @pydantic.model_validator(mode="after")
     def _no_mixing(self) -> "CheckpointList":
-        if self.artifact_references and self.loop_checkpoint_ids:
+        if self.artifact_references and self.loops_checkpoint_ids:
             raise ValueError(
                 "training_checkpoints cannot mix artifact_references (training "
-                "job checkpoints) and loop_checkpoint_ids (Loop checkpoints) "
+                "job checkpoints) and loops_checkpoint_ids (Loop checkpoints) "
                 "in the same deploy"
             )
         return self

--- a/truss/cli/train/deploy_checkpoints/deploy_checkpoints.py
+++ b/truss/cli/train/deploy_checkpoints/deploy_checkpoints.py
@@ -127,13 +127,13 @@ def _build_inference_template_request(
         }
         weights_sources.append(weights_source)
     for (
-        loop_checkpoint_id
-    ) in checkpoint_deploy_config.checkpoint_details.loop_checkpoint_ids:
+        loops_checkpoint_id
+    ) in checkpoint_deploy_config.checkpoint_details.loops_checkpoint_ids:
         weights_sources.append(
             {
-                "weight_source_type": "B10_LOOP_CHECKPOINTING",
-                "b10_loop_checkpoint_weights_source": {
-                    "checkpoint": {"loop_checkpoint_id": loop_checkpoint_id}
+                "weight_source_type": "B10_LOOPS_CHECKPOINTING",
+                "b10_loops_checkpoint_weights_source": {
+                    "checkpoint": {"loops_checkpoint_id": loops_checkpoint_id}
                 },
             }
         )
@@ -288,7 +288,7 @@ def _hydrate_deploy_config(
         and bool(deploy_config.checkpoint_details.checkpoints)
     )
     config_has_loop_checkpoints = deploy_config.checkpoint_details is not None and bool(
-        deploy_config.checkpoint_details.loop_checkpoint_ids
+        deploy_config.checkpoint_details.loops_checkpoint_ids
     )
     if run_id_provided and config_has_training_job_checkpoints:
         raise click.UsageError(
@@ -298,7 +298,7 @@ def _hydrate_deploy_config(
     if job_flag_provided and config_has_loop_checkpoints:
         raise click.UsageError(
             "--project-id / --job-id cannot be combined with "
-            "checkpoint_details.loop_checkpoint_ids from --config. Pick one source."
+            "checkpoint_details.loops_checkpoint_ids from --config. Pick one source."
         )
 
     is_loop_flow = run_id_provided or config_has_loop_checkpoints
@@ -386,11 +386,11 @@ def _ensure_loop_checkpoint_details(
 ) -> CheckpointList:
     """Resolve a Loops-checkpoint flow into a CheckpointList.
 
-    Each entry in ``loop_checkpoint_ids`` is a Loops-checkpoint PK. The
+    Each entry in ``loops_checkpoint_ids`` is a Loops-checkpoint PK. The
     server resolves it to its run + checkpoint_name on deploy and reads
     the actual weight format off the row — the CLI doesn't need to know it.
     """
-    if checkpoint_details and checkpoint_details.loop_checkpoint_ids:
+    if checkpoint_details and checkpoint_details.loops_checkpoint_ids:
         # User-authored Loops-checkpoint IDs in --config — server
         # resolves and validates on deploy; nothing for the CLI to enrich.
         return checkpoint_details
@@ -426,7 +426,7 @@ def _prompt_user_for_loop_checkpoint_details(
 
     if not checkpoint_details:
         checkpoint_details = CheckpointList()
-    checkpoint_details.loop_checkpoint_ids = [
+    checkpoint_details.loops_checkpoint_ids = [
         name_to_pk[name] for name in selected_names
     ]
     if checkpoint_details.base_model_id is None:

--- a/truss/config.schema.json
+++ b/truss/config.schema.json
@@ -181,12 +181,12 @@
           "title": "Artifact References",
           "type": "array"
         },
-        "loop_checkpoint_ids": {
+        "loops_checkpoint_ids": {
           "description": "Loop checkpoint IDs to deploy. Mutually exclusive with artifact_references.",
           "items": {
             "type": "string"
           },
-          "title": "Loop Checkpoint Ids",
+          "title": "Loops Checkpoint Ids",
           "type": "array"
         }
       },

--- a/truss/tests/cli/train/test_deploy_checkpoints.py
+++ b/truss/tests/cli/train/test_deploy_checkpoints.py
@@ -317,8 +317,8 @@ def test_resolve_loop_run_raises_when_not_found(mock_loop_remote):
 
 
 def test_ensure_loop_checkpoint_details_user_provided_passes_through(mock_loop_remote):
-    """When the user authored loop_checkpoint_ids in --config, return as-is."""
-    user_config = definitions.CheckpointList(loop_checkpoint_ids=["tcp_step100"])
+    """When the user authored loops_checkpoint_ids in --config, return as-is."""
+    user_config = definitions.CheckpointList(loops_checkpoint_ids=["tcp_step100"])
     result = _ensure_loop_checkpoint_details(mock_loop_remote, user_config, run_id=None)
     assert result is user_config
     # Did not hit the API since user authored the IDs.
@@ -346,7 +346,7 @@ def test_ensure_loop_checkpoint_details_picker_emits_ids_and_base_model(
     result = _ensure_loop_checkpoint_details(
         mock_loop_remote, checkpoint_details=None, run_id="trnr_xyz"
     )
-    assert result.loop_checkpoint_ids == ["tcp_step100"]
+    assert result.loops_checkpoint_ids == ["tcp_step100"]
     assert result.base_model_id == "Qwen/Qwen3-8B"
     mock_loop_remote.api.list_loop_checkpoints.assert_called_once_with(
         run_id="trnr_xyz"
@@ -376,12 +376,12 @@ def test_hydrate_deploy_config_rejects_run_id_with_config_checkpoints(mock_loop_
         )
 
 
-def test_hydrate_deploy_config_rejects_job_id_with_config_loop_checkpoint_ids(
+def test_hydrate_deploy_config_rejects_job_id_with_config_loops_checkpoint_ids(
     mock_loop_remote,
 ):
-    """--job-id + --config that has loop_checkpoint_ids should error."""
+    """--job-id + --config that has loops_checkpoint_ids should error."""
     deploy_config = definitions.DeployCheckpointsConfig(
-        checkpoint_details=definitions.CheckpointList(loop_checkpoint_ids=["tcp_xyz"])
+        checkpoint_details=definitions.CheckpointList(loops_checkpoint_ids=["tcp_xyz"])
     )
     with pytest.raises(
         click.UsageError, match="--project-id / --job-id cannot be combined"

--- a/truss/tests/test_config.py
+++ b/truss/tests/test_config.py
@@ -1818,11 +1818,11 @@ class TestCheckpointListNoMixing:
             ]
         )
         assert ckpt_list.artifact_references[0].training_job_id == "tj_abc"
-        assert ckpt_list.loop_checkpoint_ids == []
+        assert ckpt_list.loops_checkpoint_ids == []
 
-    def test_loop_checkpoint_ids_only_accepted(self):
-        ckpt_list = CheckpointList(loop_checkpoint_ids=["tcp_xyz"])
-        assert ckpt_list.loop_checkpoint_ids == ["tcp_xyz"]
+    def test_loops_checkpoint_ids_only_accepted(self):
+        ckpt_list = CheckpointList(loops_checkpoint_ids=["tcp_xyz"])
+        assert ckpt_list.loops_checkpoint_ids == ["tcp_xyz"]
         assert ckpt_list.artifact_references == []
 
     def test_mixing_raises(self):
@@ -1833,10 +1833,10 @@ class TestCheckpointListNoMixing:
                         training_job_id="tj_abc", paths=["rank-0/step-1/"]
                     )
                 ],
-                loop_checkpoint_ids=["tcp_xyz"],
+                loops_checkpoint_ids=["tcp_xyz"],
             )
 
     def test_empty_lists_accepted(self):
         ckpt_list = CheckpointList()
         assert ckpt_list.artifact_references == []
-        assert ckpt_list.loop_checkpoint_ids == []
+        assert ckpt_list.loops_checkpoint_ids == []


### PR DESCRIPTION
## Summary

Follow-up to #2432 — pluralizes the user-facing namespace from `loop_*` to `loops_*` to match the existing `bt://loops:` URI scheme and `truss loops` CLI commands.

- `CheckpointList.loop_checkpoint_ids` → `loops_checkpoint_ids` on both `truss.base.truss_config.CheckpointList` and `truss_train.definitions.CheckpointList`.
- Wire payload keys: `B10_LOOP_CHECKPOINTING` → `B10_LOOPS_CHECKPOINTING`, `b10_loop_checkpoint_weights_source` → `b10_loops_checkpoint_weights_source`, `loop_checkpoint_id` → `loops_checkpoint_id` in the deploy-checkpoints request to Django.
- `truss/config.schema.json` regenerated.
- Hard cutover, no aliases.

## Context

[TRN-765](https://linear.app/baseten/issue/TRN-765/use-loop-checkpoint-ids-in-deploy-checkpoints). Companion to baseten#19694, which performs the matching rename on the Django side (Pydantic types, GraphQL types, dict keys, OpenAPI spec).

## Release ordering

**Land baseten#19694 first.** Until Django parses `loops_checkpoint_ids` / `B10_LOOPS_CHECKPOINTING`, this truss client emitting the new keys would 400 on every deploy.

## Test plan

- [x] `pytest truss/tests/test_config.py truss/tests/cli/train/test_deploy_checkpoints.py truss-train/tests/test_definitions.py` — 217 passed.
- [x] `pre-commit run --all-files` — clean (ruff lint, ruff format, mypy, schema generator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)