### PR TITLE
feat(loops): add `truss loops checkpoints` view + deploy commands

### DIFF
--- a/truss/cli/loops_checkpoint_viewer.py
+++ b/truss/cli/loops_checkpoint_viewer.py
@@ -1,0 +1,79 @@
+from typing import Optional
+
+from truss.cli.train.checkpoint_viewer import (
+    OUTPUT_FORMAT_CLI_TABLE,
+    OUTPUT_FORMAT_CSV,
+    OUTPUT_FORMAT_JSON,
+    SORT_BY_CREATED,
+    SORT_ORDER_ASC,
+    SORT_ORDER_DESC,
+    CLITableCheckpointViewer,
+    CSVCheckpointViewer,
+    JSONCheckpointViewer,
+    _get_sort_key,
+)
+from truss.cli.utils.output import console
+from truss.remote.baseten.remote import BasetenRemote
+
+
+def view_loops_checkpoint_list(
+    remote_provider: BasetenRemote,
+    run_id: str,
+    sort_by: str = SORT_BY_CREATED,
+    order: str = SORT_ORDER_ASC,
+    output_format: str = OUTPUT_FORMAT_CLI_TABLE,
+) -> None:
+    """View checkpoints for a Loops run.
+
+    Mirrors `view_checkpoint_list` for training jobs but hits the Loops
+    checkpoint endpoint. Interactive file drill-down is not yet supported
+    because Loops files are listed per-checkpoint rather than per-run.
+    """
+    viewer_factories = {
+        OUTPUT_FORMAT_CSV: CSVCheckpointViewer,
+        OUTPUT_FORMAT_JSON: JSONCheckpointViewer,
+        OUTPUT_FORMAT_CLI_TABLE: CLITableCheckpointViewer,
+    }
+    viewer_cls = viewer_factories.get(output_format)
+    if not viewer_cls:
+        raise ValueError(f"Invalid output format: {output_format}")
+    viewer = viewer_cls(scope_kind="run")
+
+    try:
+        raw = remote_provider.api.list_loops_checkpoints(run_id=run_id)
+        checkpoints = raw.get("checkpoints", [])
+
+        reverse = order == SORT_ORDER_DESC
+        sort_key = _get_sort_key(sort_by)
+        checkpoints.sort(key=sort_key, reverse=reverse)
+
+        if not checkpoints:
+            viewer.output_no_checkpoints_message(run_id)
+        else:
+            viewer.output_checkpoints(checkpoints, run_id)
+    except Exception as e:
+        console.print(f"Error fetching checkpoints: {e}", style="red")
+        raise
+
+
+def resolve_run_id(
+    remote_provider: BasetenRemote, run_id: Optional[str], model_name: Optional[str]
+) -> str:
+    """Resolve a Loops run from --run-id or --model-name.
+
+    With --run-id, returns it as-is (existence is validated server-side
+    on the next call). With --model-name, picks the most recently created
+    run for that base model.
+    """
+    if run_id and model_name:
+        raise ValueError("Pass either --run-id or --model-name, not both.")
+    if run_id:
+        return run_id
+    if not model_name:
+        raise ValueError("Pass --run-id or --model-name to identify a Loops run.")
+
+    runs = remote_provider.api.list_loops_runs(base_model=model_name)
+    if not runs:
+        raise ValueError(f"No Loops runs found for base model: {model_name}")
+    runs = sorted(runs, key=lambda r: r.get("created_at") or "", reverse=True)
+    return runs[0]["id"]

--- a/truss/cli/loops_checkpoint_viewer.py
+++ b/truss/cli/loops_checkpoint_viewer.py
@@ -7,6 +7,7 @@ from truss.cli.train.checkpoint_viewer import (
     SORT_BY_CREATED,
     SORT_ORDER_ASC,
     SORT_ORDER_DESC,
+    CheckpointListViewer,
     CLITableCheckpointViewer,
     CSVCheckpointViewer,
     JSONCheckpointViewer,
@@ -29,15 +30,15 @@ def view_loops_checkpoint_list(
     checkpoint endpoint. Interactive file drill-down is not yet supported
     because Loops files are listed per-checkpoint rather than per-run.
     """
-    viewer_factories = {
-        OUTPUT_FORMAT_CSV: CSVCheckpointViewer,
-        OUTPUT_FORMAT_JSON: JSONCheckpointViewer,
-        OUTPUT_FORMAT_CLI_TABLE: CLITableCheckpointViewer,
-    }
-    viewer_cls = viewer_factories.get(output_format)
-    if not viewer_cls:
+    viewer: CheckpointListViewer
+    if output_format == OUTPUT_FORMAT_CSV:
+        viewer = CSVCheckpointViewer(scope_kind="run")
+    elif output_format == OUTPUT_FORMAT_JSON:
+        viewer = JSONCheckpointViewer(scope_kind="run")
+    elif output_format == OUTPUT_FORMAT_CLI_TABLE:
+        viewer = CLITableCheckpointViewer(scope_kind="run")
+    else:
         raise ValueError(f"Invalid output format: {output_format}")
-    viewer = viewer_cls(scope_kind="run")
 
     try:
         raw = remote_provider.api.list_loops_checkpoints(run_id=run_id)

--- a/truss/cli/loops_checkpoint_viewer.py
+++ b/truss/cli/loops_checkpoint_viewer.py
@@ -1,3 +1,4 @@
+import sys
 from typing import Optional
 
 from truss.cli.train.checkpoint_viewer import (
@@ -53,7 +54,12 @@ def view_loops_checkpoint_list(
         else:
             viewer.output_checkpoints(checkpoints, run_id)
     except Exception as e:
-        console.print(f"Error fetching checkpoints: {e}", style="red")
+        # Keep stdout clean for json/csv consumers (jq pipelines, spreadsheets);
+        # only the CLI table format gets a styled error.
+        if output_format in (OUTPUT_FORMAT_CSV, OUTPUT_FORMAT_JSON):
+            print(f"Error fetching checkpoints: {e}", file=sys.stderr)
+        else:
+            console.print(f"Error fetching checkpoints: {e}", style="red")
         raise
 
 

--- a/truss/cli/loops_checkpoint_viewer.py
+++ b/truss/cli/loops_checkpoint_viewer.py
@@ -58,23 +58,23 @@ def view_loops_checkpoint_list(
 
 
 def resolve_run_id(
-    remote_provider: BasetenRemote, run_id: Optional[str], model_name: Optional[str]
+    remote_provider: BasetenRemote, run_id: Optional[str], base_model: Optional[str]
 ) -> str:
-    """Resolve a Loops run from --run-id or --model-name.
+    """Resolve a Loops run from --run-id or --base-model.
 
     With --run-id, returns it as-is (existence is validated server-side
-    on the next call). With --model-name, picks the most recently created
+    on the next call). With --base-model, picks the most recently created
     run for that base model.
     """
-    if run_id and model_name:
-        raise ValueError("Pass either --run-id or --model-name, not both.")
+    if run_id and base_model:
+        raise ValueError("Pass either --run-id or --base-model, not both.")
     if run_id:
         return run_id
-    if not model_name:
-        raise ValueError("Pass --run-id or --model-name to identify a Loops run.")
+    if not base_model:
+        raise ValueError("Pass --run-id or --base-model to identify a Loops run.")
 
-    runs = remote_provider.api.list_loops_runs(base_model=model_name)
+    runs = remote_provider.api.list_loops_runs(base_model=base_model)
     if not runs:
-        raise ValueError(f"No Loops runs found for base model: {model_name}")
+        raise ValueError(f"No Loops runs found for base model: {base_model}")
     runs = sorted(runs, key=lambda r: r.get("created_at") or "", reverse=True)
     return runs[0]["id"]

--- a/truss/cli/loops_checkpoint_viewer.py
+++ b/truss/cli/loops_checkpoint_viewer.py
@@ -1,5 +1,4 @@
 import sys
-from typing import Optional
 
 from truss.cli.train.checkpoint_viewer import (
     OUTPUT_FORMAT_CLI_TABLE,
@@ -12,6 +11,7 @@ from truss.cli.train.checkpoint_viewer import (
     CLITableCheckpointViewer,
     CSVCheckpointViewer,
     JSONCheckpointViewer,
+    ScopeKind,
     _get_sort_key,
 )
 from truss.cli.utils.output import console
@@ -33,11 +33,11 @@ def view_loops_checkpoint_list(
     """
     viewer: CheckpointListViewer
     if output_format == OUTPUT_FORMAT_CSV:
-        viewer = CSVCheckpointViewer(scope_kind="run")
+        viewer = CSVCheckpointViewer(scope_kind=ScopeKind.RUN)
     elif output_format == OUTPUT_FORMAT_JSON:
-        viewer = JSONCheckpointViewer(scope_kind="run")
+        viewer = JSONCheckpointViewer(scope_kind=ScopeKind.RUN)
     elif output_format == OUTPUT_FORMAT_CLI_TABLE:
-        viewer = CLITableCheckpointViewer(scope_kind="run")
+        viewer = CLITableCheckpointViewer(scope_kind=ScopeKind.RUN)
     else:
         raise ValueError(f"Invalid output format: {output_format}")
 
@@ -63,22 +63,10 @@ def view_loops_checkpoint_list(
         raise
 
 
-def resolve_run_id(
-    remote_provider: BasetenRemote, run_id: Optional[str], base_model: Optional[str]
+def resolve_most_recent_run_for_base_model(
+    remote_provider: BasetenRemote, base_model: str
 ) -> str:
-    """Resolve a Loops run from --run-id or --base-model.
-
-    With --run-id, returns it as-is (existence is validated server-side
-    on the next call). With --base-model, picks the most recently created
-    run for that base model.
-    """
-    if run_id and base_model:
-        raise ValueError("Pass either --run-id or --base-model, not both.")
-    if run_id:
-        return run_id
-    if not base_model:
-        raise ValueError("Pass --run-id or --base-model to identify a Loops run.")
-
+    """Return the most recently created Loops run for the given base model."""
     runs = remote_provider.api.list_loops_runs(base_model=base_model)
     if not runs:
         raise ValueError(f"No Loops runs found for base model: {base_model}")

--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -4,11 +4,15 @@ from typing import Any, Dict, List, Optional, cast
 import requests
 import rich.table
 import rich_click as click
+import yaml
 
 import truss.cli.train.core as train_cli
 from truss.cli import remote_cli
 from truss.cli.cli import truss_cli
-from truss.cli.loops_checkpoint_viewer import resolve_run_id, view_loops_checkpoint_list
+from truss.cli.loops_checkpoint_viewer import (
+    resolve_most_recent_run_for_base_model,
+    view_loops_checkpoint_list,
+)
 from truss.cli.train import checkpoint_viewer as checkpoint_mod
 from truss.cli.utils import common
 from truss.cli.utils.output import console
@@ -372,10 +376,16 @@ def view_loops_checkpoints(
         BasetenRemote, RemoteFactory.create(remote=remote)
     )
 
-    try:
-        resolved_run_id = resolve_run_id(remote_provider, run_id, base_model)
-    except ValueError as e:
-        raise click.UsageError(str(e))
+    if run_id:
+        resolved_run_id = run_id
+    else:
+        try:
+            assert base_model is not None  # narrowed by the validation above
+            resolved_run_id = resolve_most_recent_run_for_base_model(
+                remote_provider, base_model
+            )
+        except ValueError as e:
+            raise click.UsageError(str(e))
 
     view_loops_checkpoint_list(
         remote_provider=remote_provider,
@@ -402,13 +412,9 @@ def view_loops_checkpoints(
     help="path to a python file that defines a DeployCheckpointsConfig",
 )
 @click.option(
-    "--dry-run", is_flag=True, help="Generate a truss config without deploying"
-)
-@click.option(
-    "--truss-config-output-dir",
-    type=str,
-    required=False,
-    help="Path to output the truss config to. If not provided, will output to truss_configs/<model_version_name>_<model_version_id> or truss_configs/dry_run_<timestamp> if dry run.",
+    "--dry-run",
+    is_flag=True,
+    help="Render the generated truss config to stdout without deploying.",
 )
 @click.option("--remote", type=str, required=False, help="Remote to use.")
 @common.common_options()
@@ -417,7 +423,6 @@ def deploy_loops_checkpoints(
     checkpoint_ids: Optional[str],
     config: Optional[str],
     dry_run: bool,
-    truss_config_output_dir: Optional[str],
     remote: Optional[str],
 ) -> None:
     """Deploy checkpoints from a Loops run via vLLM."""
@@ -473,8 +478,9 @@ def deploy_loops_checkpoints(
 
     if dry_run:
         console.print("did not deploy because --dry-run flag provided", style="yellow")
-
-    train_cli.write_truss_config(result, truss_config_output_dir, dry_run)
-
-    if not dry_run:
+        if result.truss_config:
+            # Render to stdout so the user can pipe / inspect without
+            # us littering the filesystem with truss_configs/ folders.
+            print(yaml.safe_dump(result.truss_config.to_dict()))
+    else:
         train_cli.print_deploy_checkpoints_success_message(result.deploy_config)

--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -431,12 +431,25 @@ def deploy_loops_checkpoints(
             "--checkpoint-ids cannot be combined with --config. "
             "Pick one source of checkpoint identifiers."
         )
+    if checkpoint_ids and run_id:
+        # Server resolves checkpoint PKs directly and ignores run_id when both
+        # are present — silently dropping the run_id would mislead users into
+        # thinking we validated their pairing.
+        raise click.UsageError(
+            "--checkpoint-ids cannot be combined with --run-id. "
+            "Loops checkpoint IDs are globally unique, so the run is implicit."
+        )
 
     parsed_checkpoint_ids = (
         [s.strip() for s in checkpoint_ids.split(",") if s.strip()]
         if checkpoint_ids
         else []
     )
+    if checkpoint_ids and not parsed_checkpoint_ids:
+        raise click.UsageError(
+            "--checkpoint-ids parsed to an empty list. Provide one or more "
+            "comma-separated Loops checkpoint IDs."
+        )
 
     if not remote:
         remote = remote_cli.inquire_remote_name()

--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -5,8 +5,11 @@ import requests
 import rich.table
 import rich_click as click
 
+import truss.cli.train.core as train_cli
 from truss.cli import remote_cli
 from truss.cli.cli import truss_cli
+from truss.cli.loops_checkpoint_viewer import resolve_run_id, view_loops_checkpoint_list
+from truss.cli.train import checkpoint_viewer as checkpoint_mod
 from truss.cli.utils import common
 from truss.cli.utils.output import console
 from truss.remote.baseten.remote import BasetenRemote
@@ -295,3 +298,150 @@ def _render_loops_samplers(samplers: List[Dict[str, Any]]) -> None:
             created_str,
         )
     console.print(table)
+
+
+@loops.group(name="checkpoints")
+def loops_checkpoints() -> None:
+    """Subcommands for working with Loops checkpoints."""
+
+
+@loops_checkpoints.command(name="view")
+@click.option("--run-id", type=str, required=False, help="Loops run ID.")
+@click.option(
+    "--model-name",
+    type=str,
+    required=False,
+    help="Base model name. Resolves to the most recent Loops run for that model.",
+)
+@click.option(
+    "--sort",
+    type=click.Choice(
+        [
+            checkpoint_mod.SORT_BY_CHECKPOINT_ID,
+            checkpoint_mod.SORT_BY_SIZE,
+            checkpoint_mod.SORT_BY_CREATED,
+            checkpoint_mod.SORT_BY_TYPE,
+        ]
+    ),
+    default=checkpoint_mod.SORT_BY_CREATED,
+    help="Sort checkpoints by checkpoint-id, size, created date, or type.",
+)
+@click.option(
+    "--order",
+    type=click.Choice([checkpoint_mod.SORT_ORDER_ASC, checkpoint_mod.SORT_ORDER_DESC]),
+    default=checkpoint_mod.SORT_ORDER_ASC,
+    help="Sort order: ascending or descending.",
+)
+@click.option(
+    "-o",
+    "--output-format",
+    type=click.Choice(
+        [
+            checkpoint_mod.OUTPUT_FORMAT_CLI_TABLE,
+            checkpoint_mod.OUTPUT_FORMAT_CSV,
+            checkpoint_mod.OUTPUT_FORMAT_JSON,
+        ]
+    ),
+    default=checkpoint_mod.OUTPUT_FORMAT_CLI_TABLE,
+    help="Output format: cli-table (default), csv, or json.",
+)
+@click.option("--remote", type=str, required=False, help="Remote to use.")
+@common.common_options()
+def view_loops_checkpoints(
+    run_id: Optional[str],
+    model_name: Optional[str],
+    sort: str,
+    order: str,
+    output_format: str,
+    remote: Optional[str],
+) -> None:
+    """List checkpoints for a Loops run.
+
+    Identify the run with --run-id, or pass --model-name to pick the most
+    recent run for that base model.
+    """
+    if run_id and model_name:
+        raise click.UsageError("Pass either --run-id or --model-name, not both.")
+    if not run_id and not model_name:
+        raise click.UsageError("Pass --run-id or --model-name to identify a Loops run.")
+
+    if not remote:
+        remote = remote_cli.inquire_remote_name()
+
+    remote_provider: BasetenRemote = cast(
+        BasetenRemote, RemoteFactory.create(remote=remote)
+    )
+
+    try:
+        resolved_run_id = resolve_run_id(remote_provider, run_id, model_name)
+    except ValueError as e:
+        raise click.UsageError(str(e))
+
+    view_loops_checkpoint_list(
+        remote_provider=remote_provider,
+        run_id=resolved_run_id,
+        sort_by=sort,
+        order=order,
+        output_format=output_format,
+    )
+
+
+@loops_checkpoints.command(name="deploy")
+@click.option("--run-id", type=str, required=False, help="Loops run ID.")
+@click.option(
+    "--config",
+    type=str,
+    required=False,
+    help="path to a python file that defines a DeployCheckpointsConfig",
+)
+@click.option(
+    "--dry-run", is_flag=True, help="Generate a truss config without deploying"
+)
+@click.option(
+    "--truss-config-output-dir",
+    type=str,
+    required=False,
+    help="Path to output the truss config to. If not provided, will output to truss_configs/<model_version_name>_<model_version_id> or truss_configs/dry_run_<timestamp> if dry run.",
+)
+@click.option("--remote", type=str, required=False, help="Remote to use.")
+@common.common_options()
+def deploy_loops_checkpoints(
+    run_id: Optional[str],
+    config: Optional[str],
+    dry_run: bool,
+    truss_config_output_dir: Optional[str],
+    remote: Optional[str],
+) -> None:
+    """Deploy checkpoints from a Loops run via vLLM."""
+    if not run_id and not config:
+        raise click.UsageError(
+            "Pass --run-id or --config (with loops_checkpoint_ids) to deploy "
+            "Loops checkpoints."
+        )
+
+    if not remote:
+        remote = remote_cli.inquire_remote_name()
+
+    remote_provider: BasetenRemote = cast(
+        BasetenRemote, RemoteFactory.create(remote=remote)
+    )
+
+    result = train_cli.create_model_version_from_inference_template(
+        remote_provider,
+        train_cli.DeployCheckpointArgs(
+            project_id=None,
+            job_id=None,
+            run_id=run_id,
+            deploy_config_path=config,
+            dry_run=dry_run,
+            is_loops_command=True,
+        ),
+    )
+
+    if dry_run:
+        console.print("did not deploy because --dry-run flag provided", style="yellow")
+
+    train_cli.write_truss_config(result, truss_config_output_dir, dry_run)
+
+    if not dry_run:
+        train_cli.print_deploy_checkpoints_success_message(result.deploy_config)

--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -154,7 +154,7 @@ def loops_runs() -> None:
 @loops_runs.command(name="view")
 @click.option("--run-id", type=str, required=False, help="Filter by run ID.")
 @click.option(
-    "--model-name", type=str, required=False, help="Filter runs by base model name."
+    "--base-model", type=str, required=False, help="Filter runs by base model name."
 )
 @click.option(
     "--reverse",
@@ -167,7 +167,7 @@ def loops_runs() -> None:
 @common.common_options()
 def view_loops_runs(
     run_id: Optional[str],
-    model_name: Optional[str],
+    base_model: Optional[str],
     reverse: bool,
     remote: Optional[str],
 ) -> None:
@@ -182,7 +182,7 @@ def view_loops_runs(
     remote_provider: BasetenRemote = cast(
         BasetenRemote, RemoteFactory.create(remote=remote)
     )
-    runs = remote_provider.api.list_loops_runs(run_id=run_id, base_model=model_name)
+    runs = remote_provider.api.list_loops_runs(run_id=run_id, base_model=base_model)
     runs = sorted(runs, key=lambda r: r.get("created_at") or "", reverse=reverse)
     _render_loops_runs(runs)
 
@@ -308,7 +308,7 @@ def loops_checkpoints() -> None:
 @loops_checkpoints.command(name="view")
 @click.option("--run-id", type=str, required=False, help="Loops run ID.")
 @click.option(
-    "--model-name",
+    "--base-model",
     type=str,
     required=False,
     help="Base model name. Resolves to the most recent Loops run for that model.",
@@ -349,7 +349,7 @@ def loops_checkpoints() -> None:
 @common.common_options()
 def view_loops_checkpoints(
     run_id: Optional[str],
-    model_name: Optional[str],
+    base_model: Optional[str],
     sort: str,
     order: str,
     output_format: str,
@@ -357,13 +357,13 @@ def view_loops_checkpoints(
 ) -> None:
     """List checkpoints for a Loops run.
 
-    Identify the run with --run-id, or pass --model-name to pick the most
+    Identify the run with --run-id, or pass --base-model to pick the most
     recent run for that base model.
     """
-    if run_id and model_name:
-        raise click.UsageError("Pass either --run-id or --model-name, not both.")
-    if not run_id and not model_name:
-        raise click.UsageError("Pass --run-id or --model-name to identify a Loops run.")
+    if run_id and base_model:
+        raise click.UsageError("Pass either --run-id or --base-model, not both.")
+    if not run_id and not base_model:
+        raise click.UsageError("Pass --run-id or --base-model to identify a Loops run.")
 
     if not remote:
         remote = remote_cli.inquire_remote_name()
@@ -373,7 +373,7 @@ def view_loops_checkpoints(
     )
 
     try:
-        resolved_run_id = resolve_run_id(remote_provider, run_id, model_name)
+        resolved_run_id = resolve_run_id(remote_provider, run_id, base_model)
     except ValueError as e:
         raise click.UsageError(str(e))
 
@@ -388,6 +388,13 @@ def view_loops_checkpoints(
 
 @loops_checkpoints.command(name="deploy")
 @click.option("--run-id", type=str, required=False, help="Loops run ID.")
+@click.option(
+    "--checkpoint-ids",
+    type=str,
+    required=False,
+    help="Comma-separated Loops checkpoint IDs (e.g. tcp_step100,tcp_step200). "
+    "Bypasses the interactive picker. Use `truss loops checkpoints view` to find IDs.",
+)
 @click.option(
     "--config",
     type=str,
@@ -407,17 +414,29 @@ def view_loops_checkpoints(
 @common.common_options()
 def deploy_loops_checkpoints(
     run_id: Optional[str],
+    checkpoint_ids: Optional[str],
     config: Optional[str],
     dry_run: bool,
     truss_config_output_dir: Optional[str],
     remote: Optional[str],
 ) -> None:
     """Deploy checkpoints from a Loops run via vLLM."""
-    if not run_id and not config:
+    if not run_id and not checkpoint_ids and not config:
         raise click.UsageError(
-            "Pass --run-id or --config (with loops_checkpoint_ids) to deploy "
-            "Loops checkpoints."
+            "Pass --run-id, --checkpoint-ids, or --config (with "
+            "loops_checkpoint_ids) to deploy Loops checkpoints."
         )
+    if checkpoint_ids and config:
+        raise click.UsageError(
+            "--checkpoint-ids cannot be combined with --config. "
+            "Pick one source of checkpoint identifiers."
+        )
+
+    parsed_checkpoint_ids = (
+        [s.strip() for s in checkpoint_ids.split(",") if s.strip()]
+        if checkpoint_ids
+        else []
+    )
 
     if not remote:
         remote = remote_cli.inquire_remote_name()
@@ -435,6 +454,7 @@ def deploy_loops_checkpoints(
             deploy_config_path=config,
             dry_run=dry_run,
             is_loops_command=True,
+            checkpoint_ids=parsed_checkpoint_ids,
         ),
     )
 

--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -402,7 +402,7 @@ def view_loops_checkpoints(
     "--checkpoint-ids",
     type=str,
     required=False,
-    help="Comma-separated Loops checkpoint IDs (e.g. tcp_step100,tcp_step200). "
+    help="Comma-separated Loops checkpoint IDs (e.g. vL3pQrS8,wK4tUvW9). "
     "Bypasses the interactive picker. Use `truss loops checkpoints view` to find IDs.",
 )
 @click.option(

--- a/truss/cli/train/checkpoint_viewer.py
+++ b/truss/cli/train/checkpoint_viewer.py
@@ -37,6 +37,7 @@ class ScopeKind(str, Enum):
     JOB = "job"
     RUN = "run"
 
+
 # Sort constants
 SORT_BY_CHECKPOINT_ID = "checkpoint-id"
 SORT_BY_CREATED = "created"

--- a/truss/cli/train/checkpoint_viewer.py
+++ b/truss/cli/train/checkpoint_viewer.py
@@ -8,6 +8,7 @@ import sys
 import tempfile
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any, Callable, Optional
 
 import requests
@@ -26,6 +27,15 @@ from pygments.lexers import get_lexer_for_filename
 from truss.cli.utils import common as cli_common
 from truss.cli.utils.output import console
 from truss.remote.baseten.remote import BasetenRemote
+
+
+class ScopeKind(str, Enum):
+    """What kind of parent a checkpoint hangs off — drives column labels and
+    JSON id keys. `str` mixin keeps it interchangeable with raw strings for
+    f-strings; switch to `enum.StrEnum` once we drop 3.9/3.10."""
+
+    JOB = "job"
+    RUN = "run"
 
 # Sort constants
 SORT_BY_CHECKPOINT_ID = "checkpoint-id"
@@ -66,8 +76,7 @@ def _get_sort_key(sort_by: str) -> Callable[[dict], Any]:
 class CheckpointListViewer(ABC):
     """Base class for checkpoint list viewers that output in different formats."""
 
-    def __init__(self, scope_kind: str = "job"):
-        # "job" for training-job checkpoints, "run" for Loops checkpoints.
+    def __init__(self, scope_kind: ScopeKind = ScopeKind.JOB):
         # Controls labels in titles, messages, and the JSON id key.
         self.scope_kind = scope_kind
 
@@ -87,13 +96,13 @@ class CLITableCheckpointViewer(CheckpointListViewer):
 
     def output_checkpoints(self, checkpoints: list[dict], scope_id: str) -> None:
         table = rich.table.Table(
-            title=f"Checkpoints for {self.scope_kind}: {scope_id}",
+            title=f"Checkpoints for {self.scope_kind.value}: {scope_id}",
             show_header=True,
             header_style="bold magenta",
             box=rich.table.box.ROUNDED,
             border_style="blue",
         )
-        is_loops = self.scope_kind == "run"
+        is_loops = self.scope_kind == ScopeKind.RUN
         if is_loops:
             # Loops has both a DB-PK (`id`, used by `loops_checkpoint_ids` in
             # configs) and a human step-name (`checkpoint_id`, used as the
@@ -102,6 +111,9 @@ class CLITableCheckpointViewer(CheckpointListViewer):
             table.add_column("Checkpoint ID", style="cyan")
             table.add_column("Checkpoint Name", style="cyan")
         else:
+            # Train checkpoints have only one identifier (`checkpoint_id` =
+            # the name, e.g. `checkpoint-100`); show that and the parent job.
+            table.add_column("Job ID", style="cyan")
             table.add_column("Checkpoint ID", style="cyan")
         table.add_column("Type")
         table.add_column("Base Model", style="yellow")
@@ -116,7 +128,7 @@ class CLITableCheckpointViewer(CheckpointListViewer):
             id_cells = (
                 (scope_id, ckpt.get("id", ""), ckpt.get("checkpoint_id", ""))
                 if is_loops
-                else (ckpt.get("checkpoint_id", ""),)
+                else (scope_id, ckpt.get("checkpoint_id", ""))
             )
             table.add_row(
                 *id_cells,
@@ -130,7 +142,8 @@ class CLITableCheckpointViewer(CheckpointListViewer):
 
     def output_no_checkpoints_message(self, scope_id: str) -> None:
         console.print(
-            f"No checkpoints found for {self.scope_kind}: {scope_id}.", style="yellow"
+            f"No checkpoints found for {self.scope_kind.value}: {scope_id}.",
+            style="yellow",
         )
 
 
@@ -138,7 +151,7 @@ class CSVCheckpointViewer(CheckpointListViewer):
     """Viewer that outputs checkpoint list in CSV format."""
 
     def _header(self) -> list[str]:
-        if self.scope_kind == "run":
+        if self.scope_kind == ScopeKind.RUN:
             return [
                 "Run ID",
                 "Checkpoint ID",
@@ -150,6 +163,7 @@ class CSVCheckpointViewer(CheckpointListViewer):
                 "Created At",
             ]
         return [
+            "Job ID",
             "Checkpoint ID",
             "Type",
             "Base Model",
@@ -161,7 +175,7 @@ class CSVCheckpointViewer(CheckpointListViewer):
     def output_checkpoints(self, checkpoints: list[dict], scope_id: str) -> None:
         writer = csv.writer(sys.stdout)
         writer.writerow(self._header())
-        is_loops = self.scope_kind == "run"
+        is_loops = self.scope_kind == ScopeKind.RUN
         for ckpt in checkpoints:
             size_str = cli_common.format_bytes_to_human_readable(
                 ckpt.get("size_bytes", 0)
@@ -170,7 +184,7 @@ class CSVCheckpointViewer(CheckpointListViewer):
             id_cells = (
                 [scope_id, ckpt.get("id", ""), ckpt.get("checkpoint_id", "")]
                 if is_loops
-                else [ckpt.get("checkpoint_id", "")]
+                else [scope_id, ckpt.get("checkpoint_id", "")]
             )
             writer.writerow(
                 [
@@ -192,7 +206,7 @@ class JSONCheckpointViewer(CheckpointListViewer):
     """Viewer that outputs checkpoint list in JSON format."""
 
     def output_checkpoints(self, checkpoints: list[dict], scope_id: str) -> None:
-        is_loops = self.scope_kind == "run"
+        is_loops = self.scope_kind == ScopeKind.RUN
         checkpoints_data = []
         for ckpt in checkpoints:
             size_str = cli_common.format_bytes_to_human_readable(
@@ -203,6 +217,8 @@ class JSONCheckpointViewer(CheckpointListViewer):
             if is_loops:
                 entry["run_id"] = scope_id
                 entry["id"] = ckpt.get("id", "")
+            else:
+                entry["job_id"] = scope_id
             entry.update(
                 {
                     "checkpoint_id": ckpt.get("checkpoint_id", ""),
@@ -218,7 +234,7 @@ class JSONCheckpointViewer(CheckpointListViewer):
             checkpoints_data.append(entry)
 
         output = {
-            f"{self.scope_kind}_id": scope_id,
+            f"{self.scope_kind.value}_id": scope_id,
             "total_checkpoints": len(checkpoints),
             "checkpoints": checkpoints_data,
         }
@@ -226,7 +242,7 @@ class JSONCheckpointViewer(CheckpointListViewer):
 
     def output_no_checkpoints_message(self, scope_id: str) -> None:
         output = {
-            f"{self.scope_kind}_id": scope_id,
+            f"{self.scope_kind.value}_id": scope_id,
             "total_checkpoints": 0,
             "checkpoints": [],
         }

--- a/truss/cli/train/checkpoint_viewer.py
+++ b/truss/cli/train/checkpoint_viewer.py
@@ -93,7 +93,16 @@ class CLITableCheckpointViewer(CheckpointListViewer):
             box=rich.table.box.ROUNDED,
             border_style="blue",
         )
-        table.add_column("Checkpoint ID", style="cyan")
+        is_loops = self.scope_kind == "run"
+        if is_loops:
+            # Loops has both a DB-PK (`id`, used by `loops_checkpoint_ids` in
+            # configs) and a human step-name (`checkpoint_id`, used as the
+            # `model` request param). Show both, plus the parent run.
+            table.add_column("Run ID", style="cyan")
+            table.add_column("Checkpoint ID", style="cyan")
+            table.add_column("Checkpoint Name", style="cyan")
+        else:
+            table.add_column("Checkpoint ID", style="cyan")
         table.add_column("Type")
         table.add_column("Base Model", style="yellow")
         table.add_column("Size", style="green")
@@ -104,8 +113,13 @@ class CLITableCheckpointViewer(CheckpointListViewer):
                 ckpt.get("size_bytes", 0)
             )
             created_str = cli_common.format_localized_time(ckpt.get("created_at", ""))
+            id_cells = (
+                (scope_id, ckpt.get("id", ""), ckpt.get("checkpoint_id", ""))
+                if is_loops
+                else (ckpt.get("checkpoint_id", ""),)
+            )
             table.add_row(
-                ckpt.get("checkpoint_id", ""),
+                *id_cells,
                 ckpt.get("checkpoint_type", ""),
                 ckpt.get("base_model", "") or "",
                 size_str,
@@ -123,26 +137,44 @@ class CLITableCheckpointViewer(CheckpointListViewer):
 class CSVCheckpointViewer(CheckpointListViewer):
     """Viewer that outputs checkpoint list in CSV format."""
 
-    def output_checkpoints(self, checkpoints: list[dict], scope_id: str) -> None:
-        writer = csv.writer(sys.stdout)
-        writer.writerow(
-            [
+    def _header(self) -> list[str]:
+        if self.scope_kind == "run":
+            return [
+                "Run ID",
                 "Checkpoint ID",
+                "Checkpoint Name",
                 "Type",
                 "Base Model",
                 "Size (bytes)",
                 "Size (human readable)",
                 "Created At",
             ]
-        )
+        return [
+            "Checkpoint ID",
+            "Type",
+            "Base Model",
+            "Size (bytes)",
+            "Size (human readable)",
+            "Created At",
+        ]
+
+    def output_checkpoints(self, checkpoints: list[dict], scope_id: str) -> None:
+        writer = csv.writer(sys.stdout)
+        writer.writerow(self._header())
+        is_loops = self.scope_kind == "run"
         for ckpt in checkpoints:
             size_str = cli_common.format_bytes_to_human_readable(
                 ckpt.get("size_bytes", 0)
             )
             created_str = cli_common.format_localized_time(ckpt.get("created_at", ""))
+            id_cells = (
+                [scope_id, ckpt.get("id", ""), ckpt.get("checkpoint_id", "")]
+                if is_loops
+                else [ckpt.get("checkpoint_id", "")]
+            )
             writer.writerow(
                 [
-                    ckpt.get("checkpoint_id", ""),
+                    *id_cells,
                     ckpt.get("checkpoint_type", ""),
                     ckpt.get("base_model", "") or "",
                     str(ckpt.get("size_bytes", 0)),
@@ -153,36 +185,34 @@ class CSVCheckpointViewer(CheckpointListViewer):
 
     def output_no_checkpoints_message(self, scope_id: str) -> None:
         writer = csv.writer(sys.stdout)
-        writer.writerow(
-            [
-                "Checkpoint ID",
-                "Type",
-                "Base Model",
-                "Size (bytes)",
-                "Size (human readable)",
-                "Created At",
-            ]
-        )
+        writer.writerow(self._header())
 
 
 class JSONCheckpointViewer(CheckpointListViewer):
     """Viewer that outputs checkpoint list in JSON format."""
 
     def output_checkpoints(self, checkpoints: list[dict], scope_id: str) -> None:
+        is_loops = self.scope_kind == "run"
         checkpoints_data = []
         for ckpt in checkpoints:
             size_str = cli_common.format_bytes_to_human_readable(
                 ckpt.get("size_bytes", 0)
             )
             created_str = cli_common.format_localized_time(ckpt.get("created_at", ""))
-            entry: dict[str, Any] = {
-                "checkpoint_id": ckpt.get("checkpoint_id", ""),
-                "checkpoint_type": ckpt.get("checkpoint_type", ""),
-                "base_model": ckpt.get("base_model", "") or "",
-                "size_bytes": ckpt.get("size_bytes", 0),
-                "size_human_readable": size_str,
-                "created_at": created_str,
-            }
+            entry: dict[str, Any] = {}
+            if is_loops:
+                entry["run_id"] = scope_id
+                entry["id"] = ckpt.get("id", "")
+            entry.update(
+                {
+                    "checkpoint_id": ckpt.get("checkpoint_id", ""),
+                    "checkpoint_type": ckpt.get("checkpoint_type", ""),
+                    "base_model": ckpt.get("base_model", "") or "",
+                    "size_bytes": ckpt.get("size_bytes", 0),
+                    "size_human_readable": size_str,
+                    "created_at": created_str,
+                }
+            )
             if ckpt.get("lora_adapter_config"):
                 entry["lora_adapter_config"] = ckpt["lora_adapter_config"]
             checkpoints_data.append(entry)

--- a/truss/cli/train/checkpoint_viewer.py
+++ b/truss/cli/train/checkpoint_viewer.py
@@ -66,13 +66,18 @@ def _get_sort_key(sort_by: str) -> Callable[[dict], Any]:
 class CheckpointListViewer(ABC):
     """Base class for checkpoint list viewers that output in different formats."""
 
+    def __init__(self, scope_kind: str = "job"):
+        # "job" for training-job checkpoints, "run" for Loops checkpoints.
+        # Controls labels in titles, messages, and the JSON id key.
+        self.scope_kind = scope_kind
+
     @abstractmethod
-    def output_checkpoints(self, checkpoints: list[dict], job_id: str) -> None:
+    def output_checkpoints(self, checkpoints: list[dict], scope_id: str) -> None:
         """Output the checkpoint list in the viewer's format."""
         pass
 
     @abstractmethod
-    def output_no_checkpoints_message(self, job_id: str) -> None:
+    def output_no_checkpoints_message(self, scope_id: str) -> None:
         """Output message when no checkpoints are found."""
         pass
 
@@ -80,9 +85,9 @@ class CheckpointListViewer(ABC):
 class CLITableCheckpointViewer(CheckpointListViewer):
     """Viewer that outputs checkpoint list as a styled CLI table."""
 
-    def output_checkpoints(self, checkpoints: list[dict], job_id: str) -> None:
+    def output_checkpoints(self, checkpoints: list[dict], scope_id: str) -> None:
         table = rich.table.Table(
-            title=f"Checkpoints for job: {job_id}",
+            title=f"Checkpoints for {self.scope_kind}: {scope_id}",
             show_header=True,
             header_style="bold magenta",
             box=rich.table.box.ROUNDED,
@@ -109,14 +114,16 @@ class CLITableCheckpointViewer(CheckpointListViewer):
 
         console.print(table)
 
-    def output_no_checkpoints_message(self, job_id: str) -> None:
-        console.print(f"No checkpoints found for job: {job_id}.", style="yellow")
+    def output_no_checkpoints_message(self, scope_id: str) -> None:
+        console.print(
+            f"No checkpoints found for {self.scope_kind}: {scope_id}.", style="yellow"
+        )
 
 
 class CSVCheckpointViewer(CheckpointListViewer):
     """Viewer that outputs checkpoint list in CSV format."""
 
-    def output_checkpoints(self, checkpoints: list[dict], job_id: str) -> None:
+    def output_checkpoints(self, checkpoints: list[dict], scope_id: str) -> None:
         writer = csv.writer(sys.stdout)
         writer.writerow(
             [
@@ -144,7 +151,7 @@ class CSVCheckpointViewer(CheckpointListViewer):
                 ]
             )
 
-    def output_no_checkpoints_message(self, job_id: str) -> None:
+    def output_no_checkpoints_message(self, scope_id: str) -> None:
         writer = csv.writer(sys.stdout)
         writer.writerow(
             [
@@ -161,7 +168,7 @@ class CSVCheckpointViewer(CheckpointListViewer):
 class JSONCheckpointViewer(CheckpointListViewer):
     """Viewer that outputs checkpoint list in JSON format."""
 
-    def output_checkpoints(self, checkpoints: list[dict], job_id: str) -> None:
+    def output_checkpoints(self, checkpoints: list[dict], scope_id: str) -> None:
         checkpoints_data = []
         for ckpt in checkpoints:
             size_str = cli_common.format_bytes_to_human_readable(
@@ -181,14 +188,18 @@ class JSONCheckpointViewer(CheckpointListViewer):
             checkpoints_data.append(entry)
 
         output = {
-            "job_id": job_id,
+            f"{self.scope_kind}_id": scope_id,
             "total_checkpoints": len(checkpoints),
             "checkpoints": checkpoints_data,
         }
         print(json.dumps(output, indent=2))
 
-    def output_no_checkpoints_message(self, job_id: str) -> None:
-        output = {"job_id": job_id, "total_checkpoints": 0, "checkpoints": []}
+    def output_no_checkpoints_message(self, scope_id: str) -> None:
+        output = {
+            f"{self.scope_kind}_id": scope_id,
+            "total_checkpoints": 0,
+            "checkpoints": [],
+        }
         print(json.dumps(output, indent=2))
 
 

--- a/truss/cli/train/checkpoint_viewer.py
+++ b/truss/cli/train/checkpoint_viewer.py
@@ -102,19 +102,14 @@ class CLITableCheckpointViewer(CheckpointListViewer):
             box=rich.table.box.ROUNDED,
             border_style="blue",
         )
-        is_loops = self.scope_kind == ScopeKind.RUN
-        if is_loops:
-            # Loops has both a DB-PK (`id`, used by `loops_checkpoint_ids` in
-            # configs) and a human step-name (`checkpoint_id`, used as the
-            # `model` request param). Show both, plus the parent run.
-            table.add_column("Run ID", style="cyan")
-            table.add_column("Checkpoint ID", style="cyan")
-            table.add_column("Checkpoint Name", style="cyan")
-        else:
-            # Train checkpoints have only one identifier (`checkpoint_id` =
-            # the name, e.g. `checkpoint-100`); show that and the parent job.
-            table.add_column("Job ID", style="cyan")
-            table.add_column("Checkpoint ID", style="cyan")
+        # Both train and loops checkpoints have a DB-PK (`id`, alphanumeric
+        # no-underscore, e.g. `vL3pQrS8`) and a human step-name
+        # (`checkpoint_id`, e.g. `checkpoint-100` / `step-100`). Show the
+        # parent scope, then both identifiers.
+        scope_column = "Run ID" if self.scope_kind == ScopeKind.RUN else "Job ID"
+        table.add_column(scope_column, style="cyan")
+        table.add_column("Checkpoint ID", style="cyan")
+        table.add_column("Checkpoint Name", style="cyan")
         table.add_column("Type")
         table.add_column("Base Model", style="yellow")
         table.add_column("Size", style="green")
@@ -125,13 +120,10 @@ class CLITableCheckpointViewer(CheckpointListViewer):
                 ckpt.get("size_bytes", 0)
             )
             created_str = cli_common.format_localized_time(ckpt.get("created_at", ""))
-            id_cells = (
-                (scope_id, ckpt.get("id", ""), ckpt.get("checkpoint_id", ""))
-                if is_loops
-                else (scope_id, ckpt.get("checkpoint_id", ""))
-            )
             table.add_row(
-                *id_cells,
+                scope_id,
+                ckpt.get("id", ""),
+                ckpt.get("checkpoint_id", ""),
                 ckpt.get("checkpoint_type", ""),
                 ckpt.get("base_model", "") or "",
                 size_str,
@@ -151,20 +143,11 @@ class CSVCheckpointViewer(CheckpointListViewer):
     """Viewer that outputs checkpoint list in CSV format."""
 
     def _header(self) -> list[str]:
-        if self.scope_kind == ScopeKind.RUN:
-            return [
-                "Run ID",
-                "Checkpoint ID",
-                "Checkpoint Name",
-                "Type",
-                "Base Model",
-                "Size (bytes)",
-                "Size (human readable)",
-                "Created At",
-            ]
+        scope_column = "Run ID" if self.scope_kind == ScopeKind.RUN else "Job ID"
         return [
-            "Job ID",
+            scope_column,
             "Checkpoint ID",
+            "Checkpoint Name",
             "Type",
             "Base Model",
             "Size (bytes)",
@@ -175,20 +158,16 @@ class CSVCheckpointViewer(CheckpointListViewer):
     def output_checkpoints(self, checkpoints: list[dict], scope_id: str) -> None:
         writer = csv.writer(sys.stdout)
         writer.writerow(self._header())
-        is_loops = self.scope_kind == ScopeKind.RUN
         for ckpt in checkpoints:
             size_str = cli_common.format_bytes_to_human_readable(
                 ckpt.get("size_bytes", 0)
             )
             created_str = cli_common.format_localized_time(ckpt.get("created_at", ""))
-            id_cells = (
-                [scope_id, ckpt.get("id", ""), ckpt.get("checkpoint_id", "")]
-                if is_loops
-                else [scope_id, ckpt.get("checkpoint_id", "")]
-            )
             writer.writerow(
                 [
-                    *id_cells,
+                    scope_id,
+                    ckpt.get("id", ""),
+                    ckpt.get("checkpoint_id", ""),
                     ckpt.get("checkpoint_type", ""),
                     ckpt.get("base_model", "") or "",
                     str(ckpt.get("size_bytes", 0)),
@@ -206,29 +185,23 @@ class JSONCheckpointViewer(CheckpointListViewer):
     """Viewer that outputs checkpoint list in JSON format."""
 
     def output_checkpoints(self, checkpoints: list[dict], scope_id: str) -> None:
-        is_loops = self.scope_kind == ScopeKind.RUN
+        scope_id_key = f"{self.scope_kind.value}_id"
         checkpoints_data = []
         for ckpt in checkpoints:
             size_str = cli_common.format_bytes_to_human_readable(
                 ckpt.get("size_bytes", 0)
             )
             created_str = cli_common.format_localized_time(ckpt.get("created_at", ""))
-            entry: dict[str, Any] = {}
-            if is_loops:
-                entry["run_id"] = scope_id
-                entry["id"] = ckpt.get("id", "")
-            else:
-                entry["job_id"] = scope_id
-            entry.update(
-                {
-                    "checkpoint_id": ckpt.get("checkpoint_id", ""),
-                    "checkpoint_type": ckpt.get("checkpoint_type", ""),
-                    "base_model": ckpt.get("base_model", "") or "",
-                    "size_bytes": ckpt.get("size_bytes", 0),
-                    "size_human_readable": size_str,
-                    "created_at": created_str,
-                }
-            )
+            entry: dict[str, Any] = {
+                scope_id_key: scope_id,
+                "id": ckpt.get("id", ""),
+                "checkpoint_id": ckpt.get("checkpoint_id", ""),
+                "checkpoint_type": ckpt.get("checkpoint_type", ""),
+                "base_model": ckpt.get("base_model", "") or "",
+                "size_bytes": ckpt.get("size_bytes", 0),
+                "size_human_readable": size_str,
+                "created_at": created_str,
+            }
             if ckpt.get("lora_adapter_config"):
                 entry["lora_adapter_config"] = ckpt["lora_adapter_config"]
             checkpoints_data.append(entry)

--- a/truss/cli/train/core.py
+++ b/truss/cli/train/core.py
@@ -25,7 +25,7 @@ from truss.cli.utils import common as cli_common
 from truss.cli.utils.output import console
 from truss.remote.baseten.remote import BasetenRemote
 from truss_train import loader
-from truss_train.definitions import DeployCheckpointsConfig
+from truss_train.definitions import CheckpointList, DeployCheckpointsConfig
 
 QUEUED_JOB_STATUSES = ["TRAINING_JOB_PENDING"]
 
@@ -311,6 +311,26 @@ def view_training_job_metrics(
 def create_model_version_from_inference_template(
     remote_provider: BasetenRemote, args: DeployCheckpointArgs
 ) -> DeploySuccessResult:
+    if args.deploy_config_path and args.checkpoint_ids:
+        raise click.UsageError(
+            "--checkpoint-ids cannot be combined with --config. "
+            "Pick one source of checkpoint identifiers."
+        )
+
+    if args.checkpoint_ids:
+        config = DeployCheckpointsConfig(
+            checkpoint_details=CheckpointList(loops_checkpoint_ids=args.checkpoint_ids)
+        )
+        return deploy_checkpoints.create_model_version_from_inference_template(
+            remote_provider,
+            config,
+            args.project_id,
+            args.job_id,
+            args.run_id,
+            args.dry_run,
+            args.is_loops_command,
+        )
+
     if not args.deploy_config_path:
         return deploy_checkpoints.create_model_version_from_inference_template(
             remote_provider,

--- a/truss/cli/train/core.py
+++ b/truss/cli/train/core.py
@@ -319,6 +319,7 @@ def create_model_version_from_inference_template(
             args.job_id,
             args.run_id,
             args.dry_run,
+            args.is_loops_command,
         )
     # User provided a checkpoint deploy config file
     with loader.import_deploy_checkpoints_config(
@@ -331,7 +332,32 @@ def create_model_version_from_inference_template(
             args.job_id,
             args.run_id,
             args.dry_run,
+            args.is_loops_command,
         )
+
+
+def write_truss_config(
+    result: DeploySuccessResult, truss_config_output_dir: Optional[str], dry_run: bool
+) -> None:
+    if not result.truss_config:
+        return
+    datestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    folder_name = (
+        f"{result.model_version.name}_{result.model_version.id}"
+        if result.model_version
+        else f"dry_run_{datestamp}"
+    )
+    output_dir_str = truss_config_output_dir or f"truss_configs/{folder_name}"
+    output_dir = Path(output_dir_str)
+    output_path = output_dir / "config.yaml"
+    os.makedirs(output_dir, exist_ok=True)
+    console.print(f"Writing truss config to {output_path}", style="yellow")
+    console.print(f"👀 Run `cat {output_path}` to view the truss config", style="green")
+    if dry_run:
+        console.print(
+            f"🚀 Run `cd {output_dir} && truss push` to deploy the truss", style="green"
+        )
+    result.truss_config.write_to_yaml_file(output_path)
 
 
 def _get_checkpoint_names(

--- a/truss/cli/train/deploy_checkpoints/deploy_checkpoints.py
+++ b/truss/cli/train/deploy_checkpoints/deploy_checkpoints.py
@@ -44,9 +44,15 @@ def create_model_version_from_inference_template(
     job_id: Optional[str],
     run_id: Optional[str],
     dry_run: bool,
+    is_loops_command: bool = False,
 ) -> DeploySuccessResult:
     checkpoint_deploy_config = _hydrate_deploy_config(
-        checkpoint_deploy_config, remote_provider, project_id, job_id, run_id
+        checkpoint_deploy_config,
+        remote_provider,
+        project_id,
+        job_id,
+        run_id,
+        is_loops_command,
     )
 
     request_data = _build_inference_template_request(
@@ -288,6 +294,7 @@ def _hydrate_deploy_config(
     project_id: Optional[str],
     job_id: Optional[str],
     run_id: Optional[str],
+    is_loops_command: bool = False,
 ) -> DeployCheckpointsConfigComplete:
     run_id_provided = run_id is not None
     job_flag_provided = bool(project_id or job_id)
@@ -299,6 +306,17 @@ def _hydrate_deploy_config(
         deploy_config.checkpoint_details is not None
         and bool(deploy_config.checkpoint_details.loops_checkpoint_ids)
     )
+    if is_loops_command and config_has_training_job_checkpoints:
+        raise click.UsageError(
+            "`truss loops checkpoints deploy` does not accept training-job "
+            "checkpoints. Remove checkpoint_details.checkpoints from --config "
+            "or use `truss train deploy_checkpoints`."
+        )
+    if not is_loops_command and config_has_loops_checkpoints:
+        raise click.UsageError(
+            "`truss train deploy_checkpoints` does not accept Loops checkpoints. "
+            "Use `truss loops checkpoints deploy` instead."
+        )
     if run_id_provided and config_has_training_job_checkpoints:
         raise click.UsageError(
             "--run-id cannot be combined with checkpoint_details.checkpoints "

--- a/truss/cli/train/types.py
+++ b/truss/cli/train/types.py
@@ -19,6 +19,7 @@ class DeployCheckpointArgs:
     job_id: Optional[str]
     run_id: Optional[str]
     deploy_config_path: Optional[str]
+    is_loops_command: bool = False
 
 
 class DeployCheckpointsConfigComplete(DeployCheckpointsConfig):

--- a/truss/cli/train/types.py
+++ b/truss/cli/train/types.py
@@ -20,9 +20,9 @@ class DeployCheckpointArgs:
     run_id: Optional[str]
     deploy_config_path: Optional[str]
     is_loops_command: bool = False
-    # Loops-only: explicit checkpoint PKs (e.g. `tcp_step100`) provided via
-    # `--checkpoint-ids`. Bypasses the interactive picker. Mutually exclusive
-    # with deploy_config_path.
+    # Loops-only: explicit checkpoint PKs (alphanumeric, no underscores —
+    # e.g. `vL3pQrS8`) provided via `--checkpoint-ids`. Bypasses the
+    # interactive picker. Mutually exclusive with deploy_config_path.
     checkpoint_ids: List[str] = field(default_factory=list)
 
 

--- a/truss/cli/train/types.py
+++ b/truss/cli/train/types.py
@@ -1,5 +1,5 @@
-from dataclasses import dataclass
-from typing import Optional
+from dataclasses import dataclass, field
+from typing import List, Optional
 
 from pydantic import BaseModel
 
@@ -20,6 +20,10 @@ class DeployCheckpointArgs:
     run_id: Optional[str]
     deploy_config_path: Optional[str]
     is_loops_command: bool = False
+    # Loops-only: explicit checkpoint PKs (e.g. `tcp_step100`) provided via
+    # `--checkpoint-ids`. Bypasses the interactive picker. Mutually exclusive
+    # with deploy_config_path.
+    checkpoint_ids: List[str] = field(default_factory=list)
 
 
 class DeployCheckpointsConfigComplete(DeployCheckpointsConfig):

--- a/truss/cli/train_commands.py
+++ b/truss/cli/train_commands.py
@@ -32,7 +32,6 @@ from truss.cli.train.cache import (
     SORT_ORDER_ASC,
     SORT_ORDER_DESC,
 )
-from truss.cli.train.types import DeploySuccessResult
 from truss.cli.utils import common
 from truss.cli.utils.output import console, error_console
 from truss.remote.baseten.core import get_training_job_logs_with_pagination
@@ -505,12 +504,6 @@ def get_job_metrics(
 @click.option("--project", type=str, required=False, help="Project name or project id.")
 @click.option("--job-id", type=str, required=False, help="Job ID.")
 @click.option(
-    "--run-id",
-    type=str,
-    required=False,
-    help="Loops run ID. Use to deploy checkpoints from a Loops run instead of a training job.",
-)
-@click.option(
     "--config",
     type=str,
     required=False,
@@ -531,7 +524,6 @@ def deploy_checkpoints(
     project_id: Optional[str],
     project: Optional[str],
     job_id: Optional[str],
-    run_id: Optional[str],
     config: Optional[str],
     remote: Optional[str],
     dry_run: bool,
@@ -544,20 +536,15 @@ def deploy_checkpoints(
     remote_provider: BasetenRemote = cast(
         BasetenRemote, RemoteFactory.create(remote=remote)
     )
-    if run_id and (project_id or project or job_id):
-        raise click.UsageError(
-            "--run-id cannot be combined with --project, --project-id, or --job-id."
-        )
-    if not run_id:
-        project_id = _maybe_resolve_project_id_from_id_or_name(
-            remote_provider, project_id=project_id, project=project
-        )
+    project_id = _maybe_resolve_project_id_from_id_or_name(
+        remote_provider, project_id=project_id, project=project
+    )
     result = train_cli.create_model_version_from_inference_template(
         remote_provider,
         train_cli.DeployCheckpointArgs(
             project_id=project_id,
             job_id=job_id,
-            run_id=run_id,
+            run_id=None,
             deploy_config_path=config,
             dry_run=dry_run,
         ),
@@ -566,35 +553,10 @@ def deploy_checkpoints(
     if dry_run:
         console.print("did not deploy because --dry-run flag provided", style="yellow")
 
-    _write_truss_config(result, truss_config_output_dir, dry_run)
+    train_cli.write_truss_config(result, truss_config_output_dir, dry_run)
 
     if not dry_run:
         train_cli.print_deploy_checkpoints_success_message(result.deploy_config)
-
-
-def _write_truss_config(
-    result: DeploySuccessResult, truss_config_output_dir: Optional[str], dry_run: bool
-) -> None:
-    if not result.truss_config:
-        return
-    # format: 20251006_123456
-    datestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    folder_name = (
-        f"{result.model_version.name}_{result.model_version.id}"
-        if result.model_version
-        else f"dry_run_{datestamp}"
-    )
-    output_dir_str = truss_config_output_dir or f"truss_configs/{folder_name}"
-    output_dir = Path(output_dir_str)
-    output_path = output_dir / "config.yaml"
-    os.makedirs(output_dir, exist_ok=True)
-    console.print(f"Writing truss config to {output_path}", style="yellow")
-    console.print(f"👀 Run `cat {output_path}` to view the truss config", style="green")
-    if dry_run:
-        console.print(
-            f"🚀 Run `cd {output_dir} && truss push` to deploy the truss", style="green"
-        )
-    result.truss_config.write_to_yaml_file(output_path)
 
 
 @train.command(name="download")

--- a/truss/tests/cli/test_loops_cli.py
+++ b/truss/tests/cli/test_loops_cli.py
@@ -592,7 +592,6 @@ def test_checkpoints_deploy_with_run_id_invokes_shared_path(mock_remote):
         patch(
             "truss.cli.loops_commands.train_cli.create_model_version_from_inference_template"
         ) as mock_create,
-        patch("truss.cli.loops_commands.train_cli.write_truss_config"),
         patch(
             "truss.cli.loops_commands.train_cli.print_deploy_checkpoints_success_message"
         ),
@@ -626,7 +625,6 @@ def test_checkpoints_deploy_with_checkpoint_ids_parses_and_forwards(mock_remote)
         patch(
             "truss.cli.loops_commands.train_cli.create_model_version_from_inference_template"
         ) as mock_create,
-        patch("truss.cli.loops_commands.train_cli.write_truss_config"),
         patch(
             "truss.cli.loops_commands.train_cli.print_deploy_checkpoints_success_message"
         ),

--- a/truss/tests/cli/test_loops_cli.py
+++ b/truss/tests/cli/test_loops_cli.py
@@ -652,6 +652,48 @@ def test_checkpoints_deploy_with_checkpoint_ids_parses_and_forwards(mock_remote)
     assert deploy_args.deploy_config_path is None
 
 
+def test_checkpoints_deploy_rejects_checkpoint_ids_with_run_id(mock_remote):
+    with patch(
+        "truss.cli.loops_commands.train_cli.create_model_version_from_inference_template"
+    ) as mock_create:
+        result = _invoke(
+            [
+                "loops",
+                "checkpoints",
+                "deploy",
+                "--remote",
+                "test_remote",
+                "--run-id",
+                "trnr_xyz",
+                "--checkpoint-ids",
+                "tcp_step100",
+            ],
+            mock_remote,
+        )
+    assert result.exit_code != 0
+    mock_create.assert_not_called()
+
+
+def test_checkpoints_deploy_rejects_whitespace_only_checkpoint_ids(mock_remote):
+    with patch(
+        "truss.cli.loops_commands.train_cli.create_model_version_from_inference_template"
+    ) as mock_create:
+        result = _invoke(
+            [
+                "loops",
+                "checkpoints",
+                "deploy",
+                "--remote",
+                "test_remote",
+                "--checkpoint-ids",
+                " , ,",
+            ],
+            mock_remote,
+        )
+    assert result.exit_code != 0
+    mock_create.assert_not_called()
+
+
 def test_checkpoints_deploy_rejects_checkpoint_ids_with_config(mock_remote, tmp_path):
     config_path = tmp_path / "deploy.py"
     config_path.write_text("")

--- a/truss/tests/cli/test_loops_cli.py
+++ b/truss/tests/cli/test_loops_cli.py
@@ -474,7 +474,7 @@ def test_checkpoints_view_with_run_id_calls_list_loops_checkpoints(mock_remote):
     mock_remote.api.list_loops_checkpoints.return_value = {
         "checkpoints": [
             {
-                "id": "tcp_step100",
+                "id": "vL3pQrS8",
                 "checkpoint_id": "step-100",
                 "checkpoint_type": "lora",
                 "base_model": "Qwen/Qwen3-8B",
@@ -498,7 +498,7 @@ def test_checkpoints_view_with_run_id_calls_list_loops_checkpoints(mock_remote):
     assert result.exit_code == 0, result.output
     mock_remote.api.list_loops_checkpoints.assert_called_once_with(run_id="trnr_xyz")
     assert "step-100" in result.output  # checkpoint name
-    assert "tcp_step100" in result.output  # Loops checkpoint PK
+    assert "vL3pQrS8" in result.output  # Loops checkpoint PK
     assert "trnr_xyz" in result.output  # table title shows the run id
 
 
@@ -547,7 +547,7 @@ def test_checkpoints_view_json_format_emits_run_id_key(mock_remote):
     mock_remote.api.list_loops_checkpoints.return_value = {
         "checkpoints": [
             {
-                "id": "tcp_step100",
+                "id": "vL3pQrS8",
                 "checkpoint_id": "step-100",
                 "checkpoint_type": "lora",
                 "base_model": "Qwen/Qwen3-8B",
@@ -573,7 +573,7 @@ def test_checkpoints_view_json_format_emits_run_id_key(mock_remote):
     assert result.exit_code == 0, result.output
     assert '"run_id": "trnr_xyz"' in result.output
     assert '"job_id"' not in result.output
-    assert '"id": "tcp_step100"' in result.output
+    assert '"id": "vL3pQrS8"' in result.output
 
 
 def test_checkpoints_deploy_requires_run_id_or_config(mock_remote):
@@ -638,14 +638,14 @@ def test_checkpoints_deploy_with_checkpoint_ids_parses_and_forwards(mock_remote)
                 "--remote",
                 "test_remote",
                 "--checkpoint-ids",
-                "tcp_step100, tcp_step200 ,tcp_step300",
+                "vL3pQrS8, wK4tUvW9 ,xM5yZaB0",
                 "--dry-run",
             ],
             mock_remote,
         )
     assert result.exit_code == 0, result.output
     deploy_args = mock_create.call_args[0][1]
-    assert deploy_args.checkpoint_ids == ["tcp_step100", "tcp_step200", "tcp_step300"]
+    assert deploy_args.checkpoint_ids == ["vL3pQrS8", "wK4tUvW9", "xM5yZaB0"]
     assert deploy_args.run_id is None
     assert deploy_args.deploy_config_path is None
 
@@ -664,7 +664,7 @@ def test_checkpoints_deploy_rejects_checkpoint_ids_with_run_id(mock_remote):
                 "--run-id",
                 "trnr_xyz",
                 "--checkpoint-ids",
-                "tcp_step100",
+                "vL3pQrS8",
             ],
             mock_remote,
         )
@@ -706,7 +706,7 @@ def test_checkpoints_deploy_rejects_checkpoint_ids_with_config(mock_remote, tmp_
                 "--remote",
                 "test_remote",
                 "--checkpoint-ids",
-                "tcp_step100",
+                "vL3pQrS8",
                 "--config",
                 str(config_path),
             ],

--- a/truss/tests/cli/test_loops_cli.py
+++ b/truss/tests/cli/test_loops_cli.py
@@ -446,7 +446,8 @@ def test_checkpoints_view_requires_run_id_or_model_name(mock_remote):
         ["loops", "checkpoints", "view", "--remote", "test_remote"], mock_remote
     )
     assert result.exit_code != 0
-    assert "--run-id or --model-name" in result.output
+    mock_remote.api.list_loops_checkpoints.assert_not_called()
+    mock_remote.api.list_loops_runs.assert_not_called()
 
 
 def test_checkpoints_view_rejects_both_run_id_and_model_name(mock_remote):
@@ -465,7 +466,8 @@ def test_checkpoints_view_rejects_both_run_id_and_model_name(mock_remote):
         mock_remote,
     )
     assert result.exit_code != 0
-    assert "either --run-id or --model-name" in result.output
+    mock_remote.api.list_loops_checkpoints.assert_not_called()
+    mock_remote.api.list_loops_runs.assert_not_called()
 
 
 def test_checkpoints_view_with_run_id_calls_list_loops_checkpoints(mock_remote):
@@ -536,7 +538,7 @@ def test_checkpoints_view_model_name_no_runs(mock_remote):
         mock_remote,
     )
     assert result.exit_code != 0
-    assert "No Loops runs found" in result.output
+    mock_remote.api.list_loops_checkpoints.assert_not_called()
 
 
 def test_checkpoints_view_json_format_emits_run_id_key(mock_remote):
@@ -571,11 +573,14 @@ def test_checkpoints_view_json_format_emits_run_id_key(mock_remote):
 
 
 def test_checkpoints_deploy_requires_run_id_or_config(mock_remote):
-    result = _invoke(
-        ["loops", "checkpoints", "deploy", "--remote", "test_remote"], mock_remote
-    )
+    with patch(
+        "truss.cli.loops_commands.train_cli.create_model_version_from_inference_template"
+    ) as mock_create:
+        result = _invoke(
+            ["loops", "checkpoints", "deploy", "--remote", "test_remote"], mock_remote
+        )
     assert result.exit_code != 0
-    assert "--run-id or --config" in result.output
+    mock_create.assert_not_called()
 
 
 def test_checkpoints_deploy_with_run_id_invokes_shared_path(mock_remote):

--- a/truss/tests/cli/test_loops_cli.py
+++ b/truss/tests/cli/test_loops_cli.py
@@ -288,7 +288,7 @@ def test_runs_view_with_run_id_filter(mock_remote):
     )
 
 
-def test_runs_view_with_model_name_filter(mock_remote):
+def test_runs_view_with_base_model_filter(mock_remote):
     mock_remote.api.list_loops_runs.return_value = []
     result = _invoke(
         [
@@ -297,7 +297,7 @@ def test_runs_view_with_model_name_filter(mock_remote):
             "view",
             "--remote",
             "test_remote",
-            "--model-name",
+            "--base-model",
             "Qwen/Qwen3-8B",
         ],
         mock_remote,
@@ -441,7 +441,7 @@ def test_samplers_view_reverse_puts_newest_first(mock_remote):
     assert result.output.index("sampler_new") < result.output.index("sampler_old")
 
 
-def test_checkpoints_view_requires_run_id_or_model_name(mock_remote):
+def test_checkpoints_view_requires_run_id_or_base_model(mock_remote):
     result = _invoke(
         ["loops", "checkpoints", "view", "--remote", "test_remote"], mock_remote
     )
@@ -450,7 +450,7 @@ def test_checkpoints_view_requires_run_id_or_model_name(mock_remote):
     mock_remote.api.list_loops_runs.assert_not_called()
 
 
-def test_checkpoints_view_rejects_both_run_id_and_model_name(mock_remote):
+def test_checkpoints_view_rejects_both_run_id_and_base_model(mock_remote):
     result = _invoke(
         [
             "loops",
@@ -460,7 +460,7 @@ def test_checkpoints_view_rejects_both_run_id_and_model_name(mock_remote):
             "test_remote",
             "--run-id",
             "trnr_xyz",
-            "--model-name",
+            "--base-model",
             "Qwen/Qwen3-8B",
         ],
         mock_remote,
@@ -474,6 +474,7 @@ def test_checkpoints_view_with_run_id_calls_list_loops_checkpoints(mock_remote):
     mock_remote.api.list_loops_checkpoints.return_value = {
         "checkpoints": [
             {
+                "id": "tcp_step100",
                 "checkpoint_id": "step-100",
                 "checkpoint_type": "lora",
                 "base_model": "Qwen/Qwen3-8B",
@@ -496,11 +497,12 @@ def test_checkpoints_view_with_run_id_calls_list_loops_checkpoints(mock_remote):
     )
     assert result.exit_code == 0, result.output
     mock_remote.api.list_loops_checkpoints.assert_called_once_with(run_id="trnr_xyz")
-    assert "step-100" in result.output
+    assert "step-100" in result.output  # checkpoint name
+    assert "tcp_step100" in result.output  # Loops checkpoint PK
     assert "trnr_xyz" in result.output  # table title shows the run id
 
 
-def test_checkpoints_view_with_model_name_picks_most_recent_run(mock_remote):
+def test_checkpoints_view_with_base_model_picks_most_recent_run(mock_remote):
     mock_remote.api.list_loops_runs.return_value = [
         {"id": "trnr_old", "created_at": "2026-05-01T00:00:00Z"},
         {"id": "trnr_new", "created_at": "2026-05-07T00:00:00Z"},
@@ -513,7 +515,7 @@ def test_checkpoints_view_with_model_name_picks_most_recent_run(mock_remote):
             "view",
             "--remote",
             "test_remote",
-            "--model-name",
+            "--base-model",
             "Qwen/Qwen3-8B",
         ],
         mock_remote,
@@ -523,7 +525,7 @@ def test_checkpoints_view_with_model_name_picks_most_recent_run(mock_remote):
     mock_remote.api.list_loops_checkpoints.assert_called_once_with(run_id="trnr_new")
 
 
-def test_checkpoints_view_model_name_no_runs(mock_remote):
+def test_checkpoints_view_base_model_no_runs(mock_remote):
     mock_remote.api.list_loops_runs.return_value = []
     result = _invoke(
         [
@@ -532,7 +534,7 @@ def test_checkpoints_view_model_name_no_runs(mock_remote):
             "view",
             "--remote",
             "test_remote",
-            "--model-name",
+            "--base-model",
             "Qwen/Qwen3-8B",
         ],
         mock_remote,
@@ -545,6 +547,7 @@ def test_checkpoints_view_json_format_emits_run_id_key(mock_remote):
     mock_remote.api.list_loops_checkpoints.return_value = {
         "checkpoints": [
             {
+                "id": "tcp_step100",
                 "checkpoint_id": "step-100",
                 "checkpoint_type": "lora",
                 "base_model": "Qwen/Qwen3-8B",
@@ -570,6 +573,7 @@ def test_checkpoints_view_json_format_emits_run_id_key(mock_remote):
     assert result.exit_code == 0, result.output
     assert '"run_id": "trnr_xyz"' in result.output
     assert '"job_id"' not in result.output
+    assert '"id": "tcp_step100"' in result.output
 
 
 def test_checkpoints_deploy_requires_run_id_or_config(mock_remote):
@@ -615,3 +619,58 @@ def test_checkpoints_deploy_with_run_id_invokes_shared_path(mock_remote):
     assert deploy_args.job_id is None
     assert deploy_args.is_loops_command is True
     assert deploy_args.dry_run is True
+
+
+def test_checkpoints_deploy_with_checkpoint_ids_parses_and_forwards(mock_remote):
+    with (
+        patch(
+            "truss.cli.loops_commands.train_cli.create_model_version_from_inference_template"
+        ) as mock_create,
+        patch("truss.cli.loops_commands.train_cli.write_truss_config"),
+        patch(
+            "truss.cli.loops_commands.train_cli.print_deploy_checkpoints_success_message"
+        ),
+    ):
+        mock_create.return_value = Mock(deploy_config=Mock(), truss_config=None)
+        result = _invoke(
+            [
+                "loops",
+                "checkpoints",
+                "deploy",
+                "--remote",
+                "test_remote",
+                "--checkpoint-ids",
+                "tcp_step100, tcp_step200 ,tcp_step300",
+                "--dry-run",
+            ],
+            mock_remote,
+        )
+    assert result.exit_code == 0, result.output
+    deploy_args = mock_create.call_args[0][1]
+    assert deploy_args.checkpoint_ids == ["tcp_step100", "tcp_step200", "tcp_step300"]
+    assert deploy_args.run_id is None
+    assert deploy_args.deploy_config_path is None
+
+
+def test_checkpoints_deploy_rejects_checkpoint_ids_with_config(mock_remote, tmp_path):
+    config_path = tmp_path / "deploy.py"
+    config_path.write_text("")
+    with patch(
+        "truss.cli.loops_commands.train_cli.create_model_version_from_inference_template"
+    ) as mock_create:
+        result = _invoke(
+            [
+                "loops",
+                "checkpoints",
+                "deploy",
+                "--remote",
+                "test_remote",
+                "--checkpoint-ids",
+                "tcp_step100",
+                "--config",
+                str(config_path),
+            ],
+            mock_remote,
+        )
+    assert result.exit_code != 0
+    mock_create.assert_not_called()

--- a/truss/tests/cli/test_loops_cli.py
+++ b/truss/tests/cli/test_loops_cli.py
@@ -439,3 +439,174 @@ def test_samplers_view_reverse_puts_newest_first(mock_remote):
     )
     assert result.exit_code == 0, result.output
     assert result.output.index("sampler_new") < result.output.index("sampler_old")
+
+
+def test_checkpoints_view_requires_run_id_or_model_name(mock_remote):
+    result = _invoke(
+        ["loops", "checkpoints", "view", "--remote", "test_remote"], mock_remote
+    )
+    assert result.exit_code != 0
+    assert "--run-id or --model-name" in result.output
+
+
+def test_checkpoints_view_rejects_both_run_id_and_model_name(mock_remote):
+    result = _invoke(
+        [
+            "loops",
+            "checkpoints",
+            "view",
+            "--remote",
+            "test_remote",
+            "--run-id",
+            "trnr_xyz",
+            "--model-name",
+            "Qwen/Qwen3-8B",
+        ],
+        mock_remote,
+    )
+    assert result.exit_code != 0
+    assert "either --run-id or --model-name" in result.output
+
+
+def test_checkpoints_view_with_run_id_calls_list_loops_checkpoints(mock_remote):
+    mock_remote.api.list_loops_checkpoints.return_value = {
+        "checkpoints": [
+            {
+                "checkpoint_id": "step-100",
+                "checkpoint_type": "lora",
+                "base_model": "Qwen/Qwen3-8B",
+                "size_bytes": 1234,
+                "created_at": "2026-05-07T12:34:56Z",
+            }
+        ]
+    }
+    result = _invoke(
+        [
+            "loops",
+            "checkpoints",
+            "view",
+            "--remote",
+            "test_remote",
+            "--run-id",
+            "trnr_xyz",
+        ],
+        mock_remote,
+    )
+    assert result.exit_code == 0, result.output
+    mock_remote.api.list_loops_checkpoints.assert_called_once_with(run_id="trnr_xyz")
+    assert "step-100" in result.output
+    assert "trnr_xyz" in result.output  # table title shows the run id
+
+
+def test_checkpoints_view_with_model_name_picks_most_recent_run(mock_remote):
+    mock_remote.api.list_loops_runs.return_value = [
+        {"id": "trnr_old", "created_at": "2026-05-01T00:00:00Z"},
+        {"id": "trnr_new", "created_at": "2026-05-07T00:00:00Z"},
+    ]
+    mock_remote.api.list_loops_checkpoints.return_value = {"checkpoints": []}
+    result = _invoke(
+        [
+            "loops",
+            "checkpoints",
+            "view",
+            "--remote",
+            "test_remote",
+            "--model-name",
+            "Qwen/Qwen3-8B",
+        ],
+        mock_remote,
+    )
+    assert result.exit_code == 0, result.output
+    mock_remote.api.list_loops_runs.assert_called_once_with(base_model="Qwen/Qwen3-8B")
+    mock_remote.api.list_loops_checkpoints.assert_called_once_with(run_id="trnr_new")
+
+
+def test_checkpoints_view_model_name_no_runs(mock_remote):
+    mock_remote.api.list_loops_runs.return_value = []
+    result = _invoke(
+        [
+            "loops",
+            "checkpoints",
+            "view",
+            "--remote",
+            "test_remote",
+            "--model-name",
+            "Qwen/Qwen3-8B",
+        ],
+        mock_remote,
+    )
+    assert result.exit_code != 0
+    assert "No Loops runs found" in result.output
+
+
+def test_checkpoints_view_json_format_emits_run_id_key(mock_remote):
+    mock_remote.api.list_loops_checkpoints.return_value = {
+        "checkpoints": [
+            {
+                "checkpoint_id": "step-100",
+                "checkpoint_type": "lora",
+                "base_model": "Qwen/Qwen3-8B",
+                "size_bytes": 1234,
+                "created_at": "2026-05-07T12:34:56Z",
+            }
+        ]
+    }
+    result = _invoke(
+        [
+            "loops",
+            "checkpoints",
+            "view",
+            "--remote",
+            "test_remote",
+            "--run-id",
+            "trnr_xyz",
+            "-o",
+            "json",
+        ],
+        mock_remote,
+    )
+    assert result.exit_code == 0, result.output
+    assert '"run_id": "trnr_xyz"' in result.output
+    assert '"job_id"' not in result.output
+
+
+def test_checkpoints_deploy_requires_run_id_or_config(mock_remote):
+    result = _invoke(
+        ["loops", "checkpoints", "deploy", "--remote", "test_remote"], mock_remote
+    )
+    assert result.exit_code != 0
+    assert "--run-id or --config" in result.output
+
+
+def test_checkpoints_deploy_with_run_id_invokes_shared_path(mock_remote):
+    with (
+        patch(
+            "truss.cli.loops_commands.train_cli.create_model_version_from_inference_template"
+        ) as mock_create,
+        patch("truss.cli.loops_commands.train_cli.write_truss_config"),
+        patch(
+            "truss.cli.loops_commands.train_cli.print_deploy_checkpoints_success_message"
+        ),
+    ):
+        mock_create.return_value = Mock(deploy_config=Mock(), truss_config=None)
+        result = _invoke(
+            [
+                "loops",
+                "checkpoints",
+                "deploy",
+                "--remote",
+                "test_remote",
+                "--run-id",
+                "trnr_xyz",
+                "--dry-run",
+            ],
+            mock_remote,
+        )
+    assert result.exit_code == 0, result.output
+    args = mock_create.call_args
+    deploy_args = args[0][1]
+    assert deploy_args.run_id == "trnr_xyz"
+    assert deploy_args.project_id is None
+    assert deploy_args.job_id is None
+    assert deploy_args.is_loops_command is True
+    assert deploy_args.dry_run is True

--- a/truss/tests/cli/train/test_deploy_checkpoints.py
+++ b/truss/tests/cli/train/test_deploy_checkpoints.py
@@ -382,15 +382,14 @@ def test_hydrate_deploy_config_rejects_run_id_with_config_checkpoints(
         )
 
 
-def test_hydrate_deploy_config_rejects_job_id_with_config_loops_checkpoint_ids(
-    mock_loops_remote,
-):
-    """--job-id + --config that has loops_checkpoint_ids should error."""
+def test_hydrate_deploy_config_train_rejects_loops_checkpoint_ids(mock_loops_remote):
+    """`truss train deploy_checkpoints` must refuse a config with loops_checkpoint_ids."""
     deploy_config = definitions.DeployCheckpointsConfig(
         checkpoint_details=definitions.CheckpointList(loops_checkpoint_ids=["tcp_xyz"])
     )
     with pytest.raises(
-        click.UsageError, match="--project-id / --job-id cannot be combined"
+        click.UsageError,
+        match="`truss train deploy_checkpoints` does not accept Loops checkpoints",
     ):
         _hydrate_deploy_config(
             deploy_config,
@@ -398,4 +397,34 @@ def test_hydrate_deploy_config_rejects_job_id_with_config_loops_checkpoint_ids(
             project_id=None,
             job_id="tj_abc",
             run_id=None,
+            is_loops_command=False,
+        )
+
+
+def test_hydrate_deploy_config_loops_rejects_training_job_checkpoints(
+    mock_loops_remote,
+):
+    """`truss loops checkpoints deploy` must refuse a config with training-job checkpoints."""
+    deploy_config = definitions.DeployCheckpointsConfig(
+        checkpoint_details=definitions.CheckpointList(
+            checkpoints=[
+                definitions.LoRACheckpoint(
+                    training_job_id="tj_abc",
+                    checkpoint_name="step-1",
+                    model_weight_format=definitions.ModelWeightsFormat.LORA,
+                )
+            ]
+        )
+    )
+    with pytest.raises(
+        click.UsageError,
+        match="`truss loops checkpoints deploy` does not accept training-job",
+    ):
+        _hydrate_deploy_config(
+            deploy_config,
+            mock_loops_remote,
+            project_id=None,
+            job_id=None,
+            run_id="trnr_xyz",
+            is_loops_command=True,
         )

--- a/truss/tests/cli/train/test_deploy_checkpoints.py
+++ b/truss/tests/cli/train/test_deploy_checkpoints.py
@@ -292,7 +292,7 @@ def mock_loops_remote():
     mock.api.list_loops_checkpoints.return_value = {
         "checkpoints": [
             {
-                "id": "tcp_step100",
+                "id": "vL3pQrS8",
                 "checkpoint_id": "step-100",
                 "base_model": "Qwen/Qwen3-8B",
                 "checkpoint_type": "lora",
@@ -320,7 +320,7 @@ def test_ensure_loops_checkpoint_details_user_provided_passes_through(
     mock_loops_remote,
 ):
     """When the user authored loops_checkpoint_ids in --config, return as-is."""
-    user_config = definitions.CheckpointList(loops_checkpoint_ids=["tcp_step100"])
+    user_config = definitions.CheckpointList(loops_checkpoint_ids=["vL3pQrS8"])
     result = _ensure_loops_checkpoint_details(
         mock_loops_remote, user_config, run_id=None
     )
@@ -350,7 +350,7 @@ def test_ensure_loops_checkpoint_details_picker_emits_ids_and_base_model(
     result = _ensure_loops_checkpoint_details(
         mock_loops_remote, checkpoint_details=None, run_id="trnr_xyz"
     )
-    assert result.loops_checkpoint_ids == ["tcp_step100"]
+    assert result.loops_checkpoint_ids == ["vL3pQrS8"]
     assert result.base_model_id == "Qwen/Qwen3-8B"
     mock_loops_remote.api.list_loops_checkpoints.assert_called_once_with(
         run_id="trnr_xyz"
@@ -385,7 +385,7 @@ def test_hydrate_deploy_config_rejects_run_id_with_config_checkpoints(
 def test_hydrate_deploy_config_train_rejects_loops_checkpoint_ids(mock_loops_remote):
     """`truss train deploy_checkpoints` must refuse a config with loops_checkpoint_ids."""
     deploy_config = definitions.DeployCheckpointsConfig(
-        checkpoint_details=definitions.CheckpointList(loops_checkpoint_ids=["tcp_xyz"])
+        checkpoint_details=definitions.CheckpointList(loops_checkpoint_ids=["vL3pQrS8"])
     )
     with pytest.raises(
         click.UsageError,

--- a/truss/tests/test_config.py
+++ b/truss/tests/test_config.py
@@ -1822,8 +1822,8 @@ class TestCheckpointListNoMixing:
         assert ckpt_list.loops_checkpoint_ids == []
 
     def test_loops_checkpoint_ids_only_accepted(self):
-        ckpt_list = CheckpointList(loops_checkpoint_ids=["tcp_xyz"])
-        assert ckpt_list.loops_checkpoint_ids == ["tcp_xyz"]
+        ckpt_list = CheckpointList(loops_checkpoint_ids=["vL3pQrS8"])
+        assert ckpt_list.loops_checkpoint_ids == ["vL3pQrS8"]
         assert ckpt_list.artifact_references == []
 
     def test_mixing_raises(self):
@@ -1834,7 +1834,7 @@ class TestCheckpointListNoMixing:
                         training_job_id="tj_abc", paths=["rank-0/step-1/"]
                     )
                 ],
-                loops_checkpoint_ids=["tcp_xyz"],
+                loops_checkpoint_ids=["vL3pQrS8"],
             )
 
     def test_empty_lists_accepted(self):


### PR DESCRIPTION
## Summary
- Adds `truss loops checkpoints view` and `truss loops checkpoints deploy` subcommands. View accepts `--run-id` or `--base-model` (resolves to most-recent run for that base model) plus the same `--sort` / `--order` / `-o/--output-format` flags as `truss train checkpoints list`. The loops view also surfaces both checkpoint identifiers (Run ID + Checkpoint ID + Checkpoint Name) in all output formats.
- Deploy is a thin alias that reuses the existing `create_model_version_from_inference_template` path. Three entry points: `--run-id` (interactive picker), `--checkpoint-ids tcp_a,tcp_b` (non-interactive), and `--config` (file). The three are mutually exclusive.
- Removes `--run-id` from `truss train deploy_checkpoints` so loops-deploy lives only behind `truss loops`. Adds a new `is_loops_command` flag on `DeployCheckpointArgs` so each CLI rejects the other side's configs with a pointer to the right command.
- Renames `truss loops runs view --model-name` to `--base-model` for consistency with the new `truss loops checkpoints view --base-model` flag and to avoid collision with `truss push --model-name` (which means deployment name). **Breaking CLI change**, but `truss loops runs view` is fresh enough (landed in #2438/#2444) that we're accepting the break.
- Light refactors to share code without coupling the surfaces: `_write_truss_config` moved to `truss.cli.train.core.write_truss_config`, and `CheckpointListViewer` takes a `scope_kind` so the JSON viewer emits `"run_id"` for loops vs. `"job_id"` for train.

## Test plan
- [x] `uv run pytest truss/tests/cli/` — all pass
- [x] `uv run pytest truss/tests/cli/test_loops_cli.py truss/tests/cli/train/test_checkpoint_viewer.py truss/tests/cli/train/test_deploy_checkpoints.py` (108+ tests, includes new tests for the new commands, the train/loops separation guard, and the `--checkpoint-ids` validation edge cases)
- [x] `uv run ruff check` / `uv run ruff format` on touched files
- [x] CLI help renders for `truss loops checkpoints`, `... view`, `... deploy`, and confirmed `--run-id` is gone from `truss train deploy_checkpoints`
- [ ] Manual end-to-end against a real remote — see `loops-checkpoints-test-plan.md` (untracked) for the matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)