### PR TITLE
Fail fast when weights metadata resolves no files

### DIFF
--- a/truss-transfer/src/create/common_metadata.rs
+++ b/truss-transfer/src/create/common_metadata.rs
@@ -64,6 +64,8 @@ pub async fn extract_cloud_metadata<T: CloudMetadataProvider>(
         };
 
         let mut list_stream = object_store.list(Some(&prefix_path));
+        let mut listed_objects = 0usize;
+        let mut matched_objects = 0usize;
 
         while let Some(meta) = list_stream
             .next()
@@ -71,6 +73,7 @@ pub async fn extract_cloud_metadata<T: CloudMetadataProvider>(
             .transpose()
             .map_err(|e| anyhow!("Failed to list objects: {}", e))?
         {
+            listed_objects += 1;
             let object_path = meta.location.to_string();
 
             // Extract relative path from the prefix (for file naming)
@@ -100,6 +103,7 @@ pub async fn extract_cloud_metadata<T: CloudMetadataProvider>(
                 debug!("Ignoring file: {}", relative_path);
                 continue;
             }
+            matched_objects += 1;
 
             let hash = provider.extract_hash(&meta);
             let last_modified_time = provider.last_modified_time(&meta);
@@ -120,6 +124,24 @@ pub async fn extract_cloud_metadata<T: CloudMetadataProvider>(
             };
 
             basetenpointers.push(pointer);
+        }
+
+        if matched_objects == 0 {
+            if listed_objects == 0 {
+                return Err(anyhow!(
+                    "No objects found for weights source '{}' under prefix '{}'. Check that the URI points to an existing object or folder.",
+                    model.repo_id,
+                    prefix
+                ));
+            }
+
+            return Err(anyhow!(
+                "No objects matched weights filters for source '{}'. Listed {} object(s), allow_patterns={:?}, ignore_patterns={:?}.",
+                model.repo_id,
+                listed_objects,
+                model.allow_patterns,
+                model.ignore_patterns
+            ));
         }
     }
 

--- a/truss-transfer/src/create/filter.rs
+++ b/truss-transfer/src/create/filter.rs
@@ -81,10 +81,19 @@ pub fn filter_repo_files(
     allow_patterns: Option<&[String]>,
     ignore_patterns: Option<&[String]>,
 ) -> Result<Vec<String>, HfError> {
+    let total_files = files.len();
     let filtered_files = files
         .into_iter()
         .filter(|file| !should_ignore_file(file, allow_patterns, ignore_patterns))
-        .collect();
+        .collect::<Vec<_>>();
+
+    if filtered_files.is_empty() {
+        return Err(HfError::InvalidMetadata(format!(
+            "No files matched weights filters. Listed {total_files} file(s), \
+            allow_patterns={:?}, ignore_patterns={:?}",
+            allow_patterns, ignore_patterns
+        )));
+    }
 
     Ok(filtered_files)
 }
@@ -136,5 +145,24 @@ mod tests {
 
         // Should allow when no patterns specified
         assert!(!should_ignore_file("any_file.txt", None, None));
+    }
+
+    #[test]
+    fn test_filter_repo_files_errors_when_allow_patterns_match_nothing() {
+        let files = vec!["model.bin".to_string(), "README.md".to_string()];
+        let allow_patterns = vec!["*.safetensors".to_string()];
+
+        let err = filter_repo_files(files, Some(&allow_patterns), None).unwrap_err();
+
+        assert!(err.to_string().contains("No files matched weights filters"));
+        assert!(err.to_string().contains("Listed 2 file(s)"));
+    }
+
+    #[test]
+    fn test_filter_repo_files_errors_when_repo_listing_is_empty() {
+        let err = filter_repo_files(vec![], None, None).unwrap_err();
+
+        assert!(err.to_string().contains("No files matched weights filters"));
+        assert!(err.to_string().contains("Listed 0 file(s)"));
     }
 }


### PR DESCRIPTION
## Summary
- fail cloud weights metadata extraction when an S3/GCS/Azure/R2 prefix lists zero objects
- fail when allow_patterns / ignore_patterns filter every listed object
- add the same empty-filter guard to Hugging Face metadata filtering
- add focused filter tests for no-match and empty-listing cases

Fixes #2354.

## Validation
- git diff --check

Note: cargo is not installed in this environment, so I could not run cargo fmt or the Rust unit tests locally. I kept the change scoped to truss-transfer metadata/filtering paths and added tests for the pure filtering guard.
