### PR TITLE
feat(loops/cli): show sampler status in `truss loops view`

### DIFF
--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -105,13 +105,24 @@ def deactivate_loops_deployment(
     console.print(f"Loops deployment for {base_model} deactivated.", style="green")
 
 
+_TERMINAL_DEPLOYMENT_STATUSES = frozenset({"STOPPED", "FAILED"})
+
+
 @loops.command(name="view")
 @click.option("--remote", type=str, required=False, help="Remote to use.")
+@click.option(
+    "--all",
+    "show_all",
+    is_flag=True,
+    default=False,
+    help="Include deployments in terminal states (STOPPED, FAILED).",
+)
 @common.common_options()
-def view_loops_deployments(remote: Optional[str]) -> None:
-    """List the caller's active Loops deployments.
+def view_loops_deployments(remote: Optional[str], show_all: bool) -> None:
+    """List the caller's Loops deployments.
 
-    Excludes deployments whose latest status is STOPPED (filtered server-side).
+    By default, deployments in terminal states (STOPPED, FAILED) are hidden.
+    Pass --all to include them.
     """
     if not remote:
         remote = remote_cli.inquire_remote_name()
@@ -120,7 +131,13 @@ def view_loops_deployments(remote: Optional[str]) -> None:
         BasetenRemote, RemoteFactory.create(remote=remote)
     )
     deployments = remote_provider.api.list_loops_deployments()
-    _render_loops_deployments(deployments)
+    if not show_all:
+        deployments = [
+            d
+            for d in deployments
+            if d["status"]["name"] not in _TERMINAL_DEPLOYMENT_STATUSES
+        ]
+    _render_loops_deployments(deployments, show_all=show_all)
 
 
 @loops.group(name="runs")
@@ -194,9 +211,18 @@ def view_loops_samplers(reverse: bool, remote: Optional[str]) -> None:
     _render_loops_samplers(samplers)
 
 
-def _render_loops_deployments(deployments: List[Dict[str, Any]]) -> None:
+def _render_loops_deployments(
+    deployments: List[Dict[str, Any]], show_all: bool = False
+) -> None:
     if not deployments:
-        console.print("No active Loops deployments.", style="yellow")
+        if show_all:
+            console.print("No Loops deployments.", style="yellow")
+        else:
+            console.print(
+                "No active Loops deployments. Pass --all to include "
+                "STOPPED and FAILED deployments.",
+                style="yellow",
+            )
         return
     table = rich.table.Table(
         show_header=True,

--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -207,18 +207,18 @@ def _render_loops_deployments(deployments: List[Dict[str, Any]]) -> None:
     )
     table.add_column("Deployment ID", style="cyan")
     table.add_column("Base Model", style="green")
-    table.add_column("Run Status")
+    table.add_column("Deployment Status")
+    table.add_column("Deployment Base URL", style="blue")
     table.add_column("Sampler Status")
-    table.add_column("Base URL", style="blue")
-    table.add_column("Deployment URL", style="blue")
+    table.add_column("Sampler Base URL", style="blue")
     for deployment in deployments:
         sampler = deployment["sampler"]
         table.add_row(
             deployment["id"],
             deployment["base_model"],
             deployment["status"]["name"],
-            sampler["status"]["name"],
             deployment["base_url"],
+            sampler["status"]["name"],
             sampler["base_url"],
         )
     console.print(table)

--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -237,7 +237,7 @@ def _render_loops_deployments(deployments: List[Dict[str, Any]]) -> None:
     table.add_column("Base Model", style="green")
     table.add_column("Deployment Status")
     table.add_column("Deployment Base URL", style="blue")
-    table.add_column("Sampler ID", style="cyan")
+    table.add_column("Sampler Deployment ID", style="cyan")
     table.add_column("Sampler Status")
     table.add_column("Sampler Base URL", style="blue")
     for deployment in deployments:
@@ -247,7 +247,7 @@ def _render_loops_deployments(deployments: List[Dict[str, Any]]) -> None:
             deployment["base_model"],
             deployment["status"]["name"],
             deployment["base_url"],
-            sampler["id"],
+            sampler["deployment_id"],
             sampler["status"]["name"],
             sampler["base_url"],
         )

--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -131,13 +131,23 @@ def view_loops_deployments(remote: Optional[str], show_all: bool) -> None:
         BasetenRemote, RemoteFactory.create(remote=remote)
     )
     deployments = remote_provider.api.list_loops_deployments()
+    if not deployments:
+        console.print("No Loops deployments.", style="yellow")
+        return
     if not show_all:
         deployments = [
             d
             for d in deployments
             if d["status"]["name"] not in _TERMINAL_DEPLOYMENT_STATUSES
         ]
-    _render_loops_deployments(deployments, show_all=show_all)
+        if not deployments:
+            console.print(
+                "No active Loops deployments. Pass --all to include "
+                "STOPPED and FAILED deployments.",
+                style="yellow",
+            )
+            return
+    _render_loops_deployments(deployments)
 
 
 @loops.group(name="runs")
@@ -211,19 +221,7 @@ def view_loops_samplers(reverse: bool, remote: Optional[str]) -> None:
     _render_loops_samplers(samplers)
 
 
-def _render_loops_deployments(
-    deployments: List[Dict[str, Any]], show_all: bool = False
-) -> None:
-    if not deployments:
-        if show_all:
-            console.print("No Loops deployments.", style="yellow")
-        else:
-            console.print(
-                "No active Loops deployments. Pass --all to include "
-                "STOPPED and FAILED deployments.",
-                style="yellow",
-            )
-        return
+def _render_loops_deployments(deployments: List[Dict[str, Any]]) -> None:
     table = rich.table.Table(
         show_header=True,
         header_style="bold magenta",

--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -212,27 +212,14 @@ def _render_loops_deployments(deployments: List[Dict[str, Any]]) -> None:
     table.add_column("Base URL", style="blue")
     table.add_column("Deployment URL", style="blue")
     for deployment in deployments:
-        sampler = deployment.get("sampler") or {}
-        sampler_url = sampler.get("base_url", "") if isinstance(sampler, dict) else ""
-        sampler_status_obj = (
-            sampler.get("status") or {} if isinstance(sampler, dict) else {}
-        )
-        sampler_status = (
-            sampler_status_obj.get("name") or ""
-            if isinstance(sampler_status_obj, dict)
-            else ""
-        )
-        status_obj = deployment.get("status") or {}
-        status_name = (
-            status_obj.get("name") or "" if isinstance(status_obj, dict) else ""
-        )
+        sampler = deployment["sampler"]
         table.add_row(
-            deployment.get("id", ""),
-            deployment.get("base_model", "") or "",
-            status_name,
-            sampler_status,
-            deployment.get("base_url", ""),
-            sampler_url,
+            deployment["id"],
+            deployment["base_model"],
+            deployment["status"]["name"],
+            sampler["status"]["name"],
+            deployment["base_url"],
+            sampler["base_url"],
         )
     console.print(table)
 

--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -207,7 +207,7 @@ def _render_loops_deployments(deployments: List[Dict[str, Any]]) -> None:
     )
     table.add_column("Deployment ID", style="cyan")
     table.add_column("Base Model", style="green")
-    table.add_column("Trainer Status")
+    table.add_column("Run Status")
     table.add_column("Sampler Status")
     table.add_column("Base URL", style="blue")
     table.add_column("Deployment URL", style="blue")

--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -207,12 +207,21 @@ def _render_loops_deployments(deployments: List[Dict[str, Any]]) -> None:
     )
     table.add_column("Deployment ID", style="cyan")
     table.add_column("Base Model", style="green")
-    table.add_column("Status")
+    table.add_column("Trainer Status")
+    table.add_column("Sampler Status")
     table.add_column("Base URL", style="blue")
     table.add_column("Deployment URL", style="blue")
     for deployment in deployments:
         sampler = deployment.get("sampler") or {}
         sampler_url = sampler.get("base_url", "") if isinstance(sampler, dict) else ""
+        sampler_status_obj = (
+            sampler.get("status") or {} if isinstance(sampler, dict) else {}
+        )
+        sampler_status = (
+            sampler_status_obj.get("name") or ""
+            if isinstance(sampler_status_obj, dict)
+            else ""
+        )
         status_obj = deployment.get("status") or {}
         status_name = (
             status_obj.get("name") or "" if isinstance(status_obj, dict) else ""
@@ -221,6 +230,7 @@ def _render_loops_deployments(deployments: List[Dict[str, Any]]) -> None:
             deployment.get("id", ""),
             deployment.get("base_model", "") or "",
             status_name,
+            sampler_status,
             deployment.get("base_url", ""),
             sampler_url,
         )

--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -140,9 +140,9 @@ def view_loops_deployments(remote: Optional[str], show_all: bool) -> None:
         return
     if not show_all:
         deployments = [
-            d
-            for d in deployments
-            if d["status"]["name"] not in _TERMINAL_DEPLOYMENT_STATUSES
+            deployment
+            for deployment in deployments
+            if deployment["status"]["name"] not in _TERMINAL_DEPLOYMENT_STATUSES
         ]
         if not deployments:
             console.print(

--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -237,6 +237,7 @@ def _render_loops_deployments(deployments: List[Dict[str, Any]]) -> None:
     table.add_column("Base Model", style="green")
     table.add_column("Deployment Status")
     table.add_column("Deployment Base URL", style="blue")
+    table.add_column("Sampler ID", style="cyan")
     table.add_column("Sampler Status")
     table.add_column("Sampler Base URL", style="blue")
     for deployment in deployments:
@@ -246,6 +247,7 @@ def _render_loops_deployments(deployments: List[Dict[str, Any]]) -> None:
             deployment["base_model"],
             deployment["status"]["name"],
             deployment["base_url"],
+            sampler["id"],
             sampler["status"]["name"],
             sampler["base_url"],
         )

--- a/truss/tests/cli/test_loops_cli.py
+++ b/truss/tests/cli/test_loops_cli.py
@@ -201,10 +201,11 @@ def test_view_lists_active_deployments(mock_remote):
             "id": "dep_abc",
             "base_model": "Qwen/Qwen3-8B",
             "base_url": "https://trainer-abc.api.baseten.co/trainer",
-            "status": {"name": "active"},
+            "status": {"name": "RUNNING"},
             "sampler": {
                 "id": "sampler_def",
                 "base_url": "https://model-def.api.baseten.co/deployment/v1/sync",
+                "status": {"name": "ACTIVE"},
             },
         }
     ]
@@ -212,7 +213,8 @@ def test_view_lists_active_deployments(mock_remote):
     assert result.exit_code == 0, result.output
     assert "dep_abc" in result.output
     assert "Qwen/Qwen3-8B" in result.output
-    assert "active" in result.output
+    assert "RUNNING" in result.output
+    assert "ACTIVE" in result.output
     assert "model-def.api.baseten.co" in result.output
 
 
@@ -234,6 +236,38 @@ def test_view_deployment_without_status_shows_empty_string(mock_remote, status_f
     if status_field is not None:
         deployment["status"] = status_field
     mock_remote.api.list_loops_deployments.return_value = [deployment]
+    result = _invoke(["loops", "view", "--remote", "test_remote"], mock_remote)
+    assert result.exit_code == 0, result.output
+    assert "dep_abc" in result.output
+    assert "None" not in result.output
+
+
+@pytest.mark.parametrize(
+    "sampler_status_field",
+    [
+        None,  # status key absent on sampler
+        {},  # status present but empty dict
+        {"name": None},  # status present with explicit null name
+    ],
+)
+def test_view_deployment_without_sampler_status_shows_empty_string(
+    mock_remote, sampler_status_field
+):
+    sampler: dict = {
+        "id": "sampler_def",
+        "base_url": "https://model-def.api.baseten.co/deployment/v1/sync",
+    }
+    if sampler_status_field is not None:
+        sampler["status"] = sampler_status_field
+    mock_remote.api.list_loops_deployments.return_value = [
+        {
+            "id": "dep_abc",
+            "base_model": "Qwen/Qwen3-8B",
+            "base_url": "https://trainer-abc.api.baseten.co/trainer",
+            "status": {"name": "RUNNING"},
+            "sampler": sampler,
+        }
+    ]
     result = _invoke(["loops", "view", "--remote", "test_remote"], mock_remote)
     assert result.exit_code == 0, result.output
     assert "dep_abc" in result.output

--- a/truss/tests/cli/test_loops_cli.py
+++ b/truss/tests/cli/test_loops_cli.py
@@ -222,7 +222,9 @@ def test_view_with_no_deployments_prints_friendly_message(mock_remote):
     mock_remote.api.list_loops_deployments.return_value = []
     result = _invoke(["loops", "view", "--remote", "test_remote"], mock_remote)
     assert result.exit_code == 0, result.output
-    assert "No active Loops deployments" in result.output
+    assert "No Loops deployments" in result.output
+    # Truly empty: don't suggest --all since there's nothing to reveal.
+    assert "--all" not in result.output
 
 
 def _deployment(deployment_id: str, status_name: str) -> dict:

--- a/truss/tests/cli/test_loops_cli.py
+++ b/truss/tests/cli/test_loops_cli.py
@@ -218,62 +218,6 @@ def test_view_lists_active_deployments(mock_remote):
     assert "model-def.api.baseten.co" in result.output
 
 
-@pytest.mark.parametrize(
-    "status_field",
-    [
-        None,  # status key absent
-        {},  # status present but empty dict
-        {"name": None},  # status present with explicit null name
-    ],
-)
-def test_view_deployment_without_status_shows_empty_string(mock_remote, status_field):
-    deployment: dict = {
-        "id": "dep_abc",
-        "base_model": "Qwen/Qwen3-8B",
-        "base_url": "https://trainer-abc.api.baseten.co/trainer",
-        "sampler": {},
-    }
-    if status_field is not None:
-        deployment["status"] = status_field
-    mock_remote.api.list_loops_deployments.return_value = [deployment]
-    result = _invoke(["loops", "view", "--remote", "test_remote"], mock_remote)
-    assert result.exit_code == 0, result.output
-    assert "dep_abc" in result.output
-    assert "None" not in result.output
-
-
-@pytest.mark.parametrize(
-    "sampler_status_field",
-    [
-        None,  # status key absent on sampler
-        {},  # status present but empty dict
-        {"name": None},  # status present with explicit null name
-    ],
-)
-def test_view_deployment_without_sampler_status_shows_empty_string(
-    mock_remote, sampler_status_field
-):
-    sampler: dict = {
-        "id": "sampler_def",
-        "base_url": "https://model-def.api.baseten.co/deployment/v1/sync",
-    }
-    if sampler_status_field is not None:
-        sampler["status"] = sampler_status_field
-    mock_remote.api.list_loops_deployments.return_value = [
-        {
-            "id": "dep_abc",
-            "base_model": "Qwen/Qwen3-8B",
-            "base_url": "https://trainer-abc.api.baseten.co/trainer",
-            "status": {"name": "RUNNING"},
-            "sampler": sampler,
-        }
-    ]
-    result = _invoke(["loops", "view", "--remote", "test_remote"], mock_remote)
-    assert result.exit_code == 0, result.output
-    assert "dep_abc" in result.output
-    assert "None" not in result.output
-
-
 def test_view_with_no_deployments_prints_friendly_message(mock_remote):
     mock_remote.api.list_loops_deployments.return_value = []
     result = _invoke(["loops", "view", "--remote", "test_remote"], mock_remote)

--- a/truss/tests/cli/test_loops_cli.py
+++ b/truss/tests/cli/test_loops_cli.py
@@ -204,6 +204,7 @@ def test_view_lists_active_deployments(mock_remote):
             "status": {"name": "RUNNING"},
             "sampler": {
                 "id": "sampler_def",
+                "deployment_id": "ov_def123",
                 "base_url": "https://model-def.api.baseten.co/deployment/v1/sync",
                 "status": {"name": "ACTIVE"},
             },
@@ -215,7 +216,7 @@ def test_view_lists_active_deployments(mock_remote):
     assert "Qwen/Qwen3-8B" in result.output
     assert "RUNNING" in result.output
     assert "ACTIVE" in result.output
-    assert "sampler_def" in result.output
+    assert "ov_def123" in result.output
     assert "model-def.api.baseten.co" in result.output
 
 
@@ -236,6 +237,7 @@ def _deployment(deployment_id: str, status_name: str) -> dict:
         "status": {"name": status_name},
         "sampler": {
             "id": f"sampler_{deployment_id}",
+            "deployment_id": f"ov_{deployment_id}",
             "base_url": f"https://model-{deployment_id}.api.baseten.co/deployment/v1/sync",
             "status": {"name": "ACTIVE"},
         },

--- a/truss/tests/cli/test_loops_cli.py
+++ b/truss/tests/cli/test_loops_cli.py
@@ -225,6 +225,67 @@ def test_view_with_no_deployments_prints_friendly_message(mock_remote):
     assert "No active Loops deployments" in result.output
 
 
+def _deployment(deployment_id: str, status_name: str) -> dict:
+    return {
+        "id": deployment_id,
+        "base_model": "Qwen/Qwen3-8B",
+        "base_url": f"https://trainer-{deployment_id}.api.baseten.co/trainer",
+        "status": {"name": status_name},
+        "sampler": {
+            "id": f"sampler_{deployment_id}",
+            "base_url": f"https://model-{deployment_id}.api.baseten.co/deployment/v1/sync",
+            "status": {"name": "ACTIVE"},
+        },
+    }
+
+
+def test_view_filters_stopped_and_failed_by_default(mock_remote):
+    mock_remote.api.list_loops_deployments.return_value = [
+        _deployment("dep_running", "RUNNING"),
+        _deployment("dep_stopped", "STOPPED"),
+        _deployment("dep_failed", "FAILED"),
+        _deployment("dep_deploying", "DEPLOYING"),
+    ]
+    result = _invoke(["loops", "view", "--remote", "test_remote"], mock_remote)
+    assert result.exit_code == 0, result.output
+    assert "dep_running" in result.output
+    assert "dep_deploying" in result.output
+    assert "dep_stopped" not in result.output
+    assert "dep_failed" not in result.output
+
+
+def test_view_all_flag_includes_terminal_states(mock_remote):
+    mock_remote.api.list_loops_deployments.return_value = [
+        _deployment("dep_running", "RUNNING"),
+        _deployment("dep_stopped", "STOPPED"),
+        _deployment("dep_failed", "FAILED"),
+    ]
+    result = _invoke(["loops", "view", "--all", "--remote", "test_remote"], mock_remote)
+    assert result.exit_code == 0, result.output
+    assert "dep_running" in result.output
+    assert "dep_stopped" in result.output
+    assert "dep_failed" in result.output
+
+
+def test_view_empty_after_filter_hints_at_all_flag(mock_remote):
+    mock_remote.api.list_loops_deployments.return_value = [
+        _deployment("dep_stopped", "STOPPED"),
+        _deployment("dep_failed", "FAILED"),
+    ]
+    result = _invoke(["loops", "view", "--remote", "test_remote"], mock_remote)
+    assert result.exit_code == 0, result.output
+    assert "No active Loops deployments" in result.output
+    assert "--all" in result.output
+
+
+def test_view_all_flag_with_no_deployments(mock_remote):
+    mock_remote.api.list_loops_deployments.return_value = []
+    result = _invoke(["loops", "view", "--all", "--remote", "test_remote"], mock_remote)
+    assert result.exit_code == 0, result.output
+    assert "No Loops deployments" in result.output
+    assert "--all" not in result.output
+
+
 def test_runs_view_no_filters_calls_search_with_none(mock_remote):
     mock_remote.api.list_loops_runs.return_value = [
         {"id": "trnr_xyz", "session_id": "sess_abc", "base_model": "Qwen/Qwen3-8B"}

--- a/truss/tests/cli/test_loops_cli.py
+++ b/truss/tests/cli/test_loops_cli.py
@@ -215,6 +215,7 @@ def test_view_lists_active_deployments(mock_remote):
     assert "Qwen/Qwen3-8B" in result.output
     assert "RUNNING" in result.output
     assert "ACTIVE" in result.output
+    assert "sampler_def" in result.output
     assert "model-def.api.baseten.co" in result.output
 
 


### PR DESCRIPTION
## Summary
- Adds `Sampler Status` and `Sampler Base URL` columns to `truss loops view`, populated from `sampler.status.name` and `sampler.base_url`. Without this, the table only reflected the deployment/run side, so a deployment could show as up while the sampler underneath was still building, unhealthy, or otherwise not serving.
- Reorganizes/renames columns so each one is explicitly scoped: `Deployment Status` / `Deployment Base URL` next to `Sampler Status` / `Sampler Base URL`.
- Filters out terminal-state deployments (`STOPPED`, `FAILED`) by default and adds `--all` to surface them when needed (e.g. debugging a failed run). The corresponding server change widens the list endpoint to return every deployment regardless of status, so the filter lives in the CLI.
- Simplifies the renderer to trust the schema — `status.name` is required on both deployment and sampler, so the previous defensive `or ""` / isinstance fallbacks were exercising states that can't appear on the wire.

## Merge order
Requires the corresponding server change (which adds `sampler.status` and stops server-side filtering) to be deployed first. The renderer indexes `sampler.status.name` directly and the client-side filter assumes the server returns all statuses.

## Test plan
- [x] `uv run pytest truss/tests/cli/test_loops_cli.py -v` (41 passed)
- [x] `uv run ruff check` / `uv run ruff format` clean
- [ ] Manual: run `truss loops view` and confirm only non-terminal deployments are shown, with sampler status populated; `truss loops view --all` includes STOPPED/FAILED rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)