### PR TITLE
fix(loops): render deployments with sampler: null without crashing

### DIFF
--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -261,15 +261,15 @@ def _render_loops_deployments(deployments: List[Dict[str, Any]]) -> None:
     table.add_column("Sampler Status")
     table.add_column("Sampler Base URL", style="blue")
     for deployment in deployments:
-        sampler = deployment["sampler"]
+        sampler = deployment.get("sampler")
         table.add_row(
             deployment["id"],
             deployment["base_model"],
             deployment["status"]["name"],
             deployment["base_url"],
-            sampler["deployment_id"],
-            sampler["status"]["name"],
-            sampler["base_url"],
+            sampler["deployment_id"] if sampler else "—",
+            sampler["status"]["name"] if sampler else "—",
+            sampler["base_url"] if sampler else "—",
         )
     console.print(table)
 
@@ -279,7 +279,7 @@ def _render_loops_deployments_json(deployments: List[Dict[str, Any]]) -> None:
     Print the deployments as jsonl. Closely follows the columns in the default format.
     """
     for deployment in deployments:
-        sampler = deployment["sampler"]
+        sampler = deployment.get("sampler")
         output = {
             "id": deployment["id"],
             "base_model": deployment["base_model"],
@@ -289,7 +289,9 @@ def _render_loops_deployments_json(deployments: List[Dict[str, Any]]) -> None:
                 "deployment_id": sampler["deployment_id"],
                 "base_url": sampler["base_url"],
                 "status": sampler["status"]["name"],
-            },
+            }
+            if sampler
+            else None,
         }
         print(json.dumps(output))
 

--- a/truss/tests/cli/test_loops_cli.py
+++ b/truss/tests/cli/test_loops_cli.py
@@ -385,6 +385,50 @@ def test_view_json_output_all_flag_includes_terminal_states(mock_remote):
     assert sorted(r["id"] for r in records) == ["dep_running", "dep_stopped"]
 
 
+def test_view_renders_deployment_with_null_sampler(mock_remote):
+    # Backend surfaces orphaned deployments with ``sampler: null`` rather
+    # than dropping them. The table must render the row with placeholders
+    # instead of KeyError'ing on sampler["..."].
+    mock_remote.api.list_loops_deployments.return_value = [
+        {
+            "id": "dep_orphan",
+            "base_model": "Qwen/Qwen3-8B",
+            "base_url": "https://trainer-orphan.api.baseten.co/trainer",
+            "status": {"name": "RUNNING"},
+            "sampler": None,
+        }
+    ]
+    result = _invoke(["loops", "view", "--remote", "test_remote"], mock_remote)
+    assert result.exit_code == 0, result.output
+    assert "dep_orphan" in result.output
+
+
+def test_view_json_output_renders_null_sampler(mock_remote):
+    mock_remote.api.list_loops_deployments.return_value = [
+        {
+            "id": "dep_orphan",
+            "base_model": "Qwen/Qwen3-8B",
+            "base_url": "https://trainer-orphan.api.baseten.co/trainer",
+            "status": {"name": "RUNNING"},
+            "sampler": None,
+        }
+    ]
+    result = _invoke(
+        ["loops", "view", "--remote", "test_remote", "-o", "json"], mock_remote
+    )
+    assert result.exit_code == 0, result.output
+    records = _parse_jsonl(result.output)
+    assert records == [
+        {
+            "id": "dep_orphan",
+            "base_model": "Qwen/Qwen3-8B",
+            "base_url": "https://trainer-orphan.api.baseten.co/trainer",
+            "status": "RUNNING",
+            "sampler": None,
+        }
+    ]
+
+
 def test_runs_view_no_filters_calls_search_with_none(mock_remote):
     mock_remote.api.list_loops_runs.return_value = [
         {"id": "trnr_xyz", "session_id": "sess_abc", "base_model": "Qwen/Qwen3-8B"}


### PR DESCRIPTION
## Summary

- `truss loops view` (table + JSON) indexed `deployment["sampler"]` directly and would `KeyError` if the backend returned `sampler: null`
- The backend now surfaces orphaned deployments (paired `SamplingServer` failed mid-create) with `sampler: null` instead of silently dropping them — see basetenlabs/baseten#20464
- Render `—` placeholders in the three sampler columns of the table and emit `"sampler": null` in the JSON output

## Test plan

- [x] Added `test_view_renders_deployment_with_null_sampler` covering the table path
- [x] Added `test_view_json_output_renders_null_sampler` covering the JSON path
- [x] `uv run pytest truss/tests/cli/test_loops_cli.py` — 48 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)