### PR TITLE
Fix path traversal in download_external_data containment guard

### DIFF
--- a/truss/util/download.py
+++ b/truss/util/download.py
@@ -20,9 +20,11 @@ def download_external_data(external_data: Optional[ExternalData], data_dir: Path
     b10cp_path = _b10cp_path()
 
     # ensure parent directories exist
+    data_dir_resolved = data_dir.resolve()
     for item in external_data.items:
-        path = data_dir / item.local_data_path
-        if data_dir not in path.parents:
+        # resolve before the containment check so ".." cannot escape data_dir
+        path = (data_dir / item.local_data_path).resolve()
+        if path != data_dir_resolved and data_dir_resolved not in path.parents:
             raise ValueError(
                 "Local data path of external data cannot point to outside data directory"
             )


### PR DESCRIPTION
### Problem (path traversal)

`download_external_data` validates each external-data item before downloading:

```python
path = data_dir / item.local_data_path
if data_dir not in path.parents:
    raise ValueError("Local data path of external data cannot point to outside data directory")
```

`pathlib` does **not** normalize `..`, so for `local_data_path = "../evil.bin"`:

- `path = data_dir / "../evil.bin"` → `Path("/data/../evil.bin")`
- `path.parents` still contains `data_dir` (`/data`), so the guard **passes**.

But the actual download paths resolve first — `_download_external_data_using_b10cp` and `_download_external_data_using_requests` both compute `(data_dir / item.local_data_path).resolve()` — which for `../evil.bin` is `/evil.bin`, **outside** `data_dir`. So a malicious/compromised model config can write arbitrary files outside the data directory.

### Repro (CPU)

| local_data_path | guard passes? | actually writes to | escapes dir? |
|---|---|---|---|
| `model.bin` | yes | `/data/model.bin` | no |
| `../evil.bin` | **yes** | `/evil.bin` | **yes** |
| `../../etc/passwd` | **yes** | `/private/etc/passwd` | **yes** |

### Fix

Resolve the path *before* the containment check and compare against the resolved `data_dir`:

```python
data_dir_resolved = data_dir.resolve()
path = (data_dir / item.local_data_path).resolve()
if path != data_dir_resolved and data_dir_resolved not in path.parents:
    raise ValueError(...)
```

After the fix, `../evil.bin` and `../../etc/passwd` are correctly rejected while `model.bin`, `a/b/model.bin`, `./x.bin` still pass. `ruff check` / `ruff format` clean.
