### PR TITLE
feat(loops): add `truss loops runs metrics` command

### DIFF
--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -1,6 +1,12 @@
 import json
-from typing import Any, Dict, List, Optional, cast
+import re
+import sys
+import time
+from contextlib import contextmanager
+from datetime import datetime, timedelta
+from typing import Any, Callable, Dict, Iterator, List, Optional, TextIO, Tuple, cast
 
+import rich.live
 import rich.table
 import rich_click as click
 import yaml
@@ -213,6 +219,356 @@ def view_loops_runs(
     runs = remote_provider.api.list_loops_runs(run_id=run_id, base_model=base_model)
     runs = sorted(runs, key=lambda r: r.get("created_at") or "", reverse=reverse)
     _render_loops_runs(runs)
+
+
+_DEFAULT_METRICS_REFRESH_SECONDS = 30
+_SPARKLINE_BLOCKS = "▁▂▃▄▅▆▇█"
+_SPARKLINE_WIDTH = 24
+_DURATION_RE = re.compile(r"^\s*(\d+)\s*([smhd])\s*$", re.IGNORECASE)
+_DURATION_UNIT_SECONDS = {"s": 1, "m": 60, "h": 3600, "d": 86400}
+# Deployments in these states have no live pods producing metrics, so they
+# can't be the trainer behind an in-flight run.
+_INACTIVE_DEPLOYMENT_STATUSES = frozenset({"FAILED", "STOPPED", "SCALED_TO_ZERO"})
+
+
+@loops_runs.command(name="metrics")
+@click.option("--run-id", type=str, required=True, help="Loops run ID.")
+@click.option(
+    "--tail",
+    is_flag=True,
+    default=False,
+    help=(
+        "Refresh continuously until interrupted. Without --tail, a single "
+        "snapshot is rendered and the command exits."
+    ),
+)
+@click.option(
+    "--refresh-rate-seconds",
+    type=int,
+    default=_DEFAULT_METRICS_REFRESH_SECONDS,
+    show_default=True,
+    help="Seconds between refreshes when --tail is set.",
+)
+@click.option(
+    "--since",
+    type=str,
+    default=None,
+    help=(
+        "Window start as a duration relative to now (e.g. '30m', '2h', '1d'). "
+        "Mutually exclusive with --start. Defaults to the run's creation time."
+    ),
+)
+@click.option(
+    "--start",
+    type=str,
+    default=None,
+    help="Window start as an ISO-8601 timestamp. Mutually exclusive with --since.",
+)
+@click.option(
+    "--end",
+    type=str,
+    default=None,
+    help="Window end as an ISO-8601 timestamp. Defaults to now.",
+)
+@click.option(
+    "-o",
+    "--output-format",
+    type=click.Choice(
+        [checkpoint_mod.OUTPUT_FORMAT_CLI_TABLE, checkpoint_mod.OUTPUT_FORMAT_JSON]
+    ),
+    default=checkpoint_mod.OUTPUT_FORMAT_CLI_TABLE,
+    help=(
+        "Output format. With --tail and json, NDJSON is emitted "
+        "(one document per refresh tick)."
+    ),
+)
+@click.option(
+    "--output-file",
+    type=click.Path(dir_okay=False, writable=True, allow_dash=True),
+    default=None,
+    help=(
+        "Write JSON output to this path instead of stdout. Use '-' for stdout. "
+        "Only valid with -o json."
+    ),
+)
+@click.option("--remote", type=str, required=False, help="Remote to use.")
+@common.common_options()
+def view_loops_run_metrics(
+    run_id: str,
+    tail: bool,
+    refresh_rate_seconds: int,
+    since: Optional[str],
+    start: Optional[str],
+    end: Optional[str],
+    output_format: str,
+    output_file: Optional[str],
+    remote: Optional[str],
+) -> None:
+    """Show request volume + concurrent requests for the trainer and sampler
+    tied to a Loops run.
+
+    Resolves the run's trainer deployment client-side by matching the run's
+    base model against the caller's non-stopped Loops deployments. By default
+    queries the window ``run.created_at → now`` and renders a single snapshot;
+    pass ``--tail`` to refresh continuously, or ``-o json`` for machine-
+    readable output (NDJSON when combined with ``--tail``).
+    """
+    if since is not None and start is not None:
+        raise click.UsageError("--since and --start are mutually exclusive.")
+    is_json = output_format == checkpoint_mod.OUTPUT_FORMAT_JSON
+    if output_file is not None and not is_json:
+        raise click.UsageError("--output-file requires -o json.")
+
+    if not remote:
+        remote = remote_cli.inquire_remote_name()
+    remote_provider: BasetenRemote = cast(
+        BasetenRemote, RemoteFactory.create(remote=remote)
+    )
+
+    run = remote_provider.api.get_loops_run(run_id)
+    deployment_id = _resolve_trainer_deployment_for_run(remote_provider, run)
+    sampler_deployment_id = (run.get("sampler") or {}).get("deployment_id")
+    run_created_at_iso = run["created_at"]
+
+    def compute_window() -> Tuple[str, str]:
+        end_iso = end if end else datetime.now().astimezone().isoformat()
+        if start:
+            start_iso = start
+        elif since:
+            start_iso = (
+                datetime.now().astimezone()
+                - timedelta(seconds=_parse_duration_seconds(since))
+            ).isoformat()
+        else:
+            start_iso = run_created_at_iso
+        return start_iso, end_iso
+
+    def fetch_snapshot() -> Dict[str, Any]:
+        start_iso, end_iso = compute_window()
+        trainer_resp = remote_provider.api.get_loops_deployment_metrics(
+            deployment_id,
+            start_epoch_millis=_iso_to_epoch_millis(start_iso),
+            end_epoch_millis=_iso_to_epoch_millis(end_iso),
+        )
+        trainer_raw = trainer_resp.get("metrics") or {}
+        sampler_block: Dict[str, Any] = {
+            "request_volume": [],
+            "concurrent_requests": [],
+        }
+        if sampler_deployment_id:
+            sampler_raw = remote_provider.api.get_model_deployment_range_metrics(
+                model_version_id=sampler_deployment_id,
+                start_iso=start_iso,
+                end_iso=end_iso,
+            )
+            sampler_block = {
+                "request_volume": sampler_raw.get("inference_volume") or [],
+                "concurrent_requests": sampler_raw.get("model_concurrent_requests")
+                or [],
+            }
+        return {
+            "run_id": run_id,
+            "trainer_deployment_id": deployment_id,
+            "sampler_deployment_id": sampler_deployment_id,
+            "window": {"start": start_iso, "end": end_iso},
+            "trainer": {
+                "request_volume": trainer_raw.get("inference_volume") or [],
+                "concurrent_requests": trainer_raw.get("concurrent_requests") or [],
+            },
+            "sampler": sampler_block,
+        }
+
+    if is_json:
+        _emit_metrics_json(
+            fetch_snapshot,
+            tail=tail,
+            refresh_rate_seconds=refresh_rate_seconds,
+            output_file=output_file,
+            run_id=run_id,
+        )
+        return
+
+    if not tail:
+        with console.status(
+            f"Fetching metrics for Loops run [cyan]{run_id}[/cyan]...", spinner="dots"
+        ):
+            snapshot = fetch_snapshot()
+        console.print(_build_metrics_table(snapshot))
+        return
+
+    with rich.live.Live(auto_refresh=False, console=console, screen=False) as live:
+        try:
+            while True:
+                live.update(_build_metrics_table(fetch_snapshot()), refresh=True)
+                time.sleep(refresh_rate_seconds)
+        except KeyboardInterrupt:
+            live.stop()
+            console.print(
+                f"\nStopped watching metrics for run {run_id}.", style="yellow"
+            )
+
+
+def _resolve_trainer_deployment_for_run(
+    remote_provider: BasetenRemote, run: Dict[str, Any]
+) -> str:
+    base_model = run.get("base_model")
+    run_id = run.get("id", "")
+    deployments = remote_provider.api.list_loops_deployments()
+    candidates = [
+        d
+        for d in deployments
+        if d.get("base_model") == base_model
+        and ((d.get("status") or {}).get("name") or "").upper()
+        not in _INACTIVE_DEPLOYMENT_STATUSES
+    ]
+    if not candidates:
+        raise click.ClickException(
+            f"No active Loops deployment found for base model {base_model!r} "
+            f"(run {run_id}). Run `truss loops view` to list deployments."
+        )
+    if len(candidates) > 1:
+        ids = ", ".join(d.get("id", "") for d in candidates)
+        raise click.ClickException(
+            f"Multiple active Loops deployments match base model {base_model!r}: "
+            f"{ids}. Cannot infer which one run {run_id} belongs to."
+        )
+    return candidates[0]["id"]
+
+
+def _parse_duration_seconds(value: str) -> int:
+    match = _DURATION_RE.match(value)
+    if not match:
+        raise click.UsageError(
+            f"Invalid duration {value!r}. Expected an integer followed by "
+            "s/m/h/d, e.g. '30s', '15m', '2h', '1d'."
+        )
+    return int(match.group(1)) * _DURATION_UNIT_SECONDS[match.group(2).lower()]
+
+
+def _iso_to_epoch_millis(iso_timestamp: str) -> int:
+    return int(
+        datetime.fromisoformat(iso_timestamp.replace("Z", "+00:00")).timestamp() * 1000
+    )
+
+
+def _latest_value(points: List[Dict[str, Any]]) -> Optional[float]:
+    if not points:
+        return None
+    return points[-1].get("value")
+
+
+def _sparkline(points: List[Dict[str, Any]]) -> str:
+    values = [p["value"] for p in points if p.get("value") is not None]
+    if not values:
+        return ""
+    width = min(_SPARKLINE_WIDTH, len(values))
+    if len(values) > width:
+        bucket = len(values) / width
+        bucketed = []
+        for i in range(width):
+            lo_idx = int(i * bucket)
+            hi_idx = max(int((i + 1) * bucket), lo_idx + 1)
+            chunk = values[lo_idx:hi_idx]
+            bucketed.append(sum(chunk) / len(chunk))
+    else:
+        bucketed = values
+    lo, hi = min(bucketed), max(bucketed)
+    if hi - lo <= 0:
+        return _SPARKLINE_BLOCKS[len(_SPARKLINE_BLOCKS) // 2] * len(bucketed)
+    return "".join(
+        _SPARKLINE_BLOCKS[int((v - lo) / (hi - lo) * (len(_SPARKLINE_BLOCKS) - 1))]
+        for v in bucketed
+    )
+
+
+def _short_iso(iso: str) -> str:
+    try:
+        return (
+            datetime.fromisoformat(iso.replace("Z", "+00:00"))
+            .astimezone()
+            .strftime("%Y-%m-%d %H:%M:%S")
+        )
+    except ValueError:
+        return iso
+
+
+def _fmt_latest(value: Optional[float]) -> str:
+    if value is None:
+        return "—"
+    return f"{value:.2f}"
+
+
+def _build_metrics_table(snapshot: Dict[str, Any]) -> rich.table.Table:
+    window = snapshot["window"]
+    table = rich.table.Table(
+        show_header=True,
+        header_style="bold magenta",
+        title=(
+            f"Metrics for Loops run [cyan]{snapshot['run_id']}[/cyan]  "
+            f"({_short_iso(window['start'])} → {_short_iso(window['end'])})"
+        ),
+        box=rich.table.box.ROUNDED,
+        border_style="blue",
+    )
+    table.add_column("Component", style="green")
+    table.add_column("Deployment", style="cyan")
+    table.add_column("Request volume (req/s)", justify="right")
+    table.add_column("Concurrent requests", justify="right")
+    table.add_column("Trend", justify="left")
+
+    trainer = snapshot["trainer"]
+    table.add_row(
+        "Trainer",
+        snapshot["trainer_deployment_id"],
+        _fmt_latest(_latest_value(trainer["request_volume"])),
+        _fmt_latest(_latest_value(trainer["concurrent_requests"])),
+        _sparkline(trainer["request_volume"]),
+    )
+
+    sampler_id = snapshot["sampler_deployment_id"]
+    sampler = snapshot["sampler"]
+    if sampler_id:
+        table.add_row(
+            "Sampler",
+            sampler_id,
+            _fmt_latest(_latest_value(sampler["request_volume"])),
+            _fmt_latest(_latest_value(sampler["concurrent_requests"])),
+            _sparkline(sampler["request_volume"]),
+        )
+    else:
+        table.add_row("Sampler", "—", "—", "—", "")
+    return table
+
+
+@contextmanager
+def _open_metrics_sink(output_file: Optional[str]) -> Iterator[TextIO]:
+    if output_file is None or output_file == "-":
+        yield sys.stdout
+        return
+    with open(output_file, "w") as f:
+        yield f
+
+
+def _emit_metrics_json(
+    fetch_snapshot: Callable[[], Dict[str, Any]],
+    *,
+    tail: bool,
+    refresh_rate_seconds: int,
+    output_file: Optional[str],
+    run_id: str,
+) -> None:
+    with _open_metrics_sink(output_file) as sink:
+        if not tail:
+            sink.write(json.dumps(fetch_snapshot()) + "\n")
+            sink.flush()
+            return
+        try:
+            while True:
+                sink.write(json.dumps(fetch_snapshot()) + "\n")
+                sink.flush()
+                time.sleep(refresh_rate_seconds)
+        except KeyboardInterrupt:
+            print(f"Stopped streaming metrics for run {run_id}.", file=sys.stderr)
 
 
 @loops.group(name="samplers")

--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -1,12 +1,8 @@
 import json
 import re
-import sys
-import time
-from contextlib import contextmanager
 from datetime import datetime, timedelta
-from typing import Any, Callable, Dict, Iterator, List, Optional, TextIO, Tuple, cast
+from typing import Any, Dict, List, Optional, Tuple, cast
 
-import rich.live
 import rich.table
 import rich_click as click
 import yaml
@@ -20,6 +16,12 @@ from truss.cli.logs.model_log_watcher import ModelDeploymentLogWatcher
 from truss.cli.loops_checkpoint_viewer import (
     resolve_most_recent_run_for_base_model,
     view_loops_checkpoint_list,
+)
+from truss.cli.loops_run_metrics_viewer import (
+    DEFAULT_METRICS_REFRESH_SECONDS,
+    emit_json_snapshots,
+    render_metrics_snapshot,
+    tail_metrics_table,
 )
 from truss.cli.train import checkpoint_viewer as checkpoint_mod
 from truss.cli.utils import common
@@ -221,9 +223,6 @@ def view_loops_runs(
     _render_loops_runs(runs)
 
 
-_DEFAULT_METRICS_REFRESH_SECONDS = 30
-_SPARKLINE_BLOCKS = "▁▂▃▄▅▆▇█"
-_SPARKLINE_WIDTH = 24
 _DURATION_RE = re.compile(r"^\s*(\d+)\s*([smhd])\s*$", re.IGNORECASE)
 _DURATION_UNIT_SECONDS = {"s": 1, "m": 60, "h": 3600, "d": 86400}
 # Deployments in these states have no live pods producing metrics, so they
@@ -245,7 +244,7 @@ _INACTIVE_DEPLOYMENT_STATUSES = frozenset({"FAILED", "STOPPED", "SCALED_TO_ZERO"
 @click.option(
     "--refresh-rate-seconds",
     type=int,
-    default=_DEFAULT_METRICS_REFRESH_SECONDS,
+    default=DEFAULT_METRICS_REFRESH_SECONDS,
     show_default=True,
     help="Seconds between refreshes when --tail is set.",
 )
@@ -379,7 +378,7 @@ def view_loops_run_metrics(
         }
 
     if is_json:
-        _emit_metrics_json(
+        emit_json_snapshots(
             fetch_snapshot,
             tail=tail,
             refresh_rate_seconds=refresh_rate_seconds,
@@ -393,19 +392,12 @@ def view_loops_run_metrics(
             f"Fetching metrics for Loops run [cyan]{run_id}[/cyan]...", spinner="dots"
         ):
             snapshot = fetch_snapshot()
-        console.print(_build_metrics_table(snapshot))
+        render_metrics_snapshot(snapshot)
         return
 
-    with rich.live.Live(auto_refresh=False, console=console, screen=False) as live:
-        try:
-            while True:
-                live.update(_build_metrics_table(fetch_snapshot()), refresh=True)
-                time.sleep(refresh_rate_seconds)
-        except KeyboardInterrupt:
-            live.stop()
-            console.print(
-                f"\nStopped watching metrics for run {run_id}.", style="yellow"
-            )
+    tail_metrics_table(
+        fetch_snapshot, refresh_rate_seconds=refresh_rate_seconds, run_id=run_id
+    )
 
 
 def _resolve_trainer_deployment_for_run(
@@ -449,126 +441,6 @@ def _iso_to_epoch_millis(iso_timestamp: str) -> int:
     return int(
         datetime.fromisoformat(iso_timestamp.replace("Z", "+00:00")).timestamp() * 1000
     )
-
-
-def _latest_value(points: List[Dict[str, Any]]) -> Optional[float]:
-    if not points:
-        return None
-    return points[-1].get("value")
-
-
-def _sparkline(points: List[Dict[str, Any]]) -> str:
-    values = [p["value"] for p in points if p.get("value") is not None]
-    if not values:
-        return ""
-    width = min(_SPARKLINE_WIDTH, len(values))
-    if len(values) > width:
-        bucket = len(values) / width
-        bucketed = []
-        for i in range(width):
-            lo_idx = int(i * bucket)
-            hi_idx = max(int((i + 1) * bucket), lo_idx + 1)
-            chunk = values[lo_idx:hi_idx]
-            bucketed.append(sum(chunk) / len(chunk))
-    else:
-        bucketed = values
-    lo, hi = min(bucketed), max(bucketed)
-    if hi - lo <= 0:
-        return _SPARKLINE_BLOCKS[len(_SPARKLINE_BLOCKS) // 2] * len(bucketed)
-    return "".join(
-        _SPARKLINE_BLOCKS[int((v - lo) / (hi - lo) * (len(_SPARKLINE_BLOCKS) - 1))]
-        for v in bucketed
-    )
-
-
-def _short_iso(iso: str) -> str:
-    try:
-        return (
-            datetime.fromisoformat(iso.replace("Z", "+00:00"))
-            .astimezone()
-            .strftime("%Y-%m-%d %H:%M:%S")
-        )
-    except ValueError:
-        return iso
-
-
-def _fmt_latest(value: Optional[float]) -> str:
-    if value is None:
-        return "—"
-    return f"{value:.2f}"
-
-
-def _build_metrics_table(snapshot: Dict[str, Any]) -> rich.table.Table:
-    window = snapshot["window"]
-    table = rich.table.Table(
-        show_header=True,
-        header_style="bold magenta",
-        title=(
-            f"Metrics for Loops run [cyan]{snapshot['run_id']}[/cyan]  "
-            f"({_short_iso(window['start'])} → {_short_iso(window['end'])})"
-        ),
-        box=rich.table.box.ROUNDED,
-        border_style="blue",
-    )
-    table.add_column("Component", style="green")
-    table.add_column("Deployment", style="cyan")
-    table.add_column("Request volume (req/s)", justify="right")
-    table.add_column("Concurrent requests", justify="right")
-    table.add_column("Trend", justify="left")
-
-    trainer = snapshot["trainer"]
-    table.add_row(
-        "Trainer",
-        snapshot["trainer_deployment_id"],
-        _fmt_latest(_latest_value(trainer["request_volume"])),
-        _fmt_latest(_latest_value(trainer["concurrent_requests"])),
-        _sparkline(trainer["request_volume"]),
-    )
-
-    sampler_id = snapshot["sampler_deployment_id"]
-    sampler = snapshot["sampler"]
-    if sampler_id:
-        table.add_row(
-            "Sampler",
-            sampler_id,
-            _fmt_latest(_latest_value(sampler["request_volume"])),
-            _fmt_latest(_latest_value(sampler["concurrent_requests"])),
-            _sparkline(sampler["request_volume"]),
-        )
-    else:
-        table.add_row("Sampler", "—", "—", "—", "")
-    return table
-
-
-@contextmanager
-def _open_metrics_sink(output_file: Optional[str]) -> Iterator[TextIO]:
-    if output_file is None or output_file == "-":
-        yield sys.stdout
-        return
-    with open(output_file, "w") as f:
-        yield f
-
-
-def _emit_metrics_json(
-    fetch_snapshot: Callable[[], Dict[str, Any]],
-    *,
-    tail: bool,
-    refresh_rate_seconds: int,
-    output_file: Optional[str],
-    run_id: str,
-) -> None:
-    with _open_metrics_sink(output_file) as sink:
-        if not tail:
-            sink.write(json.dumps(fetch_snapshot()) + "\n")
-            sink.flush()
-            return
-        try:
-            while True:
-                sink.write(json.dumps(fetch_snapshot()) + "\n")
-                sink.flush()
-                time.sleep(refresh_rate_seconds)
-        except KeyboardInterrupt:
-            print(f"Stopped streaming metrics for run {run_id}.", file=sys.stderr)
 
 
 @loops.group(name="samplers")

--- a/truss/cli/loops_run_metrics_viewer.py
+++ b/truss/cli/loops_run_metrics_viewer.py
@@ -1,0 +1,168 @@
+"""Display layer for ``truss loops runs metrics``.
+
+Owns the cli-table layout, NDJSON emission, and live-tail loop. Kept
+separate from ``loops_commands.py`` so the command body reads as wiring +
+dispatch.
+"""
+
+import json
+import sys
+import time
+from contextlib import contextmanager
+from datetime import datetime
+from typing import Any, Callable, Dict, Iterator, List, Optional, TextIO
+
+import rich.live
+import rich.table
+
+from truss.cli.utils.output import console
+
+DEFAULT_METRICS_REFRESH_SECONDS = 30
+
+_SPARKLINE_BLOCKS = "▁▂▃▄▅▆▇█"
+_SPARKLINE_WIDTH = 24
+
+
+def render_metrics_snapshot(snapshot: Dict[str, Any]) -> None:
+    """Render a single metrics snapshot as a Rich table to the console."""
+    console.print(_build_metrics_table(snapshot))
+
+
+def tail_metrics_table(
+    fetch_snapshot: Callable[[], Dict[str, Any]],
+    *,
+    refresh_rate_seconds: int,
+    run_id: str,
+) -> None:
+    """Stream cli-table updates until the caller interrupts with Ctrl+C."""
+    with rich.live.Live(auto_refresh=False, console=console, screen=False) as live:
+        try:
+            while True:
+                live.update(_build_metrics_table(fetch_snapshot()), refresh=True)
+                time.sleep(refresh_rate_seconds)
+        except KeyboardInterrupt:
+            live.stop()
+            console.print(
+                f"\nStopped watching metrics for run {run_id}.", style="yellow"
+            )
+
+
+def emit_json_snapshots(
+    fetch_snapshot: Callable[[], Dict[str, Any]],
+    *,
+    tail: bool,
+    refresh_rate_seconds: int,
+    output_file: Optional[str],
+    run_id: str,
+) -> None:
+    """Emit one JSON doc (snapshot) or NDJSON (tail) to stdout or ``output_file``."""
+    with _open_metrics_sink(output_file) as sink:
+        if not tail:
+            sink.write(json.dumps(fetch_snapshot()) + "\n")
+            sink.flush()
+            return
+        try:
+            while True:
+                sink.write(json.dumps(fetch_snapshot()) + "\n")
+                sink.flush()
+                time.sleep(refresh_rate_seconds)
+        except KeyboardInterrupt:
+            print(f"Stopped streaming metrics for run {run_id}.", file=sys.stderr)
+
+
+def _build_metrics_table(snapshot: Dict[str, Any]) -> rich.table.Table:
+    window = snapshot["window"]
+    table = rich.table.Table(
+        show_header=True,
+        header_style="bold magenta",
+        title=(
+            f"Metrics for Loops run [cyan]{snapshot['run_id']}[/cyan]  "
+            f"({_short_iso(window['start'])} → {_short_iso(window['end'])})"
+        ),
+        box=rich.table.box.ROUNDED,
+        border_style="blue",
+    )
+    table.add_column("Component", style="green")
+    table.add_column("Deployment", style="cyan")
+    table.add_column("Request volume (req/s)", justify="right")
+    table.add_column("Concurrent requests", justify="right")
+    table.add_column("Trend", justify="left")
+
+    trainer = snapshot["trainer"]
+    table.add_row(
+        "Trainer",
+        snapshot["trainer_deployment_id"],
+        _fmt_latest(_latest_value(trainer["request_volume"])),
+        _fmt_latest(_latest_value(trainer["concurrent_requests"])),
+        _sparkline(trainer["request_volume"]),
+    )
+
+    sampler_id = snapshot["sampler_deployment_id"]
+    sampler = snapshot["sampler"]
+    if sampler_id:
+        table.add_row(
+            "Sampler",
+            sampler_id,
+            _fmt_latest(_latest_value(sampler["request_volume"])),
+            _fmt_latest(_latest_value(sampler["concurrent_requests"])),
+            _sparkline(sampler["request_volume"]),
+        )
+    else:
+        table.add_row("Sampler", "—", "—", "—", "")
+    return table
+
+
+def _latest_value(points: List[Dict[str, Any]]) -> Optional[float]:
+    if not points:
+        return None
+    return points[-1].get("value")
+
+
+def _sparkline(points: List[Dict[str, Any]]) -> str:
+    values = [p["value"] for p in points if p.get("value") is not None]
+    if not values:
+        return ""
+    width = min(_SPARKLINE_WIDTH, len(values))
+    if len(values) > width:
+        bucket = len(values) / width
+        bucketed = []
+        for i in range(width):
+            lo_idx = int(i * bucket)
+            hi_idx = max(int((i + 1) * bucket), lo_idx + 1)
+            chunk = values[lo_idx:hi_idx]
+            bucketed.append(sum(chunk) / len(chunk))
+    else:
+        bucketed = values
+    lo, hi = min(bucketed), max(bucketed)
+    if hi - lo <= 0:
+        return _SPARKLINE_BLOCKS[len(_SPARKLINE_BLOCKS) // 2] * len(bucketed)
+    return "".join(
+        _SPARKLINE_BLOCKS[int((v - lo) / (hi - lo) * (len(_SPARKLINE_BLOCKS) - 1))]
+        for v in bucketed
+    )
+
+
+def _short_iso(iso: str) -> str:
+    try:
+        return (
+            datetime.fromisoformat(iso.replace("Z", "+00:00"))
+            .astimezone()
+            .strftime("%Y-%m-%d %H:%M:%S")
+        )
+    except ValueError:
+        return iso
+
+
+def _fmt_latest(value: Optional[float]) -> str:
+    if value is None:
+        return "—"
+    return f"{value:.2f}"
+
+
+@contextmanager
+def _open_metrics_sink(output_file: Optional[str]) -> Iterator[TextIO]:
+    if output_file is None or output_file == "-":
+        yield sys.stdout
+        return
+    with open(output_file, "w") as f:
+        yield f

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -1316,3 +1316,48 @@ class BasetenApi:
         self._rest_api_client.post(
             f"v1/loops/deployments/{deployment_id}/deactivate", body={}
         )
+
+    def get_loops_deployment_metrics(
+        self,
+        deployment_id: str,
+        start_epoch_millis: Optional[int] = None,
+        end_epoch_millis: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """Fetch request-traffic metrics for a Loops trainer deployment."""
+        body: Dict[str, int] = {}
+        if start_epoch_millis is not None:
+            body["start_epoch_millis"] = start_epoch_millis
+        if end_epoch_millis is not None:
+            body["end_epoch_millis"] = end_epoch_millis
+        return self._rest_api_client.post(
+            f"v1/loops/deployments/{deployment_id}/metrics", body=body
+        )
+
+    def get_model_deployment_range_metrics(
+        self,
+        model_version_id: str,
+        start_iso: str,
+        end_iso: str,
+        step_seconds: int = 15,
+    ) -> Dict[str, Any]:
+        """Fetch request-traffic metrics for a model deployment (OracleVersion).
+
+        Used to surface a Loops sampler's request volume / concurrency
+        alongside the trainer's.
+        """
+        query_string = f"""
+        {{
+            range_model_metrics(
+                model_version_id: "{model_version_id}",
+                start: "{start_iso}",
+                end: "{end_iso}",
+                step_seconds: {step_seconds},
+                time_divisor_seconds: 1
+            ) {{
+                inference_volume {{ timestamp value }}
+                model_concurrent_requests {{ timestamp value }}
+            }}
+        }}
+        """
+        resp = self._post_graphql_query(query_string)
+        return resp["data"].get("range_model_metrics") or {}

--- a/truss/tests/cli/test_loops_cli.py
+++ b/truss/tests/cli/test_loops_cli.py
@@ -837,3 +837,308 @@ def test_checkpoints_deploy_rejects_checkpoint_ids_with_config(mock_remote, tmp_
         )
     assert result.exit_code != 0
     mock_create.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# `truss loops runs metrics` — request volume / concurrency per run window.
+# ---------------------------------------------------------------------------
+
+
+def _series(values, start_ts=1700000000):
+    return [{"timestamp": start_ts + i * 15, "value": v} for i, v in enumerate(values)]
+
+
+def _setup_run_metrics_mocks(
+    mock_remote,
+    *,
+    trainer_volume,
+    trainer_concurrent,
+    sampler_volume=(),
+    sampler_concurrent=(),
+    sampler_deployment_id="ov_sampler",
+    run_base_model="Qwen/Qwen3-8B",
+    deployments_base_models=None,
+):
+    """Wire up the four API methods the metrics command calls.
+
+    `deployments_base_models` is a list of (deployment_id, base_model, status_name);
+    if omitted, defaults to one active deployment matching the run's base model.
+    """
+    mock_remote.api.get_loops_run.return_value = {
+        "id": "trnr_xyz",
+        "base_model": run_base_model,
+        "created_at": "2026-05-07T12:34:56Z",
+        "sampler": (
+            {"deployment_id": sampler_deployment_id} if sampler_deployment_id else None
+        ),
+    }
+    if deployments_base_models is None:
+        deployments_base_models = [("dep_trainer", run_base_model, "RUNNING")]
+    mock_remote.api.list_loops_deployments.return_value = [
+        {"id": dep_id, "base_model": bm, "status": {"name": status}}
+        for dep_id, bm, status in deployments_base_models
+    ]
+    mock_remote.api.get_loops_deployment_metrics.return_value = {
+        "metrics": {
+            "inference_volume": _series(trainer_volume),
+            "concurrent_requests": _series(trainer_concurrent),
+        }
+    }
+    mock_remote.api.get_model_deployment_range_metrics.return_value = {
+        "inference_volume": _series(list(sampler_volume)),
+        "model_concurrent_requests": _series(list(sampler_concurrent)),
+    }
+
+
+def test_runs_metrics_snapshot_renders_table_with_trainer_and_sampler(mock_remote):
+    _setup_run_metrics_mocks(
+        mock_remote,
+        trainer_volume=[1.0, 2.5, 3.0],
+        trainer_concurrent=[1.0, 2.0, 1.5],
+        sampler_volume=[0.2, 0.4, 0.8],
+        sampler_concurrent=[1.0, 1.0, 2.0],
+    )
+    result = _invoke(
+        ["loops", "runs", "metrics", "--remote", "test_remote", "--run-id", "trnr_xyz"],
+        mock_remote,
+    )
+    assert result.exit_code == 0, result.output
+    assert "Trainer" in result.output
+    assert "Sampler" in result.output
+    assert "dep_trainer" in result.output
+    assert "ov_sampler" in result.output
+    # Latest values surface in the right-justified value columns.
+    assert "3.00" in result.output  # trainer request volume latest
+    assert "0.80" in result.output  # sampler request volume latest
+
+
+def test_runs_metrics_snapshot_json_emits_single_document(mock_remote):
+    _setup_run_metrics_mocks(
+        mock_remote,
+        trainer_volume=[1.0, 2.0],
+        trainer_concurrent=[3.0, 4.0],
+        sampler_volume=[0.5],
+        sampler_concurrent=[1.5],
+    )
+    result = _invoke(
+        [
+            "loops",
+            "runs",
+            "metrics",
+            "--remote",
+            "test_remote",
+            "--run-id",
+            "trnr_xyz",
+            "-o",
+            "json",
+        ],
+        mock_remote,
+    )
+    assert result.exit_code == 0, result.output
+    records = _parse_jsonl(result.output)
+    assert len(records) == 1
+    doc = records[0]
+    assert doc["run_id"] == "trnr_xyz"
+    assert doc["trainer_deployment_id"] == "dep_trainer"
+    assert doc["sampler_deployment_id"] == "ov_sampler"
+    assert doc["trainer"]["request_volume"][-1]["value"] == 2.0
+    assert doc["trainer"]["concurrent_requests"][-1]["value"] == 4.0
+    assert doc["sampler"]["request_volume"][-1]["value"] == 0.5
+    assert doc["sampler"]["concurrent_requests"][-1]["value"] == 1.5
+    assert "start" in doc["window"] and "end" in doc["window"]
+
+
+def test_runs_metrics_json_output_file_writes_to_path_not_stdout(mock_remote, tmp_path):
+    _setup_run_metrics_mocks(
+        mock_remote, trainer_volume=[1.0], trainer_concurrent=[2.0]
+    )
+    out = tmp_path / "metrics.json"
+    result = _invoke(
+        [
+            "loops",
+            "runs",
+            "metrics",
+            "--remote",
+            "test_remote",
+            "--run-id",
+            "trnr_xyz",
+            "-o",
+            "json",
+            "--output-file",
+            str(out),
+        ],
+        mock_remote,
+    )
+    assert result.exit_code == 0, result.output
+    # stdout stays empty so it's safe to redirect; payload lands in the file.
+    assert result.output.strip() == ""
+    written = out.read_text().splitlines()
+    assert len(written) == 1
+    doc = json.loads(written[0])
+    assert doc["run_id"] == "trnr_xyz"
+
+
+def test_runs_metrics_since_and_start_are_mutually_exclusive(mock_remote):
+    result = _invoke(
+        [
+            "loops",
+            "runs",
+            "metrics",
+            "--remote",
+            "test_remote",
+            "--run-id",
+            "trnr_xyz",
+            "--since",
+            "1h",
+            "--start",
+            "2026-06-10T00:00:00Z",
+        ],
+        mock_remote,
+    )
+    assert result.exit_code != 0
+    assert "--since and --start are mutually exclusive" in result.output
+
+
+def test_runs_metrics_output_file_requires_json(mock_remote):
+    result = _invoke(
+        [
+            "loops",
+            "runs",
+            "metrics",
+            "--remote",
+            "test_remote",
+            "--run-id",
+            "trnr_xyz",
+            "--output-file",
+            "/tmp/x.json",
+        ],
+        mock_remote,
+    )
+    assert result.exit_code != 0
+    assert "--output-file requires -o json" in result.output
+
+
+def test_runs_metrics_invalid_duration_is_rejected(mock_remote):
+    _setup_run_metrics_mocks(
+        mock_remote, trainer_volume=[1.0], trainer_concurrent=[2.0]
+    )
+    result = _invoke(
+        [
+            "loops",
+            "runs",
+            "metrics",
+            "--remote",
+            "test_remote",
+            "--run-id",
+            "trnr_xyz",
+            "--since",
+            "5x",
+        ],
+        mock_remote,
+    )
+    assert result.exit_code != 0
+    assert "Invalid duration" in result.output
+
+
+def test_runs_metrics_no_active_deployment_for_base_model_errors(mock_remote):
+    _setup_run_metrics_mocks(
+        mock_remote,
+        trainer_volume=[],
+        trainer_concurrent=[],
+        deployments_base_models=[("dep_other", "OtherModel", "RUNNING")],
+    )
+    result = _invoke(
+        ["loops", "runs", "metrics", "--remote", "test_remote", "--run-id", "trnr_xyz"],
+        mock_remote,
+    )
+    assert result.exit_code != 0
+    assert "No active Loops deployment found for base model" in result.output
+
+
+def test_runs_metrics_ignores_inactive_deployments_when_resolving(mock_remote):
+    # A STOPPED deployment with the same base_model must not be picked as the
+    # trainer — only active ones qualify.
+    _setup_run_metrics_mocks(
+        mock_remote,
+        trainer_volume=[1.0, 2.0],
+        trainer_concurrent=[1.0, 1.0],
+        deployments_base_models=[
+            ("dep_old", "Qwen/Qwen3-8B", "STOPPED"),
+            ("dep_trainer", "Qwen/Qwen3-8B", "RUNNING"),
+        ],
+    )
+    result = _invoke(
+        [
+            "loops",
+            "runs",
+            "metrics",
+            "--remote",
+            "test_remote",
+            "--run-id",
+            "trnr_xyz",
+            "-o",
+            "json",
+        ],
+        mock_remote,
+    )
+    assert result.exit_code == 0, result.output
+    doc = _parse_jsonl(result.output)[0]
+    assert doc["trainer_deployment_id"] == "dep_trainer"
+
+
+def test_runs_metrics_handles_run_without_sampler(mock_remote):
+    _setup_run_metrics_mocks(
+        mock_remote,
+        trainer_volume=[1.0, 2.0],
+        trainer_concurrent=[1.0, 1.0],
+        sampler_deployment_id=None,
+    )
+    result = _invoke(
+        [
+            "loops",
+            "runs",
+            "metrics",
+            "--remote",
+            "test_remote",
+            "--run-id",
+            "trnr_xyz",
+            "-o",
+            "json",
+        ],
+        mock_remote,
+    )
+    assert result.exit_code == 0, result.output
+    doc = _parse_jsonl(result.output)[0]
+    assert doc["sampler_deployment_id"] is None
+    assert doc["sampler"]["request_volume"] == []
+    mock_remote.api.get_model_deployment_range_metrics.assert_not_called()
+
+
+def test_runs_metrics_since_overrides_default_window(mock_remote):
+    _setup_run_metrics_mocks(
+        mock_remote, trainer_volume=[1.0], trainer_concurrent=[1.0]
+    )
+    result = _invoke(
+        [
+            "loops",
+            "runs",
+            "metrics",
+            "--remote",
+            "test_remote",
+            "--run-id",
+            "trnr_xyz",
+            "--since",
+            "1h",
+            "-o",
+            "json",
+        ],
+        mock_remote,
+    )
+    assert result.exit_code == 0, result.output
+    # With --since 1h, the trainer-metrics call uses a start roughly one
+    # hour before now (not run.created_at = 2026-05-07).
+    call_kwargs = mock_remote.api.get_loops_deployment_metrics.call_args.kwargs
+    assert call_kwargs["start_epoch_millis"] is not None
+    # Sanity: start should be after the run's created_at of 2026-05-07.
+    run_created_ms = 1746621296000  # 2026-05-07T12:34:56Z
+    assert call_kwargs["start_epoch_millis"] > run_created_ms


### PR DESCRIPTION
## Summary

- Adds `truss loops runs metrics --run-id <id>` showing request volume + concurrent requests for the run's trainer deployment and its paired sampler, over a configurable window
- Default behavior: one snapshot for `run.created_at → now`. `--tail` keeps refreshing until interrupted (live cli-table or NDJSON in json mode)
- Window flags: `--since 30m|2h|1d` or `--start/--end` (ISO-8601, mutually exclusive with `--since`)
- Output flags: `-o cli-table|json` (matches existing `loops view` convention) and `--output-file PATH` for json

## Test plan
- [x] Unit tests cover snapshot table, snapshot json, json + `--output-file`, `--since`/`--start` mutex, `--output-file` requires json, invalid duration, no matching active deployment, inactive deployments ignored during resolution, run without sampler, and `--since` overrides the default window
- [x] `uv run pytest truss/tests/cli/test_loops_cli.py` → 56 passed
- [x] `uv run ruff check` + `uv run ruff format` clean
- [ ] Smoke against `baseten-local` once a Loops run is up — not yet run

🤖 Generated with [Claude Code](https://claude.com/claude-code)