### PR TITLE
feat(cli/train): add command to update pending job priority

### DIFF
--- a/truss-train/tests/test_recreate.py
+++ b/truss-train/tests/test_recreate.py
@@ -128,27 +128,24 @@ class TestRecreateTrainingJob:
                 train_cli.recreate_training_job(remote_provider=mock_remote)
 
 
-class TestUpdateTrainingJobPriority:
-    """Test cases for the update_training_job_priority function."""
+class TestUpdateTrainingJob:
+    """Test cases for the update_training_job function."""
 
-    def test_update_training_job_priority_success(self, mock_remote):
-        """Test updating the priority of a training job with a specific job ID."""
+    def test_update_training_job_success(self, mock_remote):
+        """Test updating a training job with a specific job ID."""
         mock_remote.api.search_training_jobs.return_value = [
             {
                 "id": "test_job_123",
-                "training_project": {
-                    "id": "project_456",
-                    "name": "aghilan-anime-project",
-                },
+                "training_project": {"id": "project_456", "name": "test-project"},
             }
         ]
-        mock_remote.api.update_pending_training_job_priority.return_value = {
+        mock_remote.api.update_training_job.return_value = {
             "id": "test_job_123",
             "priority": 42,
-            "training_project": {"id": "project_456", "name": "aghilan-anime-project"},
+            "training_project": {"id": "project_456", "name": "test-project"},
         }
 
-        result = train_cli.update_training_job_priority(
+        result = train_cli.update_training_job(
             remote_provider=mock_remote, job_id="test_job_123", priority=42
         )
 
@@ -158,19 +155,31 @@ class TestUpdateTrainingJobPriority:
         mock_remote.api.search_training_jobs.assert_called_once_with(
             job_id="test_job_123"
         )
-        mock_remote.api.update_pending_training_job_priority.assert_called_once_with(
-            "project_456", "test_job_123", 42
+        mock_remote.api.update_training_job.assert_called_once_with(
+            "project_456", "test_job_123", priority=42
         )
 
-    def test_update_training_job_priority_no_job_found(self, mock_remote):
-        """Test updating priority for a non-existent job ID."""
+    def test_update_training_job_no_job_found(self, mock_remote):
+        """Test updating a non-existent job ID."""
         mock_remote.api.search_training_jobs.return_value = []
 
         with pytest.raises(
             RuntimeError, match="No training job found with ID: nonexistent_job"
         ):
-            train_cli.update_training_job_priority(
+            train_cli.update_training_job(
                 remote_provider=mock_remote, job_id="nonexistent_job", priority=42
             )
 
-        mock_remote.api.update_pending_training_job_priority.assert_not_called()
+        mock_remote.api.update_training_job.assert_not_called()
+
+    def test_update_training_job_no_fields_raises(self, mock_remote):
+        """Test that updating with no fields provided raises an error."""
+        with pytest.raises(
+            ValueError, match="At least one field to update must be provided"
+        ):
+            train_cli.update_training_job(
+                remote_provider=mock_remote, job_id="test_job_123"
+            )
+
+        mock_remote.api.search_training_jobs.assert_not_called()
+        mock_remote.api.update_training_job.assert_not_called()

--- a/truss-train/tests/test_recreate.py
+++ b/truss-train/tests/test_recreate.py
@@ -126,3 +126,51 @@ class TestRecreateTrainingJob:
             # Should raise UsageError when user cancels
             with pytest.raises(click.UsageError, match="Training job not recreated"):
                 train_cli.recreate_training_job(remote_provider=mock_remote)
+
+
+class TestUpdateTrainingJobPriority:
+    """Test cases for the update_training_job_priority function."""
+
+    def test_update_training_job_priority_success(self, mock_remote):
+        """Test updating the priority of a training job with a specific job ID."""
+        mock_remote.api.search_training_jobs.return_value = [
+            {
+                "id": "test_job_123",
+                "training_project": {
+                    "id": "project_456",
+                    "name": "aghilan-anime-project",
+                },
+            }
+        ]
+        mock_remote.api.update_pending_training_job_priority.return_value = {
+            "id": "test_job_123",
+            "priority": 42,
+            "training_project": {"id": "project_456", "name": "aghilan-anime-project"},
+        }
+
+        result = train_cli.update_training_job_priority(
+            remote_provider=mock_remote, job_id="test_job_123", priority=42
+        )
+
+        assert result["id"] == "test_job_123"
+        assert result["priority"] == 42
+
+        mock_remote.api.search_training_jobs.assert_called_once_with(
+            job_id="test_job_123"
+        )
+        mock_remote.api.update_pending_training_job_priority.assert_called_once_with(
+            "project_456", "test_job_123", 42
+        )
+
+    def test_update_training_job_priority_no_job_found(self, mock_remote):
+        """Test updating priority for a non-existent job ID."""
+        mock_remote.api.search_training_jobs.return_value = []
+
+        with pytest.raises(
+            RuntimeError, match="No training job found with ID: nonexistent_job"
+        ):
+            train_cli.update_training_job_priority(
+                remote_provider=mock_remote, job_id="nonexistent_job", priority=42
+            )
+
+        mock_remote.api.update_pending_training_job_priority.assert_not_called()

--- a/truss/cli/train/core.py
+++ b/truss/cli/train/core.py
@@ -158,14 +158,16 @@ def recreate_training_job(
     return job_resp
 
 
-def update_training_job_priority(
-    remote_provider: BasetenRemote, job_id: str, priority: int
+def update_training_job(
+    remote_provider: BasetenRemote, job_id: str, *, priority: Optional[int] = None
 ) -> Dict[str, Any]:
+    if priority is None:
+        raise ValueError("At least one field to update must be provided.")
     job = _get_job_by_job_id(remote_provider, job_id)
     project_id = job["training_project"]["id"]
     job_id = job["id"]
-    return remote_provider.api.update_pending_training_job_priority(
-        project_id, job_id, priority
+    return remote_provider.api.update_training_job(
+        project_id, job_id, priority=priority
     )
 
 

--- a/truss/cli/train/core.py
+++ b/truss/cli/train/core.py
@@ -158,6 +158,17 @@ def recreate_training_job(
     return job_resp
 
 
+def update_training_job_priority(
+    remote_provider: BasetenRemote, job_id: str, priority: int
+) -> Dict[str, Any]:
+    job = _get_job_by_job_id(remote_provider, job_id)
+    project_id = job["training_project"]["id"]
+    job_id = job["id"]
+    return remote_provider.api.update_pending_training_job_priority(
+        project_id, job_id, priority
+    )
+
+
 def display_training_projects(projects: list[dict], remote_url: str) -> None:
     table = rich.table.Table(
         show_header=True,

--- a/truss/cli/train_commands.py
+++ b/truss/cli/train_commands.py
@@ -920,6 +920,42 @@ def update_session(
         sys.exit(1)
 
 
+@train.command(name="update_priority")
+@click.option(
+    "--job-id", type=str, required=True, help="Job ID of the PENDING training job."
+)
+@click.option(
+    "--priority",
+    type=int,
+    required=True,
+    help="New queue priority. Higher values are dequeued first. Only PENDING jobs can have their priority changed.",
+)
+@click.option("--remote", type=str, required=False, help="Remote to use.")
+@common.common_options()
+def update_priority(job_id: str, priority: int, remote: Optional[str]):
+    """Update the queue priority of a PENDING training job."""
+
+    if not remote:
+        remote = remote_cli.inquire_remote_name()
+
+    remote_provider: BasetenRemote = cast(
+        BasetenRemote, RemoteFactory.create(remote=remote)
+    )
+
+    try:
+        job = train_cli.update_training_job_priority(
+            remote_provider=remote_provider, job_id=job_id, priority=priority
+        )
+    except Exception as e:
+        error_console.print(f"Failed to update training job priority: {str(e)}")
+        sys.exit(1)
+
+    console.print(
+        f"Training job {job['id']} priority updated to {job.get('priority')}.",
+        style="green",
+    )
+
+
 @train.command(name="isession")
 @click.option("--job-id", type=str, required=True, help="Job ID of the training job.")
 @click.option("--remote", type=str, required=False, help="Remote to use.")

--- a/truss/cli/train_commands.py
+++ b/truss/cli/train_commands.py
@@ -920,20 +920,21 @@ def update_session(
         sys.exit(1)
 
 
-@train.command(name="update_priority")
-@click.option(
-    "--job-id", type=str, required=True, help="Job ID of the PENDING training job."
-)
+@train.command(name="update")
+@click.option("--job-id", type=str, required=True, help="Job ID of the training job.")
 @click.option(
     "--priority",
     type=int,
-    required=True,
+    required=False,
     help="New queue priority. Higher values are dequeued first. Only PENDING jobs can have their priority changed.",
 )
 @click.option("--remote", type=str, required=False, help="Remote to use.")
 @common.common_options()
-def update_priority(job_id: str, priority: int, remote: Optional[str]):
-    """Update the queue priority of a PENDING training job."""
+def update(job_id: str, priority: Optional[int], remote: Optional[str]):
+    """Update a training job. At least one field to update must be provided."""
+
+    if priority is None:
+        raise click.UsageError("At least one field to update must be provided.")
 
     if not remote:
         remote = remote_cli.inquire_remote_name()
@@ -943,17 +944,14 @@ def update_priority(job_id: str, priority: int, remote: Optional[str]):
     )
 
     try:
-        job = train_cli.update_training_job_priority(
+        job = train_cli.update_training_job(
             remote_provider=remote_provider, job_id=job_id, priority=priority
         )
     except Exception as e:
-        error_console.print(f"Failed to update training job priority: {str(e)}")
+        error_console.print(f"Failed to update training job: {str(e)}")
         sys.exit(1)
 
-    console.print(
-        f"Training job {job['id']} priority updated to {job.get('priority')}.",
-        style="green",
-    )
+    console.print(f"Training job {job['id']} updated.", style="green")
 
 
 @train.command(name="isession")

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -911,6 +911,15 @@ class BasetenApi:
         )
         return resp_json["training_job"]
 
+    def update_pending_training_job_priority(
+        self, project_id: str, job_id: str, priority: int
+    ):
+        resp_json = self._rest_api_client.patch(
+            f"v1/training_projects/{project_id}/jobs/{job_id}",
+            body={"priority": priority},
+        )
+        return resp_json["training_job"]
+
     def get_training_capacity(self) -> list[dict]:
         resp_json = self._rest_api_client.get("v1/training/capacity")
         return resp_json.get("gpu_capacities", [])

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -911,12 +911,14 @@ class BasetenApi:
         )
         return resp_json["training_job"]
 
-    def update_pending_training_job_priority(
-        self, project_id: str, job_id: str, priority: int
+    def update_training_job(
+        self, project_id: str, job_id: str, *, priority: Optional[int] = None
     ):
+        body: Dict[str, Any] = {}
+        if priority is not None:
+            body["priority"] = priority
         resp_json = self._rest_api_client.patch(
-            f"v1/training_projects/{project_id}/jobs/{job_id}",
-            body={"priority": priority},
+            f"v1/training_projects/{project_id}/jobs/{job_id}", body=body
         )
         return resp_json["training_job"]
 

--- a/truss/tests/remote/baseten/test_api.py
+++ b/truss/tests/remote/baseten/test_api.py
@@ -578,6 +578,28 @@ def test_upsert_training_project(mock_post, baseten_api):
     assert "training-project" == upsert_body["name"]
 
 
+def mock_update_training_job_priority_response():
+    response = Response()
+    response.status_code = 200
+    response.json = mock.Mock(
+        return_value={"training_job": {"id": "job_id", "priority": 42}}
+    )
+    return response
+
+
+@mock.patch("requests.patch", return_value=mock_update_training_job_priority_response())
+def test_update_pending_training_job_priority(mock_patch, baseten_api):
+    result = baseten_api.update_pending_training_job_priority(
+        "project_id", "job_id", 42
+    )
+
+    assert result == {"id": "job_id", "priority": 42}
+
+    called_url = mock_patch.call_args[0][0]
+    assert called_url.endswith("/v1/training_projects/project_id/jobs/job_id")
+    assert mock_patch.call_args[1]["json"] == {"priority": 42}
+
+
 # Mock responses for training job logs pagination tests
 def mock_training_job_logs_response(logs, has_more=True):
     """Helper function to create mock training job logs response"""

--- a/truss/tests/remote/baseten/test_api.py
+++ b/truss/tests/remote/baseten/test_api.py
@@ -578,7 +578,7 @@ def test_upsert_training_project(mock_post, baseten_api):
     assert "training-project" == upsert_body["name"]
 
 
-def mock_update_training_job_priority_response():
+def mock_update_training_job_response():
     response = Response()
     response.status_code = 200
     response.json = mock.Mock(
@@ -587,11 +587,9 @@ def mock_update_training_job_priority_response():
     return response
 
 
-@mock.patch("requests.patch", return_value=mock_update_training_job_priority_response())
-def test_update_pending_training_job_priority(mock_patch, baseten_api):
-    result = baseten_api.update_pending_training_job_priority(
-        "project_id", "job_id", 42
-    )
+@mock.patch("requests.patch", return_value=mock_update_training_job_response())
+def test_update_training_job(mock_patch, baseten_api):
+    result = baseten_api.update_training_job("project_id", "job_id", priority=42)
 
     assert result == {"id": "job_id", "priority": 42}
 


### PR DESCRIPTION
## Summary

Adds client-side support in truss for the new backend endpoint:

`PATCH /v1/training_projects/{project_id}/jobs/{job_id}` with body `{"priority": <int>}`, which updates the queue priority of a **PENDING** training job (higher values are dequeued first).

- `BasetenApi.update_pending_training_job_priority(project_id, job_id, priority)` issues the PATCH and unwraps the `training_job` response.
- `core.update_training_job_priority(...)` resolves the project from the job id and delegates to the API (mirrors `recreate_training_job`).
- New CLI command: `truss train update_priority --job-id <id> --priority <int>`.
- Backend validation (e.g. 400 for non-PENDING jobs) surfaces as a clean CLI error.

## Test plan

- [x] `uv run pytest truss-train/tests/test_recreate.py` (core helper: success + not-found)
- [x] `uv run pytest truss/tests/remote/baseten/test_api.py::test_update_pending_training_job_priority` (verifies PATCH URL + body + response unwrap)
- [x] `uv run pre-commit run --files ...` (ruff, ruff-format, mypy all pass)
- [x] `truss train update_priority --help` renders

_Supersedes #2519 (re-created from a renamed branch; original review comments remain on #2519)._