### PR TITLE
patch/calc_patch: fix path prefix false-positive in _strictly_under

### DIFF
--- a/truss/truss_handle/patch/calc_patch.py
+++ b/truss/truss_handle/patch/calc_patch.py
@@ -491,6 +491,6 @@ def _strictly_under(path: str, parent_paths: List[str]) -> bool:
     them. Assumes that parent paths themselves are not under each other.
     """
     for dir_path in parent_paths:
-        if path.startswith(dir_path) and not path == dir_path:
+        if path.startswith(dir_path + "/"):
             return True
     return False

--- a/truss/truss_handle/patch/calc_patch.py
+++ b/truss/truss_handle/patch/calc_patch.py
@@ -1,5 +1,6 @@
 import base64
 import logging
+import os
 from pathlib import Path
 from typing import Dict, List, Optional, Set
 
@@ -491,6 +492,6 @@ def _strictly_under(path: str, parent_paths: List[str]) -> bool:
     them. Assumes that parent paths themselves are not under each other.
     """
     for dir_path in parent_paths:
-        if path.startswith(dir_path + "/"):
+        if path.startswith(dir_path + os.sep):
             return True
     return False


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What

Fixes a bug in `_strictly_under` where a raw string `startswith` check
incorrectly matched paths that share a name prefix with a watched
directory but are not actually inside it.

For example, with the default `model_module_dir = "model"`, a file at
`model_weights/checkpoint.bin` would pass the `path.startswith("model")`
guard and be misclassified as a model-code file, generating a spurious
`ModelCodePatch` for a file that lives outside the model directory.

<!--
  How was the change described above implemented?
-->
## :computer: How

Changed the prefix check from `path.startswith(dir_path)` to
`path.startswith(dir_path + "/")`, anchoring the match to a directory
boundary. The now-redundant `not path == dir_path` guard was removed,
since `"model/"` can never equal `"model"`.

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing

- Manually verified the false-positive scenario: `"model_weights/checkpoint.bin"` no longer matches against `"model"`.
- Verified true-positive still works: `"model/foo.py"` correctly matches against `"model"`.
- Verified same-path edge case: `"model"` does not match against `"model"` (unchanged behaviour).
- No existing tests cover `_strictly_under` directly; the fix is a one-line change with no side effects on the call sites.