### PR TITLE
refactor: rename singular `loop_*` identifiers to plural `loops_*` (TRN-765)

### DIFF
--- a/truss-train/tests/test_definitions.py
+++ b/truss-train/tests/test_definitions.py
@@ -110,7 +110,7 @@ class TestTrainingJobWeightsAuthValidation:
         assert job.weights[0].auth is None
 
 
-class TestCheckpointListLoopCheckpoints:
+class TestCheckpointListLoopsCheckpoints:
     """truss-train CheckpointList: loops_checkpoint_ids field, validator, to_truss_config."""
 
     def test_loops_checkpoint_ids_round_trip_to_truss_config(self):
@@ -138,7 +138,7 @@ class TestCheckpointListLoopCheckpoints:
         assert truss_ckpt_list.artifact_references[0].training_job_id == "tj_abc"
         assert truss_ckpt_list.loops_checkpoint_ids == []
 
-    def test_mixing_checkpoints_and_loop_ids_raises(self):
+    def test_mixing_checkpoints_and_loops_ids_raises(self):
         with pytest.raises(ValidationError, match="cannot mix"):
             CheckpointList(
                 checkpoints=[

--- a/truss-train/truss_train/definitions.py
+++ b/truss-train/truss_train/definitions.py
@@ -281,7 +281,7 @@ class CheckpointList(custom_types.SafeModelNoExtra):
         if self.checkpoints and self.loops_checkpoint_ids:
             raise ValueError(
                 "checkpoint_details cannot mix checkpoints (training job "
-                "checkpoints) and loops_checkpoint_ids (Loop checkpoints) "
+                "checkpoints) and loops_checkpoint_ids (Loops checkpoints) "
                 "in the same deploy"
             )
         return self

--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -1088,7 +1088,7 @@ class CheckpointList(custom_types.ConfigModel):
     loops_checkpoint_ids: list[str] = pydantic.Field(
         default_factory=list,
         description=(
-            "Loop checkpoint IDs to deploy. Mutually exclusive with artifact_references."
+            "Loops checkpoint IDs to deploy. Mutually exclusive with artifact_references."
         ),
     )
 
@@ -1097,7 +1097,7 @@ class CheckpointList(custom_types.ConfigModel):
         if self.artifact_references and self.loops_checkpoint_ids:
             raise ValueError(
                 "training_checkpoints cannot mix artifact_references (training "
-                "job checkpoints) and loops_checkpoint_ids (Loop checkpoints) "
+                "job checkpoints) and loops_checkpoint_ids (Loops checkpoints) "
                 "in the same deploy"
             )
         return self

--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -34,7 +34,7 @@ truss_cli.add_command(loops)
 )
 @click.option("--remote", type=str, required=False, help="Remote to use.")
 @common.common_options()
-def push_loop_deployment(
+def push_loops_deployment(
     base_model: str, project_id: Optional[str], remote: Optional[str]
 ) -> None:
     """Deploy a Loops run + sampler for a base model.
@@ -51,7 +51,7 @@ def push_loop_deployment(
     )
 
     with console.status("Creating Loops session...", spinner="dots"):
-        session = remote_provider.create_loop_session(training_project_id=project_id)
+        session = remote_provider.create_loops_session(training_project_id=project_id)
     session_id = session["id"]
 
     with console.status(
@@ -60,7 +60,7 @@ def push_loop_deployment(
         f" (this may take ~5 minutes)...",
         spinner="dots",
     ):
-        run = remote_provider.create_loop_run(
+        run = remote_provider.create_loops_run(
             session_id=session_id, base_model=base_model
         )
         run_base_url = run["base_url"]
@@ -80,12 +80,12 @@ def push_loop_deployment(
     "--yes", "-y", is_flag=True, default=False, help="Skip confirmation prompt."
 )
 @common.common_options()
-def deactivate_loop_deployment(
+def deactivate_loops_deployment(
     base_model: str, remote: Optional[str], yes: bool
 ) -> None:
-    """Deactivate the active loop deployment for BASE_MODEL.
+    """Deactivate the active Loops deployment for BASE_MODEL.
 
-    Shuts down the loop's deployment. Saved checkpoints remain accessible.
+    Shuts down the Loops deployment. Saved checkpoints remain accessible.
     """
     if not remote:
         remote = remote_cli.inquire_remote_name()
@@ -96,14 +96,14 @@ def deactivate_loop_deployment(
 
     if not yes:
         click.confirm(
-            f"This will shut down the active loop deployment for {base_model}. Continue?",
+            f"This will shut down the active Loops deployment for {base_model}. Continue?",
             abort=True,
         )
 
-    with console.status("Deactivating loop deployment...", spinner="dots"):
-        remote_provider.deactivate_loop_deployment(base_model)
+    with console.status("Deactivating Loops deployment...", spinner="dots"):
+        remote_provider.deactivate_loops_deployment(base_model)
 
-    console.print(f"Loop deployment for {base_model} deactivated.", style="green")
+    console.print(f"Loops deployment for {base_model} deactivated.", style="green")
 
 
 def _poll_until_running(remote_provider: BasetenRemote, run_base_url: str) -> None:
@@ -128,7 +128,7 @@ def _poll_until_running(remote_provider: BasetenRemote, run_base_url: str) -> No
 @loops.command(name="view")
 @click.option("--remote", type=str, required=False, help="Remote to use.")
 @common.common_options()
-def view_loop_deployments(remote: Optional[str]) -> None:
+def view_loops_deployments(remote: Optional[str]) -> None:
     """List the caller's active Loops deployments.
 
     Excludes deployments whose latest status is STOPPED (filtered server-side).
@@ -139,23 +139,23 @@ def view_loop_deployments(remote: Optional[str]) -> None:
     remote_provider: BasetenRemote = cast(
         BasetenRemote, RemoteFactory.create(remote=remote)
     )
-    deployments = remote_provider.api.list_loop_deployments()
-    _render_loop_deployments(deployments)
+    deployments = remote_provider.api.list_loops_deployments()
+    _render_loops_deployments(deployments)
 
 
 @loops.group(name="runs")
-def loop_runs() -> None:
+def loops_runs() -> None:
     """Subcommands for working with Loops runs."""
 
 
-@loop_runs.command(name="view")
+@loops_runs.command(name="view")
 @click.option("--run-id", type=str, required=False, help="Filter by run ID.")
 @click.option(
     "--model-name", type=str, required=False, help="Filter runs by base model name."
 )
 @click.option("--remote", type=str, required=False, help="Remote to use.")
 @common.common_options()
-def view_loop_runs(
+def view_loops_runs(
     run_id: Optional[str], model_name: Optional[str], remote: Optional[str]
 ) -> None:
     """List Loops runs visible to the caller.
@@ -169,19 +169,19 @@ def view_loop_runs(
     remote_provider: BasetenRemote = cast(
         BasetenRemote, RemoteFactory.create(remote=remote)
     )
-    runs = remote_provider.api.list_loop_runs(run_id=run_id, base_model=model_name)
-    _render_loop_runs(runs)
+    runs = remote_provider.api.list_loops_runs(run_id=run_id, base_model=model_name)
+    _render_loops_runs(runs)
 
 
 @loops.group(name="samplers")
-def loop_samplers() -> None:
+def loops_samplers() -> None:
     """Subcommands for working with Loops samplers."""
 
 
-@loop_samplers.command(name="view")
+@loops_samplers.command(name="view")
 @click.option("--remote", type=str, required=False, help="Remote to use.")
 @common.common_options()
-def view_loop_samplers(remote: Optional[str]) -> None:
+def view_loops_samplers(remote: Optional[str]) -> None:
     """List Loops samplers visible to the caller."""
     if not remote:
         remote = remote_cli.inquire_remote_name()
@@ -189,11 +189,11 @@ def view_loop_samplers(remote: Optional[str]) -> None:
     remote_provider: BasetenRemote = cast(
         BasetenRemote, RemoteFactory.create(remote=remote)
     )
-    samplers = remote_provider.api.list_loop_samplers()
-    _render_loop_samplers(samplers)
+    samplers = remote_provider.api.list_loops_samplers()
+    _render_loops_samplers(samplers)
 
 
-def _render_loop_deployments(deployments: List[Dict[str, Any]]) -> None:
+def _render_loops_deployments(deployments: List[Dict[str, Any]]) -> None:
     if not deployments:
         console.print("No active Loops deployments.", style="yellow")
         return
@@ -219,7 +219,7 @@ def _render_loop_deployments(deployments: List[Dict[str, Any]]) -> None:
     console.print(table)
 
 
-def _render_loop_runs(runs: List[Dict[str, Any]]) -> None:
+def _render_loops_runs(runs: List[Dict[str, Any]]) -> None:
     if not runs:
         console.print("No Loops runs found.", style="yellow")
         return
@@ -240,7 +240,7 @@ def _render_loop_runs(runs: List[Dict[str, Any]]) -> None:
     console.print(table)
 
 
-def _render_loop_samplers(samplers: List[Dict[str, Any]]) -> None:
+def _render_loops_samplers(samplers: List[Dict[str, Any]]) -> None:
     if not samplers:
         console.print("No Loops samplers found.", style="yellow")
         return

--- a/truss/cli/train/deploy_checkpoints/deploy_checkpoints.py
+++ b/truss/cli/train/deploy_checkpoints/deploy_checkpoints.py
@@ -287,23 +287,24 @@ def _hydrate_deploy_config(
         deploy_config.checkpoint_details is not None
         and bool(deploy_config.checkpoint_details.checkpoints)
     )
-    config_has_loop_checkpoints = deploy_config.checkpoint_details is not None and bool(
-        deploy_config.checkpoint_details.loops_checkpoint_ids
+    config_has_loops_checkpoints = (
+        deploy_config.checkpoint_details is not None
+        and bool(deploy_config.checkpoint_details.loops_checkpoint_ids)
     )
     if run_id_provided and config_has_training_job_checkpoints:
         raise click.UsageError(
             "--run-id cannot be combined with checkpoint_details.checkpoints "
             "from --config (training job checkpoints). Pick one source."
         )
-    if job_flag_provided and config_has_loop_checkpoints:
+    if job_flag_provided and config_has_loops_checkpoints:
         raise click.UsageError(
             "--project-id / --job-id cannot be combined with "
             "checkpoint_details.loops_checkpoint_ids from --config. Pick one source."
         )
 
-    is_loop_flow = run_id_provided or config_has_loop_checkpoints
-    if is_loop_flow:
-        checkpoint_details = _ensure_loop_checkpoint_details(
+    is_loops_flow = run_id_provided or config_has_loops_checkpoints
+    if is_loops_flow:
+        checkpoint_details = _ensure_loops_checkpoint_details(
             remote_provider, deploy_config.checkpoint_details, run_id
         )
         if deploy_config.model_name:
@@ -379,7 +380,7 @@ def _ensure_checkpoint_details(
         )
 
 
-def _ensure_loop_checkpoint_details(
+def _ensure_loops_checkpoint_details(
     remote_provider: BasetenRemote,
     checkpoint_details: Optional[CheckpointList],
     run_id: Optional[str],
@@ -396,18 +397,18 @@ def _ensure_loop_checkpoint_details(
         return checkpoint_details
     if not run_id:
         raise click.UsageError("--run-id is required to deploy Loops checkpoints.")
-    return _prompt_user_for_loop_checkpoint_details(
+    return _prompt_user_for_loops_checkpoint_details(
         remote_provider, checkpoint_details, run_id
     )
 
 
-def _prompt_user_for_loop_checkpoint_details(
+def _prompt_user_for_loops_checkpoint_details(
     remote_provider: BasetenRemote,
     checkpoint_details: Optional[CheckpointList],
     run_id: str,
 ) -> CheckpointList:
-    run = _resolve_loop_run(remote_provider, run_id)
-    response = remote_provider.api.list_loop_checkpoints(run_id=run["run_id"])
+    run = _resolve_loops_run(remote_provider, run_id)
+    response = remote_provider.api.list_loops_checkpoints(run_id=run["run_id"])
     # Pick by checkpoint_name in the UI; map back to Loops-checkpoint
     # database IDs for the wire so the server doesn't need to re-resolve names.
     name_to_pk = OrderedDict(
@@ -434,8 +435,8 @@ def _prompt_user_for_loop_checkpoint_details(
     return checkpoint_details
 
 
-def _resolve_loop_run(remote_provider: BasetenRemote, run_id: str) -> dict:
-    matches = remote_provider.api.list_loop_runs(run_id=run_id)
+def _resolve_loops_run(remote_provider: BasetenRemote, run_id: str) -> dict:
+    matches = remote_provider.api.list_loops_runs(run_id=run_id)
     if not matches:
         raise click.UsageError(f"Loops run {run_id} not found.")
     return matches[0]

--- a/truss/config.schema.json
+++ b/truss/config.schema.json
@@ -182,7 +182,7 @@
           "type": "array"
         },
         "loops_checkpoint_ids": {
-          "description": "Loop checkpoint IDs to deploy. Mutually exclusive with artifact_references.",
+          "description": "Loops checkpoint IDs to deploy. Mutually exclusive with artifact_references.",
           "items": {
             "type": "string"
           },

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -892,7 +892,7 @@ class BasetenApi:
         )
         return resp_json
 
-    def list_loop_runs(
+    def list_loops_runs(
         self, run_id: Optional[str] = None, base_model: Optional[str] = None
     ):
         params: Dict[str, str] = {}
@@ -903,7 +903,7 @@ class BasetenApi:
         resp_json = self._rest_api_client.get("v1/loops/runs", url_params=params)
         return resp_json["runs"]
 
-    def list_loop_checkpoints(
+    def list_loops_checkpoints(
         self,
         run_id: Optional[str] = None,
         base_model: Optional[str] = None,
@@ -1192,14 +1192,14 @@ class BasetenApi:
             f"v1/llm_models/{model_id}/deployments", body=body
         )
 
-    def create_loop_session(self, training_project_id: Optional[str] = None) -> dict:
+    def create_loops_session(self, training_project_id: Optional[str] = None) -> dict:
         body: Dict[str, Any] = {}
         if training_project_id is not None:
             body["training_project_id"] = training_project_id
         resp_json = self._rest_api_client.post("v1/loops/sessions", body=body)
         return resp_json["session"]
 
-    def create_loop_run(
+    def create_loops_run(
         self, session_id: str, base_model: str, seed: Optional[int] = None
     ) -> dict:
         body: Dict[str, Any] = {"session_id": session_id, "base_model": base_model}
@@ -1208,31 +1208,31 @@ class BasetenApi:
         resp_json = self._rest_api_client.post("v1/loops/runs", body=body)
         return resp_json["run"]
 
-    def get_loop_session(self, session_id: str) -> dict:
+    def get_loops_session(self, session_id: str) -> dict:
         resp_json = self._rest_api_client.get(f"v1/loops/sessions/{session_id}")
         return resp_json["session"]
 
-    def get_loop_run(self, run_id: str) -> dict:
+    def get_loops_run(self, run_id: str) -> dict:
         resp_json = self._rest_api_client.get(f"v1/loops/runs/{run_id}")
         return resp_json["run"]
 
-    def get_loop_sampler(self, sampler_id: str) -> dict:
+    def get_loops_sampler(self, sampler_id: str) -> dict:
         resp_json = self._rest_api_client.get(f"v1/loops/samplers/{sampler_id}")
         return resp_json["sampler"]
 
-    def list_loop_deployments(self) -> List[Dict[str, Any]]:
+    def list_loops_deployments(self) -> List[Dict[str, Any]]:
         resp_json = self._rest_api_client.get("v1/loops/deployments")
         return resp_json["deployments"]
 
-    def get_loop_deployment(self, deployment_id: str) -> dict:
+    def get_loops_deployment(self, deployment_id: str) -> dict:
         resp_json = self._rest_api_client.get(f"v1/loops/deployments/{deployment_id}")
         return resp_json["deployment"]
 
-    def list_loop_samplers(self) -> List[Dict[str, Any]]:
+    def list_loops_samplers(self) -> List[Dict[str, Any]]:
         resp_json = self._rest_api_client.get("v1/loops/samplers")
         return resp_json["samplers"]
 
-    def list_loop_checkpoint_files(
+    def list_loops_checkpoint_files(
         self, checkpoint_id: str, page_size: int = 1000
     ) -> List[Dict[str, str]]:
         """Fetch all presigned URLs for files under a Loops checkpoint."""
@@ -1259,7 +1259,7 @@ class BasetenApi:
             )
         return all_presigned_urls
 
-    def deactivate_loop_deployment(self, deployment_id: str) -> None:
+    def deactivate_loops_deployment(self, deployment_id: str) -> None:
         self._rest_api_client.post(
             f"v1/loops/deployments/{deployment_id}/deactivate", body={}
         )

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -1023,19 +1023,19 @@ class BasetenRemote(TrussRemote):
     def upsert_training_project(self, training_project, team_id=None):
         return self._api.upsert_training_project(training_project, team_id=team_id)
 
-    def create_loop_session(self, training_project_id=None):
-        return self._api.create_loop_session(training_project_id=training_project_id)
+    def create_loops_session(self, training_project_id=None):
+        return self._api.create_loops_session(training_project_id=training_project_id)
 
-    def create_loop_run(self, session_id, base_model, seed=None):
-        return self._api.create_loop_run(
+    def create_loops_run(self, session_id, base_model, seed=None):
+        return self._api.create_loops_run(
             session_id=session_id, base_model=base_model, seed=seed
         )
 
-    def deactivate_loop_deployment(self, base_model: str) -> None:
-        deployments = self._api.list_loop_deployments()
+    def deactivate_loops_deployment(self, base_model: str) -> None:
+        deployments = self._api.list_loops_deployments()
         match = next((d for d in deployments if d["base_model"] == base_model), None)
         if match is None:
             raise RemoteError(
                 f"No active Loops deployment found for base model {base_model!r}."
             )
-        self._api.deactivate_loop_deployment(match["id"])
+        self._api.deactivate_loops_deployment(match["id"])

--- a/truss/tests/cli/test_loops_cli.py
+++ b/truss/tests/cli/test_loops_cli.py
@@ -12,8 +12,8 @@ from truss.cli.cli import truss_cli
 @pytest.fixture
 def mock_remote():
     remote = Mock()
-    remote.create_loop_session.return_value = {"id": "session_abc123"}
-    remote.create_loop_run.return_value = {
+    remote.create_loops_session.return_value = {"id": "session_abc123"}
+    remote.create_loops_run.return_value = {
         "id": "abc123",
         "base_url": "https://trainer-xyz456.api.baseten.co/trainer",
         "sampler": {
@@ -41,8 +41,8 @@ def test_push_basic(mock_remote):
     )
 
     assert result.exit_code == 0, result.output
-    mock_remote.create_loop_session.assert_called_once_with(training_project_id=None)
-    mock_remote.create_loop_run.assert_called_once_with(
+    mock_remote.create_loops_session.assert_called_once_with(training_project_id=None)
+    mock_remote.create_loops_run.assert_called_once_with(
         session_id="session_abc123", base_model="Qwen/Qwen3-8B"
     )
     assert "Qwen/Qwen3-8B" in result.output
@@ -55,7 +55,7 @@ def test_push_with_project_id(mock_remote):
     )
 
     assert result.exit_code == 0, result.output
-    mock_remote.create_loop_session.assert_called_once_with(
+    mock_remote.create_loops_session.assert_called_once_with(
         training_project_id="proj_abc"
     )
 
@@ -122,7 +122,7 @@ def test_push_fails_when_base_model_missing():
 
 
 def test_push_propagates_session_creation_error(mock_remote):
-    mock_remote.create_loop_session.side_effect = RuntimeError(
+    mock_remote.create_loops_session.side_effect = RuntimeError(
         "session creation failed"
     )
 
@@ -133,9 +133,9 @@ def test_push_propagates_session_creation_error(mock_remote):
     assert result.exit_code != 0
 
 
-def test_push_propagates_loop_run_creation_error(mock_remote):
-    mock_remote.create_loop_run.side_effect = RuntimeError(
-        "active loop deployment already exists"
+def test_push_propagates_loops_run_creation_error(mock_remote):
+    mock_remote.create_loops_run.side_effect = RuntimeError(
+        "active Loops deployment already exists"
     )
 
     result = _invoke_loops_push(
@@ -169,7 +169,7 @@ def test_deactivate_basic(mock_remote):
     )
 
     assert result.exit_code == 0, result.output
-    mock_remote.deactivate_loop_deployment.assert_called_once_with("Qwen/Qwen3-8B")
+    mock_remote.deactivate_loops_deployment.assert_called_once_with("Qwen/Qwen3-8B")
     assert "deactivated" in result.output
 
 
@@ -179,7 +179,7 @@ def test_deactivate_confirms_before_proceeding(mock_remote):
     )
 
     assert result.exit_code == 0, result.output
-    mock_remote.deactivate_loop_deployment.assert_called_once_with("Qwen/Qwen3-8B")
+    mock_remote.deactivate_loops_deployment.assert_called_once_with("Qwen/Qwen3-8B")
 
 
 def test_deactivate_aborts_on_no_confirmation(mock_remote):
@@ -188,7 +188,7 @@ def test_deactivate_aborts_on_no_confirmation(mock_remote):
     )
 
     assert result.exit_code != 0
-    mock_remote.deactivate_loop_deployment.assert_not_called()
+    mock_remote.deactivate_loops_deployment.assert_not_called()
 
 
 def test_deactivate_uses_inquire_when_remote_not_provided(mock_remote):
@@ -205,7 +205,7 @@ def test_deactivate_uses_inquire_when_remote_not_provided(mock_remote):
 
 
 def test_deactivate_propagates_error(mock_remote):
-    mock_remote.deactivate_loop_deployment.side_effect = RuntimeError(
+    mock_remote.deactivate_loops_deployment.side_effect = RuntimeError(
         "deactivation failed"
     )
 
@@ -220,7 +220,7 @@ def test_deactivate_requires_base_model(mock_remote):
     result = _invoke_loops_deactivate(["--remote", "test_remote", "--yes"], mock_remote)
 
     assert result.exit_code != 0
-    mock_remote.deactivate_loop_deployment.assert_not_called()
+    mock_remote.deactivate_loops_deployment.assert_not_called()
 
 
 def _invoke(args, mock_remote):
@@ -234,7 +234,7 @@ def _invoke(args, mock_remote):
 
 
 def test_view_lists_active_deployments(mock_remote):
-    mock_remote.api.list_loop_deployments.return_value = [
+    mock_remote.api.list_loops_deployments.return_value = [
         {
             "id": "dep_abc",
             "base_model": "Qwen/Qwen3-8B",
@@ -250,24 +250,26 @@ def test_view_lists_active_deployments(mock_remote):
 
 
 def test_view_with_no_deployments_prints_friendly_message(mock_remote):
-    mock_remote.api.list_loop_deployments.return_value = []
+    mock_remote.api.list_loops_deployments.return_value = []
     result = _invoke(["loops", "view", "--remote", "test_remote"], mock_remote)
     assert result.exit_code == 0, result.output
     assert "No active Loops deployments" in result.output
 
 
 def test_runs_view_no_filters_calls_search_with_none(mock_remote):
-    mock_remote.api.list_loop_runs.return_value = [
+    mock_remote.api.list_loops_runs.return_value = [
         {"run_id": "trnr_xyz", "session_id": "sess_abc", "base_model": "Qwen/Qwen3-8B"}
     ]
     result = _invoke(["loops", "runs", "view", "--remote", "test_remote"], mock_remote)
     assert result.exit_code == 0, result.output
-    mock_remote.api.list_loop_runs.assert_called_once_with(run_id=None, base_model=None)
+    mock_remote.api.list_loops_runs.assert_called_once_with(
+        run_id=None, base_model=None
+    )
     assert "trnr_xyz" in result.output
 
 
 def test_runs_view_with_run_id_filter(mock_remote):
-    mock_remote.api.list_loop_runs.return_value = [
+    mock_remote.api.list_loops_runs.return_value = [
         {"run_id": "trnr_xyz", "session_id": "sess_abc", "base_model": "Qwen/Qwen3-8B"}
     ]
     result = _invoke(
@@ -275,13 +277,13 @@ def test_runs_view_with_run_id_filter(mock_remote):
         mock_remote,
     )
     assert result.exit_code == 0, result.output
-    mock_remote.api.list_loop_runs.assert_called_once_with(
+    mock_remote.api.list_loops_runs.assert_called_once_with(
         run_id="trnr_xyz", base_model=None
     )
 
 
 def test_runs_view_with_model_name_filter(mock_remote):
-    mock_remote.api.list_loop_runs.return_value = []
+    mock_remote.api.list_loops_runs.return_value = []
     result = _invoke(
         [
             "loops",
@@ -295,14 +297,14 @@ def test_runs_view_with_model_name_filter(mock_remote):
         mock_remote,
     )
     assert result.exit_code == 0, result.output
-    mock_remote.api.list_loop_runs.assert_called_once_with(
+    mock_remote.api.list_loops_runs.assert_called_once_with(
         run_id=None, base_model="Qwen/Qwen3-8B"
     )
     assert "No Loops runs found" in result.output
 
 
 def test_samplers_view_lists_samplers(mock_remote):
-    mock_remote.api.list_loop_samplers.return_value = [
+    mock_remote.api.list_loops_samplers.return_value = [
         {
             "id": "sampler_def",
             "base_url": "https://model-def.api.baseten.co/deployment/v1/sync",
@@ -312,12 +314,12 @@ def test_samplers_view_lists_samplers(mock_remote):
         ["loops", "samplers", "view", "--remote", "test_remote"], mock_remote
     )
     assert result.exit_code == 0, result.output
-    mock_remote.api.list_loop_samplers.assert_called_once_with()
+    mock_remote.api.list_loops_samplers.assert_called_once_with()
     assert "sampler_def" in result.output
 
 
 def test_samplers_view_no_samplers_prints_friendly_message(mock_remote):
-    mock_remote.api.list_loop_samplers.return_value = []
+    mock_remote.api.list_loops_samplers.return_value = []
     result = _invoke(
         ["loops", "samplers", "view", "--remote", "test_remote"], mock_remote
     )

--- a/truss/tests/cli/train/test_deploy_checkpoints.py
+++ b/truss/tests/cli/train/test_deploy_checkpoints.py
@@ -5,10 +5,10 @@ import rich_click as click
 
 import truss_train.definitions as definitions
 from truss.cli.train.deploy_checkpoints.deploy_checkpoints import (
-    _ensure_loop_checkpoint_details,
+    _ensure_loops_checkpoint_details,
     _get_checkpoint_ids_to_deploy,
     _hydrate_deploy_config,
-    _resolve_loop_run,
+    _resolve_loops_run,
     hydrate_checkpoint,
 )
 from truss.cli.train.deploy_checkpoints.deploy_full_checkpoints import (
@@ -284,12 +284,12 @@ def test_hydrate_whisper_checkpoint():
 
 
 @pytest.fixture
-def mock_loop_remote():
+def mock_loops_remote():
     mock = MagicMock()
-    mock.api.list_loop_runs.return_value = [
+    mock.api.list_loops_runs.return_value = [
         {"run_id": "trnr_xyz", "base_model": "Qwen/Qwen3-8B"}
     ]
-    mock.api.list_loop_checkpoints.return_value = {
+    mock.api.list_loops_checkpoints.return_value = {
         "checkpoints": [
             {
                 "id": "tcp_step100",
@@ -303,57 +303,63 @@ def mock_loop_remote():
     return mock
 
 
-def test_resolve_loop_run_returns_first_match(mock_loop_remote):
-    result = _resolve_loop_run(mock_loop_remote, "trnr_xyz")
+def test_resolve_loops_run_returns_first_match(mock_loops_remote):
+    result = _resolve_loops_run(mock_loops_remote, "trnr_xyz")
     assert result["run_id"] == "trnr_xyz"
     assert result["base_model"] == "Qwen/Qwen3-8B"
-    mock_loop_remote.api.list_loop_runs.assert_called_once_with(run_id="trnr_xyz")
+    mock_loops_remote.api.list_loops_runs.assert_called_once_with(run_id="trnr_xyz")
 
 
-def test_resolve_loop_run_raises_when_not_found(mock_loop_remote):
-    mock_loop_remote.api.list_loop_runs.return_value = []
+def test_resolve_loops_run_raises_when_not_found(mock_loops_remote):
+    mock_loops_remote.api.list_loops_runs.return_value = []
     with pytest.raises(click.UsageError, match="Loops run trnr_missing not found"):
-        _resolve_loop_run(mock_loop_remote, "trnr_missing")
+        _resolve_loops_run(mock_loops_remote, "trnr_missing")
 
 
-def test_ensure_loop_checkpoint_details_user_provided_passes_through(mock_loop_remote):
+def test_ensure_loops_checkpoint_details_user_provided_passes_through(
+    mock_loops_remote,
+):
     """When the user authored loops_checkpoint_ids in --config, return as-is."""
     user_config = definitions.CheckpointList(loops_checkpoint_ids=["tcp_step100"])
-    result = _ensure_loop_checkpoint_details(mock_loop_remote, user_config, run_id=None)
+    result = _ensure_loops_checkpoint_details(
+        mock_loops_remote, user_config, run_id=None
+    )
     assert result is user_config
     # Did not hit the API since user authored the IDs.
-    mock_loop_remote.api.list_loop_runs.assert_not_called()
-    mock_loop_remote.api.list_loop_checkpoints.assert_not_called()
+    mock_loops_remote.api.list_loops_runs.assert_not_called()
+    mock_loops_remote.api.list_loops_checkpoints.assert_not_called()
 
 
-def test_ensure_loop_checkpoint_details_requires_run_id_when_unprovided(
-    mock_loop_remote,
+def test_ensure_loops_checkpoint_details_requires_run_id_when_unprovided(
+    mock_loops_remote,
 ):
     with pytest.raises(click.UsageError, match="--run-id is required"):
-        _ensure_loop_checkpoint_details(
-            mock_loop_remote, checkpoint_details=None, run_id=None
+        _ensure_loops_checkpoint_details(
+            mock_loops_remote, checkpoint_details=None, run_id=None
         )
 
 
-def test_ensure_loop_checkpoint_details_picker_emits_ids_and_base_model(
-    mock_loop_remote,
+def test_ensure_loops_checkpoint_details_picker_emits_ids_and_base_model(
+    mock_loops_remote,
 ):
     """With --run-id set, picker selects checkpoints and we send IDs on the wire.
 
     Single checkpoint short-circuits the inquirer prompt (mirroring TJC behavior),
     so no prompt mock is needed for this case.
     """
-    result = _ensure_loop_checkpoint_details(
-        mock_loop_remote, checkpoint_details=None, run_id="trnr_xyz"
+    result = _ensure_loops_checkpoint_details(
+        mock_loops_remote, checkpoint_details=None, run_id="trnr_xyz"
     )
     assert result.loops_checkpoint_ids == ["tcp_step100"]
     assert result.base_model_id == "Qwen/Qwen3-8B"
-    mock_loop_remote.api.list_loop_checkpoints.assert_called_once_with(
+    mock_loops_remote.api.list_loops_checkpoints.assert_called_once_with(
         run_id="trnr_xyz"
     )
 
 
-def test_hydrate_deploy_config_rejects_run_id_with_config_checkpoints(mock_loop_remote):
+def test_hydrate_deploy_config_rejects_run_id_with_config_checkpoints(
+    mock_loops_remote,
+):
     """--run-id + --config that has training-job checkpoints should error."""
     deploy_config = definitions.DeployCheckpointsConfig(
         checkpoint_details=definitions.CheckpointList(
@@ -369,7 +375,7 @@ def test_hydrate_deploy_config_rejects_run_id_with_config_checkpoints(mock_loop_
     with pytest.raises(click.UsageError, match="--run-id cannot be combined"):
         _hydrate_deploy_config(
             deploy_config,
-            mock_loop_remote,
+            mock_loops_remote,
             project_id=None,
             job_id=None,
             run_id="trnr_xyz",
@@ -377,7 +383,7 @@ def test_hydrate_deploy_config_rejects_run_id_with_config_checkpoints(mock_loop_
 
 
 def test_hydrate_deploy_config_rejects_job_id_with_config_loops_checkpoint_ids(
-    mock_loop_remote,
+    mock_loops_remote,
 ):
     """--job-id + --config that has loops_checkpoint_ids should error."""
     deploy_config = definitions.DeployCheckpointsConfig(
@@ -388,7 +394,7 @@ def test_hydrate_deploy_config_rejects_job_id_with_config_loops_checkpoint_ids(
     ):
         _hydrate_deploy_config(
             deploy_config,
-            mock_loop_remote,
+            mock_loops_remote,
             project_id=None,
             job_id="tj_abc",
             run_id=None,


### PR DESCRIPTION
## :rocket: What

Continuation of the [TRN-765](https://linear.app/baseten/issue/TRN-765) Loops naming sweep — the product is "Loops" (plural), so all singular `loop_*` Python identifiers move to plural `loops_*`.

PR #2435 already renamed `loop_checkpoint_id[s]` to `loops_checkpoint_id[s]`. This PR finishes the job for the rest of the singular identifiers.

## :computer: How

- **`BasetenApi`** (`truss/remote/baseten/api.py`): `create_loop_session/run` → `create_loops_session/run`; `get_loop_{session,run,sampler,deployment}` → `get_loops_*`; `list_loop_{runs,checkpoints,deployments,samplers,checkpoint_files}` → `list_loops_*`; `deactivate_loop_deployment` → `deactivate_loops_deployment`.
- **`BasetenRemote`** (`truss/remote/baseten/remote.py`): matching wrapper renames.
- **CLI handlers** (`truss/cli/loops_commands.py`): `push_loop_deployment` → `push_loops_deployment`, `view_loop_deployments`, `view_loop_runs`, `view_loop_samplers`, `_render_loop_*` helpers, plus user-facing strings ("loop deployment" → "Loops deployment").
- **`deploy_checkpoints.py`**: internal helpers `_ensure_loop_checkpoint_details`, `_prompt_user_for_loop_checkpoint_details`, `_resolve_loop_run`, locals `is_loop_flow` / `config_has_loop_checkpoints`.
- **Docstrings** in `truss_config.py` + `truss-train/truss_train/definitions.py`: "Loop checkpoint" prose touched up.
- **Tests** updated for renamed identifiers and the `mock_loops_remote` fixture.

The CLI command group `truss loops` is unchanged (already plural). The endpoint URL paths `/v1/loops/...` are unchanged (already plural).

## :microscope: Testing

- `uv run pytest truss/tests/cli/ truss-train/tests/` → **459 passed**.
- `uv run ruff check .` clean; `uv run ruff format --check .` clean.

## :ship: Release ordering

This is a Python-internal rename — no wire format changes. Ship after the matching Django-side rename (basetenlabs/baseten#TBD, https://github.com/basetenlabs/baseten/pull/new/samiksha/loops-plural-rename-django) lands, since the two sweeps cover related surfaces. Order doesn't strictly matter (no on-the-wire keys changed here), but landing both close together avoids surprise during code archaeology.

## Things intentionally left as `loop` (singular)

- `keepalive_loop` in `truss/cli/utils/common.py` and its tests — refers to a literal `while` loop, not the Loops product.
- `# Loop over versions` style comments — generic loop terminology.
- `event loop` / `uvloop` / `asyncio` references in `truss/templates/server/*.py` — runtime concept, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
