### PR TITLE
feat(train): print deployment logs link after deploy_checkpoints

### DIFF
--- a/truss/cli/train/deploy_checkpoints/deploy_checkpoints.py
+++ b/truss/cli/train/deploy_checkpoints/deploy_checkpoints.py
@@ -13,8 +13,10 @@ from truss.cli.train.types import (
     DeploySuccessModelVersion,
     DeploySuccessResult,
 )
+from truss.cli.utils import common as cli_common
 from truss.cli.utils.output import console
 from truss.remote.baseten.remote import BasetenRemote
+from truss.remote.baseten.service import URLConfig
 from truss_train.definitions import (
     Checkpoint,
     CheckpointList,
@@ -72,6 +74,13 @@ def create_model_version_from_inference_template(
             model_version = DeploySuccessModelVersion.model_validate(
                 result["model_version"]
             )
+            if model_version.model_id:
+                logs_url = URLConfig.model_logs_url(
+                    remote_provider.remote_url, model_version.model_id, model_version.id
+                )
+                console.print(
+                    f"🪵  View logs for your deployment at {cli_common.format_link(logs_url)}"
+                )
         elif not dry_run:
             console.print(
                 "Warning: Unexpected response format from server", style="yellow"

--- a/truss/cli/train/deploy_checkpoints/deploy_checkpoints.py
+++ b/truss/cli/train/deploy_checkpoints/deploy_checkpoints.py
@@ -74,13 +74,12 @@ def create_model_version_from_inference_template(
             model_version = DeploySuccessModelVersion.model_validate(
                 result["model_version"]
             )
-            if model_version.model_id:
-                logs_url = URLConfig.model_logs_url(
-                    remote_provider.remote_url, model_version.model_id, model_version.id
-                )
-                console.print(
-                    f"🪵  View logs for your deployment at {cli_common.format_link(logs_url)}"
-                )
+            logs_url = URLConfig.model_logs_url(
+                remote_provider.remote_url, model_version.model_id, model_version.id
+            )
+            console.print(
+                f"🪵  View logs for your deployment at {cli_common.format_link(logs_url)}"
+            )
         elif not dry_run:
             console.print(
                 "Warning: Unexpected response format from server", style="yellow"

--- a/truss/cli/train/types.py
+++ b/truss/cli/train/types.py
@@ -40,7 +40,7 @@ class DeploySuccessModelVersion(BaseModel):
 
     name: str
     id: str
-    model_id: Optional[str] = None
+    model_id: str
 
 
 class DeploySuccessResult(BaseModel):

--- a/truss/cli/train/types.py
+++ b/truss/cli/train/types.py
@@ -40,6 +40,7 @@ class DeploySuccessModelVersion(BaseModel):
 
     name: str
     id: str
+    model_id: Optional[str] = None
 
 
 class DeploySuccessResult(BaseModel):

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -1088,6 +1088,7 @@ class BasetenApi:
                 model_version {
                     id
                     name
+                    model_id
                 }
                 truss_config
             }


### PR DESCRIPTION
## Summary
After a successful `truss train deploy_checkpoints` run, print a clickable link to the new deployment's logs page — mirroring what `truss push` already prints (`cli.py:960`, `cli.py:1314-1318`).

- Extend the `create_model_version_from_inference_template` mutation to also select `model_id` on the returned `model_version`.
- Add `model_id: Optional[str] = None` to `DeploySuccessModelVersion` (extras were already allowed; spelling it out gives type safety).
- After the existing "Successfully created model version" / "Model version ID" prints, emit `🪵  View logs for your deployment at <link>`, where the link comes from `URLConfig.model_logs_url(remote_url, model_id, version_id)` → `{app}/models/{model_id}/logs/{version_id}`.

## Test plan
- [x] `uv run pytest truss/tests/cli/train/test_deploy_checkpoints.py -q` (14 passed)
- [ ] Manual: `truss train deploy_checkpoints --run-id <id>` prints a logs link that resolves to the new deployment's logs page in the Baseten UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)