### PR TITLE
fix: align CheckpointList mixing-error message with Django side (TRN-765)

### DIFF
--- a/truss-train/tests/test_definitions.py
+++ b/truss-train/tests/test_definitions.py
@@ -139,7 +139,7 @@ class TestCheckpointListLoopsCheckpoints:
         assert truss_ckpt_list.loops_checkpoint_ids == []
 
     def test_mixing_checkpoints_and_loops_ids_raises(self):
-        with pytest.raises(ValidationError, match="cannot mix"):
+        with pytest.raises(ValidationError, match="Cannot mix"):
             CheckpointList(
                 checkpoints=[
                     LoRACheckpoint(

--- a/truss-train/truss_train/definitions.py
+++ b/truss-train/truss_train/definitions.py
@@ -280,9 +280,9 @@ class CheckpointList(custom_types.SafeModelNoExtra):
     def _no_mixing(self) -> "CheckpointList":
         if self.checkpoints and self.loops_checkpoint_ids:
             raise ValueError(
-                "checkpoint_details cannot mix checkpoints (training job "
-                "checkpoints) and loops_checkpoint_ids (Loops checkpoints) "
-                "in the same deploy"
+                "Cannot mix training job checkpoints and loops checkpoints in "
+                "the same deploy. Use either checkpoints or "
+                "loops_checkpoint_ids, not both."
             )
         return self
 

--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -1096,9 +1096,9 @@ class CheckpointList(custom_types.ConfigModel):
     def _no_mixing(self) -> "CheckpointList":
         if self.artifact_references and self.loops_checkpoint_ids:
             raise ValueError(
-                "training_checkpoints cannot mix artifact_references (training "
-                "job checkpoints) and loops_checkpoint_ids (Loops checkpoints) "
-                "in the same deploy"
+                "Cannot mix training job checkpoints and loops checkpoints in "
+                "the same deploy. Use either artifact_references / checkpoints "
+                "or loops_checkpoint_ids, not both."
             )
         return self
 

--- a/truss/tests/test_config.py
+++ b/truss/tests/test_config.py
@@ -1826,7 +1826,7 @@ class TestCheckpointListNoMixing:
         assert ckpt_list.artifact_references == []
 
     def test_mixing_raises(self):
-        with pytest.raises(pydantic.ValidationError, match="cannot mix"):
+        with pytest.raises(pydantic.ValidationError, match="Cannot mix"):
             CheckpointList(
                 artifact_references=[
                     TrainingArtifactReference(


### PR DESCRIPTION
## :rocket: What

The truss CLI and the Django-side vendored `truss_base` both validate the same user YAML for mixing `artifact_references` / training-job checkpoints with `loops_checkpoint_ids`, but they were emitting different error text. Users hit a different message depending on whether validation tripped client-side or server-side.

This aligns the truss-side phrasing with what Django emits (basetenlabs/baseten#19694):

> Cannot mix training job checkpoints and loops checkpoints in the same deploy. Use either artifact_references / checkpoints or loops_checkpoint_ids, not both.

## :computer: How

- `truss/base/truss_config.py::CheckpointList._no_mixing`: rewrote the error string.
- `truss-train/truss_train/definitions.py::CheckpointList._no_mixing`: same rewrite (uses `checkpoints` rather than `artifact_references / checkpoints` since this is the truss-train shape).
- Updated the matching `pytest.raises(..., match="cannot mix")` to `match="Cannot mix"` to track the new capitalization.

No field renames, no schema changes — `truss/config.schema.json` regenerated cleanly with no diff.

## :microscope: Testing

- `uv run pytest truss/tests/test_config.py truss-train/tests/test_definitions.py` → **203 passed**.
- `uv run ruff check .` clean; `uv run ruff format --check .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
