### PR TITLE
Add replicas option for Loops deployments

### DIFF
--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -38,10 +38,24 @@ truss_cli.add_command(loops)
     required=False,
     help="Training project ID to associate the deployment with.",
 )
+@click.option(
+    "--replicas",
+    type=int,
+    required=False,
+    help=(
+        "Number of data-parallel trainer replicas to provision. The trainer "
+        "deployment runs this many copies of the model's preset node group "
+        "(e.g. --replicas 4 on a 4-node preset → 16 nodes, 4 DP workers). "
+        "Must be a positive integer; defaults to 1."
+    ),
+)
 @click.option("--remote", type=str, required=False, help="Remote to use.")
 @common.common_options()
 def push_loops_deployment(
-    base_model: str, project_id: Optional[str], remote: Optional[str]
+    base_model: str,
+    project_id: Optional[str],
+    replicas: Optional[int],
+    remote: Optional[str],
 ) -> None:
     """Deploy a Loops run + sampler for a base model.
 
@@ -49,6 +63,11 @@ def push_loops_deployment(
     the project already has an active Loops deployment for this base
     model, the command fails with a validation error.
     """
+    if replicas is not None and replicas < 1:
+        raise click.BadParameter(
+            "--replicas must be a positive integer.", param_hint="--replicas"
+        )
+
     if not remote:
         remote = remote_cli.inquire_remote_name()
 
@@ -64,7 +83,9 @@ def push_loops_deployment(
         f"Provisioning Loops run and sampler for [cyan]{base_model}[/cyan]...",
         spinner="dots",
     ):
-        remote_provider.create_loops_run(session_id=session_id, base_model=base_model)
+        remote_provider.create_loops_run(
+            session_id=session_id, base_model=base_model, replicas=replicas
+        )
 
     # Readiness is now the loops SDK's responsibility — clients block on
     # construction (TrainingClient → /health, SamplingClient → deployment

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -1274,11 +1274,17 @@ class BasetenApi:
         return resp_json["session"]
 
     def create_loops_run(
-        self, session_id: str, base_model: str, seed: Optional[int] = None
+        self,
+        session_id: str,
+        base_model: str,
+        seed: Optional[int] = None,
+        replicas: Optional[int] = None,
     ) -> dict:
         body: Dict[str, Any] = {"session_id": session_id, "base_model": base_model}
         if seed is not None:
             body["seed"] = seed
+        if replicas is not None:
+            body["replicas"] = replicas
         resp_json = self._rest_api_client.post("v1/loops/runs", body=body)
         return resp_json["run"]
 

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -1028,8 +1028,5 @@ class BasetenRemote(TrussRemote):
 
     def create_loops_run(self, session_id, base_model, seed=None, replicas=None):
         return self._api.create_loops_run(
-            session_id=session_id,
-            base_model=base_model,
-            seed=seed,
-            replicas=replicas,
+            session_id=session_id, base_model=base_model, seed=seed, replicas=replicas
         )

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -1026,7 +1026,10 @@ class BasetenRemote(TrussRemote):
     def create_loops_session(self, training_project_id=None):
         return self._api.create_loops_session(training_project_id=training_project_id)
 
-    def create_loops_run(self, session_id, base_model, seed=None):
+    def create_loops_run(self, session_id, base_model, seed=None, replicas=None):
         return self._api.create_loops_run(
-            session_id=session_id, base_model=base_model, seed=seed
+            session_id=session_id,
+            base_model=base_model,
+            seed=seed,
+            replicas=replicas,
         )

--- a/truss/tests/cli/test_loops_cli.py
+++ b/truss/tests/cli/test_loops_cli.py
@@ -52,8 +52,7 @@ def test_push_basic(mock_remote):
 
 def test_push_with_replicas(mock_remote):
     result = _invoke_loops_push(
-        ["Qwen/Qwen3-8B", "--remote", "test_remote", "--replicas", "4"],
-        mock_remote,
+        ["Qwen/Qwen3-8B", "--remote", "test_remote", "--replicas", "4"], mock_remote
     )
 
     assert result.exit_code == 0, result.output
@@ -64,8 +63,7 @@ def test_push_with_replicas(mock_remote):
 
 def test_push_rejects_non_positive_replicas(mock_remote):
     result = _invoke_loops_push(
-        ["Qwen/Qwen3-8B", "--remote", "test_remote", "--replicas", "0"],
-        mock_remote,
+        ["Qwen/Qwen3-8B", "--remote", "test_remote", "--replicas", "0"], mock_remote
     )
 
     assert result.exit_code != 0

--- a/truss/tests/cli/test_loops_cli.py
+++ b/truss/tests/cli/test_loops_cli.py
@@ -45,9 +45,31 @@ def test_push_basic(mock_remote):
     assert result.exit_code == 0, result.output
     mock_remote.create_loops_session.assert_called_once_with(training_project_id=None)
     mock_remote.create_loops_run.assert_called_once_with(
-        session_id="session_abc123", base_model="Qwen/Qwen3-8B"
+        session_id="session_abc123", base_model="Qwen/Qwen3-8B", replicas=None
     )
     assert "Qwen/Qwen3-8B" in result.output
+
+
+def test_push_with_replicas(mock_remote):
+    result = _invoke_loops_push(
+        ["Qwen/Qwen3-8B", "--remote", "test_remote", "--replicas", "4"],
+        mock_remote,
+    )
+
+    assert result.exit_code == 0, result.output
+    mock_remote.create_loops_run.assert_called_once_with(
+        session_id="session_abc123", base_model="Qwen/Qwen3-8B", replicas=4
+    )
+
+
+def test_push_rejects_non_positive_replicas(mock_remote):
+    result = _invoke_loops_push(
+        ["Qwen/Qwen3-8B", "--remote", "test_remote", "--replicas", "0"],
+        mock_remote,
+    )
+
+    assert result.exit_code != 0
+    mock_remote.create_loops_run.assert_not_called()
 
 
 def test_push_with_project_id(mock_remote):


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What

Adds a `--replicas` option to `truss loops push` so users can request multiple data-parallel trainer replicas when provisioning a Loops run.

Example:

```bash
truss loops push Qwen/Qwen3-8B --project-id proj_abc --replicas 4
```

<!--
  How was the change described above implemented?
-->
## :computer: How

- Adds a Click `--replicas` option to the Loops push command.
- Validates that `--replicas` is a positive integer before making any API calls.
- Threads `replicas` through the remote provider and Baseten API client.
- Sends `replicas` in the `POST /v1/loops/runs` body only when explicitly provided, preserving the existing backend default otherwise.

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing

### 1. Truss CLI local validation

Setup:

- Repo: `truss`
- Branch: `xiaohan/loops-replicas-dp`
- Current PR head after author-metadata rewrite: `ddb183d4`
- Local path: `/Users/xiaohan/Codes/truss`

Command run:

```bash
uv run pytest truss/tests/cli/test_loops_cli.py -q
```

Expected:

- Existing Loops CLI behavior remains compatible.
- New `--replicas` option is accepted and forwarded to `create_loops_run`.
- Non-positive `--replicas` values are rejected client-side.

Actual:

```text
50 passed, 1 warning in 0.10s
```

### 2. Production validation against merged backend support

Setup:

- Truss repo branch: `xiaohan/loops-replicas-dp`
- Remote: `baseten`
- Remote URL: `https://app.baseten.co`
- Training project used for validation: `4q9dm63`
- Backend support from `baseten` PR `#21396` has been merged and promoted.

Commands used for representative pushes:

```bash
uv run truss --non-interactive loops push moonshotai/Kimi-K2.6 \
  --remote baseten \
  --project-id 4q9dm63 \
  --replicas 2

uv run truss --non-interactive loops push Qwen/Qwen3.5-122B-A10B \
  --remote baseten \
  --project-id 4q9dm63 \
  --replicas 2
```

Expected:

- The Truss CLI forwards `--replicas 2` to the production `POST /v1/loops/runs` request.
- The production backend accepts the request when the selected model preset can be mapped to an available multi-node / variable-node trainer instance type.
- Existing flows remain backwards compatible when `--replicas` is omitted.

Actual successful provisioning cases:

- `moonshotai/Kimi-K2.6 --replicas 2`
  - Loops deployment ID: `jwd1yew`
  - Trainer base URL: `https://trainer-jwd1yew.api.baseten.co/trainer`
  - Sampler deployment ID: `w527erv`
  - Sampler base URL: `https://model-wx42lgyq.api.baseten.co/deployment/w527erv/sync`
  - Result: trainer and sampler provisioned successfully. Both later moved to `SCALED_TO_ZERO`; sampler logs show `Scaling down replicas due to inactivity`, so this was normal idle scale-down, not a deployment failure.
- `Qwen/Qwen3.5-122B-A10B --replicas 2`
  - Loops deployment IDs observed: `8w67gyq`, `vq04d13`
  - Current/latest observed state: trainer provisioning accepted; sampler active or scaled-to-zero depending on idle state.
  - Result: production accepted the multi-replica request for this large Qwen model because the backend could resolve a compatible multi-node trainer shape.

Actual expected backend rejection cases:

```bash
uv run truss --non-interactive loops push Qwen/Qwen3-0.6B \
  --remote baseten \
  --project-id 4q9dm63 \
  --replicas 2
```

```text
Client error: No available instance type for model 'Qwen/Qwen3-0.6B' at max_seq_len=8192 (org=charles--parsed--com)
ERROR HTTPError: 400 Client Error: Bad Request for url: https://api.baseten.co/v1/loops/runs
```

```bash
uv run truss --non-interactive loops push Qwen/Qwen3.6-35B-A3B \
  --remote baseten \
  --project-id 4q9dm63 \
  --replicas 2
```

```text
Client error: No available instance type for model 'Qwen/Qwen3.6-35B-A3B' at max_seq_len=131072 (org=charles--parsed--com)
ERROR HTTPError: 400 Client Error: Bad Request for url: https://api.baseten.co/v1/loops/runs
```

These failures are not CLI forwarding failures. They happen after the new field reaches the backend. The backend computes `total_node_count = preset_node_count * replicas` and then requires an available trainer instance type matching that total node shape. Some model presets currently multiply into unavailable production catalog shapes, for example no available variable-node H200 SKU with `gpu_count=1` for the single-GPU Qwen preset, and no matching multi-node shape for the tested Qwen 35B preset.

Conclusion:

- This PR correctly exposes and forwards `--replicas`.
- Production accepts `--replicas` for models whose Loops trainer preset can resolve to available multi-node / variable-node resources, validated with Kimi and the large Qwen deployment.
- Production returns a clear backend 400 for models whose requested replica count would require unavailable trainer hardware shapes. That is expected backend admission behavior and not a Truss CLI issue.
