### PR TITLE
Revert "Add validation to prevent no_build with predict_endpoint (#2291)"

### DIFF
--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -1142,15 +1142,6 @@ class DockerServer(custom_types.ConfigModel):
             raise ValueError("start_command is required when no_build is not true")
         return self
 
-    @pydantic.model_validator(mode="after")
-    def _validate_no_build_with_predict_endpoint(self) -> "DockerServer":
-        if self.no_build and self.predict_endpoint:
-            raise ValueError(
-                "predict_endpoint is not supported when no_build is true. "
-                "With no_build, your custom server must handle routing directly."
-            )
-        return self
-
 
 class TrainingArtifactReference(custom_types.ConfigModel):
     training_job_id: str = pydantic.Field(

--- a/truss/tests/test_config.py
+++ b/truss/tests/test_config.py
@@ -1379,36 +1379,6 @@ def test_docker_server_run_as_user_id(run_as_user_id, expected, raises):
         assert docker_server.run_as_user_id == expected
 
 
-def test_docker_server_no_build_with_predict_endpoint_raises():
-    """no_build=true with predict_endpoint should raise validation error."""
-    with pytest.raises(
-        pydantic.ValidationError,
-        match="predict_endpoint is not supported when no_build is true",
-    ):
-        DockerServer(
-            start_command="python main.py",
-            server_port=8000,
-            predict_endpoint="/v1/completions",
-            readiness_endpoint="/health",
-            liveness_endpoint="/health",
-            no_build=True,
-        )
-
-
-def test_docker_server_no_build_without_predict_endpoint_valid():
-    """no_build=true without predict_endpoint should be valid."""
-    docker_server = DockerServer(
-        start_command="python main.py",
-        server_port=8000,
-        predict_endpoint="/v1/completions",
-        readiness_endpoint="/health",
-        liveness_endpoint="/health",
-        no_build=False,
-    )
-    assert docker_server.no_build is False
-    assert docker_server.predict_endpoint == "/v1/completions"
-
-
 # =============================================================================
 # Weights Configuration Tests
 # =============================================================================


### PR DESCRIPTION
This reverts commit da026bfdbcd7f406c5ff1bba7b2adf399f30c7f4.

## :rocket: What

PR #2291 inadvertently made a required field disallowed, we must not make it disallowed until it is no longer required.

## :computer: How

Revert #2291 until we can properly make the field optional.

## :microscope: Testing

Existing unit tests