### PR TITLE
feat(cli/train): add --spot flag to truss train push

### DIFF
--- a/truss-train/tests/test_deployment.py
+++ b/truss-train/tests/test_deployment.py
@@ -7,11 +7,13 @@ from truss.base import truss_config
 from truss.remote.baseten import custom_types as b10_types
 from truss_train import deployment
 from truss_train.definitions import (
+    AvailabilityModel,
     CacheConfig,
     Compute,
     Image,
     Runtime,
     TrainingJob,
+    TrainingProject,
     Workspace,
 )
 
@@ -411,3 +413,34 @@ class TestArchiveSizeValidation:
                 config_path.parent,
                 TrainingJob(image=Image(base_image="hello-world")),
             )
+
+
+def _project(compute: Compute) -> TrainingProject:
+    return TrainingProject(
+        name="test-project",
+        job=TrainingJob(image=Image(base_image="hello-world"), compute=compute),
+    )
+
+
+class TestSpotOverride:
+    """`--spot` forces availability_model to spot, taking priority over the config."""
+
+    def test_spot_flag_overrides_default(self):
+        project = _project(Compute())
+        deployment._apply_cli_overrides(project, spot=True)
+        assert project.job.compute.availability_model == AvailabilityModel.SPOT
+
+    def test_spot_flag_overrides_config_dedicated(self):
+        project = _project(Compute(availability_model=AvailabilityModel.DEDICATED))
+        deployment._apply_cli_overrides(project, spot=True)
+        assert project.job.compute.availability_model == AvailabilityModel.SPOT
+
+    def test_no_spot_flag_preserves_config_spot(self):
+        project = _project(Compute(availability_model=AvailabilityModel.SPOT))
+        deployment._apply_cli_overrides(project, spot=False)
+        assert project.job.compute.availability_model == AvailabilityModel.SPOT
+
+    def test_no_spot_flag_preserves_default(self):
+        project = _project(Compute())
+        deployment._apply_cli_overrides(project, spot=False)
+        assert project.job.compute.availability_model == AvailabilityModel.DEDICATED

--- a/truss-train/truss_train/deployment.py
+++ b/truss-train/truss_train/deployment.py
@@ -15,6 +15,7 @@ from truss.remote.baseten.remote import BasetenRemote
 from truss.remote.baseten.utils import transfer
 from truss_train.definitions import (
     DEFAULT_INTERACTIVE_SESSION_TIMEOUT_MINUTES,
+    AvailabilityModel,
     InteractiveSession,
     InteractiveSessionTrigger,
     TrainingJob,
@@ -332,6 +333,7 @@ def _apply_cli_overrides(
     node_count: Optional[int] = None,
     entrypoint: Optional[str] = None,
     priority: Optional[int] = None,
+    spot: bool = False,
 ) -> None:
     """Apply CLI flag overrides to the training project configuration."""
     if interactive_trigger is not None or interactive_timeout_minutes is not None:
@@ -391,6 +393,12 @@ def _apply_cli_overrides(
             )
         training_project.job.priority = priority
 
+    if spot:
+        # The flag always wins. We don't warn when overriding a config value because
+        # the default (dedicated) is indistinguishable from an explicit dedicated, so a
+        # warning would fire on the common path (no availability_model set in config).
+        training_project.job.compute.availability_model = AvailabilityModel.SPOT
+
 
 def create_training_job(
     remote_provider: BasetenRemote,
@@ -405,6 +413,7 @@ def create_training_job(
     node_count: Optional[int] = None,
     entrypoint: Optional[str] = None,
     priority: Optional[int] = None,
+    spot: bool = False,
 ) -> dict:
     if job_name_from_cli:
         if training_project.job.name:
@@ -426,6 +435,7 @@ def create_training_job(
         node_count=node_count,
         entrypoint=entrypoint,
         priority=priority,
+        spot=spot,
     )
 
     source_dir = config.absolute().parent

--- a/truss/cli/train_commands.py
+++ b/truss/cli/train_commands.py
@@ -181,6 +181,12 @@ def _resolve_team_name(
     required=False,
     help="Job priority (higher values run first when capacity frees up).",
 )
+@click.option(
+    "--spot",
+    is_flag=True,
+    help="Run on interruptible spot capacity (overrides availability_model in the config). "
+    "You are responsible for checkpointing your own progress.",
+)
 @common.common_options()
 def push_training_job(
     config: Path,
@@ -194,6 +200,7 @@ def push_training_job(
     node_count: Optional[int],
     entrypoint: Optional[str],
     priority: Optional[int],
+    spot: bool,
 ):
     """Run a training job"""
     from truss_train import deployment, loader
@@ -231,6 +238,7 @@ def push_training_job(
                 node_count=node_count,
                 entrypoint=entrypoint,
                 priority=priority,
+                spot=spot,
             )
 
     # Note: This post create logic needs to happen outside the context


### PR DESCRIPTION
_Stacked on #2520 — review/merge that first; this PR targets `john/add-availability-model` and the diff will collapse once the base merges._

## 🚀 What

Adds a `--spot` flag to `truss train push`. When passed, the job runs on interruptible **spot** capacity, overriding `compute.availability_model` from the config file — **the flag takes priority**.

```
truss train push config.py --spot
```

When using spot, the user is responsible for checkpointing their own progress.

## 💻 How

- New `--spot` boolean flag on the `push` command, threaded through `deployment.create_training_job` → `_apply_cli_overrides`, alongside the existing `--accelerator` / `--node-count` / `--priority` overrides.
- When set, forces `compute.availability_model = AvailabilityModel.SPOT`.
- The override is **silent**: `dedicated` is the default and is indistinguishable from an explicitly-configured `dedicated`, so a warning would fire on the common path (no `availability_model` in config). This matches the existing convention, where overriding a *default* value doesn't warn.

## 🔬 Testing

- Added `TestSpotOverride`: `--spot` overrides the default and an explicit `dedicated`; absence of the flag preserves both the config's `spot` and the default `dedicated`.
- `uv run truss train push --help` renders the flag; verified the override sets `availability_model` to `spot` end-to-end.
- `uv run pytest truss-train/tests/` passes; `ruff check`/`format` clean.