### PR TITLE
remove instance type validation from truss train workstation

### DIFF
--- a/truss/cli/train/workstation.py
+++ b/truss/cli/train/workstation.py
@@ -18,9 +18,10 @@ from truss_train.definitions import (
     TrainingJob,
     TrainingProject,
 )
+from truss.base.truss_config import Accelerator
 
 DEFAULT_BASE_IMAGE = "nvidia/cuda:12.8.1-devel-ubuntu24.04"
-SUPPORTED_WORKSTATION_ACCELERATORS = ("H100", "H200", "B200")
+SUPPORTED_WORKSTATION_ACCELERATORS = [acc.value for acc in Accelerator if acc.value != Accelerator._B10.value]
 
 
 def copy_workstation_templates(target_dir: Path) -> None:

--- a/truss/cli/train/workstation.py
+++ b/truss/cli/train/workstation.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 from truss.base import truss_config
 from truss.base.constants import WORKSTATION_TEMPLATE_DIR
+from truss.base.truss_config import Accelerator
 from truss_train.definitions import (
     BasetenCheckpoint,
     CacheConfig,
@@ -18,10 +19,11 @@ from truss_train.definitions import (
     TrainingJob,
     TrainingProject,
 )
-from truss.base.truss_config import Accelerator
 
 DEFAULT_BASE_IMAGE = "nvidia/cuda:12.8.1-devel-ubuntu24.04"
-SUPPORTED_WORKSTATION_ACCELERATORS = [acc.value for acc in Accelerator if acc.value != Accelerator._B10.value]
+SUPPORTED_WORKSTATION_ACCELERATORS = [
+    acc.value for acc in Accelerator if acc.value != Accelerator._B10.value
+]
 
 
 def copy_workstation_templates(target_dir: Path) -> None:


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
* Remove instance type validation from truss train workstation. Allow validation to happen server side based on org's configs

<img width="883" height="579" alt="image" src="https://github.com/user-attachments/assets/405a66b2-7f98-402e-a405-849fff5bd8da" />

<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing
