### PR TITLE
feat(cli): Egress restrictions in truss runtime config

### DIFF
--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -655,8 +655,8 @@ def _validate_cidr(value: str) -> str:
 class EgressRestrictions(custom_types.ConfigModel):
     """Egress network restrictions for a model version.
 
-    Enterprise-only. Setting both ``ip_allow_list`` and ``fqdn_allow_list`` to
-    ``null`` or ``[]`` blocks all outbound network egress. Omitting the
+    Setting both ``ip_allow_list`` and ``fqdn_allow_list`` to ``null`` or
+    ``[]`` blocks all outbound network egress. Omitting the
     ``egress_restrictions`` block (or setting it to ``null``) preserves the
     default behavior of allowing all egress.
     """
@@ -731,8 +731,7 @@ class Runtime(custom_types.ConfigModel):
         default=None,
         description=(
             "Egress network restrictions for the model version. When unset, "
-            "all egress is allowed (default). Enterprise-only; enforced "
-            "server-side."
+            "all egress is allowed (default)."
         ),
     )
     truss_server_version_override: Optional[str] = pydantic.Field(

--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -625,22 +625,14 @@ class RemoteSSH(custom_types.ConfigModel):
     )
 
 
-_FQDN_LABEL_REGEX = re.compile(r"^(?!-)[A-Za-z0-9-]{1,63}(?<!-)$")
+_FQDN_PATTERN = re.compile(r"^([a-zA-Z0-9*]([-a-zA-Z0-9_*]*[a-zA-Z0-9*])*\.?)*$")
 
 
 def _validate_fqdn(value: str) -> str:
     if not value:
         raise ValueError("FQDN entries cannot be empty.")
-    if len(value) > 253:
-        raise ValueError(f"FQDN '{value}' exceeds 253 characters.")
-    labels = value.split(".")
-    if len(labels) < 2:
-        raise ValueError(f"FQDN '{value}' must contain at least two labels.")
-    for index, label in enumerate(labels):
-        if index == 0 and label == "*":
-            continue
-        if not _FQDN_LABEL_REGEX.match(label):
-            raise ValueError(f"Invalid FQDN '{value}': label '{label}' is malformed.")
+    if not _FQDN_PATTERN.match(value):
+        raise ValueError(f"Invalid FQDN '{value}'.")
     return value
 
 
@@ -672,8 +664,8 @@ class EgressRestrictions(custom_types.ConfigModel):
     fqdn_allow_list: Optional[list[str]] = pydantic.Field(
         default=None,
         description=(
-            "Allowed outbound fully-qualified domain names. A leading '*.' "
-            "wildcard matches any single subdomain label."
+            "Allowed outbound fully-qualified domain names. Supports "
+            "wildcards: '*' may appear anywhere in a label."
         ),
         examples=[["*.baseten.co", "huggingface.co"]],
     )

--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -1,4 +1,5 @@
 import enum
+import ipaddress
 import logging
 import math
 import os
@@ -624,6 +625,74 @@ class RemoteSSH(custom_types.ConfigModel):
     )
 
 
+_FQDN_LABEL_REGEX = re.compile(r"^(?!-)[A-Za-z0-9-]{1,63}(?<!-)$")
+
+
+def _validate_fqdn(value: str) -> str:
+    if not value:
+        raise ValueError("FQDN entries cannot be empty.")
+    if len(value) > 253:
+        raise ValueError(f"FQDN '{value}' exceeds 253 characters.")
+    labels = value.split(".")
+    if len(labels) < 2:
+        raise ValueError(f"FQDN '{value}' must contain at least two labels.")
+    for index, label in enumerate(labels):
+        if index == 0 and label == "*":
+            continue
+        if not _FQDN_LABEL_REGEX.match(label):
+            raise ValueError(f"Invalid FQDN '{value}': label '{label}' is malformed.")
+    return value
+
+
+def _validate_cidr(value: str) -> str:
+    try:
+        ipaddress.ip_network(value, strict=True)
+    except ValueError as e:
+        raise ValueError(f"Invalid IP CIDR '{value}': {e}") from e
+    return value
+
+
+class EgressRestrictions(custom_types.ConfigModel):
+    """Egress network restrictions for a model version.
+
+    Enterprise-only. Setting both ``ip_allow_list`` and ``fqdn_allow_list`` to
+    ``null`` or ``[]`` blocks all outbound network egress. Omitting the
+    ``egress_restrictions`` block (or setting it to ``null``) preserves the
+    default behavior of allowing all egress.
+    """
+
+    ip_allow_list: Optional[list[str]] = pydantic.Field(
+        default=None,
+        description=(
+            "Allowed outbound IP CIDR ranges. Use null or [] alongside an "
+            "equally restrictive fqdn_allow_list to block all egress."
+        ),
+        examples=[["1.1.1.1/32", "8.8.8.8/32"]],
+    )
+    fqdn_allow_list: Optional[list[str]] = pydantic.Field(
+        default=None,
+        description=(
+            "Allowed outbound fully-qualified domain names. A leading '*.' "
+            "wildcard matches any single subdomain label."
+        ),
+        examples=[["*.baseten.co", "huggingface.co"]],
+    )
+
+    @pydantic.field_validator("ip_allow_list")
+    @classmethod
+    def _validate_ip_allow_list(cls, v: Optional[list[str]]) -> Optional[list[str]]:
+        if v is None:
+            return v
+        return [_validate_cidr(entry) for entry in v]
+
+    @pydantic.field_validator("fqdn_allow_list")
+    @classmethod
+    def _validate_fqdn_allow_list(cls, v: Optional[list[str]]) -> Optional[list[str]]:
+        if v is None:
+            return v
+        return [_validate_fqdn(entry) for entry in v]
+
+
 class Runtime(custom_types.ConfigModel):
     """Runtime settings for your model instance."""
 
@@ -657,6 +726,14 @@ class Runtime(custom_types.ConfigModel):
     remote_ssh: RemoteSSH = pydantic.Field(
         default_factory=RemoteSSH,
         description="Configuration for SSH access to running model instances.",
+    )
+    egress_restrictions: Optional[EgressRestrictions] = pydantic.Field(
+        default=None,
+        description=(
+            "Egress network restrictions for the model version. When unset, "
+            "all egress is allowed (default). Enterprise-only; enforced "
+            "server-side."
+        ),
     )
     truss_server_version_override: Optional[str] = pydantic.Field(
         None,

--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -625,7 +625,10 @@ class RemoteSSH(custom_types.ConfigModel):
     )
 
 
-_FQDN_PATTERN = re.compile(r"^([a-zA-Z0-9*]([-a-zA-Z0-9_*]*[a-zA-Z0-9*])*\.?)*$")
+_FQDN_PATTERN = re.compile(
+    r"^(?:[a-zA-Z0-9*](?:[a-zA-Z0-9*-]{0,61}[a-zA-Z0-9*])?)"
+    r"(?:\.(?:[a-zA-Z0-9*](?:[a-zA-Z0-9*-]{0,61}[a-zA-Z0-9*])?))*$"
+)
 
 
 def _validate_fqdn(value: str) -> str:
@@ -636,11 +639,15 @@ def _validate_fqdn(value: str) -> str:
     return value
 
 
-def _validate_cidr(value: str) -> str:
+def _validate_ip_or_cidr(value: str) -> str:
+    # Bare IP addresses (e.g. "1.2.3.4") are normalized to a /32 CIDR range
+    # at deploy time.
     try:
-        ipaddress.ip_network(value, strict=True)
+        network = ipaddress.ip_network(value, strict=False)
     except ValueError as e:
-        raise ValueError(f"Invalid IP CIDR '{value}': {e}") from e
+        raise ValueError(f"Invalid IP or CIDR '{value}': {e}") from e
+    if network.version != 4:
+        raise ValueError(f"Invalid IP or CIDR '{value}': IPv6 is not supported.")
     return value
 
 
@@ -656,10 +663,11 @@ class EgressRestrictions(custom_types.ConfigModel):
     ip_allow_list: Optional[list[str]] = pydantic.Field(
         default=None,
         description=(
-            "Allowed outbound IP CIDR ranges. Use null or [] alongside an "
-            "equally restrictive fqdn_allow_list to block all egress."
+            "Allowed outbound IPv4 addresses or CIDR ranges. Use null or [] "
+            "alongside an equally restrictive fqdn_allow_list to block all "
+            "egress."
         ),
-        examples=[["1.1.1.1/32", "8.8.8.8/32"]],
+        examples=[["1.1.1.1", "8.8.8.8/32"]],
     )
     fqdn_allow_list: Optional[list[str]] = pydantic.Field(
         default=None,
@@ -675,7 +683,7 @@ class EgressRestrictions(custom_types.ConfigModel):
     def _validate_ip_allow_list(cls, v: Optional[list[str]]) -> Optional[list[str]]:
         if v is None:
             return v
-        return [_validate_cidr(entry) for entry in v]
+        return [_validate_ip_or_cidr(entry) for entry in v]
 
     @pydantic.field_validator("fqdn_allow_list")
     @classmethod

--- a/truss/config.schema.json
+++ b/truss/config.schema.json
@@ -443,10 +443,10 @@
             }
           ],
           "default": null,
-          "description": "Allowed outbound IP CIDR ranges. Use null or [] alongside an equally restrictive fqdn_allow_list to block all egress.",
+          "description": "Allowed outbound IPv4 addresses or CIDR ranges. Use null or [] alongside an equally restrictive fqdn_allow_list to block all egress.",
           "examples": [
             [
-              "1.1.1.1/32",
+              "1.1.1.1",
               "8.8.8.8/32"
             ]
           ],

--- a/truss/config.schema.json
+++ b/truss/config.schema.json
@@ -426,6 +426,58 @@
       "title": "DockerServer",
       "type": "object"
     },
+    "EgressRestrictions": {
+      "additionalProperties": true,
+      "description": "Egress network restrictions for a model version.\n\nSetting both ``ip_allow_list`` and ``fqdn_allow_list`` to ``null`` or\n``[]`` blocks all outbound network egress. Omitting the\n``egress_restrictions`` block (or setting it to ``null``) preserves the\ndefault behavior of allowing all egress.",
+      "properties": {
+        "ip_allow_list": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Allowed outbound IP CIDR ranges. Use null or [] alongside an equally restrictive fqdn_allow_list to block all egress.",
+          "examples": [
+            [
+              "1.1.1.1/32",
+              "8.8.8.8/32"
+            ]
+          ],
+          "title": "Ip Allow List"
+        },
+        "fqdn_allow_list": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Allowed outbound fully-qualified domain names. A leading '*.' wildcard matches any single subdomain label.",
+          "examples": [
+            [
+              "*.baseten.co",
+              "huggingface.co"
+            ]
+          ],
+          "title": "Fqdn Allow List"
+        }
+      },
+      "title": "EgressRestrictions",
+      "type": "object"
+    },
     "ExternalData": {
       "description": "[Experimental] External data is data that is not contained in the Truss folder.\n\nTypically, this will be data stored remotely. This data is guaranteed to be made\navailable under the data directory of the truss.",
       "items": {
@@ -893,6 +945,18 @@
         },
         "remote_ssh": {
           "$ref": "#/$defs/RemoteSSH"
+        },
+        "egress_restrictions": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EgressRestrictions"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Egress network restrictions for the model version. When unset, all egress is allowed (default)."
         },
         "truss_server_version_override": {
           "anyOf": [

--- a/truss/config.schema.json
+++ b/truss/config.schema.json
@@ -465,7 +465,7 @@
             }
           ],
           "default": null,
-          "description": "Allowed outbound fully-qualified domain names. A leading '*.' wildcard matches any single subdomain label.",
+          "description": "Allowed outbound fully-qualified domain names. Supports wildcards: '*' may appear anywhere in a label.",
           "examples": [
             [
               "*.baseten.co",

--- a/truss/tests/test_config.py
+++ b/truss/tests/test_config.py
@@ -21,6 +21,7 @@ from truss.base.truss_config import (
     DockerAuthSettings,
     DockerAuthType,
     DockerServer,
+    EgressRestrictions,
     HTTPOptions,
     ModelCache,
     ModelRepo,
@@ -1841,3 +1842,147 @@ class TestCheckpointListNoMixing:
         ckpt_list = CheckpointList()
         assert ckpt_list.artifact_references == []
         assert ckpt_list.loops_checkpoint_ids == []
+
+
+class TestEgressRestrictions:
+    """Egress allow lists under runtime.egress_restrictions."""
+
+    def test_default_is_none(self):
+        config = TrussConfig()
+        assert config.runtime.egress_restrictions is None
+
+    def test_allow_lists_with_ips_and_fqdns(self, tmp_path):
+        yaml_content = """
+        runtime:
+          egress_restrictions:
+            ip_allow_list:
+              - 1.1.1.1/32
+              - 8.8.8.8/32
+            fqdn_allow_list:
+              - "*.baseten.co"
+              - huggingface.co
+        """
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(yaml_content)
+
+        config = TrussConfig.from_yaml(config_path)
+        restrictions = config.runtime.egress_restrictions
+        assert restrictions is not None
+        assert restrictions.ip_allow_list == ["1.1.1.1/32", "8.8.8.8/32"]
+        assert restrictions.fqdn_allow_list == ["*.baseten.co", "huggingface.co"]
+
+    def test_null_allow_lists_block_all_egress(self, tmp_path):
+        yaml_content = """
+        runtime:
+          egress_restrictions:
+            ip_allow_list: null
+            fqdn_allow_list: null
+        """
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(yaml_content)
+
+        config = TrussConfig.from_yaml(config_path)
+        restrictions = config.runtime.egress_restrictions
+        assert restrictions is not None
+        assert restrictions.ip_allow_list is None
+        assert restrictions.fqdn_allow_list is None
+
+    def test_empty_lists_block_all_egress(self):
+        restrictions = EgressRestrictions(ip_allow_list=[], fqdn_allow_list=[])
+        assert restrictions.ip_allow_list == []
+        assert restrictions.fqdn_allow_list == []
+
+    def test_egress_restrictions_null_means_allow_all(self, tmp_path):
+        yaml_content = """
+        runtime:
+          egress_restrictions: null
+        """
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(yaml_content)
+
+        config = TrussConfig.from_yaml(config_path)
+        assert config.runtime.egress_restrictions is None
+
+    def test_omitted_means_allow_all(self, tmp_path):
+        yaml_content = """
+        runtime:
+          predict_concurrency: 2
+        """
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(yaml_content)
+
+        config = TrussConfig.from_yaml(config_path)
+        assert config.runtime.egress_restrictions is None
+
+    def test_invalid_cidr_raises(self):
+        with pytest.raises(pydantic.ValidationError, match="Invalid IP CIDR"):
+            EgressRestrictions(ip_allow_list=["not-an-ip"])
+
+    def test_cidr_with_host_bits_rejected(self):
+        with pytest.raises(pydantic.ValidationError, match="Invalid IP CIDR"):
+            EgressRestrictions(ip_allow_list=["10.0.0.5/24"])
+
+    def test_ipv6_cidr_accepted(self):
+        restrictions = EgressRestrictions(ip_allow_list=["2001:db8::/32"])
+        assert restrictions.ip_allow_list == ["2001:db8::/32"]
+
+    def test_invalid_fqdn_raises(self):
+        with pytest.raises(pydantic.ValidationError, match="Invalid FQDN"):
+            EgressRestrictions(fqdn_allow_list=["bad_label.com"])
+
+    def test_single_label_fqdn_rejected(self):
+        with pytest.raises(pydantic.ValidationError, match="at least two labels"):
+            EgressRestrictions(fqdn_allow_list=["localhost"])
+
+    def test_wildcard_only_in_leading_position(self):
+        EgressRestrictions(fqdn_allow_list=["*.baseten.co"])
+        with pytest.raises(pydantic.ValidationError, match="Invalid FQDN"):
+            EgressRestrictions(fqdn_allow_list=["foo.*.baseten.co"])
+
+    def test_serialization_roundtrip(self, tmp_path):
+        config = TrussConfig()
+        config.runtime.egress_restrictions = EgressRestrictions(
+            ip_allow_list=["1.1.1.1/32"], fqdn_allow_list=["huggingface.co"]
+        )
+
+        out_path = tmp_path / "out.yaml"
+        config.write_to_yaml_file(out_path, verbose=False)
+
+        dumped = yaml.safe_load(out_path.read_text())
+        assert dumped["runtime"]["egress_restrictions"]["ip_allow_list"] == [
+            "1.1.1.1/32"
+        ]
+        assert dumped["runtime"]["egress_restrictions"]["fqdn_allow_list"] == [
+            "huggingface.co"
+        ]
+
+        config_new = TrussConfig.from_yaml(out_path)
+        assert config_new.runtime.egress_restrictions is not None
+        assert config_new.runtime.egress_restrictions.ip_allow_list == ["1.1.1.1/32"]
+        assert config_new.runtime.egress_restrictions.fqdn_allow_list == [
+            "huggingface.co"
+        ]
+
+    def test_block_all_serialization_roundtrip(self, tmp_path):
+        config = TrussConfig()
+        config.runtime.egress_restrictions = EgressRestrictions(
+            ip_allow_list=None, fqdn_allow_list=None
+        )
+
+        out_path = tmp_path / "out.yaml"
+        config.write_to_yaml_file(out_path, verbose=True)
+
+        config_new = TrussConfig.from_yaml(out_path)
+        assert config_new.runtime.egress_restrictions is not None
+        assert config_new.runtime.egress_restrictions.ip_allow_list is None
+        assert config_new.runtime.egress_restrictions.fqdn_allow_list is None
+
+    def test_assignment_validation(self):
+        config = TrussConfig()
+        config.runtime.egress_restrictions = EgressRestrictions(
+            ip_allow_list=["1.1.1.1/32"]
+        )
+        with pytest.raises(pydantic.ValidationError, match="Invalid IP CIDR"):
+            config.runtime.egress_restrictions = EgressRestrictions(
+                ip_allow_list=["999.999.999.999/32"]
+            )

--- a/truss/tests/test_config.py
+++ b/truss/tests/test_config.py
@@ -1928,16 +1928,23 @@ class TestEgressRestrictions:
 
     def test_invalid_fqdn_raises(self):
         with pytest.raises(pydantic.ValidationError, match="Invalid FQDN"):
-            EgressRestrictions(fqdn_allow_list=["bad_label.com"])
-
-    def test_single_label_fqdn_rejected(self):
-        with pytest.raises(pydantic.ValidationError, match="at least two labels"):
-            EgressRestrictions(fqdn_allow_list=["localhost"])
-
-    def test_wildcard_only_in_leading_position(self):
-        EgressRestrictions(fqdn_allow_list=["*.baseten.co"])
+            EgressRestrictions(fqdn_allow_list=["-bad.com"])
         with pytest.raises(pydantic.ValidationError, match="Invalid FQDN"):
-            EgressRestrictions(fqdn_allow_list=["foo.*.baseten.co"])
+            EgressRestrictions(fqdn_allow_list=["bad-.com"])
+        with pytest.raises(pydantic.ValidationError, match="cannot be empty"):
+            EgressRestrictions(fqdn_allow_list=[""])
+
+    def test_wildcards(self):
+        EgressRestrictions(fqdn_allow_list=["*.baseten.co"])
+        EgressRestrictions(fqdn_allow_list=["foo.*.baseten.co"])
+        EgressRestrictions(fqdn_allow_list=["*"])
+        EgressRestrictions(fqdn_allow_list=["sub*domain.example.com"])
+
+    def test_underscores_allowed(self):
+        EgressRestrictions(fqdn_allow_list=["bad_label.com"])
+
+    def test_single_label_accepted(self):
+        EgressRestrictions(fqdn_allow_list=["localhost"])
 
     def test_serialization_roundtrip(self, tmp_path):
         config = TrussConfig()

--- a/truss/tests/test_config.py
+++ b/truss/tests/test_config.py
@@ -1915,16 +1915,20 @@ class TestEgressRestrictions:
         assert config.runtime.egress_restrictions is None
 
     def test_invalid_cidr_raises(self):
-        with pytest.raises(pydantic.ValidationError, match="Invalid IP CIDR"):
+        with pytest.raises(pydantic.ValidationError, match="Invalid IP or CIDR"):
             EgressRestrictions(ip_allow_list=["not-an-ip"])
 
-    def test_cidr_with_host_bits_rejected(self):
-        with pytest.raises(pydantic.ValidationError, match="Invalid IP CIDR"):
-            EgressRestrictions(ip_allow_list=["10.0.0.5/24"])
+    def test_bare_ip_accepted(self):
+        restrictions = EgressRestrictions(ip_allow_list=["1.2.3.4"])
+        assert restrictions.ip_allow_list == ["1.2.3.4"]
 
-    def test_ipv6_cidr_accepted(self):
-        restrictions = EgressRestrictions(ip_allow_list=["2001:db8::/32"])
-        assert restrictions.ip_allow_list == ["2001:db8::/32"]
+    def test_cidr_with_host_bits_accepted(self):
+        restrictions = EgressRestrictions(ip_allow_list=["10.0.0.5/24"])
+        assert restrictions.ip_allow_list == ["10.0.0.5/24"]
+
+    def test_ipv6_rejected(self):
+        with pytest.raises(pydantic.ValidationError, match="IPv6 is not supported"):
+            EgressRestrictions(ip_allow_list=["2001:db8::/32"])
 
     def test_invalid_fqdn_raises(self):
         with pytest.raises(pydantic.ValidationError, match="Invalid FQDN"):
@@ -1940,8 +1944,17 @@ class TestEgressRestrictions:
         EgressRestrictions(fqdn_allow_list=["*"])
         EgressRestrictions(fqdn_allow_list=["sub*domain.example.com"])
 
-    def test_underscores_allowed(self):
-        EgressRestrictions(fqdn_allow_list=["bad_label.com"])
+    def test_underscores_rejected(self):
+        with pytest.raises(pydantic.ValidationError, match="Invalid FQDN"):
+            EgressRestrictions(fqdn_allow_list=["bad_label.com"])
+
+    def test_trailing_dot_rejected(self):
+        with pytest.raises(pydantic.ValidationError, match="Invalid FQDN"):
+            EgressRestrictions(fqdn_allow_list=["example.com."])
+
+    def test_label_too_long_rejected(self):
+        with pytest.raises(pydantic.ValidationError, match="Invalid FQDN"):
+            EgressRestrictions(fqdn_allow_list=["a" * 64 + ".com"])
 
     def test_single_label_accepted(self):
         EgressRestrictions(fqdn_allow_list=["localhost"])
@@ -1989,7 +2002,7 @@ class TestEgressRestrictions:
         config.runtime.egress_restrictions = EgressRestrictions(
             ip_allow_list=["1.1.1.1/32"]
         )
-        with pytest.raises(pydantic.ValidationError, match="Invalid IP CIDR"):
+        with pytest.raises(pydantic.ValidationError, match="Invalid IP or CIDR"):
             config.runtime.egress_restrictions = EgressRestrictions(
                 ip_allow_list=["999.999.999.999/32"]
             )


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What

Supporting egress restrictions in truss runtime config for model version scoped egress restrictions.

Example:
```yaml
```yaml
model_name: my-llm
description: A text generation model.
requirements:
  - torch
  - transformers
  - accelerate
resources:
  cpu: "4"
  memory: 16Gi
  accelerator: L4
runtime:
	egress_restrictions:
	  ip_allow_list:
	    - 1.1.1.1/32
	    - 8.8.8.8/32
	  fqdn_allow_list:
	    - *.baseten.co
	    - huggingface.co
```

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
- UTs
- Local push