### PR TITLE
feat(loops/cli): json output for `truss loops view`

### DIFF
--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -147,19 +147,19 @@ def view_loops_deployments(
         BasetenRemote, RemoteFactory.create(remote=remote)
     )
     deployments = remote_provider.api.list_loops_deployments()
-    if not deployments:
-        if output_format == checkpoint_mod.OUTPUT_FORMAT_JSON:
-            _render_loops_deployments_json([])
-            return
+    is_human_output = output_format == checkpoint_mod.OUTPUT_FORMAT_CLI_TABLE
+
+    if not deployments and is_human_output:
         console.print("No Loops deployments.", style="yellow")
         return
+
     if not show_all:
         deployments = [
             deployment
             for deployment in deployments
             if deployment["status"]["name"] not in _TERMINAL_DEPLOYMENT_STATUSES
         ]
-        if not deployments and output_format == checkpoint_mod.OUTPUT_FORMAT_CLI_TABLE:
+        if not deployments and is_human_output:
             console.print(
                 "No active Loops deployments. Pass --all to include "
                 "STOPPED and FAILED deployments.",

--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -159,19 +159,18 @@ def view_loops_deployments(
             for deployment in deployments
             if deployment["status"]["name"] not in _TERMINAL_DEPLOYMENT_STATUSES
         ]
-        if not deployments:
-            if output_format == checkpoint_mod.OUTPUT_FORMAT_JSON:
-                _render_loops_deployments_json([])
-                return
+        if not deployments and output_format == checkpoint_mod.OUTPUT_FORMAT_CLI_TABLE:
             console.print(
                 "No active Loops deployments. Pass --all to include "
                 "STOPPED and FAILED deployments.",
                 style="yellow",
             )
             return
+
     if output_format == checkpoint_mod.OUTPUT_FORMAT_JSON:
         _render_loops_deployments_json(deployments)
         return
+
     _render_loops_deployments(deployments)
 
 
@@ -276,24 +275,23 @@ def _render_loops_deployments(deployments: List[Dict[str, Any]]) -> None:
 
 
 def _render_loops_deployments_json(deployments: List[Dict[str, Any]]) -> None:
-    deployments_data = []
+    """
+    Print the deployments as jsonl. Closely follows the columns in the default format.
+    """
     for deployment in deployments:
         sampler = deployment["sampler"]
-        deployments_data.append(
-            {
-                "id": deployment["id"],
-                "base_model": deployment["base_model"],
-                "base_url": deployment["base_url"],
-                "status": deployment["status"]["name"],
-                "sampler": {
-                    "deployment_id": sampler["deployment_id"],
-                    "base_url": sampler["base_url"],
-                    "status": sampler["status"]["name"],
-                },
-            }
-        )
-    output = {"total_deployments": len(deployments), "deployments": deployments_data}
-    print(json.dumps(output, indent=2))
+        output = {
+            "id": deployment["id"],
+            "base_model": deployment["base_model"],
+            "base_url": deployment["base_url"],
+            "status": deployment["status"]["name"],
+            "sampler": {
+                "deployment_id": sampler["deployment_id"],
+                "base_url": sampler["base_url"],
+                "status": sampler["status"]["name"],
+            },
+        }
+        print(json.dumps(output))
 
 
 def _render_loops_runs(runs: List[Dict[str, Any]]) -> None:

--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any, Dict, List, Optional, cast
 
 import rich.table
@@ -121,8 +122,19 @@ _TERMINAL_DEPLOYMENT_STATUSES = frozenset({"STOPPED", "FAILED"})
     default=False,
     help="Include deployments in terminal states (STOPPED, FAILED).",
 )
+@click.option(
+    "-o",
+    "--output-format",
+    type=click.Choice(
+        [checkpoint_mod.OUTPUT_FORMAT_CLI_TABLE, checkpoint_mod.OUTPUT_FORMAT_JSON]
+    ),
+    default=checkpoint_mod.OUTPUT_FORMAT_CLI_TABLE,
+    help="Output format: cli-table (default) or json.",
+)
 @common.common_options()
-def view_loops_deployments(remote: Optional[str], show_all: bool) -> None:
+def view_loops_deployments(
+    remote: Optional[str], show_all: bool, output_format: str
+) -> None:
     """List the caller's Loops deployments.
 
     By default, deployments in terminal states (STOPPED, FAILED) are hidden.
@@ -136,6 +148,9 @@ def view_loops_deployments(remote: Optional[str], show_all: bool) -> None:
     )
     deployments = remote_provider.api.list_loops_deployments()
     if not deployments:
+        if output_format == checkpoint_mod.OUTPUT_FORMAT_JSON:
+            _render_loops_deployments_json([])
+            return
         console.print("No Loops deployments.", style="yellow")
         return
     if not show_all:
@@ -145,12 +160,18 @@ def view_loops_deployments(remote: Optional[str], show_all: bool) -> None:
             if deployment["status"]["name"] not in _TERMINAL_DEPLOYMENT_STATUSES
         ]
         if not deployments:
+            if output_format == checkpoint_mod.OUTPUT_FORMAT_JSON:
+                _render_loops_deployments_json([])
+                return
             console.print(
                 "No active Loops deployments. Pass --all to include "
                 "STOPPED and FAILED deployments.",
                 style="yellow",
             )
             return
+    if output_format == checkpoint_mod.OUTPUT_FORMAT_JSON:
+        _render_loops_deployments_json(deployments)
+        return
     _render_loops_deployments(deployments)
 
 
@@ -252,6 +273,27 @@ def _render_loops_deployments(deployments: List[Dict[str, Any]]) -> None:
             sampler["base_url"],
         )
     console.print(table)
+
+
+def _render_loops_deployments_json(deployments: List[Dict[str, Any]]) -> None:
+    deployments_data = []
+    for deployment in deployments:
+        sampler = deployment["sampler"]
+        deployments_data.append(
+            {
+                "id": deployment["id"],
+                "base_model": deployment["base_model"],
+                "base_url": deployment["base_url"],
+                "status": deployment["status"]["name"],
+                "sampler": {
+                    "deployment_id": sampler["deployment_id"],
+                    "base_url": sampler["base_url"],
+                    "status": sampler["status"]["name"],
+                },
+            }
+        )
+    output = {"total_deployments": len(deployments), "deployments": deployments_data}
+    print(json.dumps(output, indent=2))
 
 
 def _render_loops_runs(runs: List[Dict[str, Any]]) -> None:

--- a/truss/tests/cli/test_loops_cli.py
+++ b/truss/tests/cli/test_loops_cli.py
@@ -1,5 +1,6 @@
 """Tests for truss loops CLI commands."""
 
+import json
 import os
 import re
 from unittest.mock import Mock, patch
@@ -289,6 +290,82 @@ def test_view_all_flag_with_no_deployments(mock_remote):
     assert result.exit_code == 0, result.output
     assert "No Loops deployments" in result.output
     assert "--all" not in result.output
+
+
+def test_view_json_output_emits_structured_payload(mock_remote):
+    mock_remote.api.list_loops_deployments.return_value = [
+        {
+            "id": "dep_abc",
+            "base_model": "Qwen/Qwen3-8B",
+            "base_url": "https://trainer-abc.api.baseten.co/trainer",
+            "status": {"name": "RUNNING"},
+            "sampler": {
+                "id": "sampler_def",
+                "deployment_id": "ov_def123",
+                "base_url": "https://model-def.api.baseten.co/deployment/v1/sync",
+                "status": {"name": "ACTIVE"},
+            },
+        }
+    ]
+    result = _invoke(
+        ["loops", "view", "--remote", "test_remote", "-o", "json"], mock_remote
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["total_deployments"] == 1
+    deployment = payload["deployments"][0]
+    assert deployment == {
+        "id": "dep_abc",
+        "base_model": "Qwen/Qwen3-8B",
+        "base_url": "https://trainer-abc.api.baseten.co/trainer",
+        "status": "RUNNING",
+        "sampler": {
+            "deployment_id": "ov_def123",
+            "base_url": "https://model-def.api.baseten.co/deployment/v1/sync",
+            "status": "ACTIVE",
+        },
+    }
+
+
+def test_view_json_output_with_no_deployments_emits_empty_payload(mock_remote):
+    mock_remote.api.list_loops_deployments.return_value = []
+    result = _invoke(
+        ["loops", "view", "--remote", "test_remote", "-o", "json"], mock_remote
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload == {"total_deployments": 0, "deployments": []}
+
+
+def test_view_json_output_filters_terminal_states_by_default(mock_remote):
+    mock_remote.api.list_loops_deployments.return_value = [
+        _deployment("dep_running", "RUNNING"),
+        _deployment("dep_stopped", "STOPPED"),
+        _deployment("dep_failed", "FAILED"),
+    ]
+    result = _invoke(
+        ["loops", "view", "--remote", "test_remote", "-o", "json"], mock_remote
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    ids = [d["id"] for d in payload["deployments"]]
+    assert ids == ["dep_running"]
+    assert payload["total_deployments"] == 1
+
+
+def test_view_json_output_all_flag_includes_terminal_states(mock_remote):
+    mock_remote.api.list_loops_deployments.return_value = [
+        _deployment("dep_running", "RUNNING"),
+        _deployment("dep_stopped", "STOPPED"),
+    ]
+    result = _invoke(
+        ["loops", "view", "--all", "--remote", "test_remote", "-o", "json"], mock_remote
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    ids = sorted(d["id"] for d in payload["deployments"])
+    assert ids == ["dep_running", "dep_stopped"]
+    assert payload["total_deployments"] == 2
 
 
 def test_runs_view_no_filters_calls_search_with_none(mock_remote):

--- a/truss/tests/cli/test_loops_cli.py
+++ b/truss/tests/cli/test_loops_cli.py
@@ -292,7 +292,11 @@ def test_view_all_flag_with_no_deployments(mock_remote):
     assert "--all" not in result.output
 
 
-def test_view_json_output_emits_structured_payload(mock_remote):
+def _parse_jsonl(output: str) -> list[dict]:
+    return [json.loads(line) for line in output.splitlines() if line.strip()]
+
+
+def test_view_json_output_emits_one_object_per_deployment(mock_remote):
     mock_remote.api.list_loops_deployments.return_value = [
         {
             "id": "dep_abc",
@@ -311,30 +315,31 @@ def test_view_json_output_emits_structured_payload(mock_remote):
         ["loops", "view", "--remote", "test_remote", "-o", "json"], mock_remote
     )
     assert result.exit_code == 0, result.output
-    payload = json.loads(result.output)
-    assert payload["total_deployments"] == 1
-    deployment = payload["deployments"][0]
-    assert deployment == {
-        "id": "dep_abc",
-        "base_model": "Qwen/Qwen3-8B",
-        "base_url": "https://trainer-abc.api.baseten.co/trainer",
-        "status": "RUNNING",
-        "sampler": {
-            "deployment_id": "ov_def123",
-            "base_url": "https://model-def.api.baseten.co/deployment/v1/sync",
-            "status": "ACTIVE",
-        },
-    }
+    records = _parse_jsonl(result.output)
+    assert records == [
+        {
+            "id": "dep_abc",
+            "base_model": "Qwen/Qwen3-8B",
+            "base_url": "https://trainer-abc.api.baseten.co/trainer",
+            "status": "RUNNING",
+            "sampler": {
+                "deployment_id": "ov_def123",
+                "base_url": "https://model-def.api.baseten.co/deployment/v1/sync",
+                "status": "ACTIVE",
+            },
+        }
+    ]
 
 
-def test_view_json_output_with_no_deployments_emits_empty_payload(mock_remote):
+def test_view_json_output_with_no_deployments_emits_nothing(mock_remote):
+    # JSONL stream of zero records: no stdout content, and crucially no
+    # friendly "No Loops deployments." message that would corrupt the stream.
     mock_remote.api.list_loops_deployments.return_value = []
     result = _invoke(
         ["loops", "view", "--remote", "test_remote", "-o", "json"], mock_remote
     )
     assert result.exit_code == 0, result.output
-    payload = json.loads(result.output)
-    assert payload == {"total_deployments": 0, "deployments": []}
+    assert result.output.strip() == ""
 
 
 def test_view_json_output_filters_terminal_states_by_default(mock_remote):
@@ -347,10 +352,24 @@ def test_view_json_output_filters_terminal_states_by_default(mock_remote):
         ["loops", "view", "--remote", "test_remote", "-o", "json"], mock_remote
     )
     assert result.exit_code == 0, result.output
-    payload = json.loads(result.output)
-    ids = [d["id"] for d in payload["deployments"]]
-    assert ids == ["dep_running"]
-    assert payload["total_deployments"] == 1
+    records = _parse_jsonl(result.output)
+    assert [r["id"] for r in records] == ["dep_running"]
+
+
+def test_view_json_output_filter_to_empty_emits_nothing(mock_remote):
+    # Raw list non-empty but the default terminal-state filter empties it;
+    # JSON consumers should get an empty stream — no "pass --all" hint that
+    # the CLI table prints.
+    mock_remote.api.list_loops_deployments.return_value = [
+        _deployment("dep_stopped", "STOPPED"),
+        _deployment("dep_failed", "FAILED"),
+    ]
+    result = _invoke(
+        ["loops", "view", "--remote", "test_remote", "-o", "json"], mock_remote
+    )
+    assert result.exit_code == 0, result.output
+    assert result.output.strip() == ""
+    assert "--all" not in result.output
 
 
 def test_view_json_output_all_flag_includes_terminal_states(mock_remote):
@@ -362,10 +381,8 @@ def test_view_json_output_all_flag_includes_terminal_states(mock_remote):
         ["loops", "view", "--all", "--remote", "test_remote", "-o", "json"], mock_remote
     )
     assert result.exit_code == 0, result.output
-    payload = json.loads(result.output)
-    ids = sorted(d["id"] for d in payload["deployments"])
-    assert ids == ["dep_running", "dep_stopped"]
-    assert payload["total_deployments"] == 2
+    records = _parse_jsonl(result.output)
+    assert sorted(r["id"] for r in records) == ["dep_running", "dep_stopped"]
 
 
 def test_runs_view_no_filters_calls_search_with_none(mock_remote):


### PR DESCRIPTION
## :rocket: What

Adds `-o/--output-format` to `truss loops view` so scripts and `jq` pipelines can consume the deployment list as line-delimited JSON. Default behavior (`cli-table`) is unchanged.

```sh
$ truss loops view -o json
{"id": "dep_abc", "base_model": "Qwen/Qwen3-8B", "base_url": "https://trainer-abc.api.baseten.co/trainer", "status": "RUNNING", "sampler": {"deployment_id": "ov_def123", "base_url": "https://model-def.api.baseten.co/deployment/v1/sync", "status": "ACTIVE"}}
```

One JSON object per deployment, no top-level wrapper — easy to stream into `jq -c`, append to logs, or read line-by-line. An empty result set produces no output (rather than a friendly "No Loops deployments." message that would corrupt the stream).

## :computer: How

- Reuses `OUTPUT_FORMAT_CLI_TABLE` / `OUTPUT_FORMAT_JSON` from `truss.cli.train.checkpoint_viewer`, matching the option style already used by `truss loops checkpoints view`.
- New `_render_loops_deployments_json` emits one `json.dumps(...)` per deployment to stdout. Fields mirror the table columns; sampler fields are nested under a `sampler` object.
- `view_loops_deployments` keeps the original empty-state messages behind an `is_human_output` guard so the JSON path bypasses them and silently emits zero records when the list (or the post-filter list) is empty.

## :microscope: Testing

- `uv run pytest truss/tests/cli/test_loops_cli.py` — 46/46 pass, including 5 new tests covering: structured per-line payload, raw-empty stream, filter-to-empty stream, default terminal-state filtering, and `--all` interaction.
- `uv run ruff format` + `uv run ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)