### PR TITLE
Scope truss watch model resolution to a single model to avoid fetching all signatures

### DIFF
--- a/truss/cli/resolvers/model_team_resolver.py
+++ b/truss/cli/resolvers/model_team_resolver.py
@@ -93,22 +93,31 @@ def resolve_model_for_watch(
             raise click.ClickException(
                 f"Model '{model_name}' not found in team '{provided_team_name}'."
             )
-        return matching[0], matching[0].get("versions", [])
+        model = matching[0]
+    else:
+        matching_models = _get_matching_models(
+            model_name,
+            existing_teams,
+            lambda: remote_provider.api.get_models_for_watch(
+                chainlets_only=chainlets_only
+            ),
+        )
 
-    matching_models = _get_matching_models(
-        model_name,
-        existing_teams,
-        lambda: remote_provider.api.get_models_for_watch(chainlets_only=chainlets_only),
-    )
+        if not matching_models:
+            raise click.ClickException(f"Model '{model_name}' not found.")
 
-    if not matching_models:
-        raise click.ClickException(f"Model '{model_name}' not found.")
+        if len(matching_models) == 1:
+            model = matching_models[0]
+        else:
+            model = _prompt_for_team_from_models(
+                matching_models, existing_teams, prompt
+            )
 
-    if len(matching_models) == 1:
-        return matching_models[0], matching_models[0].get("versions", [])
-
-    model = _prompt_for_team_from_models(matching_models, existing_teams, prompt)
-    return model, model.get("versions", [])
+    # Load full version info (including truss_signature) for only the resolved
+    # model. Identification above uses a lightweight query, so we avoid fetching
+    # signatures for every model in the team.
+    resolved = remote_provider.api.get_model_with_versions_by_id(model["id"])["model"]
+    return resolved, resolved.get("versions", [])
 
 
 def resolve_model_team_name(

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -560,7 +560,14 @@ class BasetenApi:
     def get_models_for_watch(
         self, team_id: Optional[str] = None, chainlets_only: Optional[bool] = False
     ):
-        """Get models with full version info needed for watch disambiguation."""
+        """Get lightweight model info (id/name/team) for watch disambiguation.
+
+        Only the fields needed to identify and disambiguate a model by name are
+        requested. Version info (including the potentially large ``truss_signature``)
+        is loaded separately for the single resolved model via
+        :meth:`get_model_with_versions_by_id`, to avoid fetching signatures for
+        every model in the team.
+        """
         # If team_id is provided, filter by team; otherwise get all models
         if team_id:
             filter_arg = f'team_id: "{team_id}"'
@@ -575,6 +582,27 @@ class BasetenApi:
         query_string = f"""
         {{
             models({filter_arg}) {{
+                id
+                name
+                team {{
+                    id
+                    name
+                }}
+            }}
+        }}
+        """
+        resp = self._post_graphql_query(query_string)
+        return resp["data"]
+
+    def get_model_with_versions_by_id(self, model_id: str):
+        """Get a single model with full version info needed for watch.
+
+        Returns the model identified by ``model_id`` along with its versions,
+        including ``truss_hash`` and ``truss_signature`` used to compute patches.
+        """
+        query_string = f"""
+        {{
+            model(id: "{model_id}") {{
                 id
                 name
                 hostname

--- a/truss/tests/cli/test_model_team_resolver.py
+++ b/truss/tests/cli/test_model_team_resolver.py
@@ -393,7 +393,12 @@ class TestResolveModelForWatch:
             name: TeamType(**team_data) for name, team_data in teams.items()
         }
         mock_api.get_teams.return_value = teams_with_type
+        # Identification uses the lightweight query...
         mock_api.get_models_for_watch.return_value = {"models": models}
+        # ...and full version info is loaded for only the resolved model by id.
+        mock_api.get_model_with_versions_by_id.side_effect = lambda model_id: {
+            "model": next(m for m in models if m["id"] == model_id)
+        }
         return mock_remote
 
     def test_single_model_found(self):
@@ -508,6 +513,9 @@ class TestResolveModelForWatch:
         }
         mock_api.get_teams.return_value = teams_with_type
         mock_api.get_models_for_watch.return_value = {"models": models_team1}
+        mock_api.get_model_with_versions_by_id.side_effect = lambda model_id: {
+            "model": next(m for m in models_team1 if m["id"] == model_id)
+        }
 
         model, versions = resolve_model_for_watch(
             mock_remote, "my-model", provided_team_name="Team Alpha"
@@ -518,6 +526,8 @@ class TestResolveModelForWatch:
         mock_api.get_models_for_watch.assert_called_once_with(
             team_id="team1", chainlets_only=False
         )
+        # Full version info is loaded for only the resolved model.
+        mock_api.get_model_with_versions_by_id.assert_called_once_with("model1")
 
     def test_provided_team_name_invalid(self):
         """Test that providing an invalid team name raises an error."""

--- a/truss/tests/remote/baseten/test_api.py
+++ b/truss/tests/remote/baseten/test_api.py
@@ -722,3 +722,39 @@ def test_create_bis_llm_model_version_routing(mock_post, baseten_api):
         mock_post.call_args[0][0]
         == "https://api.baseten.co/v1/llm_models/llm-model-123/deployments"
     )
+
+
+@mock.patch("requests.post", return_value=mock_successful_response())
+def test_get_models_for_watch_is_lightweight(mock_post, baseten_api):
+    # Identification query must not pull version signatures for every model.
+    baseten_api.get_models_for_watch()
+
+    query = mock_post.call_args[1]["json"]["query"]
+    assert "all: true" in query
+    assert "id" in query
+    assert "name" in query
+    assert "team" in query
+    assert "versions" not in query
+    assert "truss_signature" not in query
+
+
+@mock.patch("requests.post", return_value=mock_successful_response())
+def test_get_models_for_watch_with_team_and_chainlets(mock_post, baseten_api):
+    baseten_api.get_models_for_watch(team_id="team1", chainlets_only=True)
+
+    query = mock_post.call_args[1]["json"]["query"]
+    assert 'team_id: "team1"' in query
+    assert "chainlets_only: true" in query
+    assert "truss_signature" not in query
+
+
+@mock.patch("requests.post", return_value=mock_successful_response())
+def test_get_model_with_versions_by_id_includes_signature(mock_post, baseten_api):
+    # The resolved model is loaded by id with full version info for patching.
+    baseten_api.get_model_with_versions_by_id("model123")
+
+    query = mock_post.call_args[1]["json"]["query"]
+    assert 'model(id: "model123")' in query
+    assert "versions" in query
+    assert "truss_hash" in query
+    assert "truss_signature" in query

--- a/truss/tests/remote/baseten/test_remote.py
+++ b/truss/tests/remote/baseten/test_remote.py
@@ -86,6 +86,18 @@ def test_get_service_by_model_name(remote):
             ]
         }
     }
+    # Full version info is loaded for only the resolved model by id.
+    model_response = {
+        "data": {
+            "model": {
+                "name": "model_name",
+                "id": "model_id",
+                "hostname": "hostname",
+                "team": {"id": "team1", "name": "Team Alpha"},
+                "versions": versions,
+            }
+        }
+    }
 
     with requests_mock.Mocker() as m:
         m.post(
@@ -93,8 +105,10 @@ def test_get_service_by_model_name(remote):
             [
                 {"json": teams_response},
                 {"json": models_response},
+                {"json": model_response},
                 {"json": teams_response},
                 {"json": models_response},
+                {"json": model_response},
             ],
         )
 
@@ -133,6 +147,18 @@ def test_get_service_by_model_name_no_dev_version(remote):
             ]
         }
     }
+    # Full version info is loaded for only the resolved model by id.
+    model_response = {
+        "data": {
+            "model": {
+                "name": "model_name",
+                "id": "model_id",
+                "hostname": "hostname",
+                "team": {"id": "team1", "name": "Team Alpha"},
+                "versions": versions,
+            }
+        }
+    }
 
     with requests_mock.Mocker() as m:
         m.post(
@@ -140,8 +166,10 @@ def test_get_service_by_model_name_no_dev_version(remote):
             [
                 {"json": teams_response},
                 {"json": models_response},
+                {"json": model_response},
                 {"json": teams_response},
                 {"json": models_response},
+                {"json": model_response},
             ],
         )
 
@@ -180,6 +208,18 @@ def test_get_service_by_model_name_no_prod_version(remote):
             ]
         }
     }
+    # Full version info is loaded for only the resolved model by id.
+    model_response = {
+        "data": {
+            "model": {
+                "name": "model_name",
+                "id": "model_id",
+                "hostname": "hostname",
+                "team": {"id": "team1", "name": "Team Alpha"},
+                "versions": versions,
+            }
+        }
+    }
 
     with requests_mock.Mocker() as m:
         m.post(
@@ -187,8 +227,10 @@ def test_get_service_by_model_name_no_prod_version(remote):
             [
                 {"json": teams_response},
                 {"json": models_response},
+                {"json": model_response},
                 {"json": teams_response},
                 {"json": models_response},
+                {"json": model_response},
             ],
         )
 


### PR DESCRIPTION
## :rocket: What

`truss watch` could hang for minutes before printing anything (sometimes failing with a JSON decode error) for orgs/teams with many models. Root cause: model resolution fetched `versions { ... truss_signature ... }` for *every* model in the team via `get_models_for_watch(all/team_id)`, producing responses up to hundreds of MB (~389 MB observed for one team). This scopes the heavy fetch to the single resolved model.

Introduced a while back in #2107 (watch team disambiguation): that PR added `get_models_for_watch`, which fetched every model's full version + signature payload to match one model by name. It was latent until teams grew large enough for the aggregate signature size to make the response slow to download/parse.

## :computer: How

- `BasetenApi.get_models_for_watch` now requests only `id`/`name`/`team`, enough to identify and disambiguate a model by name. Dropped the `versions` / `truss_signature` block.
- Added `BasetenApi.get_model_with_versions_by_id`, which loads full version info (incl. `truss_hash`/`truss_signature`) for one model by id.
- `resolve_model_for_watch` now identifies the model with the lightweight query, then loads versions for only the resolved model. Return contract `(model, versions)` is unchanged, so `watch` / `push --watch` callsites are untouched. Turns watch from O(all team signatures) into O(one model).

## :microscope: Testing

- Updated `test_model_team_resolver.py` for the two-phase flow (identify -> load by id), covering single/multiple/no match and `--team`.
- Added `test_api.py` guards: identify query omits `versions`/`truss_signature` (and still honors `team_id`/`chainlets_only`); by-id query includes them.
- Manual end-to-end `truss watch` test.