### PR TITLE
Send upgrade-available notice to stderr

### DIFF
--- a/truss/cli/utils/output.py
+++ b/truss/cli/utils/output.py
@@ -23,6 +23,7 @@ rich.spinner.SPINNERS["failed"] = {"interval": 500, "frames": ["😤 ", " 😤"]
 
 
 console = Console()
+stderr_console = Console(stderr=True)
 error_console = Console(stderr=True, style="bold red")
 
 

--- a/truss/cli/utils/self_upgrade.py
+++ b/truss/cli/utils/self_upgrade.py
@@ -7,7 +7,7 @@ from importlib.metadata import PackageNotFoundError, distribution
 from pathlib import Path
 from typing import Optional
 
-from truss.cli.utils.output import console
+from truss.cli.utils.output import console, stderr_console
 from truss.util import user_config
 
 
@@ -123,14 +123,14 @@ def notify_if_outdated(current_version: str) -> None:
         return
 
     latest = update_info.latest_version
-    console.print(
+    stderr_console.print(
         f"▪▪▪▪ There's a new version of truss available, {latest} "
         f"(you are currently on {current_version})!"
     )
-    console.print(
+    stderr_console.print(
         "▪▪▪▪ To upgrade to the latest version, run: [bold cyan]truss upgrade[/bold cyan]"
     )
     settings_path = user_config._SettingsWrapper.path()
-    console.print(
+    stderr_console.print(
         f"▪▪▪▪ To disable this check, set `check_for_updates` to false in {settings_path}"
     )

--- a/truss/tests/cli/test_self_upgrade.py
+++ b/truss/tests/cli/test_self_upgrade.py
@@ -281,10 +281,11 @@ class TestNotifyIfOutdated:
         self_upgrade.notify_if_outdated("0.11.0")
 
         captured = capsys.readouterr()
-        assert "0.12.3" in captured.out
-        assert "0.11.0" in captured.out
-        assert "truss upgrade" in captured.out
-        assert "check_for_updates" in captured.out
+        assert captured.out == ""
+        assert "0.12.3" in captured.err
+        assert "0.11.0" in captured.err
+        assert "truss upgrade" in captured.err
+        assert "check_for_updates" in captured.err
 
     def test_no_notification_when_up_to_date(self, monkeypatch, capsys):
         mock_state = mock.Mock()


### PR DESCRIPTION
## :rocket: What

The "There's a new version of truss available" output is going to stdout always before CLI code is run that switches default console to stderr on `--output json`. To fix, we're just always putting this on stderr because that's where it reasonably belongs anyways.

## :computer: How

Have upgrade notices send to stderr console.

## :microscope: Testing

Adjusted existing tests to check stderr