### PR TITLE
refactor(loops): deactivate by deployment id

### DIFF
--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -81,18 +81,19 @@ def push_loops_deployment(
 
 
 @loops.command(name="deactivate")
-@click.argument("base_model", type=str)
+@click.argument("deployment_id", type=str)
 @click.option("--remote", type=str, required=False, help="Remote to use.")
 @click.option(
     "--yes", "-y", is_flag=True, default=False, help="Skip confirmation prompt."
 )
 @common.common_options()
 def deactivate_loops_deployment(
-    base_model: str, remote: Optional[str], yes: bool
+    deployment_id: str, remote: Optional[str], yes: bool
 ) -> None:
-    """Deactivate the active Loops deployment for BASE_MODEL.
+    """Deactivate the Loops deployment with DEPLOYMENT_ID.
 
     Shuts down the Loops deployment. Saved checkpoints remain accessible.
+    Use `truss loops view` to find deployment IDs.
     """
     if not remote:
         remote = remote_cli.inquire_remote_name()
@@ -103,14 +104,14 @@ def deactivate_loops_deployment(
 
     if not yes:
         click.confirm(
-            f"This will shut down the active Loops deployment for {base_model}. Continue?",
+            f"This will shut down Loops deployment {deployment_id}. Continue?",
             abort=True,
         )
 
     with console.status("Deactivating Loops deployment...", spinner="dots"):
-        remote_provider.deactivate_loops_deployment(base_model)
+        remote_provider.api.deactivate_loops_deployment(deployment_id)
 
-    console.print(f"Loops deployment for {base_model} deactivated.", style="green")
+    console.print(f"Loops deployment {deployment_id} deactivated.", style="green")
 
 
 def _poll_until_running(remote_provider: BasetenRemote, run_base_url: str) -> None:

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -1030,12 +1030,3 @@ class BasetenRemote(TrussRemote):
         return self._api.create_loops_run(
             session_id=session_id, base_model=base_model, seed=seed
         )
-
-    def deactivate_loops_deployment(self, base_model: str) -> None:
-        deployments = self._api.list_loops_deployments()
-        match = next((d for d in deployments if d["base_model"] == base_model), None)
-        if match is None:
-            raise RemoteError(
-                f"No active Loops deployment found for base model {base_model!r}."
-            )
-        self._api.deactivate_loops_deployment(match["id"])

--- a/truss/tests/cli/test_loops_cli.py
+++ b/truss/tests/cli/test_loops_cli.py
@@ -168,30 +168,30 @@ def _invoke_loops_deactivate(args, mock_remote, input=None):
 
 def test_deactivate_basic(mock_remote):
     result = _invoke_loops_deactivate(
-        ["Qwen/Qwen3-8B", "--remote", "test_remote", "--yes"], mock_remote
+        ["dep_abc", "--remote", "test_remote", "--yes"], mock_remote
     )
 
     assert result.exit_code == 0, result.output
-    mock_remote.deactivate_loops_deployment.assert_called_once_with("Qwen/Qwen3-8B")
+    mock_remote.api.deactivate_loops_deployment.assert_called_once_with("dep_abc")
     assert "deactivated" in result.output
 
 
 def test_deactivate_confirms_before_proceeding(mock_remote):
     result = _invoke_loops_deactivate(
-        ["Qwen/Qwen3-8B", "--remote", "test_remote"], mock_remote, input="y\n"
+        ["dep_abc", "--remote", "test_remote"], mock_remote, input="y\n"
     )
 
     assert result.exit_code == 0, result.output
-    mock_remote.deactivate_loops_deployment.assert_called_once_with("Qwen/Qwen3-8B")
+    mock_remote.api.deactivate_loops_deployment.assert_called_once_with("dep_abc")
 
 
 def test_deactivate_aborts_on_no_confirmation(mock_remote):
     result = _invoke_loops_deactivate(
-        ["Qwen/Qwen3-8B", "--remote", "test_remote"], mock_remote, input="n\n"
+        ["dep_abc", "--remote", "test_remote"], mock_remote, input="n\n"
     )
 
     assert result.exit_code != 0
-    mock_remote.deactivate_loops_deployment.assert_not_called()
+    mock_remote.api.deactivate_loops_deployment.assert_not_called()
 
 
 def test_deactivate_uses_inquire_when_remote_not_provided(mock_remote):
@@ -202,28 +202,28 @@ def test_deactivate_uses_inquire_when_remote_not_provided(mock_remote):
         with patch(
             "truss.cli.remote_cli.inquire_remote_name", return_value="inquired_remote"
         ) as mock_inquire:
-            runner.invoke(truss_cli, ["loops", "deactivate", "Qwen/Qwen3-8B", "--yes"])
+            runner.invoke(truss_cli, ["loops", "deactivate", "dep_abc", "--yes"])
 
     mock_inquire.assert_called_once()
 
 
 def test_deactivate_propagates_error(mock_remote):
-    mock_remote.deactivate_loops_deployment.side_effect = RuntimeError(
+    mock_remote.api.deactivate_loops_deployment.side_effect = RuntimeError(
         "deactivation failed"
     )
 
     result = _invoke_loops_deactivate(
-        ["Qwen/Qwen3-8B", "--remote", "test_remote", "--yes"], mock_remote
+        ["dep_abc", "--remote", "test_remote", "--yes"], mock_remote
     )
 
     assert result.exit_code != 0
 
 
-def test_deactivate_requires_base_model(mock_remote):
+def test_deactivate_requires_deployment_id(mock_remote):
     result = _invoke_loops_deactivate(["--remote", "test_remote", "--yes"], mock_remote)
 
     assert result.exit_code != 0
-    mock_remote.deactivate_loops_deployment.assert_not_called()
+    mock_remote.api.deactivate_loops_deployment.assert_not_called()
 
 
 def _invoke(args, mock_remote):


### PR DESCRIPTION
## :rocket: What

- `truss loops deactivate` now takes a `DEPLOYMENT_ID` positional arg instead of a base model name.
- Removed the `BasetenRemote.deactivate_loops_deployment` wrapper that resolved a base model to a deployment id by listing active deployments.

## :computer: How

Backend session re-use was recently updated so that Loops sessions are no longer pinned to the calling user, and we can no longer assume the most recent active trainer deployment for a base model is the one the user wants to shut down. The CLI now requires an explicit deployment id — `truss loops view` surfaces them — and calls `BasetenApi.deactivate_loops_deployment` directly. Help text and confirmation prompt updated to reference the deployment id.

The `resolve_most_recent_run_for_base_model` helper used by `truss loops checkpoints view --base-model` was left alone: it only picks a run for read-only checkpoint listing, not for destructive actions.

## :microscope: Testing

- `uv run pytest truss/tests/cli/test_loops_cli.py -v` — 39 passed (deactivate tests updated to assert on `mock_remote.api.deactivate_loops_deployment` with a deployment id).
- `uv run ruff check` / `uv run ruff format` — clean.