### PR TITLE
fix(loops): adapt to LoopsRunV1 list-shape change (run_id -> id)

### DIFF
--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -250,7 +250,7 @@ def _render_loops_runs(runs: List[Dict[str, Any]]) -> None:
     table.add_column("Created At", style="dim")
     for run in runs:
         table.add_row(
-            run.get("run_id", ""),
+            run.get("id", ""),
             run.get("session_id", ""),
             run.get("base_model", ""),
             run.get("created_at", "") or "",

--- a/truss/cli/train/deploy_checkpoints/deploy_checkpoints.py
+++ b/truss/cli/train/deploy_checkpoints/deploy_checkpoints.py
@@ -408,7 +408,7 @@ def _prompt_user_for_loops_checkpoint_details(
     run_id: str,
 ) -> CheckpointList:
     run = _resolve_loops_run(remote_provider, run_id)
-    response = remote_provider.api.list_loops_checkpoints(run_id=run["run_id"])
+    response = remote_provider.api.list_loops_checkpoints(run_id=run["id"])
     # Pick by checkpoint_name in the UI; map back to Loops-checkpoint
     # database IDs for the wire so the server doesn't need to re-resolve names.
     name_to_pk = OrderedDict(
@@ -416,7 +416,7 @@ def _prompt_user_for_loops_checkpoint_details(
         for checkpoint in response["checkpoints"]
     )
     if not name_to_pk:
-        raise click.UsageError(f"No checkpoints found for Loops run {run['run_id']}.")
+        raise click.UsageError(f"No checkpoints found for Loops run {run['id']}.")
     response_checkpoints = OrderedDict(
         (checkpoint["checkpoint_id"], checkpoint)
         for checkpoint in response["checkpoints"]

--- a/truss/tests/cli/test_loops_cli.py
+++ b/truss/tests/cli/test_loops_cli.py
@@ -261,7 +261,7 @@ def test_view_with_no_deployments_prints_friendly_message(mock_remote):
 
 def test_runs_view_no_filters_calls_search_with_none(mock_remote):
     mock_remote.api.list_loops_runs.return_value = [
-        {"run_id": "trnr_xyz", "session_id": "sess_abc", "base_model": "Qwen/Qwen3-8B"}
+        {"id": "trnr_xyz", "session_id": "sess_abc", "base_model": "Qwen/Qwen3-8B"}
     ]
     result = _invoke(["loops", "runs", "view", "--remote", "test_remote"], mock_remote)
     assert result.exit_code == 0, result.output
@@ -273,7 +273,7 @@ def test_runs_view_no_filters_calls_search_with_none(mock_remote):
 
 def test_runs_view_with_run_id_filter(mock_remote):
     mock_remote.api.list_loops_runs.return_value = [
-        {"run_id": "trnr_xyz", "session_id": "sess_abc", "base_model": "Qwen/Qwen3-8B"}
+        {"id": "trnr_xyz", "session_id": "sess_abc", "base_model": "Qwen/Qwen3-8B"}
     ]
     result = _invoke(
         ["loops", "runs", "view", "--remote", "test_remote", "--run-id", "trnr_xyz"],

--- a/truss/tests/cli/train/test_deploy_checkpoints.py
+++ b/truss/tests/cli/train/test_deploy_checkpoints.py
@@ -287,7 +287,7 @@ def test_hydrate_whisper_checkpoint():
 def mock_loops_remote():
     mock = MagicMock()
     mock.api.list_loops_runs.return_value = [
-        {"run_id": "trnr_xyz", "base_model": "Qwen/Qwen3-8B"}
+        {"id": "trnr_xyz", "base_model": "Qwen/Qwen3-8B"}
     ]
     mock.api.list_loops_checkpoints.return_value = {
         "checkpoints": [
@@ -305,7 +305,7 @@ def mock_loops_remote():
 
 def test_resolve_loops_run_returns_first_match(mock_loops_remote):
     result = _resolve_loops_run(mock_loops_remote, "trnr_xyz")
-    assert result["run_id"] == "trnr_xyz"
+    assert result["id"] == "trnr_xyz"
     assert result["base_model"] == "Qwen/Qwen3-8B"
     mock_loops_remote.api.list_loops_runs.assert_called_once_with(run_id="trnr_xyz")
 


### PR DESCRIPTION
## Summary

The Django side (basetenlabs/baseten#19727) unifies `LoopsRunV1` and `LoopsRunListItemV1` into a single `LoopsRunV1` for `GET /v1/loops/runs`. Per-item wire shape changes from:

```
{run_id, session_id, base_model, created_at}
```

to:

```
{id, session_id, base_model, base_url, created_at,
 sampler: {id, base_url, created_at}}
```

Truss callers that read this list response need their `run_id` accesses changed to `id`. The `list_loops_runs` *query parameter* name (`?run_id=...`) is unchanged on the request side.

## Files touched

- `truss/cli/loops_commands.py` — `_render_loops_runs` reads `run.get("id", "")` for the "Run ID" rich-table column.
- `truss/cli/train/deploy_checkpoints/deploy_checkpoints.py` — `_prompt_user_for_loops_checkpoint_details` now passes `run["id"]` into `list_loops_checkpoints` and uses it in the user-facing "no checkpoints found" error.
- `truss/tests/cli/test_loops_cli.py` — updates mocked `list_loops_runs` payloads from `run_id` to `id`.
- `truss/tests/cli/train/test_deploy_checkpoints.py` — same mock update plus the `result["id"]` assertion in `test_resolve_loops_run_returns_first_match`.

Net change: 4 files, +7 / -7.

## Companion change

Django: basetenlabs/baseten#19727

## Test plan

- [ ] `uv run ruff format --check .`
- [ ] `uv run ruff check .`
- [ ] `uv run pytest truss/tests/cli/test_loops_cli.py truss/tests/cli/train/test_deploy_checkpoints.py`
- [ ] Manual: `truss loops runs view` against a backend running the companion Django PR renders the run id correctly.
- [ ] Manual: `truss train deploy_checkpoints --run-id <id>` resolves the run and lists its checkpoints.

> Note: the local sandbox blocked `ruff`/`pytest` invocations, so CI is the first place these get exercised. The change is a pure dict-key rename on a small, well-tested surface.

Generated with [Claude Code](https://claude.com/claude-code)