### PR TITLE
feat(loops/cli): show deployment status in `truss loops view`

### DIFF
--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -207,14 +207,18 @@ def _render_loops_deployments(deployments: List[Dict[str, Any]]) -> None:
     )
     table.add_column("Deployment ID", style="cyan")
     table.add_column("Base Model", style="green")
+    table.add_column("Status")
     table.add_column("Base URL", style="blue")
     table.add_column("Deployment URL", style="blue")
     for deployment in deployments:
         sampler = deployment.get("sampler") or {}
         sampler_url = sampler.get("base_url", "") if isinstance(sampler, dict) else ""
+        status_obj = deployment.get("status") or {}
+        status_name = status_obj.get("name", "") if isinstance(status_obj, dict) else ""
         table.add_row(
             deployment.get("id", ""),
             deployment.get("base_model", "") or "",
+            status_name,
             deployment.get("base_url", ""),
             sampler_url,
         )

--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -214,7 +214,9 @@ def _render_loops_deployments(deployments: List[Dict[str, Any]]) -> None:
         sampler = deployment.get("sampler") or {}
         sampler_url = sampler.get("base_url", "") if isinstance(sampler, dict) else ""
         status_obj = deployment.get("status") or {}
-        status_name = status_obj.get("name", "") if isinstance(status_obj, dict) else ""
+        status_name = (
+            status_obj.get("name") or "" if isinstance(status_obj, dict) else ""
+        )
         table.add_row(
             deployment.get("id", ""),
             deployment.get("base_model", "") or "",

--- a/truss/tests/cli/test_loops_cli.py
+++ b/truss/tests/cli/test_loops_cli.py
@@ -201,6 +201,7 @@ def test_view_lists_active_deployments(mock_remote):
             "id": "dep_abc",
             "base_model": "Qwen/Qwen3-8B",
             "base_url": "https://trainer-abc.api.baseten.co/trainer",
+            "status": {"name": "active"},
             "sampler": {
                 "id": "sampler_def",
                 "base_url": "https://model-def.api.baseten.co/deployment/v1/sync",
@@ -211,7 +212,22 @@ def test_view_lists_active_deployments(mock_remote):
     assert result.exit_code == 0, result.output
     assert "dep_abc" in result.output
     assert "Qwen/Qwen3-8B" in result.output
+    assert "active" in result.output
     assert "model-def.api.baseten.co" in result.output
+
+
+def test_view_deployment_without_status_shows_empty_string(mock_remote):
+    mock_remote.api.list_loops_deployments.return_value = [
+        {
+            "id": "dep_abc",
+            "base_model": "Qwen/Qwen3-8B",
+            "base_url": "https://trainer-abc.api.baseten.co/trainer",
+            "sampler": {},
+        }
+    ]
+    result = _invoke(["loops", "view", "--remote", "test_remote"], mock_remote)
+    assert result.exit_code == 0, result.output
+    assert "dep_abc" in result.output
 
 
 def test_view_with_no_deployments_prints_friendly_message(mock_remote):

--- a/truss/tests/cli/test_loops_cli.py
+++ b/truss/tests/cli/test_loops_cli.py
@@ -216,18 +216,28 @@ def test_view_lists_active_deployments(mock_remote):
     assert "model-def.api.baseten.co" in result.output
 
 
-def test_view_deployment_without_status_shows_empty_string(mock_remote):
-    mock_remote.api.list_loops_deployments.return_value = [
-        {
-            "id": "dep_abc",
-            "base_model": "Qwen/Qwen3-8B",
-            "base_url": "https://trainer-abc.api.baseten.co/trainer",
-            "sampler": {},
-        }
-    ]
+@pytest.mark.parametrize(
+    "status_field",
+    [
+        None,  # status key absent
+        {},  # status present but empty dict
+        {"name": None},  # status present with explicit null name
+    ],
+)
+def test_view_deployment_without_status_shows_empty_string(mock_remote, status_field):
+    deployment: dict = {
+        "id": "dep_abc",
+        "base_model": "Qwen/Qwen3-8B",
+        "base_url": "https://trainer-abc.api.baseten.co/trainer",
+        "sampler": {},
+    }
+    if status_field is not None:
+        deployment["status"] = status_field
+    mock_remote.api.list_loops_deployments.return_value = [deployment]
     result = _invoke(["loops", "view", "--remote", "test_remote"], mock_remote)
     assert result.exit_code == 0, result.output
     assert "dep_abc" in result.output
+    assert "None" not in result.output
 
 
 def test_view_with_no_deployments_prints_friendly_message(mock_remote):


### PR DESCRIPTION
## :rocket: What

Add a **Status** column to `truss loops view` so users can see the current status of their trainer deployments at a glance (TRN-855).

## :computer: How

- Read `deployment.status.name` from the `GET /v1/loops/deployments` API response (already returned by the server)
- Add the value as a new `Status` column between `Base Model` and `Base URL` in `_render_loops_deployments`
- Gracefully handle missing/null `status` fields by showing an empty string

## :microscope: Testing

- Updated `test_view_lists_active_deployments` to include a `status` field and assert it appears in the output
- Added `test_view_deployment_without_status_shows_empty_string` to cover the missing-status case
- All 38 tests pass