### PR TITLE
fix(config): validate hf:// URIs require owner/repo structure

### DIFF
--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -497,6 +497,14 @@ class WeightsSource(custom_types.ConfigModel):
                     f"Invalid HuggingFace URI format: '{v}'. "
                     f"Expected format: hf://owner/repo"
                 )
+            # Strip optional @revision suffix before structural validation
+            path_without_revision = repo_part.split("@")[0]
+            path_segments = path_without_revision.split("/")
+            if len(path_segments) < 2 or not path_segments[0] or not path_segments[1]:
+                raise ValueError(
+                    f"Invalid HuggingFace URI format: '{v}'. "
+                    f"Expected format: hf://owner/repo"
+                )
 
         return v
 

--- a/truss/tests/remote/baseten/test_remote.py
+++ b/truss/tests/remote/baseten/test_remote.py
@@ -658,8 +658,12 @@ def test_push_uses_bis_llm_service_for_bis_llm(
     mock_truss_handle.spec.config.environment_variables = {"HF_TOKEN": "secret"}
     mock_truss_handle.spec.config.weights = Weights(
         [
-            WeightsSource(source="hf://test-org/model-1", mount_location="/models/base"),
-            WeightsSource(source="hf://test-org/model-2", mount_location="/models/adapter"),
+            WeightsSource(
+                source="hf://test-org/model-1", mount_location="/models/base"
+            ),
+            WeightsSource(
+                source="hf://test-org/model-2", mount_location="/models/adapter"
+            ),
         ]
     )
 

--- a/truss/tests/remote/baseten/test_remote.py
+++ b/truss/tests/remote/baseten/test_remote.py
@@ -658,8 +658,8 @@ def test_push_uses_bis_llm_service_for_bis_llm(
     mock_truss_handle.spec.config.environment_variables = {"HF_TOKEN": "secret"}
     mock_truss_handle.spec.config.weights = Weights(
         [
-            WeightsSource(source="hf://model-1", mount_location="/models/base"),
-            WeightsSource(source="hf://model-2", mount_location="/models/adapter"),
+            WeightsSource(source="hf://test-org/model-1", mount_location="/models/base"),
+            WeightsSource(source="hf://test-org/model-2", mount_location="/models/adapter"),
         ]
     )
 
@@ -701,8 +701,8 @@ def test_push_uses_bis_llm_service_for_bis_llm(
     assert kwargs["body"]["llm_config"] == {"model": "test-llm"}
     assert kwargs["body"]["llm_version"] == "v1"
     assert kwargs["body"]["weights"] == [
-        {"source": "hf://model-1", "mount_location": "/models/base"},
-        {"source": "hf://model-2", "mount_location": "/models/adapter"},
+        {"source": "hf://test-org/model-1", "mount_location": "/models/base"},
+        {"source": "hf://test-org/model-2", "mount_location": "/models/adapter"},
     ]
     assert kwargs["body"]["environment_variables"] == {"HF_TOKEN": "secret"}
     assert kwargs["body"]["metadata"] == {

--- a/truss/tests/test_config.py
+++ b/truss/tests/test_config.py
@@ -1573,6 +1573,34 @@ class TestWeightsSource:
         ):
             WeightsSource(source="hf://", mount_location="/models/llama")
 
+    def test_hf_uri_missing_repo_segment(self):
+        """HuggingFace URI with only an owner and no repo should error."""
+        with pytest.raises(
+            pydantic.ValidationError, match="Invalid HuggingFace URI format"
+        ):
+            WeightsSource(source="hf://owner", mount_location="/models/llama")
+
+    def test_hf_uri_empty_repo_segment(self):
+        """HuggingFace URI with owner but empty repo (trailing slash) should error."""
+        with pytest.raises(
+            pydantic.ValidationError, match="Invalid HuggingFace URI format"
+        ):
+            WeightsSource(source="hf://owner/", mount_location="/models/llama")
+
+    def test_hf_uri_revision_only_no_owner_or_repo(self):
+        """HuggingFace URI with only a revision and no owner/repo should error."""
+        with pytest.raises(
+            pydantic.ValidationError, match="Invalid HuggingFace URI format"
+        ):
+            WeightsSource(source="hf://@main", mount_location="/models/llama")
+
+    def test_hf_uri_single_segment_with_revision(self):
+        """HuggingFace URI with single path segment and revision but no owner should error."""
+        with pytest.raises(
+            pydantic.ValidationError, match="Invalid HuggingFace URI format"
+        ):
+            WeightsSource(source="hf://only-repo@main", mount_location="/models/llama")
+
     def test_aws_oidc_missing_role_arn(self):
         """AWS OIDC without role ARN should error."""
         with pytest.raises(


### PR DESCRIPTION
## :rocket: What

`WeightsSource._validate_source` accepted malformed `hf://` URIs that
were missing the required `owner/repo` two-part structure. The following
invalid inputs all passed validation silently:

- `hf://owner` — no repo segment
- `hf://owner/` — empty repo segment (trailing slash only)
- `hf://@main` — revision only, no owner or repo
- `hf://only-repo@main` — single path segment with revision, no owner

These would surface as cryptic runtime errors in `truss-transfer` or
the HuggingFace API instead of a clear config-time message.

## :computer: How

Extended the `hf://` branch of `_validate_source` to strip any optional
`@revision` suffix and then verify that the remaining path contains at
least two non-empty segments separated by `/` (i.e. `owner/repo`).
The existing checks (non-empty, no leading `/`) are preserved; the new
structural check runs after them.

## :microscope: Testing

Added four test cases to `TestWeightsSource` in `truss/tests/test_config.py`,
one for each invalid shape identified above:

- `test_hf_uri_missing_repo_segment`
- `test_hf_uri_empty_repo_segment`
- `test_hf_uri_revision_only_no_owner_or_repo`
- `test_hf_uri_single_segment_with_revision`

All four fail on the original code and pass after the fix. Existing
valid-URI tests (`hf://owner/repo`, `hf://owner/repo@rev`) continue
to pass unchanged.