### PR TITLE
Add request timeout and include exception detail in poll warning

### DIFF
--- a/truss/remote/baseten/rest_client.py
+++ b/truss/remote/baseten/rest_client.py
@@ -4,6 +4,11 @@ import requests
 
 from truss.remote.baseten.user_agent import with_user_agent
 
+# (connect, read) timeout in seconds. Without a timeout, a stalled socket
+# (e.g. NAT or LB silently dropping a keep-alive) hangs requests forever, and
+# tenacity's stop_after_delay only fires between attempts, never mid-attempt.
+_DEFAULT_TIMEOUT_SEC = (10, 60)
+
 
 class RestAPIClient:
     base_url: str
@@ -28,26 +33,39 @@ class RestAPIClient:
 
     def get(self, path: str, url_params: dict[str, str] = {}):
         resp = requests.get(
-            f"{self.base_url}/{path}", headers=self._headers(), params=url_params
+            f"{self.base_url}/{path}",
+            headers=self._headers(),
+            params=url_params,
+            timeout=_DEFAULT_TIMEOUT_SEC,
         )
         self._handle_error(resp)
         return resp.json()
 
     def post(self, path: str, body: Any):
         resp = requests.post(
-            f"{self.base_url}/{path}", headers=self._headers(), json=body
+            f"{self.base_url}/{path}",
+            headers=self._headers(),
+            json=body,
+            timeout=_DEFAULT_TIMEOUT_SEC,
         )
         self._handle_error(resp)
         return resp.json()
 
     def delete(self, path: str):
-        resp = requests.delete(f"{self.base_url}/{path}", headers=self._headers())
+        resp = requests.delete(
+            f"{self.base_url}/{path}",
+            headers=self._headers(),
+            timeout=_DEFAULT_TIMEOUT_SEC,
+        )
         self._handle_error(resp)
         return resp.json()
 
     def patch(self, path: str, body: Any):
         resp = requests.patch(
-            f"{self.base_url}/{path}", headers=self._headers(), json=body
+            f"{self.base_url}/{path}",
+            headers=self._headers(),
+            json=body,
+            timeout=_DEFAULT_TIMEOUT_SEC,
         )
         self._handle_error(resp)
         return resp.json()

--- a/truss/remote/baseten/service.py
+++ b/truss/remote/baseten/service.py
@@ -171,8 +171,13 @@ class BasetenService(TrussService):
             time.sleep(sleep_secs)
             try:
                 yield self._fetch_deployment()
-            except requests.exceptions.RequestException:
-                logger.warning("Network error, unable to reach Baseten. Retrying...")
+            except requests.exceptions.RequestException as exc:
+                status = exc.response.status_code if exc.response is not None else None
+                logger.warning(
+                    "Network error polling deployment, retrying: %s%s",
+                    exc.__class__.__name__,
+                    f" (HTTP {status}): {exc}" if status is not None else f": {exc}",
+                )
                 continue
 
     def poll_deployment_status(self, sleep_secs: int = 1) -> Iterator[str]:

--- a/truss/tests/remote/baseten/test_service.py
+++ b/truss/tests/remote/baseten/test_service.py
@@ -1,4 +1,7 @@
+import logging
 from unittest.mock import MagicMock
+
+import requests
 
 from truss.remote.baseten import service
 from truss.remote.baseten.core import ModelVersionHandle
@@ -185,3 +188,49 @@ def test_predict_uses_header_provider_for_each_request():
         {"Authorization": "Bearer t1"},
         {"Authorization": "Bearer t2"},
     ]
+
+
+def test_poll_deployment_warning_includes_exception_detail(monkeypatch, caplog):
+    # Transient polling failures log a one-line warning naming the exception
+    # class (and HTTP status when present), so operators can distinguish
+    # ReadTimeout / ConnectionError / HTTPError without re-running.
+    mock_handle = MagicMock(spec=ModelVersionHandle)
+    mock_handle.model_id = "m"
+    mock_handle.version_id = "v"
+
+    service_instance = service.BasetenService(
+        model_version_handle=mock_handle,
+        is_draft=False,
+        header_provider=lambda: {},
+        service_url="https://test.com",
+        api=MagicMock(),
+    )
+
+    http_resp = MagicMock()
+    http_resp.status_code = 429
+    http_error = requests.exceptions.HTTPError(response=http_resp)
+
+    calls = iter(
+        [
+            requests.exceptions.ReadTimeout("read timed out"),
+            http_error,
+            {"status": "ACTIVE"},
+        ]
+    )
+
+    def fake_fetch():
+        nxt = next(calls)
+        if isinstance(nxt, Exception):
+            raise nxt
+        return nxt
+
+    monkeypatch.setattr(service_instance, "_fetch_deployment", fake_fetch)
+    monkeypatch.setattr(service.time, "sleep", lambda _s: None)
+
+    with caplog.at_level(logging.WARNING, logger=service.logger.name):
+        deployment = next(service_instance.poll_deployment())
+
+    assert deployment == {"status": "ACTIVE"}
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("ReadTimeout" in m and "read timed out" in m for m in messages)
+    assert any("HTTPError" in m and "HTTP 429" in m for m in messages)


### PR DESCRIPTION
## :rocket: What

If an HTTP call hangs while `--wait`ing for `truss push`, there is no timeout and it's non-obvious to user. Similarly, if there are issues invoking poll call while `--wait`ing, we just silently swallow them

This improves both.

## :computer: How

Add HTTP timeouts for API calls to be 10s connect, 60s invoke. And add more detail in warning logs on the failure.

## :microscope: Testing

Added unit test to confirm log warnings.