### PR TITLE
refactor(cli/loops): drop _poll_until_running; SDK owns readiness gating

### DIFF
--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -67,9 +67,7 @@ def push_loops_deployment(
     # status). The CLI just confirms the resources were provisioned.
     console.print(
         f"✨ Loops deployment for [cyan]{base_model}[/cyan] provisioned.\n"
-        f"   Trainer and sampler will finish coming up in the background"
-        f" (~5 minutes for first cold-start); the loops SDK will block on"
-        f" client construction until each is ready.",
+        f"   Trainer and sampler will finish coming up in the background",
         style="green",
     )
 

--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -1,7 +1,5 @@
-import time
 from typing import Any, Dict, List, Optional, cast
 
-import requests
 import rich.table
 import rich_click as click
 import yaml
@@ -18,9 +16,6 @@ from truss.cli.utils import common
 from truss.cli.utils.output import console
 from truss.remote.baseten.remote import BasetenRemote
 from truss.remote.remote_factory import RemoteFactory
-
-_READY_TIMEOUT_SECONDS = 600
-_POLL_INTERVAL_SECONDS = 10
 
 
 @click.group()
@@ -62,20 +57,19 @@ def push_loops_deployment(
     session_id = session["id"]
 
     with console.status(
-        # Loops run cold-start typically takes ~5 minutes.
-        f"Deploying Loops run and sampler for [cyan]{base_model}[/cyan]"
-        f" (this may take ~5 minutes)...",
+        f"Provisioning Loops run and sampler for [cyan]{base_model}[/cyan]...",
         spinner="dots",
     ):
-        run = remote_provider.create_loops_run(
-            session_id=session_id, base_model=base_model
-        )
-        run_base_url = run["base_url"]
-        _poll_until_running(remote_provider, run_base_url)
+        remote_provider.create_loops_run(session_id=session_id, base_model=base_model)
 
+    # Readiness is now the loops SDK's responsibility — clients block on
+    # construction (TrainingClient → /health, SamplingClient → deployment
+    # status). The CLI just confirms the resources were provisioned.
     console.print(
-        f"✨ Loops deployment for [cyan]{base_model}[/cyan] is ready.\n"
-        f"   Run and sampler have been provisioned.",
+        f"✨ Loops deployment for [cyan]{base_model}[/cyan] provisioned.\n"
+        f"   Trainer and sampler will finish coming up in the background"
+        f" (~5 minutes for first cold-start); the loops SDK will block on"
+        f" client construction until each is ready.",
         style="green",
     )
 
@@ -111,25 +105,6 @@ def deactivate_loops_deployment(
         remote_provider.deactivate_loops_deployment(base_model)
 
     console.print(f"Loops deployment for {base_model} deactivated.", style="green")
-
-
-def _poll_until_running(remote_provider: BasetenRemote, run_base_url: str) -> None:
-    """Poll GET {run_base_url}/health until the Loops run is up."""
-    health_url = f"{run_base_url}/health"
-    auth_header = remote_provider.fetch_auth_header()
-    deadline = time.monotonic() + _READY_TIMEOUT_SECONDS
-    while time.monotonic() < deadline:
-        try:
-            resp = requests.get(health_url, headers=auth_header, timeout=10)
-            if resp.status_code == 200:
-                return
-        except requests.RequestException:
-            pass
-        time.sleep(_POLL_INTERVAL_SECONDS)
-    raise click.ClickException(
-        f"Timed out waiting for Loops deployment to become ready after"
-        f" {_READY_TIMEOUT_SECONDS}s."
-    )
 
 
 @loops.command(name="view")

--- a/truss/tests/cli/test_loops_cli.py
+++ b/truss/tests/cli/test_loops_cli.py
@@ -33,9 +33,7 @@ def _invoke_loops_push(args, mock_remote):
     with patch(
         "truss.remote.remote_factory.RemoteFactory.create", return_value=mock_remote
     ):
-        with patch("requests.get") as mock_get:
-            mock_get.return_value = Mock(status_code=200)
-            return runner.invoke(truss_cli, ["loops", "push"] + args)
+        return runner.invoke(truss_cli, ["loops", "push"] + args)
 
 
 def test_push_basic(mock_remote):
@@ -63,43 +61,6 @@ def test_push_with_project_id(mock_remote):
     )
 
 
-def test_push_polls_until_running(mock_remote):
-    # First two polls return 503, third returns 200.
-    responses = [Mock(status_code=503), Mock(status_code=503), Mock(status_code=200)]
-
-    runner = CliRunner()
-    with patch(
-        "truss.remote.remote_factory.RemoteFactory.create", return_value=mock_remote
-    ):
-        with patch("requests.get", side_effect=responses):
-            with patch("truss.cli.loops_commands.time.sleep"):
-                result = runner.invoke(
-                    truss_cli,
-                    ["loops", "push", "Qwen/Qwen3-8B", "--remote", "test_remote"],
-                )
-
-    assert result.exit_code == 0, result.output
-
-
-def test_push_times_out_waiting_for_health(mock_remote):
-    runner = CliRunner()
-    with patch(
-        "truss.remote.remote_factory.RemoteFactory.create", return_value=mock_remote
-    ):
-        with patch("requests.get", return_value=Mock(status_code=503)):
-            with patch("truss.cli.loops_commands.time.sleep"):
-                with patch(
-                    "truss.cli.loops_commands.time.monotonic", side_effect=[0, 0, 700]
-                ):
-                    result = runner.invoke(
-                        truss_cli,
-                        ["loops", "push", "Qwen/Qwen3-8B", "--remote", "test_remote"],
-                    )
-
-    assert result.exit_code != 0
-    assert "Timed out" in result.output
-
-
 def test_push_uses_inquire_when_remote_not_provided(mock_remote):
     runner = CliRunner()
     with patch(
@@ -108,9 +69,7 @@ def test_push_uses_inquire_when_remote_not_provided(mock_remote):
         with patch(
             "truss.cli.remote_cli.inquire_remote_name", return_value="inquired_remote"
         ) as mock_inquire:
-            with patch("requests.get") as mock_get:
-                mock_get.return_value = Mock(status_code=200)
-                result = runner.invoke(truss_cli, ["loops", "push", "Qwen/Qwen3-8B"])
+            result = runner.invoke(truss_cli, ["loops", "push", "Qwen/Qwen3-8B"])
 
     assert result.exit_code == 0, result.output
     mock_inquire.assert_called_once()


### PR DESCRIPTION
## Summary

`truss loops push` previously polled `{run_base_url}/health` until 200
before reporting the deployment ready. That wait now lives in the loops
SDK (`ServiceClient.create_lora_training_client` /
`create_sampling_client`) so every consumer — not just the CLI — gets
it. See basetenlabs/baseten-loops#29 for the SDK change.

- Removes `_poll_until_running` and its `requests` / `time` imports.
- Removes the two CLI-level readiness/timeout tests
  (`test_push_polls_until_running`, `test_push_times_out_waiting_for_health`)
  and drops `requests.get` patches from sibling tests that no longer
  hit it.
- Updates the CLI success message to make clear the trainer + sampler
  are still warming up after the command returns; the SDK will block
  on client construction until each is ready.

## Test plan

- [x] `uv run pytest truss/tests/cli/test_loops_cli.py -v` — 37/37 passed locally
- [x] `uv run ruff check`/`format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
