### PR TITLE
fix(loops): trim deploy error message + 'deployment' wording

### DIFF
--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -440,10 +440,7 @@ def deploy_loops_checkpoints(
         # Server resolves checkpoint PKs directly and ignores run_id when both
         # are present — silently dropping the run_id would mislead users into
         # thinking we validated their pairing.
-        raise click.UsageError(
-            "--checkpoint-ids cannot be combined with --run-id. "
-            "Loops checkpoint IDs are globally unique, so the run is implicit."
-        )
+        raise click.UsageError("--checkpoint-ids cannot be combined with --run-id.")
 
     parsed_checkpoint_ids = (
         [s.strip() for s in checkpoint_ids.split(",") if s.strip()]

--- a/truss/cli/train/deploy_checkpoints/deploy_checkpoints.py
+++ b/truss/cli/train/deploy_checkpoints/deploy_checkpoints.py
@@ -71,11 +71,11 @@ def create_model_version_from_inference_template(
         model_version = None
         if result and result.get("model_version"):
             console.print(
-                f"Successfully created model version: {result['model_version']['name']}",
+                f"Successfully created deployment: {result['model_version']['name']}",
                 style="green",
             )
             console.print(
-                f"Model version ID: {result['model_version']['id']}", style="yellow"
+                f"Deployment ID: {result['model_version']['id']}", style="yellow"
             )
             model_version = DeploySuccessModelVersion.model_validate(
                 result["model_version"]
@@ -93,7 +93,7 @@ def create_model_version_from_inference_template(
             console.print(f"Response: {result}", style="yellow")
 
     except Exception as e:
-        console.print(f"Error creating model version: {e}", style="red")
+        console.print(f"Error creating deployment: {e}", style="red")
         raise
 
     return DeploySuccessResult(


### PR DESCRIPTION
## Summary
- Drops the \"Loops checkpoint IDs are globally unique, so the run is implicit\" clause from the `--checkpoint-ids` + `--run-id` mutually-exclusive error. The remaining message just states the flags are mutually exclusive.
- Renames user-facing \"model version\" → \"deployment\" in the deploy success/error console output for `truss loops checkpoints deploy` (and the shared underlying function, which `truss train deploy_checkpoints` also uses). Internal `model_version` field names on the response object stay as-is.

## Test plan
- [x] `uv run ruff check truss/ && uv run ruff format` clean
- [x] `uv run pytest truss/tests/cli/test_loops_cli.py truss/tests/cli/train/test_checkpoint_viewer.py truss/tests/cli/train/test_deploy_checkpoints.py` (110 pass)
- [ ] Manual: `truss loops checkpoints deploy --run-id X --checkpoint-ids Y` → trimmed error
- [ ] Manual: `truss loops checkpoints deploy --run-id X --dry-run` → success message says \"deployment\" not \"model version\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)