### PR TITLE
feat(cli): truss loops logs --trainer-deployment-id / --deployment-id

### DIFF
--- a/truss/cli/logs/loops_deployment_log_watcher.py
+++ b/truss/cli/logs/loops_deployment_log_watcher.py
@@ -3,26 +3,26 @@ from typing import Any, List, Optional
 from truss.cli.logs.base_watcher import LogWatcher
 from truss.remote.baseten.api import BasetenApi
 
-# TrainerDeployment statuses that are still producing (or about to produce)
+# Loops-deployment statuses that are still producing (or about to produce)
 # logs. Tail mode keeps polling while the deployment is in one of these
 # states; once it transitions to FAILED or STOPPED, the watcher exits.
 _RUNNING_STATUSES = {"CREATED", "DEPLOYING", "RUNNING"}
 
 
-class LoopsTrainerDeploymentLogWatcher(LogWatcher):
-    """Tails logs from a Loops trainer deployment's pods.
+class LoopsDeploymentLogWatcher(LogWatcher):
+    """Tails logs from a Loops deployment.
 
     Mirrors ``TrainingLogWatcher`` — same poll-with-clock-skew-buffer pattern
-    from ``LogWatcher`` — but uses the trainer-deployment-scoped logs endpoint
+    from ``LogWatcher`` — but uses the Loops-deployment-scoped logs endpoint
     and exits when the deployment is no longer in a running state.
     """
 
-    _trainer_deployment_id: str
+    _loops_deployment_id: str
     _current_status: Optional[str] = None
 
-    def __init__(self, api: BasetenApi, trainer_deployment_id: str):
+    def __init__(self, api: BasetenApi, loops_deployment_id: str):
         super().__init__(api)
-        self._trainer_deployment_id = trainer_deployment_id
+        self._loops_deployment_id = loops_deployment_id
 
     def before_polling(self) -> None:
         self._current_status = self._get_current_status()
@@ -31,7 +31,7 @@ class LoopsTrainerDeploymentLogWatcher(LogWatcher):
         self, start_epoch_millis: Optional[int], end_epoch_millis: Optional[int]
     ) -> List[Any]:
         return self.api.get_loops_deployment_logs(
-            self._trainer_deployment_id, start_epoch_millis, end_epoch_millis
+            self._loops_deployment_id, start_epoch_millis, end_epoch_millis
         )
 
     def should_poll_again(self) -> bool:
@@ -48,6 +48,6 @@ class LoopsTrainerDeploymentLogWatcher(LogWatcher):
         # cheaper and the response carries the latest status directly. A 404
         # (e.g. post-deactivation) surfaces as an exception we let propagate;
         # the watcher will exit on the next ``should_poll_again`` call.
-        deployment = self.api.get_loops_deployment(self._trainer_deployment_id)
+        deployment = self.api.get_loops_deployment(self._loops_deployment_id)
         status = deployment.get("status") or {}
         return status.get("name")

--- a/truss/cli/logs/loops_trainer_deployment_log_watcher.py
+++ b/truss/cli/logs/loops_trainer_deployment_log_watcher.py
@@ -44,12 +44,10 @@ class LoopsTrainerDeploymentLogWatcher(LogWatcher):
         pass
 
     def _get_current_status(self) -> Optional[str]:
-        # The Loops deployments list view returns each deployment's latest
-        # status. Filter for ours; if the backend stops returning it (e.g.
-        # post-deactivation) treat that as a terminal signal so tail exits.
-        deployments = self.api.list_loops_deployments()
-        for deployment in deployments:
-            if deployment.get("id") == self._trainer_deployment_id:
-                status = deployment.get("status") or {}
-                return status.get("name")
-        return None
+        # Hit the per-deployment endpoint instead of paging the full list —
+        # cheaper and the response carries the latest status directly. A 404
+        # (e.g. post-deactivation) surfaces as an exception we let propagate;
+        # the watcher will exit on the next ``should_poll_again`` call.
+        deployment = self.api.get_loops_deployment(self._trainer_deployment_id)
+        status = deployment.get("status") or {}
+        return status.get("name")

--- a/truss/cli/logs/loops_trainer_deployment_log_watcher.py
+++ b/truss/cli/logs/loops_trainer_deployment_log_watcher.py
@@ -1,0 +1,55 @@
+from typing import Any, List, Optional
+
+from truss.cli.logs.base_watcher import LogWatcher
+from truss.remote.baseten.api import BasetenApi
+
+# TrainerDeployment statuses that are still producing (or about to produce)
+# logs. Tail mode keeps polling while the deployment is in one of these
+# states; once it transitions to FAILED or STOPPED, the watcher exits.
+_RUNNING_STATUSES = {"CREATED", "DEPLOYING", "RUNNING"}
+
+
+class LoopsTrainerDeploymentLogWatcher(LogWatcher):
+    """Tails logs from a Loops trainer deployment's pods.
+
+    Mirrors ``TrainingLogWatcher`` — same poll-with-clock-skew-buffer pattern
+    from ``LogWatcher`` — but uses the trainer-deployment-scoped logs endpoint
+    and exits when the deployment is no longer in a running state.
+    """
+
+    _trainer_deployment_id: str
+    _current_status: Optional[str] = None
+
+    def __init__(self, api: BasetenApi, trainer_deployment_id: str):
+        super().__init__(api)
+        self._trainer_deployment_id = trainer_deployment_id
+
+    def before_polling(self) -> None:
+        self._current_status = self._get_current_status()
+
+    def fetch_logs(
+        self, start_epoch_millis: Optional[int], end_epoch_millis: Optional[int]
+    ) -> List[Any]:
+        return self.api.get_loops_deployment_logs(
+            self._trainer_deployment_id, start_epoch_millis, end_epoch_millis
+        )
+
+    def should_poll_again(self) -> bool:
+        return self._current_status in _RUNNING_STATUSES
+
+    def post_poll(self) -> None:
+        self._current_status = self._get_current_status()
+
+    def after_polling(self) -> None:
+        pass
+
+    def _get_current_status(self) -> Optional[str]:
+        # The Loops deployments list view returns each deployment's latest
+        # status. Filter for ours; if the backend stops returning it (e.g.
+        # post-deactivation) treat that as a terminal signal so tail exits.
+        deployments = self.api.list_loops_deployments()
+        for deployment in deployments:
+            if deployment.get("id") == self._trainer_deployment_id:
+                status = deployment.get("status") or {}
+                return status.get("name")
+        return None

--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -7,6 +7,11 @@ import yaml
 import truss.cli.train.core as train_cli
 from truss.cli import remote_cli
 from truss.cli.cli import truss_cli
+from truss.cli.logs import utils as cli_log_utils
+from truss.cli.logs.loops_trainer_deployment_log_watcher import (
+    LoopsTrainerDeploymentLogWatcher,
+)
+from truss.cli.logs.model_log_watcher import ModelDeploymentLogWatcher
 from truss.cli.loops_checkpoint_viewer import (
     resolve_most_recent_run_for_base_model,
     view_loops_checkpoint_list,
@@ -461,3 +466,100 @@ def deploy_loops_checkpoints(
             print(yaml.safe_dump(result.truss_config.to_dict()))
     else:
         train_cli.print_deploy_checkpoints_success_message(result.deploy_config)
+
+
+def _resolve_sampler_model_id(
+    remote_provider: BasetenRemote, sampler_deployment_id: str
+) -> str:
+    """Find the model_id for a sampler's inference deployment.
+
+    The Loops deployments list endpoint returns each deployment's sampler
+    with both ``deployment_id`` (the OracleVersion id) and ``model_id`` (the
+    Oracle id). We don't want users to have to pass both flags, so resolve
+    the model_id client-side by matching on the deployment_id they gave us.
+    """
+    deployments = remote_provider.api.list_loops_deployments()
+    for deployment in deployments:
+        sampler = deployment.get("sampler") or {}
+        if sampler.get("deployment_id") == sampler_deployment_id:
+            return sampler["model_id"]
+    raise click.ClickException(
+        f"No Loops deployment found whose sampler matches deployment {sampler_deployment_id!r}. "
+        "Run `truss loops view` to list active deployments."
+    )
+
+
+@loops.command(name="logs")
+@click.option(
+    "--trainer-deployment-id",
+    type=str,
+    required=False,
+    help="Fetch logs from the trainer pods of a Loops deployment.",
+)
+@click.option(
+    "--deployment-id",
+    type=str,
+    required=False,
+    help=(
+        "Fetch logs from the sampler's inference deployment. The companion "
+        "model id is resolved automatically by matching against the caller's "
+        "active Loops deployments."
+    ),
+)
+@click.option(
+    "--tail",
+    is_flag=True,
+    default=False,
+    help="Continue polling for new log lines until the deployment goes inactive (or Ctrl+C).",
+)
+@click.option("--remote", type=str, required=False, help="Remote to use.")
+@common.common_options()
+def view_loops_logs(
+    trainer_deployment_id: Optional[str],
+    deployment_id: Optional[str],
+    tail: bool,
+    remote: Optional[str],
+) -> None:
+    """Fetch logs from one half of a Loops deployment.
+
+    Pass exactly one of ``--trainer-deployment-id`` (the trainer pods) or
+    ``--deployment-id`` (the sampler's inference deployment). The two
+    sides have separate log streams; pick the one you're debugging.
+    """
+    if bool(trainer_deployment_id) == bool(deployment_id):
+        raise click.UsageError(
+            "Pass exactly one of --trainer-deployment-id or --deployment-id."
+        )
+
+    if not remote:
+        remote = remote_cli.inquire_remote_name()
+    remote_provider: BasetenRemote = cast(
+        BasetenRemote, RemoteFactory.create(remote=remote)
+    )
+
+    if trainer_deployment_id is not None:
+        if tail:
+            watcher = LoopsTrainerDeploymentLogWatcher(
+                remote_provider.api, trainer_deployment_id
+            )
+            for log in watcher.watch():
+                cli_log_utils.output_log(log)
+        else:
+            logs = remote_provider.api.get_loops_deployment_logs(trainer_deployment_id)
+            for log in cli_log_utils.parse_logs(logs):
+                cli_log_utils.output_log(log)
+        return
+
+    # --deployment-id path: reuse the existing model-deployment log machinery.
+    assert deployment_id is not None  # narrowed by the XOR check above
+    model_id = _resolve_sampler_model_id(remote_provider, deployment_id)
+    if tail:
+        watcher = ModelDeploymentLogWatcher(
+            remote_provider.api, model_id, deployment_id
+        )
+        for log in watcher.watch():
+            cli_log_utils.output_log(log)
+    else:
+        logs = remote_provider.api.get_model_deployment_logs(model_id, deployment_id)
+        for log in cli_log_utils.parse_logs(logs):
+            cli_log_utils.output_log(log)

--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -539,10 +539,10 @@ def view_loops_logs(
 
     if trainer_deployment_id is not None:
         if tail:
-            watcher = LoopsTrainerDeploymentLogWatcher(
+            trainer_watcher = LoopsTrainerDeploymentLogWatcher(
                 remote_provider.api, trainer_deployment_id
             )
-            for log in watcher.watch():
+            for log in trainer_watcher.watch():
                 cli_log_utils.output_log(log)
         else:
             logs = remote_provider.api.get_loops_deployment_logs(trainer_deployment_id)
@@ -554,10 +554,10 @@ def view_loops_logs(
     assert deployment_id is not None  # narrowed by the XOR check above
     model_id = _resolve_sampler_model_id(remote_provider, deployment_id)
     if tail:
-        watcher = ModelDeploymentLogWatcher(
+        model_watcher = ModelDeploymentLogWatcher(
             remote_provider.api, model_id, deployment_id
         )
-        for log in watcher.watch():
+        for log in model_watcher.watch():
             cli_log_utils.output_log(log)
     else:
         logs = remote_provider.api.get_model_deployment_logs(model_id, deployment_id)

--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -273,7 +273,12 @@ def _render_loops_samplers(samplers: List[Dict[str, Any]]) -> None:
         box=rich.table.box.ROUNDED,
         border_style="blue",
     )
+    # Two distinct IDs to surface: the user-facing Sampler ID (used by
+    # ``truss loops samplers view --sampler-id``) and the Sampler Deployment
+    # ID (the underlying model-deployment hashid, used by
+    # ``truss loops logs --sampler-deployment-id``).
     table.add_column("Sampler ID", style="cyan")
+    table.add_column("Sampler Deployment ID", style="cyan")
     table.add_column("Base Model", style="green")
     table.add_column("Base URL", style="blue")
     table.add_column("Created At")
@@ -282,6 +287,7 @@ def _render_loops_samplers(samplers: List[Dict[str, Any]]) -> None:
         created_str = common.format_localized_time(created_at) if created_at else ""
         table.add_row(
             sampler.get("id", ""),
+            sampler.get("deployment_id", "") or "",
             sampler.get("base_model", ""),
             sampler.get("base_url", ""),
             created_str,
@@ -491,19 +497,23 @@ def _resolve_sampler_model_id(
 
 @loops.command(name="logs")
 @click.option(
-    "--trainer-deployment-id",
-    type=str,
-    required=False,
-    help="Fetch logs from the trainer pods of a Loops deployment.",
-)
-@click.option(
-    "--deployment-id",
+    "--loops-deployment-id",
     type=str,
     required=False,
     help=(
-        "Fetch logs from the sampler's inference deployment. The companion "
-        "model id is resolved automatically by matching against the caller's "
-        "active Loops deployments."
+        "Fetch logs from the trainer pods of a Loops deployment. The id is "
+        "the ``Deployment ID`` column in ``truss loops view``."
+    ),
+)
+@click.option(
+    "--sampler-deployment-id",
+    type=str,
+    required=False,
+    help=(
+        "Fetch logs from the sampler's inference deployment. The id is the "
+        "``Sampler Deployment ID`` column in ``truss loops samplers view``. "
+        "The companion model id is resolved automatically by matching "
+        "against the caller's active Loops deployments."
     ),
 )
 @click.option(
@@ -515,20 +525,20 @@ def _resolve_sampler_model_id(
 @click.option("--remote", type=str, required=False, help="Remote to use.")
 @common.common_options()
 def view_loops_logs(
-    trainer_deployment_id: Optional[str],
-    deployment_id: Optional[str],
+    loops_deployment_id: Optional[str],
+    sampler_deployment_id: Optional[str],
     tail: bool,
     remote: Optional[str],
 ) -> None:
     """Fetch logs from one half of a Loops deployment.
 
-    Pass exactly one of ``--trainer-deployment-id`` (the trainer pods) or
-    ``--deployment-id`` (the sampler's inference deployment). The two
-    sides have separate log streams; pick the one you're debugging.
+    Pass exactly one of ``--loops-deployment-id`` (the trainer pods) or
+    ``--sampler-deployment-id`` (the sampler's inference deployment). The
+    two sides have separate log streams; pick the one you're debugging.
     """
-    if bool(trainer_deployment_id) == bool(deployment_id):
+    if bool(loops_deployment_id) == bool(sampler_deployment_id):
         raise click.UsageError(
-            "Pass exactly one of --trainer-deployment-id or --deployment-id."
+            "Pass exactly one of --loops-deployment-id or --sampler-deployment-id."
         )
 
     if not remote:
@@ -537,29 +547,31 @@ def view_loops_logs(
         BasetenRemote, RemoteFactory.create(remote=remote)
     )
 
-    if trainer_deployment_id is not None:
+    if loops_deployment_id is not None:
         if tail:
             trainer_watcher = LoopsTrainerDeploymentLogWatcher(
-                remote_provider.api, trainer_deployment_id
+                remote_provider.api, loops_deployment_id
             )
             for log in trainer_watcher.watch():
                 cli_log_utils.output_log(log)
         else:
-            logs = remote_provider.api.get_loops_deployment_logs(trainer_deployment_id)
+            logs = remote_provider.api.get_loops_deployment_logs(loops_deployment_id)
             for log in cli_log_utils.parse_logs(logs):
                 cli_log_utils.output_log(log)
         return
 
-    # --deployment-id path: reuse the existing model-deployment log machinery.
-    assert deployment_id is not None  # narrowed by the XOR check above
-    model_id = _resolve_sampler_model_id(remote_provider, deployment_id)
+    # --sampler-deployment-id path: reuse the existing model-deployment log machinery.
+    assert sampler_deployment_id is not None  # narrowed by the XOR check above
+    model_id = _resolve_sampler_model_id(remote_provider, sampler_deployment_id)
     if tail:
         model_watcher = ModelDeploymentLogWatcher(
-            remote_provider.api, model_id, deployment_id
+            remote_provider.api, model_id, sampler_deployment_id
         )
         for log in model_watcher.watch():
             cli_log_utils.output_log(log)
     else:
-        logs = remote_provider.api.get_model_deployment_logs(model_id, deployment_id)
+        logs = remote_provider.api.get_model_deployment_logs(
+            model_id, sampler_deployment_id
+        )
         for log in cli_log_utils.parse_logs(logs):
             cli_log_utils.output_log(log)

--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -8,9 +8,7 @@ import truss.cli.train.core as train_cli
 from truss.cli import remote_cli
 from truss.cli.cli import truss_cli
 from truss.cli.logs import utils as cli_log_utils
-from truss.cli.logs.loops_trainer_deployment_log_watcher import (
-    LoopsTrainerDeploymentLogWatcher,
-)
+from truss.cli.logs.loops_deployment_log_watcher import LoopsDeploymentLogWatcher
 from truss.cli.logs.model_log_watcher import ModelDeploymentLogWatcher
 from truss.cli.loops_checkpoint_viewer import (
     resolve_most_recent_run_for_base_model,
@@ -501,8 +499,8 @@ def _resolve_sampler_model_id(
     type=str,
     required=False,
     help=(
-        "Fetch logs from the trainer pods of a Loops deployment. The id is "
-        "the ``Deployment ID`` column in ``truss loops view``."
+        "Fetch logs from a Loops deployment. The id is the "
+        "``Deployment ID`` column in ``truss loops view``."
     ),
 )
 @click.option(
@@ -532,7 +530,7 @@ def view_loops_logs(
 ) -> None:
     """Fetch logs from one half of a Loops deployment.
 
-    Pass exactly one of ``--loops-deployment-id`` (the trainer pods) or
+    Pass exactly one of ``--loops-deployment-id`` (the Loops deployment) or
     ``--sampler-deployment-id`` (the sampler's inference deployment). The
     two sides have separate log streams; pick the one you're debugging.
     """
@@ -549,10 +547,10 @@ def view_loops_logs(
 
     if loops_deployment_id is not None:
         if tail:
-            trainer_watcher = LoopsTrainerDeploymentLogWatcher(
+            loops_watcher = LoopsDeploymentLogWatcher(
                 remote_provider.api, loops_deployment_id
             )
-            for log in trainer_watcher.watch():
+            for log in loops_watcher.watch():
                 cli_log_utils.output_log(log)
         else:
             logs = remote_provider.api.get_loops_deployment_logs(loops_deployment_id)

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -1074,6 +1074,30 @@ class BasetenApi:
         # NB(nikhil): reverse order so latest logs are at the end
         return resp_json["logs"][::-1]
 
+    def get_loops_deployment_logs(
+        self,
+        trainer_deployment_id: str,
+        start_epoch_millis: Optional[int] = None,
+        end_epoch_millis: Optional[int] = None,
+    ):
+        """Fetch trainer-pod logs for a Loops (TrainerDeployment) deployment.
+
+        Backend endpoint is GET-only — uses query params, not a request body
+        like the training-job / model-deployment endpoints.
+        """
+        params: Dict[str, str] = {}
+        if start_epoch_millis:
+            params["start_epoch_millis"] = str(start_epoch_millis)
+        if end_epoch_millis:
+            params["end_epoch_millis"] = str(end_epoch_millis)
+
+        resp_json = self._rest_api_client.get(
+            f"v1/loops/deployments/{trainer_deployment_id}/logs", url_params=params
+        )
+        # Reverse so latest logs are at the end (matches the training-job /
+        # model-deployment helpers above).
+        return resp_json["logs"][::-1]
+
     def create_model_version_from_inference_template(self, request_data: dict):
         """
         Create a model version from an inference template using GraphQL mutation.

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -1076,11 +1076,11 @@ class BasetenApi:
 
     def get_loops_deployment_logs(
         self,
-        trainer_deployment_id: str,
+        loops_deployment_id: str,
         start_epoch_millis: Optional[int] = None,
         end_epoch_millis: Optional[int] = None,
     ):
-        """Fetch trainer-pod logs for a Loops (TrainerDeployment) deployment.
+        """Fetch logs for a Loops deployment.
 
         Backend endpoint is GET-only — uses query params, not a request body
         like the training-job / model-deployment endpoints.
@@ -1092,7 +1092,7 @@ class BasetenApi:
             params["end_epoch_millis"] = str(end_epoch_millis)
 
         resp_json = self._rest_api_client.get(
-            f"v1/loops/deployments/{trainer_deployment_id}/logs", url_params=params
+            f"v1/loops/deployments/{loops_deployment_id}/logs", url_params=params
         )
         # Reverse so latest logs are at the end (matches the training-job /
         # model-deployment helpers above).


### PR DESCRIPTION
## What

New \`truss loops logs\` subcommand that fetches logs from either half of a Loops deployment:

\`\`\`
truss loops logs --trainer-deployment-id <id>          # trainer pods
truss loops logs --deployment-id <id>                  # sampler's inference deployment
truss loops logs --trainer-deployment-id <id> --tail
truss loops logs --deployment-id <id> --tail
\`\`\`

The two modes are mutually exclusive — pass exactly one flag. Pairs with the backend endpoint added in [basetenlabs/baseten#20444](https://github.com/basetenlabs/baseten/pull/20444) and reuses the existing \`ModelDeploymentLogWatcher\` for the sampler side.

## How

Three changes:

### 1. \`BasetenApi.get_loops_deployment_logs\`

Thin GET wrapper around \`/v1/loops/deployments/<id>/logs\`. Mirrors \`get_training_job_logs\` / \`get_model_deployment_logs\` (reverse-orders results so latest is at the end), but uses query params instead of a POST body — the backend endpoint is GET-only.

### 2. \`LoopsTrainerDeploymentLogWatcher\`

Subclass of \`LogWatcher\` (same poll-with-clock-skew-buffer pattern that \`TrainingLogWatcher\` uses). Tail mode keeps polling while the deployment's latest status is in \`{CREATED, DEPLOYING, RUNNING}\`; exits when it transitions to \`FAILED\` or \`STOPPED\`.

### 3. \`truss loops logs\` subcommand

Wires the two paths together with shared output formatting via \`cli_log_utils.output_log\`. For \`--deployment-id\` we resolve the companion \`model_id\` by hitting \`GET /v1/loops/deployments\` and matching \`sampler.deployment_id\` — so users don't have to remember the model_id from \`truss loops view\`. Raises \`ClickException\` with a helpful pointer if the deployment_id doesn't match any active Loops deployment.

## Testing

Validated locally against the dev stack:

- \`truss loops logs --trainer-deployment-id x5qe2qo --remote baseten-local\` returns real log lines:
  \`\`\`
  [2026-05-27 20:34:24]: (g00r0) trainer log line 19 at Thu May 28 00:34:24 UTC 2026
  [2026-05-27 20:34:25]: (g00r0) trainer log line 20 at Thu May 28 00:34:25 UTC 2026
  [2026-05-27 20:34:26]: (g00r0) trainer done
  \`\`\`
  Format matches \`truss train logs\` exactly.

- \`--tail\` keeps polling and exits cleanly when the deployment transitions out of a running state.

- Passing both flags errors out: \`UsageError: Pass exactly one of --trainer-deployment-id or --deployment-id.\`

- Passing neither errors out the same way.

- Unknown \`--deployment-id\` gives \`ClickException: No Loops deployment found whose sampler matches deployment 'nonexistent'. Run \`truss loops view\` to list active deployments.\`

## Release requirements

- **Pre-release:** [basetenlabs/baseten#20444](https://github.com/basetenlabs/baseten/pull/20444) needs to be merged + deployed before this CLI surface is fully functional. Until then \`--trainer-deployment-id\` returns 404. The \`--deployment-id\` path uses the existing model-logs endpoint and works today.
- **Post-release:** None.
- **External communication:** None until the backend PR ships.