### PR TITLE
Pass proxy/CA env vars through clean_uv_env

### DIFF
--- a/truss/templates/base.Dockerfile.jinja
+++ b/truss/templates/base.Dockerfile.jinja
@@ -57,7 +57,12 @@ NB(nikhil): We use a semi-complex uv installation command across the board:
 - Use the python executable currently on the path, will respect activated virtual envs.
 - `--system --break-system-packages` bypasses checks if we're actually installing into system python, but has no effect otherwise.
 #}
-{%- set clean_uv_env = 'env -i PATH="$PATH" HOME="$HOME"' %}
+{#- Strip env to isolate `UV_*` vars, but keep PATH/HOME and standard proxy/CA vars. #}
+{%- set clean_uv_env =
+    'env -i PATH="$PATH" HOME="$HOME"'
+    + ' HTTP_PROXY="$HTTP_PROXY" HTTPS_PROXY="$HTTPS_PROXY" NO_PROXY="$NO_PROXY"'
+    + ' SSL_CERT_FILE="$SSL_CERT_FILE" REQUESTS_CA_BUNDLE="$REQUESTS_CA_BUNDLE" PIP_CERT="$PIP_CERT"'
+%}
 {%- set sys_pip_install_command =
     "UV_HTTP_TIMEOUT=${UV_HTTP_TIMEOUT:-300} " +
     "uv pip install --system --break-system-packages " +

--- a/truss/tests/contexts/image_builder/test_serving_image_builder.py
+++ b/truss/tests/contexts/image_builder/test_serving_image_builder.py
@@ -71,6 +71,37 @@ def test_apt_mirror_url_override(mock_machine, custom_model_truss_dir, monkeypat
     assert "mirror://mirrors.ubuntu.com/US.txt" not in dockerfile
 
 
+@patch("platform.machine", return_value="amd")
+def test_clean_uv_env_passes_proxy_and_ca_vars(mock_machine, custom_model_truss_dir):
+    th = TrussHandle(custom_model_truss_dir)
+    th.update_python_version("py313")
+    th.set_base_image("baseten/truss-server-base:3.13-v0.4.3", "/usr/local/bin/python3")
+    th.live_reload(True)
+    image_builder = ServingImageBuilderContext.run(th.spec.truss_dir)
+
+    with TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir)
+        image_builder.prepare_image_build_dir(tmp_path)
+        dockerfile = (tmp_path / "Dockerfile").read_text()
+
+    uv_env_lines = [
+        line for line in dockerfile.splitlines() if "env -i" in line and " uv " in line
+    ]
+    assert uv_env_lines, (
+        "expected `env -i ... uv ...` lines for live_reload control env"
+    )
+    for line in uv_env_lines:
+        for var in (
+            'HTTP_PROXY="$HTTP_PROXY"',
+            'HTTPS_PROXY="$HTTPS_PROXY"',
+            'NO_PROXY="$NO_PROXY"',
+            'SSL_CERT_FILE="$SSL_CERT_FILE"',
+            'REQUESTS_CA_BUNDLE="$REQUESTS_CA_BUNDLE"',
+            'PIP_CERT="$PIP_CERT"',
+        ):
+            assert var in line, f"{var} missing from: {line}"
+
+
 @pytest.mark.parametrize("env_value", [None, ""])
 @patch("platform.machine", return_value="amd")
 def test_apt_mirror_url_default(


### PR DESCRIPTION
## :rocket: What

The `env -i` prefix used for `uv` commands in the control and docker-server envs was stripping `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY` and the standard CA-bundle vars (`SSL_CERT_FILE` / `REQUESTS_CA_BUNDLE` / `PIP_CERT`), so those installs ignored any configured proxy or custom trust store.

## :computer: How

Add those vars to the `env -i ... uv ...` allowlist. UV_* vars stay isolated, which was the original intent of #2329.

## :microscope: Testing

Rendered a sample Dockerfile and confirmed the generated `RUN env -i ... uv ...` lines now include the proxy/CA vars.

Made with [Cursor](https://cursor.com)