### PR TITLE
feat(train): support availability_model (spot/dedicated) on compute

### DIFF
--- a/truss-train/tests/test_definitions.py
+++ b/truss-train/tests/test_definitions.py
@@ -3,6 +3,7 @@ from pydantic import ValidationError
 
 from truss.base import truss_config
 from truss_train.definitions import (
+    AvailabilityModel,
     BasetenCheckpoint,
     CheckpointList,
     Compute,
@@ -66,6 +67,20 @@ class TestLoopsCheckpoint:
         assert dumped["checkpoints"][0]["typ"] == "baseten_named_checkpoint"
         assert dumped["checkpoints"][1]["typ"] == "loops_checkpoint"
         assert dumped["checkpoints"][1]["run_id"] == "run123"
+
+
+class TestComputeAvailabilityModel:
+    def test_defaults_to_dedicated(self):
+        assert Compute().availability_model == AvailabilityModel.DEDICATED
+        assert Compute().model_dump()["availability_model"] == "dedicated"
+
+    def test_spot_serializes_to_string_value(self):
+        dumped = Compute(availability_model=AvailabilityModel.SPOT).model_dump()
+        assert dumped["availability_model"] == "spot"
+
+    def test_invalid_value_raises(self):
+        with pytest.raises(ValidationError):
+            Compute(availability_model="on_demand")
 
 
 def _minimal_job(**kwargs):

--- a/truss-train/tests/test_deployment.py
+++ b/truss-train/tests/test_deployment.py
@@ -7,11 +7,13 @@ from truss.base import truss_config
 from truss.remote.baseten import custom_types as b10_types
 from truss_train import deployment
 from truss_train.definitions import (
+    AvailabilityModel,
     CacheConfig,
     Compute,
     Image,
     Runtime,
     TrainingJob,
+    TrainingProject,
     Workspace,
 )
 
@@ -411,3 +413,34 @@ class TestArchiveSizeValidation:
                 config_path.parent,
                 TrainingJob(image=Image(base_image="hello-world")),
             )
+
+
+def _project(compute: Compute) -> TrainingProject:
+    return TrainingProject(
+        name="test-project",
+        job=TrainingJob(image=Image(base_image="hello-world"), compute=compute),
+    )
+
+
+class TestSpotOverride:
+    """`--spot` forces availability_model to spot, taking priority over the config."""
+
+    def test_spot_flag_overrides_default(self):
+        project = _project(Compute())
+        deployment._apply_cli_overrides(project, spot=True)
+        assert project.job.compute.availability_model == AvailabilityModel.SPOT
+
+    def test_spot_flag_overrides_config_dedicated(self):
+        project = _project(Compute(availability_model=AvailabilityModel.DEDICATED))
+        deployment._apply_cli_overrides(project, spot=True)
+        assert project.job.compute.availability_model == AvailabilityModel.SPOT
+
+    def test_no_spot_flag_preserves_config_spot(self):
+        project = _project(Compute(availability_model=AvailabilityModel.SPOT))
+        deployment._apply_cli_overrides(project, spot=False)
+        assert project.job.compute.availability_model == AvailabilityModel.SPOT
+
+    def test_no_spot_flag_preserves_default(self):
+        project = _project(Compute())
+        deployment._apply_cli_overrides(project, spot=False)
+        assert project.job.compute.availability_model == AvailabilityModel.DEDICATED

--- a/truss-train/truss_train/__init__.py
+++ b/truss-train/truss_train/__init__.py
@@ -1,5 +1,6 @@
 from truss.base.truss_config import WeightsSource
 from truss_train.definitions import (
+    AvailabilityModel,
     AWSIAMDockerAuth,
     BasetenCheckpoint,
     CacheConfig,
@@ -28,6 +29,7 @@ from truss_train.public_api import push
 
 __all__ = [
     "push",
+    "AvailabilityModel",
     "Compute",
     "Runtime",
     "SecretReference",

--- a/truss-train/truss_train/definitions.py
+++ b/truss-train/truss_train/definitions.py
@@ -26,11 +26,24 @@ class SecretReference(custom_types.SafeModelNoExtra):
     name: str
 
 
+class AvailabilityModel(str, enum.Enum):
+    """Capacity guarantee under which a training job is scheduled.
+
+    ``DEDICATED`` is on-demand capacity that is not preempted (the default). ``SPOT`` is
+    interruptible capacity that may be preempted; the user is responsible for
+    checkpointing their own progress.
+    """
+
+    DEDICATED = "dedicated"
+    SPOT = "spot"
+
+
 class Compute(custom_types.SafeModelNoExtra):
     node_count: int = 1
     cpu_count: int = 1
     memory: str = "2Gi"
     accelerator: Optional[truss_config.AcceleratorSpec] = None
+    availability_model: AvailabilityModel = AvailabilityModel.DEDICATED
 
     def model_dump(self, *args, **kwargs):
         data = super().model_dump(*args, **kwargs)
@@ -39,6 +52,7 @@ class Compute(custom_types.SafeModelNoExtra):
                 "accelerator": self.accelerator.accelerator.value,
                 "count": self.accelerator.count,
             }
+        data["availability_model"] = self.availability_model.value
         return data
 
     def to_truss_config(self) -> truss_config.Resources:

--- a/truss-train/truss_train/deployment.py
+++ b/truss-train/truss_train/deployment.py
@@ -15,6 +15,7 @@ from truss.remote.baseten.remote import BasetenRemote
 from truss.remote.baseten.utils import transfer
 from truss_train.definitions import (
     DEFAULT_INTERACTIVE_SESSION_TIMEOUT_MINUTES,
+    AvailabilityModel,
     InteractiveSession,
     InteractiveSessionTrigger,
     TrainingJob,
@@ -332,6 +333,7 @@ def _apply_cli_overrides(
     node_count: Optional[int] = None,
     entrypoint: Optional[str] = None,
     priority: Optional[int] = None,
+    spot: bool = False,
 ) -> None:
     """Apply CLI flag overrides to the training project configuration."""
     if interactive_trigger is not None or interactive_timeout_minutes is not None:
@@ -391,6 +393,12 @@ def _apply_cli_overrides(
             )
         training_project.job.priority = priority
 
+    if spot:
+        # The flag always wins. We don't warn when overriding a config value because
+        # the default (dedicated) is indistinguishable from an explicit dedicated, so a
+        # warning would fire on the common path (no availability_model set in config).
+        training_project.job.compute.availability_model = AvailabilityModel.SPOT
+
 
 def create_training_job(
     remote_provider: BasetenRemote,
@@ -405,6 +413,7 @@ def create_training_job(
     node_count: Optional[int] = None,
     entrypoint: Optional[str] = None,
     priority: Optional[int] = None,
+    spot: bool = False,
 ) -> dict:
     if job_name_from_cli:
         if training_project.job.name:
@@ -426,6 +435,7 @@ def create_training_job(
         node_count=node_count,
         entrypoint=entrypoint,
         priority=priority,
+        spot=spot,
     )
 
     source_dir = config.absolute().parent

--- a/truss/cli/train/core.py
+++ b/truss/cli/train/core.py
@@ -439,6 +439,9 @@ def display_training_job(
     table.add_row("Status", job["current_status"])
     table.add_row("Instance Type", job["instance_type"]["name"])
     table.add_row("Priority", str(job.get("priority") or 0))
+    table.add_row(
+        "Availability Model", str(job.get("availability_model") or "dedicated")
+    )
     if user_email := job.get("user", {}).get("email"):
         table.add_row("Created By", user_email)
     table.add_row("Created", cli_common.format_localized_time(job["created_at"]))

--- a/truss/cli/train_commands.py
+++ b/truss/cli/train_commands.py
@@ -181,6 +181,12 @@ def _resolve_team_name(
     required=False,
     help="Job priority (higher values run first when capacity frees up).",
 )
+@click.option(
+    "--spot",
+    is_flag=True,
+    help="Run on interruptible spot capacity (overrides availability_model in the config). "
+    "You are responsible for checkpointing your own progress.",
+)
 @common.common_options()
 def push_training_job(
     config: Path,
@@ -194,6 +200,7 @@ def push_training_job(
     node_count: Optional[int],
     entrypoint: Optional[str],
     priority: Optional[int],
+    spot: bool,
 ):
     """Run a training job"""
     from truss_train import deployment, loader
@@ -231,6 +238,7 @@ def push_training_job(
                 node_count=node_count,
                 entrypoint=entrypoint,
                 priority=priority,
+                spot=spot,
             )
 
     # Note: This post create logic needs to happen outside the context


### PR DESCRIPTION
## 🚀 What

Adds an `availability_model` field to the training job `Compute` spec so users can choose the capacity guarantee for a training job:

- `dedicated` (default) — non-preemptible on-demand capacity; today's behavior.
- `spot` — interruptible capacity that may be preempted. When using `spot`, the user is responsible for checkpointing their own progress.

The server-side create-training-job contract already accepts this field on the `compute` block; this change wires up the Truss SDK/CLI so it can actually be set.

> **Note:** Kept as a draft until the backend is fully wired up end-to-end — we don't want this surfaced to users before scheduling acts on the flag.

## 💻 How

- Added an `AvailabilityModel` enum (`dedicated` / `spot`) in `truss_train/definitions.py` and exported it from `truss_train`.
- Added `availability_model: AvailabilityModel = AvailabilityModel.DEDICATED` to `Compute`, serialized as its string value in `Compute.model_dump()` so it lands at `compute.availability_model` in the request — matching the server contract 1:1, no remapping.
- Surfaced the value in the `truss train` job detail view.

## 🔬 Testing

- Added `TestComputeAvailabilityModel`: dedicated default, spot serializes to `"spot"`, invalid values rejected.
- Verified end-to-end serialization emits `compute.availability_model` as a string.
- `uv run pytest truss-train/tests/` passes; `ruff check`/`format` clean.