### PR TITLE
trt_llm/validation: fix AttributeError on class-level assignments and misleading class-not-found error

### DIFF
--- a/truss/tests/trt_llm/test_validation.py
+++ b/truss/tests/trt_llm/test_validation.py
@@ -62,6 +62,18 @@ class Model:
             "foo",
             False,
         ),
+        # class body has a class-level assignment — must not crash with AttributeError
+        (
+            """
+class Model:
+    class_attr = "hello"
+    def __init__(self, foo):
+        pass
+            """,
+            "Model",
+            "foo",
+            False,
+        ),
     ],
 )
 def test_has_class_init_arg(src, expected_arg, class_name, expected_to_raise):
@@ -70,6 +82,18 @@ def test_has_class_init_arg(src, expected_arg, class_name, expected_to_raise):
             _verify_has_class_init_arg(src, class_name, expected_arg)
     else:
         _verify_has_class_init_arg(src, class_name, expected_arg)
+
+
+def test_class_not_found_error_message_is_accurate():
+    """When the named class doesn't exist the error must say 'not found', not
+    mislead the user into thinking the class exists but lacks __init__."""
+    src = """
+class Model:
+    def __init__(self, trt_llm):
+        pass
+    """
+    with pytest.raises(ValidationError, match="not found"):
+        _verify_has_class_init_arg(src, "WrongClassName", "trt_llm")
 
 
 def test_validate(custom_model_trt_llm):

--- a/truss/trt_llm/validation.py
+++ b/truss/trt_llm/validation.py
@@ -17,14 +17,16 @@ def validate(truss_spec: TrussSpec):
 
 def _verify_has_class_init_arg(source: str, class_name: str, arg_name: str):
     tree = ast.parse(source)
+    model_class_found = False
     model_class_init_found = False
     for node in tree.body:
         if isinstance(node, ast.ClassDef) and node.name == class_name:
+            model_class_found = True
             for child in node.body:
-                if child.name == "__init__":  # type: ignore[attr-defined]
+                if isinstance(child, ast.FunctionDef) and child.name == "__init__":
                     model_class_init_found = True
                     arg_found = False
-                    for arg in child.args.args:  # type: ignore[attr-defined]
+                    for arg in child.args.args:
                         if arg.arg == arg_name:
                             arg_found = True
                     if not arg_found:
@@ -36,6 +38,10 @@ def _verify_has_class_init_arg(source: str, class_name: str, arg_name: str):
                             )
                         )
 
+    if not model_class_found:
+        raise ValidationError(
+            f"Model class `{class_name}` was not found in the model file; when using `trt_llm` the class is required"
+        )
     if not model_class_init_found:
         raise ValidationError(
             "Model class does not have an `__init__` method; when using `trt_llm` it is required"


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What

Fixes two bugs in `truss/trt_llm/validation.py` inside `_verify_has_class_init_arg`:

1. **`AttributeError` crash** when a model class contains class-level attribute assignments (e.g. `x = 1`). The inner loop over the class body visited all statement nodes, but `ast.Assign` and similar nodes do not have a `.name` attribute — causing an unhandled `AttributeError` at runtime.

2. **Misleading error message** when the target class is not found in the source file at all. Previously, both "class not found" and "class has no `__init__`" produced the same error text, leaving users confused about whether their class name was wrong or simply missing an `__init__`.

<!--
  How was the change described above implemented?
-->
## :computer: How

- Guarded the `child.name` access with `isinstance(child, ast.FunctionDef)` so only function nodes are checked — eliminating the `AttributeError` on `ast.Assign`, `ast.AnnAssign`, `ast.Expr` (docstrings), etc.
- Introduced a separate `model_class_found` flag tracked at the class-loop level. If the named class is absent entirely, a distinct, accurate error is raised (`"Model class \`{class_name}\` was not found in the model file"`), separate from the existing "no `__init__`" error.
- Removed the now-unnecessary `# type: ignore[attr-defined]` comments.

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing

- Added a new parametrize entry to `test_has_class_init_arg` covering a class with a class-level assignment (`class_attr = "hello"`); this test crashed with `AttributeError` before the fix and passes after.
- Added `test_class_not_found_error_message_is_accurate` which asserts the raised `ValidationError` matches `"not found"` when a non-existent class name is passed; previously the wrong message was returned.
- All existing tests in `truss/tests/trt_llm/test_validation.py` continue to pass unchanged.