### PR TITLE
feat: send request deadline from performance client

### DIFF
--- a/baseten-performance-client/Cargo.lock
+++ b/baseten-performance-client/Cargo.lock
@@ -2177,7 +2177,7 @@ dependencies = [
 
 [[package]]
 name = "sharded-slab"
-version = "0.1.8"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [

--- a/baseten-performance-client/Cargo.lock
+++ b/baseten-performance-client/Cargo.lock
@@ -179,7 +179,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "baseten-performance-client"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "baseten_performance_client_core",
  "futures",
@@ -216,7 +216,7 @@ dependencies = [
 
 [[package]]
 name = "baseten_performance_client"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "baseten_performance_client_core",
  "futures",
@@ -233,7 +233,7 @@ dependencies = [
 
 [[package]]
 name = "baseten_performance_client_core"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "axum",
  "ctor 0.6.3",
@@ -2177,7 +2177,7 @@ dependencies = [
 
 [[package]]
 name = "sharded-slab"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [

--- a/baseten-performance-client/core/Cargo.toml
+++ b/baseten-performance-client/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "baseten_performance_client_core"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 description = "High performance HTTP client for Baseten.co and other APIs"
 license = "MIT"

--- a/baseten-performance-client/core/src/constants.rs
+++ b/baseten-performance-client/core/src/constants.rs
@@ -39,6 +39,8 @@ pub(crate) const HTTP2_CLIENT_OPTIMUM_QUEUED: usize = 8;
 // Slow providers where customers have reported issues
 pub(crate) const WARNING_SLOW_PROVIDERS: [&str; 3] = ["fireworks.ai", "together.ai", "modal.com"];
 pub(crate) const CUSTOMER_HEADER_NAME: &str = "x-baseten-customer-request-id";
+pub(crate) const REQUEST_TIMEOUT_HEADER_NAME: &str = "Request-Timeout-Ms";
+pub(crate) const REQUEST_DEADLINE_HEADER_NAME: &str = "Request-Deadline-Ms";
 
 // Logging constants
 pub const DEFAULT_LOG_LEVEL: &str = "warn";

--- a/baseten-performance-client/core/src/http_client.rs
+++ b/baseten-performance-client/core/src/http_client.rs
@@ -8,8 +8,23 @@ use rand::Rng;
 use reqwest::Client;
 use std::collections::HashSet;
 use std::sync::atomic::Ordering;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tracing;
+
+fn add_timeout_headers(
+    request_builder: reqwest::RequestBuilder,
+    request_timeout: Duration,
+) -> reqwest::RequestBuilder {
+    let timeout_ms = ((request_timeout.as_secs_f64() * 1000.0).ceil() as u64).to_string();
+    let now_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64;
+    let deadline_ms = (now_ms + request_timeout.as_millis() as u64).to_string();
+    request_builder
+        .header(REQUEST_TIMEOUT_HEADER_NAME, timeout_ms)
+        .header(REQUEST_DEADLINE_HEADER_NAME, deadline_ms)
+}
 
 // Unified HTTP request helper
 pub(crate) async fn send_http_request_with_retry<T, R>(
@@ -33,6 +48,8 @@ where
             .json(&payload)
             .timeout(request_timeout)
             .header(CUSTOMER_HEADER_NAME, &customer_request_id_header);
+
+        request_builder = add_timeout_headers(request_builder, request_timeout);
 
         if let Some(ref headers) = config.extra_headers {
             for (key, value) in headers {
@@ -86,6 +103,8 @@ where
             .bearer_auth(&api_key)
             .timeout(request_timeout)
             .header(CUSTOMER_HEADER_NAME, &customer_request_id_header);
+
+        request_builder = add_timeout_headers(request_builder, request_timeout);
 
         if method.has_body() {
             request_builder = request_builder.json(&payload);

--- a/baseten-performance-client/node_bindings/Cargo.toml
+++ b/baseten-performance-client/node_bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "baseten-performance-client"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 
 [lib]

--- a/baseten-performance-client/node_bindings/npm/android-arm-eabi/package.json
+++ b/baseten-performance-client/node_bindings/npm/android-arm-eabi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-android-arm-eabi",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "os": [
     "android"
   ],

--- a/baseten-performance-client/node_bindings/npm/android-arm64/package.json
+++ b/baseten-performance-client/node_bindings/npm/android-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-android-arm64",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "os": [
     "android"
   ],

--- a/baseten-performance-client/node_bindings/npm/darwin-arm64/package.json
+++ b/baseten-performance-client/node_bindings/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-darwin-arm64",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "os": [
     "darwin"
   ],

--- a/baseten-performance-client/node_bindings/npm/darwin-universal/package.json
+++ b/baseten-performance-client/node_bindings/npm/darwin-universal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-darwin-universal",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "os": [
     "darwin"
   ],

--- a/baseten-performance-client/node_bindings/npm/darwin-x64/package.json
+++ b/baseten-performance-client/node_bindings/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-darwin-x64",
-  "version": "0.1.5",
+  "version": "0.1.8",
   "os": [
     "darwin"
   ],

--- a/baseten-performance-client/node_bindings/npm/freebsd-x64/package.json
+++ b/baseten-performance-client/node_bindings/npm/freebsd-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-freebsd-x64",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "os": [
     "freebsd"
   ],

--- a/baseten-performance-client/node_bindings/npm/linux-arm-gnueabihf/package.json
+++ b/baseten-performance-client/node_bindings/npm/linux-arm-gnueabihf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-linux-arm-gnueabihf",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "os": [
     "linux"
   ],

--- a/baseten-performance-client/node_bindings/npm/linux-arm-musleabihf/package.json
+++ b/baseten-performance-client/node_bindings/npm/linux-arm-musleabihf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-linux-arm-musleabihf",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "os": [
     "linux"
   ],

--- a/baseten-performance-client/node_bindings/npm/linux-arm64-gnu/package.json
+++ b/baseten-performance-client/node_bindings/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-linux-arm64-gnu",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "os": [
     "linux"
   ],

--- a/baseten-performance-client/node_bindings/npm/linux-arm64-musl/package.json
+++ b/baseten-performance-client/node_bindings/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-linux-arm64-musl",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "os": [
     "linux"
   ],

--- a/baseten-performance-client/node_bindings/npm/linux-riscv64-gnu/package.json
+++ b/baseten-performance-client/node_bindings/npm/linux-riscv64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-linux-riscv64-gnu",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "os": [
     "linux"
   ],

--- a/baseten-performance-client/node_bindings/npm/linux-x64-gnu/package.json
+++ b/baseten-performance-client/node_bindings/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-linux-x64-gnu",
-  "version": "0.1.5",
+  "version": "0.1.8",
   "os": [
     "linux"
   ],

--- a/baseten-performance-client/node_bindings/npm/linux-x64-musl/package.json
+++ b/baseten-performance-client/node_bindings/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-linux-x64-musl",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "os": [
     "linux"
   ],

--- a/baseten-performance-client/node_bindings/npm/win32-arm64-msvc/package.json
+++ b/baseten-performance-client/node_bindings/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-win32-arm64-msvc",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "os": [
     "win32"
   ],

--- a/baseten-performance-client/node_bindings/npm/win32-ia32-msvc/package.json
+++ b/baseten-performance-client/node_bindings/npm/win32-ia32-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-win32-ia32-msvc",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "os": [
     "win32"
   ],

--- a/baseten-performance-client/node_bindings/npm/win32-x64-msvc/package.json
+++ b/baseten-performance-client/node_bindings/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-win32-x64-msvc",
-  "version": "0.1.5",
+  "version": "0.1.8",
   "os": [
     "win32"
   ],

--- a/baseten-performance-client/node_bindings/package.json
+++ b/baseten-performance-client/node_bindings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "main": "index.js",
   "types": "index.d.ts",
   "napi": {

--- a/baseten-performance-client/python_bindings/Cargo.toml
+++ b/baseten-performance-client/python_bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "baseten_performance_client"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 
 [dependencies]

--- a/baseten-performance-client/python_bindings/pyproject.toml
+++ b/baseten-performance-client/python_bindings/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
   "requests"
 ]


### PR DESCRIPTION
# Performance Client v0.1.8

## Summary

Add timeout headers to all outgoing requests to enable server-side timeout awareness and cancellation.

## Changes

### Timeout Headers

Added two headers to all outgoing requests to inform the server of client timeout expectations:

- **`Request-Timeout-Ms`**: Relative timeout in milliseconds (rounded up)
- **`Request-Deadline-Ms`**: Absolute deadline as Unix timestamp in milliseconds

These headers enable server-side timeout enforcement via Go context deadlines, allowing servers to:
- Cancel requests that exceed the client's timeout
- Return appropriate errors before client-side timeout
- Improve resource utilization by avoiding work that will be discarded

### Implementation

```rust
fn add_timeout_headers(
    request_builder: reqwest::RequestBuilder,
    request_timeout: Duration,
) -> reqwest::RequestBuilder {
    let timeout_ms = ((request_timeout.as_secs_f64() * 1000.0).ceil() as u64).to_string();
    let now_ms = SystemTime::now()
        .duration_since(UNIX_EPOCH)
        .unwrap()
        .as_millis() as u64;
    let deadline_ms = (now_ms + request_timeout.as_millis() as u64).to_string();
    request_builder
        .header(REQUEST_TIMEOUT_HEADER_NAME, timeout_ms)
        .header(REQUEST_DEADLINE_HEADER_NAME, deadline_ms)
}
```

**Key details:**
- Timeout is rounded up to next millisecond (conservative)
- Deadline is computed at last moment for accuracy
- Users can override headers via `extra_headers` if needed

## Example Headers

With `timeout_s=30.5`:
```
Request-Timeout-Ms: 30500
Request-Deadline-Ms: 1715812345678  # now + 30.5s
```

## Version

Bumped to `0.1.8` across:
- Rust core (`core/Cargo.toml`)
- Python bindings (`python_bindings/Cargo.toml`, `pyproject.toml`)
- Node.js bindings (`node_bindings/Cargo.toml`, `package.json`, all npm platform packages)

## Related

- Retry semaphore changes were merged in #2456 (v0.1.7)
