### PR TITLE
Raise clear error on team prompt in non-interactive context

### DIFF
--- a/truss/cli/remote_cli.py
+++ b/truss/cli/remote_cli.py
@@ -121,6 +121,12 @@ def inquire_team(
     prompt: str = "👥 Which team do you want to push to?",
 ) -> Optional[str]:
     if existing_teams is not None:
+        if not check_is_interactive():
+            available_teams_str = format_available_teams(existing_teams)
+            raise click.UsageError(
+                "Team selection required but running in a non-interactive context. "
+                f"Pass --team <name> (available: {available_teams_str})."
+            )
         # Sort with default team first, then alphanumerically (case-insensitive)
         sorted_teams = sorted(
             existing_teams.items(),

--- a/truss/tests/cli/test_model_team_resolver.py
+++ b/truss/tests/cli/test_model_team_resolver.py
@@ -698,8 +698,11 @@ class TestNonInteractiveResolution:
 class TestInquireTeamEdgeCases:
     """Test edge cases for inquire_team with team names containing '(default)'."""
 
+    @patch("truss.cli.remote_cli.check_is_interactive", return_value=True)
     @patch("truss.cli.remote_cli.inquirer.select")
-    def test_team_name_containing_default_not_default_team(self, mock_select):
+    def test_team_name_containing_default_not_default_team(
+        self, mock_select, mock_interactive
+    ):
         """Team named 'My Team (default)' that is NOT the default should return exact name."""
         teams = {
             "My Team (default)": TeamType(
@@ -715,8 +718,11 @@ class TestInquireTeamEdgeCases:
 
         assert result == "My Team (default)"
 
+    @patch("truss.cli.remote_cli.check_is_interactive", return_value=True)
     @patch("truss.cli.remote_cli.inquirer.select")
-    def test_team_name_containing_default_is_default_team(self, mock_select):
+    def test_team_name_containing_default_is_default_team(
+        self, mock_select, mock_interactive
+    ):
         """Team named 'My Team (default)' that IS the default should return exact name."""
         teams = {
             "My Team (default)": TeamType(
@@ -732,8 +738,11 @@ class TestInquireTeamEdgeCases:
 
         assert result == "My Team (default)"
 
+    @patch("truss.cli.remote_cli.check_is_interactive", return_value=True)
     @patch("truss.cli.remote_cli.inquirer.select")
-    def test_regular_default_team_returns_clean_name(self, mock_select):
+    def test_regular_default_team_returns_clean_name(
+        self, mock_select, mock_interactive
+    ):
         """Regular team that is default should return clean name without suffix."""
         teams = {
             "Team Alpha": TeamType(id="team1", name="Team Alpha", default=True),
@@ -746,3 +755,20 @@ class TestInquireTeamEdgeCases:
         result = inquire_team(existing_teams=teams)
 
         assert result == "Team Alpha"
+
+    @patch("truss.cli.remote_cli.check_is_interactive", return_value=False)
+    def test_non_interactive_raises_usage_error(self, mock_interactive):
+        """When not interactive, inquire_team should raise UsageError listing teams."""
+        teams = {
+            "Team Alpha": TeamType(id="team1", name="Team Alpha", default=True),
+            "Team Beta": TeamType(id="team2", name="Team Beta", default=False),
+        }
+
+        with pytest.raises(click.UsageError) as exc_info:
+            inquire_team(existing_teams=teams)
+
+        message = str(exc_info.value)
+        assert "non-interactive" in message
+        assert "--team" in message
+        assert "Team Alpha" in message
+        assert "Team Beta" in message


### PR DESCRIPTION
## :rocket: What

Cannot select team in non-interactive context

## :computer: How

Error when team name selection needed in non-interactive context instead of trying selection

## :microscope: Testing

Adjusted existing tests and added new test