### PR TITLE
fix(loops/cli): exclude trainer-target checkpoints from deploy picker

### DIFF
--- a/truss/cli/train/deploy_checkpoints/deploy_checkpoints.py
+++ b/truss/cli/train/deploy_checkpoints/deploy_checkpoints.py
@@ -32,6 +32,7 @@ from .deploy_lora_checkpoints import hydrate_lora_checkpoint
 from .deploy_whisper_checkpoints import hydrate_whisper_checkpoint
 
 HF_TOKEN_ENVVAR_NAME = "HF_TOKEN"
+TRAINER_CHECKPOINT_TARGET = "trainer"
 # If we change this, make sure to update the logic in backend codebase
 CHECKPOINT_PATTERN = re.compile(r".*checkpoint-\d+(?:-\d+)?$")
 ALLOWED_DEPLOYMENT_NAMES = re.compile(r"^[0-9a-zA-Z_\-\.]*$")
@@ -434,17 +435,26 @@ def _prompt_user_for_loops_checkpoint_details(
 ) -> CheckpointList:
     run = _resolve_loops_run(remote_provider, run_id)
     response = remote_provider.api.list_loops_checkpoints(run_id=run["id"])
+    deployable_checkpoints = [
+        checkpoint
+        for checkpoint in response["checkpoints"]
+        if checkpoint.get("target") != TRAINER_CHECKPOINT_TARGET
+    ]
+    if not deployable_checkpoints:
+        raise click.UsageError(
+            f"No deployable checkpoints found for Loops run {run['id']}. Trainer "
+            "checkpoints hold training state and cannot be served; only sampler "
+            "checkpoints can be deployed."
+        )
     # Pick by checkpoint_name in the UI; map back to Loops-checkpoint
     # database IDs for the wire so the server doesn't need to re-resolve names.
     name_to_pk = OrderedDict(
         (checkpoint["checkpoint_id"], checkpoint["id"])
-        for checkpoint in response["checkpoints"]
+        for checkpoint in deployable_checkpoints
     )
-    if not name_to_pk:
-        raise click.UsageError(f"No checkpoints found for Loops run {run['id']}.")
     response_checkpoints = OrderedDict(
         (checkpoint["checkpoint_id"], checkpoint)
-        for checkpoint in response["checkpoints"]
+        for checkpoint in deployable_checkpoints
     )
     selected_names = _get_checkpoint_ids_to_deploy(
         list(name_to_pk.keys()), response_checkpoints

--- a/truss/tests/cli/train/test_deploy_checkpoints.py
+++ b/truss/tests/cli/train/test_deploy_checkpoints.py
@@ -357,6 +357,59 @@ def test_ensure_loops_checkpoint_details_picker_emits_ids_and_base_model(
     )
 
 
+def test_ensure_loops_checkpoint_details_picker_filters_trainer_target(
+    mock_loops_remote,
+):
+    """Trainer-target checkpoints are not deployable and must be excluded from the
+    picker. A sampler and trainer checkpoint can share a name, so only filtering
+    out the trainer one leaves a unique, deployable choice."""
+    mock_loops_remote.api.list_loops_checkpoints.return_value = {
+        "checkpoints": [
+            {
+                "id": "vL3pQrS8",
+                "checkpoint_id": "step-100",
+                "base_model": "Qwen/Qwen3-8B",
+                "checkpoint_type": "lora",
+                "lora_adapter_config": {"r": 16},
+                "target": "sampler",
+            },
+            {
+                "id": "wK4tUvW9",
+                "checkpoint_id": "step-100",
+                "base_model": "Qwen/Qwen3-8B",
+                "checkpoint_type": "lora",
+                "lora_adapter_config": {"r": 16},
+                "target": "trainer",
+            },
+        ]
+    }
+    result = _ensure_loops_checkpoint_details(
+        mock_loops_remote, checkpoint_details=None, run_id="trnr_xyz"
+    )
+    assert result.loops_checkpoint_ids == ["vL3pQrS8"]
+
+
+def test_ensure_loops_checkpoint_details_picker_raises_when_only_trainer_targets(
+    mock_loops_remote,
+):
+    mock_loops_remote.api.list_loops_checkpoints.return_value = {
+        "checkpoints": [
+            {
+                "id": "wK4tUvW9",
+                "checkpoint_id": "step-100",
+                "base_model": "Qwen/Qwen3-8B",
+                "checkpoint_type": "lora",
+                "lora_adapter_config": {"r": 16},
+                "target": "trainer",
+            }
+        ]
+    }
+    with pytest.raises(click.UsageError, match="No deployable checkpoints"):
+        _ensure_loops_checkpoint_details(
+            mock_loops_remote, checkpoint_details=None, run_id="trnr_xyz"
+        )
+
+
 def test_hydrate_deploy_config_rejects_run_id_with_config_checkpoints(
     mock_loops_remote,
 ):


### PR DESCRIPTION
## :rocket: What

`truss loops checkpoints deploy --run-id <run>` listed **every** checkpoint for the run in the interactive picker — including **trainer-target** checkpoints, which aren't deployable. Trainer checkpoints hold full training state (under `weights/`); only **sampler-target** checkpoints hold loadable inference weights (under `sampler_weights/`). Deploying a trainer checkpoint would serve garbage.

Companion to the backend guard in basetenlabs/baseten#21734, which rejects trainer-target checkpoints server-side. This PR stops them from being offered in the first place.

## :computer: How

In `_prompt_user_for_loops_checkpoint_details`, filter the `list_loops_checkpoints` response to sampler-target checkpoints before building the picker, and raise a clear `UsageError` when a run has no deployable checkpoints.

Filtering also fixes a latent collision: a sampler and a trainer checkpoint can share a `checkpoint_name`, which would clobber each other in the `name -> pk` `OrderedDict` the picker builds. The backend always populates `target` (legacy NULL rows resolve to `sampler`), and the filter excludes only explicit `trainer`, so absent/empty targets stay deployable — backward compatible.

Scope note: the explicit `--checkpoint-ids` / `--config` path passes IDs straight through (by design, no enrichment); those are validated server-side by the backend guard. The `view` command already shows a `target` column, so no change there.

## :microscope: Testing

Added to `test_deploy_checkpoints.py`:
- trainer-target checkpoint sharing a name with a sampler one → only the sampler is offered
- run with only trainer-target checkpoints → `UsageError`

17/17 tests pass; `ruff` + `mypy` clean.
