### PR TITLE
feat(train): support B200 truss train workstations

### DIFF
--- a/truss/cli/train/workstation.py
+++ b/truss/cli/train/workstation.py
@@ -20,6 +20,7 @@ from truss_train.definitions import (
 )
 
 DEFAULT_BASE_IMAGE = "nvidia/cuda:12.8.1-devel-ubuntu24.04"
+SUPPORTED_WORKSTATION_ACCELERATORS = ("H100", "H200", "B200")
 
 
 def copy_workstation_templates(target_dir: Path) -> None:

--- a/truss/cli/train_commands.py
+++ b/truss/cli/train_commands.py
@@ -32,6 +32,12 @@ from truss.cli.train.cache import (
     SORT_ORDER_ASC,
     SORT_ORDER_DESC,
 )
+from truss.cli.train.workstation import (
+    DEFAULT_BASE_IMAGE,
+    SUPPORTED_WORKSTATION_ACCELERATORS,
+    build_workstation_project,
+    copy_workstation_templates,
+)
 from truss.cli.utils import common
 from truss.cli.utils.output import console, error_console
 from truss.remote.baseten.core import get_training_job_logs_with_pagination
@@ -1086,7 +1092,7 @@ def capacity(remote: Optional[str]):
 @train.command(name="workstation")
 @click.option(
     "--accelerator",
-    type=click.Choice(["H100", "H200"], case_sensitive=False),
+    type=click.Choice(SUPPORTED_WORKSTATION_ACCELERATORS, case_sensitive=False),
     default="H100",
     help="GPU accelerator type (default: H100).",
 )
@@ -1165,11 +1171,6 @@ def workstation(
     """Spin up an SSH workstation on Baseten training infrastructure."""
     import tempfile
 
-    from truss.cli.train.workstation import (
-        DEFAULT_BASE_IMAGE,
-        build_workstation_project,
-        copy_workstation_templates,
-    )
     from truss_train.public_api import push
 
     if gpu_count is not None and node_count is not None:

--- a/truss/tests/cli/train/test_workstation.py
+++ b/truss/tests/cli/train/test_workstation.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from truss.cli.train.workstation import (
+    SUPPORTED_WORKSTATION_ACCELERATORS,
     build_workstation_project,
     copy_workstation_templates,
 )
@@ -37,14 +38,15 @@ def test_build_workstation_project_defaults():
     assert job.interactive_session.session_provider == InteractiveSessionProvider.SSH
 
 
-def test_build_workstation_project_h200_multi_gpu():
+@pytest.mark.parametrize("accelerator", SUPPORTED_WORKSTATION_ACCELERATORS)
+def test_build_workstation_project_supported_accelerators_multi_gpu(accelerator):
     project = build_workstation_project(
-        accelerator="H200", gpu_count=4, project_id="my-workstation"
+        accelerator=accelerator, gpu_count=4, project_id="my-workstation"
     )
     assert project.name == "my-workstation"
 
     job = project.job
-    assert job.compute.accelerator.accelerator.value == "H200"
+    assert job.compute.accelerator.accelerator.value == accelerator
     assert job.compute.accelerator.count == 4
 
 


### PR DESCRIPTION
Summary:
- Add B200 to workstation accelerator choices
- Add tests covering supported workstation accelerators and B200 CLI handling

Tests:
- uv run pytest truss/tests/cli/train/test_workstation.py -v
- uv run pytest truss/tests/test_config.py::test_acc_spec_from_str -v
- uv run ruff check .