### PR TITLE
feat: log bundled files at DEBUG during truss push (#781)

### DIFF
--- a/truss/remote/baseten/utils/tar.py
+++ b/truss/remote/baseten/utils/tar.py
@@ -1,5 +1,6 @@
 import contextlib
 import io
+import logging
 import tarfile
 import tempfile
 from pathlib import Path
@@ -10,6 +11,17 @@ if TYPE_CHECKING:
 
 from truss.base.constants import CONFIG_FILE
 from truss.util.path import collect_files
+
+logger = logging.getLogger(__name__)
+
+
+def _human_readable_size(num_bytes: int) -> str:
+    size = float(num_bytes)
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if size < 1024 or unit == "TB":
+            return f"{int(size)} B" if unit == "B" else f"{size:.1f} {unit}"
+        size /= 1024
+    return f"{size:.1f} TB"
 
 
 class ReadProgressIndicatorFileHandle:
@@ -45,6 +57,21 @@ def create_tar_with_progress_bar(
     total_size = sum(f.stat().st_size for f in files_to_include)
     if config_yaml_override is not None:
         total_size += len(config_yaml_override)
+
+    if logger.isEnabledFor(logging.DEBUG):
+        listing = "\n".join(
+            f"  {f.relative_to(source_dir)} ({_human_readable_size(f.stat().st_size)})"
+            for f in sorted(
+                files_to_include, key=lambda f: f.stat().st_size, reverse=True
+            )
+        )
+        logger.debug(
+            "Packing %d files (%s) for upload:\n%s",
+            len(files_to_include),
+            _human_readable_size(total_size),
+            listing,
+        )
+
     temp_file = tempfile.NamedTemporaryFile(suffix=".tgz", delete=delete)
 
     progress_context = (

--- a/truss/remote/baseten/utils/tar.py
+++ b/truss/remote/baseten/utils/tar.py
@@ -60,7 +60,7 @@ def create_tar_with_progress_bar(
 
     if logger.isEnabledFor(logging.DEBUG):
         listing = "\n".join(
-            f"  {f.relative_to(source_dir)} ({_human_readable_size(f.stat().st_size)})"
+            f"  {f.relative_to(source_dir).as_posix()} ({_human_readable_size(f.stat().st_size)})"
             for f in sorted(
                 files_to_include, key=lambda f: f.stat().st_size, reverse=True
             )

--- a/truss/tests/remote/baseten/test_tar.py
+++ b/truss/tests/remote/baseten/test_tar.py
@@ -1,6 +1,8 @@
 import logging
+import os
 import tempfile
 from pathlib import Path
+from typing import Optional
 
 from truss.remote.baseten.utils.tar import (
     _human_readable_size,
@@ -13,6 +15,15 @@ _TAR_LOGGER = "truss.remote.baseten.utils.tar"
 def _write(path: Path, num_bytes: int) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_bytes(b"\0" * num_bytes)
+
+
+def _pack(root: Path, ignore_patterns: Optional[list] = None) -> None:
+    # delete=False avoids a Windows NamedTemporaryFile reopen error, as core.py does.
+    tar = create_tar_with_progress_bar(root, ignore_patterns, delete=False)
+    try:
+        os.unlink(tar.name)
+    except OSError:
+        pass
 
 
 def test_human_readable_size():
@@ -29,7 +40,7 @@ def test_debug_logs_bundled_files_largest_first(caplog):
         _write(root / "model" / "weights.bin", 5 * 1024 * 1024)
 
         with caplog.at_level(logging.DEBUG, logger=_TAR_LOGGER):
-            create_tar_with_progress_bar(root)
+            _pack(root)
 
     text = caplog.text
     assert "Packing 3 files" in text
@@ -39,12 +50,28 @@ def test_debug_logs_bundled_files_largest_first(caplog):
     assert text.index("weights.bin") < text.index("config.yaml")
 
 
+def test_manifest_reflects_bundle_not_directory(caplog):
+    # Manifest reflects the packed set, not the dir: ignored files are excluded.
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _write(root / "model" / "model.py", 30)
+        _write(root / "junk.pyc", 5 * 1024 * 1024)
+
+        with caplog.at_level(logging.DEBUG, logger=_TAR_LOGGER):
+            _pack(root, ignore_patterns=["*.pyc"])
+
+    text = caplog.text
+    assert "Packing 1 files" in text
+    assert "model/model.py" in text
+    assert "junk.pyc" not in text
+
+
 def test_no_file_listing_below_debug(caplog):
     with tempfile.TemporaryDirectory() as tmp:
         root = Path(tmp)
         _write(root / "config.yaml", 40)
 
         with caplog.at_level(logging.INFO, logger=_TAR_LOGGER):
-            create_tar_with_progress_bar(root)
+            _pack(root)
 
     assert "Packing" not in caplog.text

--- a/truss/tests/remote/baseten/test_tar.py
+++ b/truss/tests/remote/baseten/test_tar.py
@@ -1,0 +1,50 @@
+import logging
+import tempfile
+from pathlib import Path
+
+from truss.remote.baseten.utils.tar import (
+    _human_readable_size,
+    create_tar_with_progress_bar,
+)
+
+_TAR_LOGGER = "truss.remote.baseten.utils.tar"
+
+
+def _write(path: Path, num_bytes: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"\0" * num_bytes)
+
+
+def test_human_readable_size():
+    assert _human_readable_size(5) == "5 B"
+    assert _human_readable_size(2048) == "2.0 KB"
+    assert _human_readable_size(5 * 1024 * 1024) == "5.0 MB"
+
+
+def test_debug_logs_bundled_files_largest_first(caplog):
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _write(root / "config.yaml", 40)
+        _write(root / "model" / "model.py", 30)
+        _write(root / "model" / "weights.bin", 5 * 1024 * 1024)
+
+        with caplog.at_level(logging.DEBUG, logger=_TAR_LOGGER):
+            create_tar_with_progress_bar(root)
+
+    text = caplog.text
+    assert "Packing 3 files" in text
+    assert "model/weights.bin (5.0 MB)" in text
+    assert "config.yaml (40 B)" in text
+    # Largest file is listed before the smaller ones.
+    assert text.index("weights.bin") < text.index("config.yaml")
+
+
+def test_no_file_listing_below_debug(caplog):
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _write(root / "config.yaml", 40)
+
+        with caplog.at_level(logging.INFO, logger=_TAR_LOGGER):
+            create_tar_with_progress_bar(root)
+
+    assert "Packing" not in caplog.text


### PR DESCRIPTION
Closes #781

## Problem

`truss push` shows a byte-total progress bar (`Packing Truss`) while bundling, but never reveals which files it's uploading. When a push is unexpectedly slow, there's no way to tell whether an unintended large file got swept in. That is exactly what #781 asks for ("It would be nice to see what files are being uploaded").

Today even `truss push --log DEBUG` shows nothing about the bundle contents, because `create_tar_with_progress_bar` logs nothing.

## Change

Log the file manifest at DEBUG in `create_tar_with_progress_bar`, sorted largest-first with human-readable sizes:

```
$ truss push --log DEBUG
DEBUG  Packing 4 files (4.8 MB) for upload:
  model/accidental_weights.bin (4.8 MB)   <- the culprit, surfaced first
  config.yaml (39 B)
  model/model.py (29 B)
  requirements.txt (5 B)
```

Sorting by size puts the slow-push offender at the top.

## Design notes

- **Reuses the existing `--log` flag** instead of adding a new `--verbose` flag. If you would prefer a dedicated flag that prints a clean standalone manifest (closer to the issue's literal wording), that is a small change and I am happy to switch.
- **Gated behind `logger.isEnabledFor(DEBUG)`**, so default `truss push` output is unchanged (no new noise, and no extra `stat()` work when not logging).
- **Inlined a small `_human_readable_size` helper** rather than importing `truss.cli.utils.common.format_bytes_to_human_readable`. That import creates a circular import (`cli.utils.common` imports `self_upgrade`, which imports `user_config`, which imports `remote_factory`, which imports the `remote.baseten` package this module lives in). Verified by running it.

## Tests

`truss/tests/remote/baseten/test_tar.py`:
- manifest is logged at DEBUG with sizes, largest file listed first
- nothing is logged below DEBUG (default pushes unaffected)
- `_human_readable_size` formatting

`uv run pytest` green, `uv run pre-commit run` clean (ruff, ruff-format, mypy).