### PR TITLE
server/model_wrapper: fix ArgConfig.prepare_args silently skipping NONE branch and raising NotImplementedError

### DIFF
--- a/truss/templates/server/model_wrapper.py
+++ b/truss/templates/server/model_wrapper.py
@@ -192,7 +192,7 @@ class ArgConfig(enum.Enum):
         args: _ArgsType
         if descriptor.arg_config == ArgConfig.NONE:
             args = ()
-        if descriptor.arg_config == ArgConfig.INPUTS_ONLY:
+        elif descriptor.arg_config == ArgConfig.INPUTS_ONLY:
             args = (inputs,)
         elif descriptor.arg_config == ArgConfig.REQUEST_ONLY:
             args = (request,)
@@ -201,7 +201,6 @@ class ArgConfig(enum.Enum):
         else:
             raise NotImplementedError(f"Arg config {descriptor.arg_config}.")
         return args
-
 
 @dataclasses.dataclass
 class MethodDescriptor:

--- a/truss/templates/server/model_wrapper.py
+++ b/truss/templates/server/model_wrapper.py
@@ -201,7 +201,6 @@ class ArgConfig(enum.Enum):
         else:
             raise NotImplementedError(f"Arg config {descriptor.arg_config}.")
         return args
-
 @dataclasses.dataclass
 class MethodDescriptor:
     is_async: bool

--- a/truss/templates/server/model_wrapper.py
+++ b/truss/templates/server/model_wrapper.py
@@ -201,6 +201,8 @@ class ArgConfig(enum.Enum):
         else:
             raise NotImplementedError(f"Arg config {descriptor.arg_config}.")
         return args
+
+
 @dataclasses.dataclass
 class MethodDescriptor:
     is_async: bool


### PR DESCRIPTION
## :rocket: What

Fixes a control-flow bug in `ArgConfig.prepare_args` where a model method
with zero arguments (beyond `self`) would raise `NotImplementedError` at
runtime instead of correctly returning an empty args tuple.

The root cause: the `NONE` branch used a standalone `if` instead of `elif`,
so after setting `args = ()` it fell into a separate if-elif-else ladder.
Since `ArgConfig.NONE` matched none of `INPUTS_ONLY`, `REQUEST_ONLY`, or
`INPUTS_AND_REQUEST`, the `else` arm raised `NotImplementedError`.

## :computer: How

Changed the second `if` to `elif` on the `INPUTS_ONLY` branch in
`ArgConfig.prepare_args` (line 195 of `model_wrapper.py`), making all four
branches part of a single mutually exclusive if-elif-else chain. The `NONE`
case now correctly returns `()` and the `else` raise remains as a guard for
genuinely unrecognised enum values.

## :microscope: Testing

Manually traced the execution path through `ArgConfig.from_method` (returns
`NONE` when a bound method has 0 parameters beyond `self`) and confirmed that
`prepare_args` previously fell through to `raise NotImplementedError` for
that case. After the fix, the `NONE` branch returns `()` as intended.