### PR TITLE
feat(loops): polish view tables and add sort to samplers view

### DIFF
--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -192,9 +192,16 @@ def loops_samplers() -> None:
 
 
 @loops_samplers.command(name="view")
+@click.option(
+    "--sort-order",
+    type=click.Choice(["asc", "desc"]),
+    default="asc",
+    show_default=True,
+    help="Sort order by created_at. asc puts the most recent sampler at the bottom.",
+)
 @click.option("--remote", type=str, required=False, help="Remote to use.")
 @common.common_options()
-def view_loops_samplers(remote: Optional[str]) -> None:
+def view_loops_samplers(sort_order: str, remote: Optional[str]) -> None:
     """List Loops samplers visible to the caller."""
     if not remote:
         remote = remote_cli.inquire_remote_name()
@@ -203,6 +210,11 @@ def view_loops_samplers(remote: Optional[str]) -> None:
         BasetenRemote, RemoteFactory.create(remote=remote)
     )
     samplers = remote_provider.api.list_loops_samplers()
+    samplers = sorted(
+        samplers,
+        key=lambda s: s.get("created_at") or "",
+        reverse=(sort_order == "desc"),
+    )
     _render_loops_samplers(samplers)
 
 
@@ -219,8 +231,8 @@ def _render_loops_deployments(deployments: List[Dict[str, Any]]) -> None:
     )
     table.add_column("Deployment ID", style="cyan")
     table.add_column("Base Model", style="green")
-    table.add_column("Base URL", style="dim")
-    table.add_column("Deployment URL", style="dim")
+    table.add_column("Base URL", style="blue")
+    table.add_column("Deployment URL", style="blue")
     for deployment in deployments:
         sampler = deployment.get("sampler") or {}
         sampler_url = sampler.get("base_url", "") if isinstance(sampler, dict) else ""
@@ -247,13 +259,17 @@ def _render_loops_runs(runs: List[Dict[str, Any]]) -> None:
     table.add_column("Run ID", style="cyan")
     table.add_column("Session ID", style="cyan")
     table.add_column("Base Model", style="green")
-    table.add_column("Created At", style="dim")
+    table.add_column("Base URL", style="blue")
+    table.add_column("Created At")
     for run in runs:
+        created_at = run.get("created_at") or ""
+        created_str = common.format_localized_time(created_at) if created_at else ""
         table.add_row(
             run.get("id", ""),
             run.get("session_id", ""),
             run.get("base_model", ""),
-            run.get("created_at", "") or "",
+            run.get("base_url", ""),
+            created_str,
         )
     console.print(table)
 
@@ -270,7 +286,16 @@ def _render_loops_samplers(samplers: List[Dict[str, Any]]) -> None:
         border_style="blue",
     )
     table.add_column("Sampler ID", style="cyan")
-    table.add_column("Base URL", style="dim")
+    table.add_column("Base Model", style="green")
+    table.add_column("Base URL", style="blue")
+    table.add_column("Created At")
     for sampler in samplers:
-        table.add_row(sampler.get("id", ""), sampler.get("base_url", ""))
+        created_at = sampler.get("created_at") or ""
+        created_str = common.format_localized_time(created_at) if created_at else ""
+        table.add_row(
+            sampler.get("id", ""),
+            sampler.get("base_model", ""),
+            sampler.get("base_url", ""),
+            created_str,
+        )
     console.print(table)

--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -154,18 +154,18 @@ def loops_runs() -> None:
     "--model-name", type=str, required=False, help="Filter runs by base model name."
 )
 @click.option(
-    "--sort-order",
-    type=click.Choice(["asc", "desc"]),
-    default="asc",
-    show_default=True,
-    help="Sort order by created_at. asc puts the most recent run at the bottom.",
+    "--reverse",
+    "-r",
+    is_flag=True,
+    default=False,
+    help="Reverse the default order (oldest first) so the most recent run is shown first.",
 )
 @click.option("--remote", type=str, required=False, help="Remote to use.")
 @common.common_options()
 def view_loops_runs(
     run_id: Optional[str],
     model_name: Optional[str],
-    sort_order: str,
+    reverse: bool,
     remote: Optional[str],
 ) -> None:
     """List Loops runs visible to the caller.
@@ -180,9 +180,7 @@ def view_loops_runs(
         BasetenRemote, RemoteFactory.create(remote=remote)
     )
     runs = remote_provider.api.list_loops_runs(run_id=run_id, base_model=model_name)
-    runs = sorted(
-        runs, key=lambda r: r.get("created_at") or "", reverse=(sort_order == "desc")
-    )
+    runs = sorted(runs, key=lambda r: r.get("created_at") or "", reverse=reverse)
     _render_loops_runs(runs)
 
 
@@ -193,15 +191,15 @@ def loops_samplers() -> None:
 
 @loops_samplers.command(name="view")
 @click.option(
-    "--sort-order",
-    type=click.Choice(["asc", "desc"]),
-    default="asc",
-    show_default=True,
-    help="Sort order by created_at. asc puts the most recent sampler at the bottom.",
+    "--reverse",
+    "-r",
+    is_flag=True,
+    default=False,
+    help="Reverse the default order (oldest first) so the most recent sampler is shown first.",
 )
 @click.option("--remote", type=str, required=False, help="Remote to use.")
 @common.common_options()
-def view_loops_samplers(sort_order: str, remote: Optional[str]) -> None:
+def view_loops_samplers(reverse: bool, remote: Optional[str]) -> None:
     """List Loops samplers visible to the caller."""
     if not remote:
         remote = remote_cli.inquire_remote_name()
@@ -211,9 +209,7 @@ def view_loops_samplers(sort_order: str, remote: Optional[str]) -> None:
     )
     samplers = remote_provider.api.list_loops_samplers()
     samplers = sorted(
-        samplers,
-        key=lambda s: s.get("created_at") or "",
-        reverse=(sort_order == "desc"),
+        samplers, key=lambda s: s.get("created_at") or "", reverse=reverse
     )
     _render_loops_samplers(samplers)
 

--- a/truss/tests/cli/test_loops_cli.py
+++ b/truss/tests/cli/test_loops_cli.py
@@ -351,7 +351,7 @@ def test_runs_view_renders_base_url_and_localized_created_at(mock_remote):
     assert _LOCALIZED_TIMESTAMP_RE.search(result.output) is not None
 
 
-def test_runs_view_sort_order_asc_puts_newest_at_bottom(mock_remote):
+def test_runs_view_default_puts_newest_at_bottom(mock_remote):
     mock_remote.api.list_loops_runs.return_value = [
         {
             "id": "trnr_old",
@@ -371,7 +371,7 @@ def test_runs_view_sort_order_asc_puts_newest_at_bottom(mock_remote):
     assert result.output.index("trnr_old") < result.output.index("trnr_new")
 
 
-def test_runs_view_sort_order_desc_puts_newest_first(mock_remote):
+def test_runs_view_reverse_puts_newest_first(mock_remote):
     mock_remote.api.list_loops_runs.return_value = [
         {
             "id": "trnr_old",
@@ -387,14 +387,13 @@ def test_runs_view_sort_order_desc_puts_newest_first(mock_remote):
         },
     ]
     result = _invoke(
-        ["loops", "runs", "view", "--remote", "test_remote", "--sort-order", "desc"],
-        mock_remote,
+        ["loops", "runs", "view", "--remote", "test_remote", "--reverse"], mock_remote
     )
     assert result.exit_code == 0, result.output
     assert result.output.index("trnr_new") < result.output.index("trnr_old")
 
 
-def test_samplers_view_sort_order_asc_puts_newest_at_bottom(mock_remote):
+def test_samplers_view_default_puts_newest_at_bottom(mock_remote):
     mock_remote.api.list_loops_samplers.return_value = [
         {
             "id": "sampler_old",
@@ -419,7 +418,7 @@ def test_samplers_view_sort_order_asc_puts_newest_at_bottom(mock_remote):
     assert _LOCALIZED_TIMESTAMP_RE.search(result.output) is not None
 
 
-def test_samplers_view_sort_order_desc_puts_newest_first(mock_remote):
+def test_samplers_view_reverse_puts_newest_first(mock_remote):
     mock_remote.api.list_loops_samplers.return_value = [
         {
             "id": "sampler_old",
@@ -435,15 +434,7 @@ def test_samplers_view_sort_order_desc_puts_newest_first(mock_remote):
         },
     ]
     result = _invoke(
-        [
-            "loops",
-            "samplers",
-            "view",
-            "--remote",
-            "test_remote",
-            "--sort-order",
-            "desc",
-        ],
+        ["loops", "samplers", "view", "--remote", "test_remote", "--reverse"],
         mock_remote,
     )
     assert result.exit_code == 0, result.output

--- a/truss/tests/cli/test_loops_cli.py
+++ b/truss/tests/cli/test_loops_cli.py
@@ -1,12 +1,15 @@
 """Tests for truss loops CLI commands."""
 
 import os
+import re
 from unittest.mock import Mock, patch
 
 import pytest
 from click.testing import CliRunner
 
 from truss.cli.cli import truss_cli
+
+_LOCALIZED_TIMESTAMP_RE = re.compile(r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}")
 
 
 @pytest.fixture
@@ -328,3 +331,120 @@ def test_samplers_view_no_samplers_prints_friendly_message(mock_remote):
     )
     assert result.exit_code == 0, result.output
     assert "No Loops samplers found" in result.output
+
+
+def test_runs_view_renders_base_url_and_localized_created_at(mock_remote):
+    mock_remote.api.list_loops_runs.return_value = [
+        {
+            "id": "trnr_xyz",
+            "session_id": "sess_abc",
+            "base_model": "Qwen/Qwen3-8B",
+            "base_url": "https://trainer-xyz.api.baseten.co/trainer",
+            "created_at": "2026-05-07T12:34:56Z",
+        }
+    ]
+    result = _invoke(["loops", "runs", "view", "--remote", "test_remote"], mock_remote)
+    assert result.exit_code == 0, result.output
+    assert "trainer-xyz.api.baseten.co" in result.output
+    # The raw ISO suffix should be replaced by the localized format.
+    assert "2026-05-07T12:34:56Z" not in result.output
+    assert _LOCALIZED_TIMESTAMP_RE.search(result.output) is not None
+
+
+def test_runs_view_sort_order_asc_puts_newest_at_bottom(mock_remote):
+    mock_remote.api.list_loops_runs.return_value = [
+        {
+            "id": "trnr_old",
+            "session_id": "sess_a",
+            "base_model": "Qwen/Qwen3-8B",
+            "created_at": "2026-05-01T00:00:00Z",
+        },
+        {
+            "id": "trnr_new",
+            "session_id": "sess_b",
+            "base_model": "Qwen/Qwen3-8B",
+            "created_at": "2026-05-07T00:00:00Z",
+        },
+    ]
+    result = _invoke(["loops", "runs", "view", "--remote", "test_remote"], mock_remote)
+    assert result.exit_code == 0, result.output
+    assert result.output.index("trnr_old") < result.output.index("trnr_new")
+
+
+def test_runs_view_sort_order_desc_puts_newest_first(mock_remote):
+    mock_remote.api.list_loops_runs.return_value = [
+        {
+            "id": "trnr_old",
+            "session_id": "sess_a",
+            "base_model": "Qwen/Qwen3-8B",
+            "created_at": "2026-05-01T00:00:00Z",
+        },
+        {
+            "id": "trnr_new",
+            "session_id": "sess_b",
+            "base_model": "Qwen/Qwen3-8B",
+            "created_at": "2026-05-07T00:00:00Z",
+        },
+    ]
+    result = _invoke(
+        ["loops", "runs", "view", "--remote", "test_remote", "--sort-order", "desc"],
+        mock_remote,
+    )
+    assert result.exit_code == 0, result.output
+    assert result.output.index("trnr_new") < result.output.index("trnr_old")
+
+
+def test_samplers_view_sort_order_asc_puts_newest_at_bottom(mock_remote):
+    mock_remote.api.list_loops_samplers.return_value = [
+        {
+            "id": "sampler_old",
+            "base_model": "Qwen/Qwen3-8B",
+            "base_url": "https://model-old.api.baseten.co/deployment/v1/sync",
+            "created_at": "2026-05-01T00:00:00Z",
+        },
+        {
+            "id": "sampler_new",
+            "base_model": "Qwen/Qwen3-8B",
+            "base_url": "https://model-new.api.baseten.co/deployment/v1/sync",
+            "created_at": "2026-05-07T00:00:00Z",
+        },
+    ]
+    result = _invoke(
+        ["loops", "samplers", "view", "--remote", "test_remote"], mock_remote
+    )
+    assert result.exit_code == 0, result.output
+    assert result.output.index("sampler_old") < result.output.index("sampler_new")
+    # Verify localized timestamp formatting (ISO suffix replaced).
+    assert "2026-05-01T00:00:00Z" not in result.output
+    assert _LOCALIZED_TIMESTAMP_RE.search(result.output) is not None
+
+
+def test_samplers_view_sort_order_desc_puts_newest_first(mock_remote):
+    mock_remote.api.list_loops_samplers.return_value = [
+        {
+            "id": "sampler_old",
+            "base_model": "Qwen/Qwen3-8B",
+            "base_url": "https://model-old.api.baseten.co/deployment/v1/sync",
+            "created_at": "2026-05-01T00:00:00Z",
+        },
+        {
+            "id": "sampler_new",
+            "base_model": "Qwen/Qwen3-8B",
+            "base_url": "https://model-new.api.baseten.co/deployment/v1/sync",
+            "created_at": "2026-05-07T00:00:00Z",
+        },
+    ]
+    result = _invoke(
+        [
+            "loops",
+            "samplers",
+            "view",
+            "--remote",
+            "test_remote",
+            "--sort-order",
+            "desc",
+        ],
+        mock_remote,
+    )
+    assert result.exit_code == 0, result.output
+    assert result.output.index("sampler_new") < result.output.index("sampler_old")


### PR DESCRIPTION
## Summary
- `truss loops runs view`: add `Base URL` column.
- `truss loops samplers view`: add `Base Model` and `Created At` columns; add `--sort-order [asc|desc]` (default `asc`, newest at the bottom) sorting client-side by `created_at`.
- Recolor URL columns from `dim` → `blue` and render `Created At` via `common.format_localized_time` (local time, `YYYY-MM-DD HH:MM:SS`), matching the training-jobs / checkpoint-viewer CLI conventions.

## Test plan
- [x] `uv run pytest truss/tests/cli/test_loops_cli.py -v` (22 passed)
- [ ] Manual: `truss loops runs view` shows the new `Base URL` and a localized `Created At`
- [ ] Manual: `truss loops samplers view` shows `Base Model` + `Created At`; `--sort-order desc` reverses order

🤖 Generated with [Claude Code](https://claude.com/claude-code)