### PR TITLE
cli: surface model_id, deployment_id, and endpoint after a deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,11 +123,15 @@ You should see:
 ```output
 ✨ Model Qwen 2.5 3B was successfully pushed ✨
 
-🪵  View logs for your deployment at https://app.baseten.co/models/abc1d2ef/logs/xyz123
+   Model ID:      abc1d2ef
+   Deployment ID: xyz123
+   Endpoint:      https://model-abc1d2ef.api.baseten.co
+   Logs:          https://app.baseten.co/models/abc1d2ef/logs/xyz123
+
 👀 Watching for changes to truss...
 ```
 
-The logs URL contains your model ID, the string after `/models/` (e.g., `abc1d2ef`). You'll need this to call the model's API. You can also find it in your [Baseten dashboard](https://app.baseten.co/models/).
+You'll need the model ID to call the model's API. You can also find it in your [Baseten dashboard](https://app.baseten.co/models/).
 
 Baseten now downloads the model weights from Hugging Face, compiles them with TensorRT-LLM, and deploys the resulting container to an L4 GPU. You can watch progress in the logs linked above.
 
@@ -183,7 +187,10 @@ uvx truss watch
 You should see:
 
 ```output
-🪵  View logs for your deployment at https://app.baseten.co/models/<model_id>/logs/<deployment_id>
+   Model ID:      <model_id>
+   Deployment ID: <deployment_id>
+   Endpoint:      https://model-<model_id>.api.baseten.co
+   Logs:          https://app.baseten.co/models/<model_id>/logs/<deployment_id>
 🚰 Attempting to sync truss with remote
 No changes observed, skipping patching.
 👀 Watching for changes to truss...

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -933,7 +933,16 @@ def push(
         labels=labels_dict,
     )
 
-    console.print(f"✨ Model {model_name} was successfully pushed ✨")
+    console.print(f"✨ Model {model_name} was successfully pushed ✨\n")
+
+    if isinstance(service, BasetenService):
+        common.print_deployment_links(
+            model_id=service.model_id,
+            version_id=service.model_version_id,
+            hostname=service.hostname,
+            logs_url=service.logs_url,
+        )
+        console.print()
 
     if service.is_draft:
         draft_model_text = """
@@ -955,10 +964,6 @@ def push(
             f"deploys, it will become the next {environment} deployment of your model."
         )
         console.print(promotion_text, style="green")
-
-    console.print(
-        f"🪵  View logs for your deployment at {common.format_link(service.logs_url)}"
-    )
 
     if tr.spec.config.runtime.remote_ssh.enabled and isinstance(
         service, BasetenService
@@ -1314,14 +1319,17 @@ def watch(
     logs_url = URLConfig.model_logs_url(
         remote_provider.remote_url, model_id, dev_version_id
     )
-    console.print(
-        f"🪵  View logs for your development model at {common.format_link(logs_url)}"
-    )
-
     model_hostname = resolved_model.get("hostname")
     if not model_hostname:
         console.print("❌ Could not determine model hostname", style="red")
         sys.exit(1)
+
+    common.print_deployment_links(
+        model_id=model_id,
+        version_id=dev_version_id,
+        hostname=model_hostname,
+        logs_url=logs_url,
+    )
 
     common.wait_for_development_model_ready(
         model_hostname=model_hostname,

--- a/truss/cli/train/deploy_checkpoints/deploy_checkpoints.py
+++ b/truss/cli/train/deploy_checkpoints/deploy_checkpoints.py
@@ -71,11 +71,8 @@ def create_model_version_from_inference_template(
         model_version = None
         if result and result.get("model_version"):
             console.print(
-                f"Successfully created deployment: {result['model_version']['name']}",
+                f"Successfully created deployment: {result['model_version']['name']}\n",
                 style="green",
-            )
-            console.print(
-                f"Deployment ID: {result['model_version']['id']}", style="yellow"
             )
             model_version = DeploySuccessModelVersion.model_validate(
                 result["model_version"]
@@ -83,8 +80,10 @@ def create_model_version_from_inference_template(
             logs_url = URLConfig.model_logs_url(
                 remote_provider.remote_url, model_version.model_id, model_version.id
             )
-            console.print(
-                f"🪵  View logs for your deployment at {cli_common.format_link(logs_url)}"
+            cli_common.print_deployment_links(
+                model_id=model_version.model_id,
+                version_id=model_version.id,
+                logs_url=logs_url,
             )
         elif not dry_run:
             console.print(

--- a/truss/cli/utils/common.py
+++ b/truss/cli/utils/common.py
@@ -200,6 +200,21 @@ def format_link(url: str, display_text: Optional[str] = None) -> str:
     return f"[link={url}]{display_text}[/link]"
 
 
+def print_deployment_links(
+    *, model_id: str, version_id: str, logs_url: str, hostname: Optional[str] = None
+) -> None:
+    """Print a labeled block of deployment identifiers and links.
+
+    Shared across deployment-touching commands (`truss push`, `truss watch`,
+    `truss train ... deploy_checkpoints`) so they render the same format.
+    """
+    console.print(f"   [bold]{'Model ID:':<14}[/bold] {model_id}")
+    console.print(f"   [bold]{'Deployment ID:':<14}[/bold] {version_id}")
+    if hostname:
+        console.print(f"   [bold]{'Endpoint:':<14}[/bold] {hostname}")
+    console.print(f"   [bold]{'Logs:':<14}[/bold] {format_link(logs_url)}")
+
+
 def is_human_log_level(ctx: click.Context) -> bool:
     return get_required_option(ctx, "log") != _HUMANFRIENDLY_LOG_LEVEL
 

--- a/truss/remote/baseten/service.py
+++ b/truss/remote/baseten/service.py
@@ -117,6 +117,10 @@ class BasetenService(TrussService):
     def model_version_id(self) -> str:
         return self._model_version_handle.version_id
 
+    @property
+    def hostname(self) -> str:
+        return self._model_version_handle.hostname
+
     def predict(self, model_request_body: Dict) -> Any:
         response = self._send_request(
             self.predict_url, "POST", data=model_request_body, stream=True

--- a/truss/tests/cli/test_cli.py
+++ b/truss/tests/cli/test_cli.py
@@ -832,6 +832,45 @@ def test_push_publish_flag_shows_deprecation_warning(
     assert "DEPRECATED" in result.output
 
 
+def test_push_output_shows_model_id_deployment_id_and_endpoint(
+    custom_model_truss_dir_with_pre_and_post,
+    remote,
+    mock_baseten_requests,
+    mock_upload_truss,
+    mock_create_truss_service,
+):
+    """A successful push surfaces model_id, deployment_id, and endpoint as
+    labeled lines so first-time users don't have to parse them out of the
+    logs URL."""
+    runner = CliRunner()
+    remote.push = Mock(return_value=_make_mock_service())
+
+    with patch("truss.cli.cli.RemoteFactory.create", return_value=remote):
+        remote.api.get_teams = Mock(return_value={})
+        with patch("truss.cli.cli.resolve_model_team_name", return_value=(None, None)):
+            result = runner.invoke(
+                truss_cli,
+                [
+                    "push",
+                    str(custom_model_truss_dir_with_pre_and_post),
+                    "--remote",
+                    "baseten",
+                    "--model-name",
+                    "model_name",
+                ],
+            )
+
+    assert result.exit_code == 0, result.output
+    assert "Model ID:" in result.output
+    assert "model_id" in result.output
+    assert "Deployment ID:" in result.output
+    assert "version_id" in result.output
+    assert "Endpoint:" in result.output
+    assert "https://model-model_id.api.baseten.co" in result.output
+    assert "Logs:" in result.output
+    assert "https://app.baseten.co/models/model_id/logs/version_id" in result.output
+
+
 def test_push_watch_creates_development_deployment(
     custom_model_truss_dir_with_pre_and_post,
     remote,
@@ -1325,6 +1364,7 @@ def _make_mock_service(**overrides):
     mock_service.is_draft = False
     mock_service.model_id = "model_id"
     mock_service.model_version_id = "version_id"
+    mock_service.hostname = "https://model-model_id.api.baseten.co"
     mock_service.predict_url = (
         "https://model.api.baseten.co/deployment/version_id/predict"
     )


### PR DESCRIPTION
After `truss push`, the model_id was only available embedded in the logs URL. First-time users had to parse it out to call their model. 
This PR adds a labeled block showing Model ID, Deployment ID, Endpoint, and Logs as the post-success output, and extracts a shared `print_deployment_links` helper that `truss push`, `truss watch`, and `truss train ... deploy_checkpoints` all call instead of the three near-duplicate print statements they had before.

```
  ✨ Model Qwen-2.5-3B was successfully pushed ✨

     Model ID:      abc1d2ef
     Deployment ID: xyz123
     Endpoint:      https://model-abc1d2ef.api.baseten.co
     Logs:          https://app.baseten.co/models/abc1d2ef/logs/xyz123
```

  For truss train ... deploy_checkpoints (no endpoint, since that flow doesn't fetch a hostname yet):

  Successfully created deployment: my-checkpoint-deploy

```sh
     Model ID:      abc1d2ef
     Deployment ID: xyz123
     Logs:          https://app.baseten.co/models/abc1d2ef/logs/xyz123
```
  And truss watch re-attaching to an existing dev deployment:
```sh
     Model ID:      abc1d2ef
     Deployment ID: xyz123
     Endpoint:      https://model-abc1d2ef.api.baseten.co
     Logs:          https://app.baseten.co/models/abc1d2ef/logs/xyz123
```