### PR TITLE
Add time-range and filter flags to `truss model-logs`

### DIFF
--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -1069,7 +1069,7 @@ def push(
 @click.option(
     "--tail",
     is_flag=True,
-    help="Stream new logs as they arrive. Cannot be combined with the filter flags.",
+    help="Stream new logs as they arrive. Cannot be combined with the time-range or filter flags.",
 )
 @click.option(
     "--start",
@@ -1187,7 +1187,9 @@ def model_logs(
         or includes
         or excludes
     ):
-        raise click.UsageError("--tail cannot be combined with the filter flags.")
+        raise click.UsageError(
+            "--tail cannot be combined with the time-range or filter flags."
+        )
 
     if not remote:
         remote = remote_cli.inquire_remote_name()

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -5,6 +5,7 @@ import sys
 import tarfile
 import threading
 import time
+from datetime import datetime
 from pathlib import Path
 from typing import Optional, cast
 
@@ -1063,30 +1064,159 @@ def push(
 @click.option(
     "--remote", type=str, required=False, help="Name of the remote in .trussrc."
 )
-@click.option("--model-id", type=str, required=True)
-@click.option("--deployment-id", type=str, required=True)
-@click.option("--tail", is_flag=True, help="Tail for ongoing logs.")
+@click.option("--model-id", type=str, required=True, help="ID of the model.")
+@click.option("--deployment-id", type=str, required=True, help="ID of the deployment.")
+@click.option(
+    "--tail",
+    is_flag=True,
+    help="Stream new logs as they arrive. Cannot be combined with the filter flags.",
+)
+@click.option(
+    "--start",
+    type=click.DateTime(
+        formats=[
+            "%Y-%m-%d",
+            "%Y-%m-%dT%H:%M:%S",
+            "%Y-%m-%d %H:%M:%S",
+            "%Y-%m-%dT%H:%M:%S%z",
+            "%Y-%m-%d %H:%M:%S%z",
+        ]
+    ),
+    default=None,
+    help=(
+        "Start of the log time range (ISO 8601). No-timezone values are local. "
+        "Defaults to a short look-back ending at --end. Window must be <= 7 days."
+    ),
+)
+@click.option(
+    "--end",
+    type=click.DateTime(
+        formats=[
+            "%Y-%m-%d",
+            "%Y-%m-%dT%H:%M:%S",
+            "%Y-%m-%d %H:%M:%S",
+            "%Y-%m-%dT%H:%M:%S%z",
+            "%Y-%m-%d %H:%M:%S%z",
+        ]
+    ),
+    default=None,
+    help=(
+        "End of the log time range (ISO 8601). No-timezone values are local. "
+        "Defaults to now. Window must be <= 7 days."
+    ),
+)
+@click.option(
+    "--since",
+    type=str,
+    default=None,
+    help=(
+        "Logs from a relative time ago until now, as <N><unit> with unit "
+        "s/m/h/d (e.g. '90s', '2h', '3d'). Max '7d'. Excludes --start/--end."
+    ),
+)
+@click.option(
+    "--min-level",
+    type=click.Choice(["debug", "info", "warning", "error"], case_sensitive=False),
+    default=None,
+    help=(
+        "Minimum log severity. Defaults to all lines. Any value returns lines "
+        "at or above that severity and drops lines with no level."
+    ),
+)
+@click.option(
+    "--includes",
+    type=str,
+    multiple=True,
+    help="Case-sensitive substring that must appear in the message (repeatable).",
+)
+@click.option(
+    "--excludes",
+    type=str,
+    multiple=True,
+    help="Case-sensitive substring that drops any line containing it (repeatable).",
+)
+@click.option(
+    "--search-pattern",
+    type=str,
+    default=None,
+    help="RE2 regex matched against the message. Prefer --includes/--excludes.",
+)
+@click.option(
+    "--replica",
+    type=str,
+    default=None,
+    help="Only return logs emitted by this replica (5-char short ID).",
+)
+@click.option(
+    "--request-id",
+    type=str,
+    default=None,
+    help="Only return logs tagged with this inference request ID.",
+)
 @common.common_options()
 def model_logs(
-    remote: Optional[str], model_id: str, deployment_id: str, tail: bool = False
+    remote: Optional[str],
+    model_id: str,
+    deployment_id: str,
+    tail: bool = False,
+    start: Optional[datetime] = None,
+    end: Optional[datetime] = None,
+    since: Optional[str] = None,
+    min_level: Optional[str] = None,
+    includes: tuple[str, ...] = (),
+    excludes: tuple[str, ...] = (),
+    search_pattern: Optional[str] = None,
+    replica: Optional[str] = None,
+    request_id: Optional[str] = None,
 ) -> None:
     """
-    Fetches logs for the packaged model
+    Fetches logs for the packaged model.
+
+    Defaults to a short look-back window. Use --start/--end or --since to scope
+    the window (max 7 days), the filter flags to narrow results, or --tail to
+    stream live logs.
     """
+    if tail and (
+        start is not None
+        or end is not None
+        or since is not None
+        or min_level is not None
+        or replica is not None
+        or request_id is not None
+        or search_pattern is not None
+        or includes
+        or excludes
+    ):
+        raise click.UsageError("--tail cannot be combined with the filter flags.")
 
     if not remote:
         remote = remote_cli.inquire_remote_name()
     remote_provider = cast(BasetenRemote, RemoteFactory.create(remote=remote))
-    if not tail:
-        logs = remote_provider.api.get_model_deployment_logs(model_id, deployment_id)
-        for log in cli_log_utils.parse_logs(logs):
-            cli_log_utils.output_log(log)
-    else:
+
+    if tail:
         log_watcher = ModelDeploymentLogWatcher(
             remote_provider.api, model_id, deployment_id
         )
         for log in log_watcher.watch():
             cli_log_utils.output_log(log)
+        return
+
+    start_ms, end_ms = cli_log_utils.resolve_log_time_range(start, end, since)
+    logs = remote_provider.api.get_model_deployment_logs(
+        model_id,
+        deployment_id,
+        start_ms,
+        end_ms,
+        # Backend LogLevelV1 values are uppercase, but the flag accepts any case.
+        min_level=min_level.upper() if min_level else None,
+        replica=replica,
+        request_id=request_id,
+        search_pattern=search_pattern,
+        includes=list(includes),
+        excludes=list(excludes),
+    )
+    for log in cli_log_utils.parse_logs(logs):
+        cli_log_utils.output_log(log)
 
 
 @truss_cli.command()

--- a/truss/cli/logs/utils.py
+++ b/truss/cli/logs/utils.py
@@ -1,10 +1,17 @@
-from datetime import datetime
-from typing import Any, List, Optional
+import re
+from datetime import datetime, timedelta, timezone
+from typing import Any, List, Optional, Tuple
 
 import pydantic
+import rich_click as click
 from rich import text
 
 from truss.cli.utils.output import console
+
+MAX_LOG_RANGE = timedelta(days=7)
+
+_SINCE_RE = re.compile(r"^(\d+)([smhd])$")
+_SINCE_UNIT_TO_SECONDS = {"s": 1, "m": 60, "h": 3600, "d": 86400}
 
 
 class ParsedLog(pydantic.BaseModel):
@@ -15,6 +22,77 @@ class ParsedLog(pydantic.BaseModel):
     @classmethod
     def from_raw(self, raw_log: Any) -> "ParsedLog":
         return ParsedLog(**raw_log)
+
+
+def parse_since(value: str) -> timedelta:
+    """Parse a `--since` duration like '90s', '30m', '2h', '3d' into a timedelta.
+
+    Accepts integer values with a single unit suffix: s (seconds), m (minutes),
+    h (hours), or d (days). Rejects zero, negative, malformed, or out-of-range
+    values. Maximum allowed duration is MAX_LOG_RANGE (7 days).
+    """
+    match = _SINCE_RE.match(value.strip()) if value else None
+    if not match:
+        raise click.BadParameter(
+            f"Invalid --since value '{value}'. Expected format <N><unit> where "
+            f"unit is s (seconds), m (minutes), h (hours), or d (days). "
+            f"Examples: '90s', '30m', '2h', '3d'."
+        )
+
+    amount = int(match.group(1))
+    if amount <= 0:
+        raise click.BadParameter("--since must be greater than zero.")
+
+    delta = timedelta(seconds=amount * _SINCE_UNIT_TO_SECONDS[match.group(2)])
+    if delta > MAX_LOG_RANGE:
+        raise click.BadParameter(f"--since must be at most 7d (got '{value}').")
+    return delta
+
+
+def _ensure_tz_aware(dt: datetime) -> datetime:
+    # Naive datetimes are interpreted in the local timezone (matching how logs
+    # are displayed). astimezone() on a naive value assumes local time.
+    if dt.tzinfo is None:
+        return dt.astimezone()
+    return dt
+
+
+def _to_epoch_millis(dt: datetime) -> int:
+    return int(_ensure_tz_aware(dt).timestamp() * 1000)
+
+
+def resolve_log_time_range(
+    start: Optional[datetime], end: Optional[datetime], since: Optional[str]
+) -> Tuple[Optional[int], Optional[int]]:
+    """Resolve --start/--end/--since into (start_epoch_millis, end_epoch_millis).
+
+    Omitted bounds are returned as None so the server applies its own defaults
+    (missing end -> now, missing start -> default look-back). Naive datetimes
+    are interpreted in the local timezone. The 7-day window is checked here only
+    when both bounds are given; --since cannot be combined with --start/--end.
+    """
+    if since is not None and (start is not None or end is not None):
+        raise click.UsageError("--since cannot be combined with --start or --end.")
+
+    if since is not None:
+        delta = parse_since(since)
+        now = datetime.now(timezone.utc)
+        return _to_epoch_millis(now - delta), _to_epoch_millis(now)
+
+    if start is not None and end is not None:
+        start = _ensure_tz_aware(start)
+        end = _ensure_tz_aware(end)
+        if start >= end:
+            raise click.UsageError("--start must be earlier than --end.")
+        if end - start > MAX_LOG_RANGE:
+            raise click.UsageError(
+                "Log time range must be at most 7 days. Narrow --start/--end or "
+                "use --since."
+            )
+
+    start_ms = _to_epoch_millis(start) if start is not None else None
+    end_ms = _to_epoch_millis(end) if end is not None else None
+    return start_ms, end_ms
 
 
 def format_log(log: ParsedLog) -> str:

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -1093,10 +1093,31 @@ class BasetenApi:
         deployment_id: str,
         start_epoch_millis: Optional[int] = None,
         end_epoch_millis: Optional[int] = None,
+        min_level: Optional[str] = None,
+        replica: Optional[str] = None,
+        request_id: Optional[str] = None,
+        search_pattern: Optional[str] = None,
+        includes: Optional[List[str]] = None,
+        excludes: Optional[List[str]] = None,
     ):
+        body: Dict[str, Any] = dict(
+            self._prepare_time_range_query(start_epoch_millis, end_epoch_millis)
+        )
+        if min_level:
+            body["min_level"] = min_level
+        if replica:
+            body["replica"] = replica
+        if request_id:
+            body["request_id"] = request_id
+        if search_pattern:
+            body["search_pattern"] = search_pattern
+        if includes:
+            body["includes"] = includes
+        if excludes:
+            body["excludes"] = excludes
+
         resp_json = self._rest_api_client.post(
-            f"v1/models/{model_id}/deployments/{deployment_id}/logs",
-            body=self._prepare_time_range_query(start_epoch_millis, end_epoch_millis),
+            f"v1/models/{model_id}/deployments/{deployment_id}/logs", body=body
         )
 
         # NB(nikhil): reverse order so latest logs are at the end

--- a/truss/tests/cli/test_cli.py
+++ b/truss/tests/cli/test_cli.py
@@ -1628,3 +1628,108 @@ def test_model_config_requires_model_id_and_deployment_id():
     result = _invoke_model_config([])
     assert result.exit_code != 0
     assert "--model-id" in result.output
+
+
+def test_model_logs_passes_filters():
+    mock_remote = Mock()
+    mock_remote.api.get_model_deployment_logs.return_value = []
+    runner = CliRunner()
+    with patch("truss.cli.cli.RemoteFactory.create", return_value=mock_remote):
+        result = runner.invoke(
+            truss_cli,
+            [
+                "model-logs",
+                "--remote",
+                "remote1",
+                "--model-id",
+                "m1",
+                "--deployment-id",
+                "d1",
+                "--min-level",
+                "info",  # lower-case input normalized to the backend's casing
+                "--replica",
+                "abcde",
+                "--request-id",
+                "r1",
+                "--search-pattern",
+                "oops.*",
+                "--includes",
+                "foo",
+                "--includes",
+                "bar",
+                "--excludes",
+                "noise",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    mock_remote.api.get_model_deployment_logs.assert_called_once_with(
+        "m1",
+        "d1",
+        None,
+        None,
+        min_level="INFO",
+        replica="abcde",
+        request_id="r1",
+        search_pattern="oops.*",
+        includes=["foo", "bar"],
+        excludes=["noise"],
+    )
+
+
+def test_model_logs_defaults_omit_filters():
+    mock_remote = Mock()
+    mock_remote.api.get_model_deployment_logs.return_value = []
+    runner = CliRunner()
+    with patch("truss.cli.cli.RemoteFactory.create", return_value=mock_remote):
+        result = runner.invoke(
+            truss_cli,
+            [
+                "model-logs",
+                "--remote",
+                "remote1",
+                "--model-id",
+                "m1",
+                "--deployment-id",
+                "d1",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    mock_remote.api.get_model_deployment_logs.assert_called_once_with(
+        "m1",
+        "d1",
+        None,
+        None,
+        min_level=None,
+        replica=None,
+        request_id=None,
+        search_pattern=None,
+        includes=[],
+        excludes=[],
+    )
+
+
+def test_model_logs_tail_with_filter_errors():
+    mock_remote = Mock()
+    runner = CliRunner()
+    with patch("truss.cli.cli.RemoteFactory.create", return_value=mock_remote):
+        result = runner.invoke(
+            truss_cli,
+            [
+                "model-logs",
+                "--remote",
+                "remote1",
+                "--model-id",
+                "m1",
+                "--deployment-id",
+                "d1",
+                "--tail",
+                "--min-level",
+                "info",
+            ],
+        )
+
+    assert result.exit_code != 0
+    assert "filter flags" in result.output
+    mock_remote.api.get_model_deployment_logs.assert_not_called()

--- a/truss/tests/cli/test_cli.py
+++ b/truss/tests/cli/test_cli.py
@@ -1731,5 +1731,5 @@ def test_model_logs_tail_with_filter_errors():
         )
 
     assert result.exit_code != 0
-    assert "filter flags" in result.output
+    assert "--tail cannot be combined" in result.output
     mock_remote.api.get_model_deployment_logs.assert_not_called()

--- a/truss/tests/cli/test_cli.py
+++ b/truss/tests/cli/test_cli.py
@@ -1731,5 +1731,5 @@ def test_model_logs_tail_with_filter_errors():
         )
 
     assert result.exit_code != 0
-    assert "--tail cannot be combined" in result.output
+    assert "cannot be combined" in result.output
     mock_remote.api.get_model_deployment_logs.assert_not_called()

--- a/truss/tests/cli/test_logs_utils.py
+++ b/truss/tests/cli/test_logs_utils.py
@@ -1,0 +1,149 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import rich_click as click
+
+from truss.cli.logs.utils import MAX_LOG_RANGE, parse_since, resolve_log_time_range
+
+
+def test_parse_since_minutes():
+    assert parse_since("30m") == timedelta(minutes=30)
+
+
+def test_parse_since_hours():
+    assert parse_since("2h") == timedelta(hours=2)
+
+
+def test_parse_since_days():
+    assert parse_since("3d") == timedelta(days=3)
+
+
+def test_parse_since_seconds():
+    assert parse_since("90s") == timedelta(seconds=90)
+
+
+def test_parse_since_boundary_7d_ok():
+    assert parse_since("7d") == MAX_LOG_RANGE
+
+
+def test_parse_since_boundary_in_hours_ok():
+    assert parse_since("168h") == MAX_LOG_RANGE
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "0m",
+        "0h",
+        "0d",
+        "8d",
+        "169h",
+        "5x",
+        "abc",
+        "",
+        "30",
+        " 30m ",  # outer whitespace ok via strip, but no decimals/units mismatch
+        "-1h",
+        "1.5h",
+        "1h30m",
+    ],
+)
+def test_parse_since_invalid(value):
+    # ' 30m ' is actually valid because we strip
+    if value == " 30m ":
+        assert parse_since(value) == timedelta(minutes=30)
+        return
+    with pytest.raises(click.BadParameter):
+        parse_since(value)
+
+
+def test_resolve_returns_none_when_no_inputs():
+    assert resolve_log_time_range(None, None, None) == (None, None)
+
+
+def test_resolve_since_sets_window_ending_now():
+    start_ms, end_ms = resolve_log_time_range(None, None, "1h")
+    now_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
+    # End should be ~now (within a few seconds).
+    assert abs(end_ms - now_ms) < 5_000
+    # Start should be ~1h before end.
+    assert abs((end_ms - start_ms) - 3_600_000) < 5_000
+
+
+def test_resolve_only_start_leaves_end_none():
+    # Omitted --end is deferred to the server (sent as None), not backfilled.
+    start = datetime(2026, 5, 14, 0, 0, 0, tzinfo=timezone.utc)
+    start_ms, end_ms = resolve_log_time_range(start, None, None)
+    assert start_ms == int(start.timestamp() * 1000)
+    assert end_ms is None
+
+
+def test_resolve_only_start_skips_window_check():
+    # With end deferred, a far-past start is not rejected client-side; the
+    # server enforces the window once it backfills end.
+    start = datetime(2020, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    start_ms, end_ms = resolve_log_time_range(start, None, None)
+    assert start_ms == int(start.timestamp() * 1000)
+    assert end_ms is None
+
+
+def test_resolve_only_end_leaves_start_none():
+    # Omitted --start is deferred to the server (sent as None), not backfilled.
+    end = datetime(2026, 5, 14, 0, 0, 0, tzinfo=timezone.utc)
+    start_ms, end_ms = resolve_log_time_range(None, end, None)
+    assert start_ms is None
+    assert end_ms == int(end.timestamp() * 1000)
+
+
+def test_resolve_both_honored():
+    start = datetime(2026, 5, 13, 0, 0, 0, tzinfo=timezone.utc)
+    end = datetime(2026, 5, 14, 0, 0, 0, tzinfo=timezone.utc)
+    start_ms, end_ms = resolve_log_time_range(start, end, None)
+    assert start_ms == int(start.timestamp() * 1000)
+    assert end_ms == int(end.timestamp() * 1000)
+
+
+def test_resolve_naive_datetime_treated_as_local():
+    # Naive input is interpreted in the local timezone (astimezone() on a naive
+    # value assumes local), matching how logs are displayed.
+    naive = datetime(2026, 5, 14, 12, 0, 0)
+    start_ms, _ = resolve_log_time_range(naive, None, None)
+    assert start_ms == int(naive.astimezone().timestamp() * 1000)
+
+
+def test_resolve_aware_datetime_respects_offset():
+    aware = datetime(2026, 5, 14, 12, 0, 0, tzinfo=timezone(timedelta(hours=5)))
+    start_ms, _ = resolve_log_time_range(aware, None, None)
+    assert start_ms == int(aware.timestamp() * 1000)
+
+
+def test_resolve_start_after_end_errors():
+    start = datetime(2026, 5, 14, 0, 0, 0, tzinfo=timezone.utc)
+    end = datetime(2026, 5, 13, 0, 0, 0, tzinfo=timezone.utc)
+    with pytest.raises(click.UsageError):
+        resolve_log_time_range(start, end, None)
+
+
+def test_resolve_start_equals_end_errors():
+    dt = datetime(2026, 5, 14, 0, 0, 0, tzinfo=timezone.utc)
+    with pytest.raises(click.UsageError):
+        resolve_log_time_range(dt, dt, None)
+
+
+def test_resolve_window_over_7d_errors():
+    start = datetime(2026, 5, 1, 0, 0, 0, tzinfo=timezone.utc)
+    end = datetime(2026, 5, 14, 0, 0, 0, tzinfo=timezone.utc)
+    with pytest.raises(click.UsageError):
+        resolve_log_time_range(start, end, None)
+
+
+def test_resolve_since_with_start_errors():
+    start = datetime(2026, 5, 14, 0, 0, 0, tzinfo=timezone.utc)
+    with pytest.raises(click.UsageError):
+        resolve_log_time_range(start, None, "1h")
+
+
+def test_resolve_since_with_end_errors():
+    end = datetime(2026, 5, 14, 0, 0, 0, tzinfo=timezone.utc)
+    with pytest.raises(click.UsageError):
+        resolve_log_time_range(None, end, "1h")

--- a/truss/tests/remote/baseten/test_api.py
+++ b/truss/tests/remote/baseten/test_api.py
@@ -758,3 +758,49 @@ def test_get_model_with_versions_by_id_includes_signature(mock_post, baseten_api
     assert "versions" in query
     assert "truss_hash" in query
     assert "truss_signature" in query
+
+
+def test_get_model_deployment_logs_passes_filters(baseten_api):
+    mock_rest_client = mock.Mock()
+    mock_rest_client.post.return_value = {"logs": []}
+    baseten_api._rest_api_client = mock_rest_client
+
+    baseten_api.get_model_deployment_logs(
+        "model-1",
+        "deploy-1",
+        start_epoch_millis=1000,
+        end_epoch_millis=2000,
+        min_level="INFO",
+        replica="abcde",
+        request_id="req-1",
+        search_pattern="oops.*",
+        includes=["foo", "bar"],
+        excludes=["noise"],
+    )
+
+    args, kwargs = mock_rest_client.post.call_args
+    assert args[0] == "v1/models/model-1/deployments/deploy-1/logs"
+    assert kwargs["body"] == {
+        "start_epoch_millis": 1000,
+        "end_epoch_millis": 2000,
+        "min_level": "INFO",
+        "replica": "abcde",
+        "request_id": "req-1",
+        "search_pattern": "oops.*",
+        "includes": ["foo", "bar"],
+        "excludes": ["noise"],
+    }
+
+
+def test_get_model_deployment_logs_omits_unset_filters(baseten_api):
+    # Unset/empty filters and bounds are left out of the body entirely so the
+    # server applies its own defaults.
+    mock_rest_client = mock.Mock()
+    mock_rest_client.post.return_value = {"logs": []}
+    baseten_api._rest_api_client = mock_rest_client
+
+    baseten_api.get_model_deployment_logs(
+        "model-1", "deploy-1", includes=[], excludes=[]
+    )
+
+    assert mock_rest_client.post.call_args[1]["body"] == {}


### PR DESCRIPTION
## :rocket: What

Adds the following to `truss model-logs`:

- Time range: `--start`, `--end`, `--since` (`s`/`m`/`h`/`d`, e.g. `90s`, `2h`, `3d`; 7-day max). Naive `--start`/`--end` are interpreted as local time, matching how logs are displayed.
- Filters: `--min-level`, `--includes`/`--excludes` (repeatable substrings), `--search-pattern` (RE2 regex), `--replica`, `--request-id`

Takes over closed PR #2464 and incorporates the server-side log filters shipped to the REST API.

## :computer: How

- Omitted `--start`/`--end` are sent as `None`; the server backfills them (missing end defaults to now, missing start defaults to 30m before end), so the effective default is `--since 30m`. The client only validates the window (start < end, <= 7d) when both bounds are given.
- `--min-level` takes lowercase choices and is uppercased before sending; `--includes`/`--excludes` are repeatable.
- Filters are threaded through `get_model_deployment_logs`, building onto the dict from `_prepare_time_range_query`.

## :microscope: Testing

- Unit tests for time-range parsing (local-tz, seconds unit, defer-to-server defaulting) in `test_logs_utils.py`.
- Filter pass-through tests in `test_api.py`.
- `truss model-logs` CLI tests in `test_cli.py`.
- Manual testing against real model logs.