### PR TITLE
feat(cli): add --start/--end/--since to truss model-logs

### DIFF
--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -5,6 +5,7 @@ import sys
 import tarfile
 import threading
 import time
+from datetime import datetime
 from pathlib import Path
 from typing import Optional, cast
 
@@ -1058,30 +1059,86 @@ def push(
 @click.option(
     "--remote", type=str, required=False, help="Name of the remote in .trussrc."
 )
-@click.option("--model-id", type=str, required=True)
-@click.option("--deployment-id", type=str, required=True)
-@click.option("--tail", is_flag=True, help="Tail for ongoing logs.")
+@click.option("--model-id", type=str, required=True, help="ID of the model.")
+@click.option("--deployment-id", type=str, required=True, help="ID of the deployment.")
+@click.option(
+    "--tail",
+    is_flag=True,
+    help=(
+        "Stream new logs as they arrive. Cannot be combined with --start, --end, "
+        "or --since."
+    ),
+)
+@click.option(
+    "--start",
+    type=click.DateTime(formats=["%Y-%m-%d", "%Y-%m-%dT%H:%M:%S", "%Y-%m-%d %H:%M:%S"]),
+    default=None,
+    help=(
+        "Start of the log time range, interpreted as UTC. Accepts ISO 8601 "
+        "(e.g. '2026-05-14' or '2026-05-14T12:00:00'). If omitted but --end is "
+        "given, defaults to 7 days before --end. Window must be at most 7 days."
+    ),
+)
+@click.option(
+    "--end",
+    type=click.DateTime(formats=["%Y-%m-%d", "%Y-%m-%dT%H:%M:%S", "%Y-%m-%d %H:%M:%S"]),
+    default=None,
+    help=(
+        "End of the log time range, interpreted as UTC. Accepts ISO 8601 "
+        "(e.g. '2026-05-14T12:00:00'). If omitted but --start is given, "
+        "defaults to now. Window must be at most 7 days."
+    ),
+)
+@click.option(
+    "--since",
+    type=str,
+    default=None,
+    help=(
+        "Shortcut for fetching logs from a relative time ago until now. "
+        "Format: <N><unit> where unit is m (minutes), h (hours), or d (days). "
+        "Examples: '30m', '2h', '3d'. Maximum '7d'. Mutually exclusive with "
+        "--start and --end."
+    ),
+)
 @common.common_options()
 def model_logs(
-    remote: Optional[str], model_id: str, deployment_id: str, tail: bool = False
+    remote: Optional[str],
+    model_id: str,
+    deployment_id: str,
+    tail: bool = False,
+    start: Optional[datetime] = None,
+    end: Optional[datetime] = None,
+    since: Optional[str] = None,
 ) -> None:
     """
-    Fetches logs for the packaged model
+    Fetches logs for the packaged model.
+
+    By default returns all available logs. Use --start/--end or --since to scope
+    the window (max 7 days). Use --tail to stream live logs.
     """
+    if tail and (start is not None or end is not None or since is not None):
+        raise click.UsageError(
+            "--tail cannot be combined with --start, --end, or --since."
+        )
 
     if not remote:
         remote = remote_cli.inquire_remote_name()
     remote_provider = cast(BasetenRemote, RemoteFactory.create(remote=remote))
-    if not tail:
-        logs = remote_provider.api.get_model_deployment_logs(model_id, deployment_id)
-        for log in cli_log_utils.parse_logs(logs):
-            cli_log_utils.output_log(log)
-    else:
+
+    if tail:
         log_watcher = ModelDeploymentLogWatcher(
             remote_provider.api, model_id, deployment_id
         )
         for log in log_watcher.watch():
             cli_log_utils.output_log(log)
+        return
+
+    start_ms, end_ms = cli_log_utils.resolve_log_time_range(start, end, since)
+    logs = remote_provider.api.get_model_deployment_logs(
+        model_id, deployment_id, start_ms, end_ms
+    )
+    for log in cli_log_utils.parse_logs(logs):
+        cli_log_utils.output_log(log)
 
 
 @truss_cli.command()

--- a/truss/cli/logs/utils.py
+++ b/truss/cli/logs/utils.py
@@ -1,10 +1,17 @@
-from datetime import datetime
-from typing import Any, List, Optional
+import re
+from datetime import datetime, timedelta, timezone
+from typing import Any, List, Optional, Tuple
 
 import pydantic
+import rich_click as click
 from rich import text
 
 from truss.cli.utils.output import console
+
+MAX_LOG_RANGE = timedelta(days=7)
+
+_SINCE_RE = re.compile(r"^(\d+)([mhd])$")
+_SINCE_UNIT_TO_SECONDS = {"m": 60, "h": 3600, "d": 86400}
 
 
 class ParsedLog(pydantic.BaseModel):
@@ -15,6 +22,76 @@ class ParsedLog(pydantic.BaseModel):
     @classmethod
     def from_raw(self, raw_log: Any) -> "ParsedLog":
         return ParsedLog(**raw_log)
+
+
+def parse_since(value: str) -> timedelta:
+    """Parse a `--since` duration like '30m', '2h', '3d' into a timedelta.
+
+    Accepts integer values with a single unit suffix: m (minutes), h (hours),
+    or d (days). Rejects zero, negative, malformed, or out-of-range values.
+    Maximum allowed duration is MAX_LOG_RANGE (7 days).
+    """
+    match = _SINCE_RE.match(value.strip()) if value else None
+    if not match:
+        raise click.BadParameter(
+            f"Invalid --since value '{value}'. Expected format <N><unit> where "
+            f"unit is m (minutes), h (hours), or d (days). Examples: '30m', '2h', '3d'."
+        )
+
+    amount = int(match.group(1))
+    if amount <= 0:
+        raise click.BadParameter("--since must be greater than zero.")
+
+    delta = timedelta(seconds=amount * _SINCE_UNIT_TO_SECONDS[match.group(2)])
+    if delta > MAX_LOG_RANGE:
+        raise click.BadParameter(f"--since must be at most 7d (got '{value}').")
+    return delta
+
+
+def _to_epoch_millis(dt: datetime) -> int:
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return int(dt.timestamp() * 1000)
+
+
+def resolve_log_time_range(
+    start: Optional[datetime], end: Optional[datetime], since: Optional[str]
+) -> Tuple[Optional[int], Optional[int]]:
+    """Resolve --start/--end/--since into (start_epoch_millis, end_epoch_millis).
+
+    Returns (None, None) when none of the inputs are supplied. Naive datetimes
+    are interpreted as UTC. Enforces a 7-day maximum window and rejects
+    combining --since with --start/--end.
+    """
+    if since is not None and (start is not None or end is not None):
+        raise click.UsageError("--since cannot be combined with --start or --end.")
+
+    if since is not None:
+        delta = parse_since(since)
+        now = datetime.now(timezone.utc)
+        return _to_epoch_millis(now - delta), _to_epoch_millis(now)
+
+    if start is None and end is None:
+        return None, None
+
+    if end is None:
+        end = datetime.now(timezone.utc)
+    if start is None:
+        start = end - MAX_LOG_RANGE
+
+    if start.tzinfo is None:
+        start = start.replace(tzinfo=timezone.utc)
+    if end.tzinfo is None:
+        end = end.replace(tzinfo=timezone.utc)
+
+    if start >= end:
+        raise click.UsageError("--start must be earlier than --end.")
+    if end - start > MAX_LOG_RANGE:
+        raise click.UsageError(
+            "Log time range must be at most 7 days. Narrow --start/--end or use --since."
+        )
+
+    return _to_epoch_millis(start), _to_epoch_millis(end)
 
 
 def format_log(log: ParsedLog) -> str:

--- a/truss/cli/logs/utils.py
+++ b/truss/cli/logs/utils.py
@@ -75,7 +75,11 @@ def resolve_log_time_range(
         return None, None
 
     if end is None:
-        end = datetime.now(timezone.utc)
+        # Click's DateTime parses --start at second precision (no microseconds),
+        # so floor "now" to seconds here. Otherwise a user passing --start at
+        # exactly 7 days ago would fail the MAX_LOG_RANGE check by the
+        # microsecond fraction in datetime.now().
+        end = datetime.now(timezone.utc).replace(microsecond=0)
     if start is None:
         start = end - MAX_LOG_RANGE
 

--- a/truss/tests/cli/test_logs_utils.py
+++ b/truss/tests/cli/test_logs_utils.py
@@ -1,0 +1,129 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import rich_click as click
+
+from truss.cli.logs.utils import MAX_LOG_RANGE, parse_since, resolve_log_time_range
+
+
+def test_parse_since_minutes():
+    assert parse_since("30m") == timedelta(minutes=30)
+
+
+def test_parse_since_hours():
+    assert parse_since("2h") == timedelta(hours=2)
+
+
+def test_parse_since_days():
+    assert parse_since("3d") == timedelta(days=3)
+
+
+def test_parse_since_boundary_7d_ok():
+    assert parse_since("7d") == MAX_LOG_RANGE
+
+
+def test_parse_since_boundary_in_hours_ok():
+    assert parse_since("168h") == MAX_LOG_RANGE
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "0m",
+        "0h",
+        "0d",
+        "8d",
+        "169h",
+        "5x",
+        "abc",
+        "",
+        "30",
+        " 30m ",  # outer whitespace ok via strip, but no decimals/units mismatch
+        "-1h",
+        "1.5h",
+        "1h30m",
+    ],
+)
+def test_parse_since_invalid(value):
+    # ' 30m ' is actually valid because we strip
+    if value == " 30m ":
+        assert parse_since(value) == timedelta(minutes=30)
+        return
+    with pytest.raises(click.BadParameter):
+        parse_since(value)
+
+
+def test_resolve_returns_none_when_no_inputs():
+    assert resolve_log_time_range(None, None, None) == (None, None)
+
+
+def test_resolve_since_sets_window_ending_now():
+    start_ms, end_ms = resolve_log_time_range(None, None, "1h")
+    now_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
+    # End should be ~now (within a few seconds).
+    assert abs(end_ms - now_ms) < 5_000
+    # Start should be ~1h before end.
+    assert abs((end_ms - start_ms) - 3_600_000) < 5_000
+
+
+def test_resolve_only_start_defaults_end_to_now():
+    start = datetime(2026, 5, 14, 0, 0, 0, tzinfo=timezone.utc)
+    start_ms, end_ms = resolve_log_time_range(start, None, None)
+    assert start_ms == int(start.timestamp() * 1000)
+    now_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
+    assert abs(end_ms - now_ms) < 5_000
+
+
+def test_resolve_only_end_defaults_start_to_end_minus_7d():
+    end = datetime(2026, 5, 14, 0, 0, 0, tzinfo=timezone.utc)
+    start_ms, end_ms = resolve_log_time_range(None, end, None)
+    assert end_ms == int(end.timestamp() * 1000)
+    assert end_ms - start_ms == int(MAX_LOG_RANGE.total_seconds() * 1000)
+
+
+def test_resolve_both_honored():
+    start = datetime(2026, 5, 13, 0, 0, 0, tzinfo=timezone.utc)
+    end = datetime(2026, 5, 14, 0, 0, 0, tzinfo=timezone.utc)
+    start_ms, end_ms = resolve_log_time_range(start, end, None)
+    assert start_ms == int(start.timestamp() * 1000)
+    assert end_ms == int(end.timestamp() * 1000)
+
+
+def test_resolve_naive_datetime_treated_as_utc():
+    naive = datetime(2026, 5, 14, 0, 0, 0)
+    aware = naive.replace(tzinfo=timezone.utc)
+    start_ms_naive, _ = resolve_log_time_range(naive, None, None)
+    start_ms_aware, _ = resolve_log_time_range(aware, None, None)
+    assert start_ms_naive == start_ms_aware
+
+
+def test_resolve_start_after_end_errors():
+    start = datetime(2026, 5, 14, 0, 0, 0, tzinfo=timezone.utc)
+    end = datetime(2026, 5, 13, 0, 0, 0, tzinfo=timezone.utc)
+    with pytest.raises(click.UsageError):
+        resolve_log_time_range(start, end, None)
+
+
+def test_resolve_start_equals_end_errors():
+    dt = datetime(2026, 5, 14, 0, 0, 0, tzinfo=timezone.utc)
+    with pytest.raises(click.UsageError):
+        resolve_log_time_range(dt, dt, None)
+
+
+def test_resolve_window_over_7d_errors():
+    start = datetime(2026, 5, 1, 0, 0, 0, tzinfo=timezone.utc)
+    end = datetime(2026, 5, 14, 0, 0, 0, tzinfo=timezone.utc)
+    with pytest.raises(click.UsageError):
+        resolve_log_time_range(start, end, None)
+
+
+def test_resolve_since_with_start_errors():
+    start = datetime(2026, 5, 14, 0, 0, 0, tzinfo=timezone.utc)
+    with pytest.raises(click.UsageError):
+        resolve_log_time_range(start, None, "1h")
+
+
+def test_resolve_since_with_end_errors():
+    end = datetime(2026, 5, 14, 0, 0, 0, tzinfo=timezone.utc)
+    with pytest.raises(click.UsageError):
+        resolve_log_time_range(None, end, "1h")

--- a/truss/tests/cli/test_logs_utils.py
+++ b/truss/tests/cli/test_logs_utils.py
@@ -74,6 +74,14 @@ def test_resolve_only_start_defaults_end_to_now():
     assert abs(end_ms - now_ms) < 5_000
 
 
+def test_resolve_only_start_at_exact_7d_boundary_accepted():
+    # Regression: --start exactly 7d ago at second precision must not be
+    # rejected because datetime.now() has microsecond precision.
+    start = (datetime.now(timezone.utc) - MAX_LOG_RANGE).replace(microsecond=0)
+    start_ms, end_ms = resolve_log_time_range(start, None, None)
+    assert end_ms - start_ms <= int(MAX_LOG_RANGE.total_seconds() * 1000)
+
+
 def test_resolve_only_end_defaults_start_to_end_minus_7d():
     end = datetime(2026, 5, 14, 0, 0, 0, tzinfo=timezone.utc)
     start_ms, end_ms = resolve_log_time_range(None, end, None)


### PR DESCRIPTION
## Summary
- Expose the logs API's existing `start_epoch_millis` / `end_epoch_millis` parameters as user-friendly CLI flags on `truss model-logs`.
- Add `--start` and `--end` (ISO 8601, interpreted as UTC) and `--since` (relative duration with `m`/`h`/`d` suffix, e.g. `30m`, `2h`, `3d`).
- Cap the window at 7 days; reject invalid combinations (`--tail` with any time flag, `--since` with `--start`/`--end`, `start >= end`, window > 7d).
- Missing-side defaults: if only `--start` is given, end is now; if only `--end` is given, start is `end - 7d`.

## Test plan
- [x] `uv run pytest truss/tests/cli/test_logs_utils.py -v` — 29 tests pass
- [x] `uv run ruff check` / `ruff format` clean
- [x] `uv run truss model-logs --help` renders cleanly
- [ ] Manual e2e against a real deployment:
  - `truss model-logs --model-id <id> --deployment-id <id> --since 30m`
  - `truss model-logs --model-id <id> --deployment-id <id> --start 2026-05-13 --end 2026-05-14`
  - `--since 8d` → rejected
  - `--start ... --end ...` with >7d span → rejected
  - `--tail --since 1h` → rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)