### PR TITLE
feat(loops): add `truss loops view --org` to list the whole org's deployments

### DIFF
--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -144,6 +144,13 @@ _TERMINAL_DEPLOYMENT_STATUSES = frozenset({"STOPPED", "FAILED"})
     help="Include deployments in terminal states (STOPPED, FAILED).",
 )
 @click.option(
+    "--org",
+    "org_wide",
+    is_flag=True,
+    default=False,
+    help="List every Loops deployment in your organization (with its owner), not just your own.",
+)
+@click.option(
     "-o",
     "--output-format",
     type=click.Choice(
@@ -154,12 +161,13 @@ _TERMINAL_DEPLOYMENT_STATUSES = frozenset({"STOPPED", "FAILED"})
 )
 @common.common_options()
 def view_loops_deployments(
-    remote: Optional[str], show_all: bool, output_format: str
+    remote: Optional[str], show_all: bool, org_wide: bool, output_format: str
 ) -> None:
-    """List the caller's Loops deployments.
+    """List Loops deployments.
 
-    By default, deployments in terminal states (STOPPED, FAILED) are hidden.
-    Pass --all to include them.
+    Lists your own deployments by default; pass --org to list every deployment
+    in your organization, with an Owner column. Deployments in terminal states
+    (STOPPED, FAILED) are hidden unless you pass --all.
     """
     if not remote:
         remote = remote_cli.inquire_remote_name()
@@ -167,7 +175,9 @@ def view_loops_deployments(
     remote_provider: BasetenRemote = cast(
         BasetenRemote, RemoteFactory.create(remote=remote)
     )
-    deployments = remote_provider.api.list_loops_deployments()
+    deployments = remote_provider.api.list_loops_deployments(
+        scope="org" if org_wide else None
+    )
     is_human_output = output_format == checkpoint_mod.OUTPUT_FORMAT_CLI_TABLE
 
     if not deployments and is_human_output:
@@ -192,7 +202,7 @@ def view_loops_deployments(
         _render_loops_deployments_json(deployments)
         return
 
-    _render_loops_deployments(deployments)
+    _render_loops_deployments(deployments, show_owner=org_wide)
 
 
 @loops.group(name="runs")
@@ -266,7 +276,9 @@ def view_loops_samplers(reverse: bool, remote: Optional[str]) -> None:
     _render_loops_samplers(samplers)
 
 
-def _render_loops_deployments(deployments: List[Dict[str, Any]]) -> None:
+def _render_loops_deployments(
+    deployments: List[Dict[str, Any]], show_owner: bool = False
+) -> None:
     table = rich.table.Table(
         show_header=True,
         header_style="bold magenta",
@@ -275,6 +287,8 @@ def _render_loops_deployments(deployments: List[Dict[str, Any]]) -> None:
         border_style="blue",
     )
     table.add_column("Deployment ID", style="cyan")
+    if show_owner:
+        table.add_column("Owner", style="magenta")
     table.add_column("Base Model", style="green")
     table.add_column("Deployment Status")
     table.add_column("Deployment Base URL", style="blue")
@@ -283,15 +297,20 @@ def _render_loops_deployments(deployments: List[Dict[str, Any]]) -> None:
     table.add_column("Sampler Base URL", style="blue")
     for deployment in deployments:
         sampler = deployment.get("sampler")
-        table.add_row(
-            deployment["id"],
-            deployment["base_model"],
-            deployment["status"]["name"],
-            deployment["base_url"],
-            sampler["deployment_id"] if sampler else "—",
-            sampler["status"]["name"] if sampler else "—",
-            sampler["base_url"] if sampler else "—",
+        row = [deployment["id"]]
+        if show_owner:
+            row.append((deployment.get("user") or {}).get("email") or "—")
+        row.extend(
+            [
+                deployment["base_model"],
+                deployment["status"]["name"],
+                deployment["base_url"],
+                sampler["deployment_id"] if sampler else "—",
+                sampler["status"]["name"] if sampler else "—",
+                sampler["base_url"] if sampler else "—",
+            ]
         )
+        table.add_row(*row)
     console.print(table)
 
 

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -1301,8 +1301,15 @@ class BasetenApi:
         resp_json = self._rest_api_client.get(f"v1/loops/samplers/{sampler_id}")
         return resp_json["sampler"]
 
-    def list_loops_deployments(self) -> List[Dict[str, Any]]:
-        resp_json = self._rest_api_client.get("v1/loops/deployments")
+    def list_loops_deployments(
+        self, scope: Optional[str] = None
+    ) -> List[Dict[str, Any]]:
+        # scope="org" lists every deployment in the caller's org (each with its
+        # owning user); omit/"mine" lists just the caller's.
+        url_params = {"scope": scope} if scope else {}
+        resp_json = self._rest_api_client.get(
+            "v1/loops/deployments", url_params=url_params
+        )
         return resp_json["deployments"]
 
     def get_loops_deployment(self, deployment_id: str) -> dict:

--- a/truss/tests/cli/test_loops_cli.py
+++ b/truss/tests/cli/test_loops_cli.py
@@ -423,6 +423,71 @@ def test_view_renders_deployment_with_null_sampler(mock_remote):
     assert "dep_orphan" in result.output
 
 
+def test_view_default_requests_caller_scope(mock_remote):
+    mock_remote.api.list_loops_deployments.return_value = []
+    result = _invoke(["loops", "view", "--remote", "test_remote"], mock_remote)
+    assert result.exit_code == 0, result.output
+    mock_remote.api.list_loops_deployments.assert_called_once_with(scope=None)
+
+
+def test_view_org_flag_requests_org_scope(mock_remote):
+    mock_remote.api.list_loops_deployments.return_value = []
+    result = _invoke(["loops", "view", "--org", "--remote", "test_remote"], mock_remote)
+    assert result.exit_code == 0, result.output
+    mock_remote.api.list_loops_deployments.assert_called_once_with(scope="org")
+
+
+def test_view_org_flag_renders_owner_column(mock_remote):
+    mock_remote.api.list_loops_deployments.return_value = [
+        {
+            "id": "dep_abc",
+            "base_model": "Qwen/Qwen3-8B",
+            "base_url": "https://trainer-abc.api.baseten.co/trainer",
+            "status": {"name": "RUNNING"},
+            "user": {"email": "owner@baseten.co"},
+            "sampler": None,
+        }
+    ]
+    result = _invoke(["loops", "view", "--org", "--remote", "test_remote"], mock_remote)
+    assert result.exit_code == 0, result.output
+    assert "Owner" in result.output
+    assert "owner@baseten.co" in result.output
+
+
+def test_view_without_org_flag_hides_owner_column(mock_remote):
+    mock_remote.api.list_loops_deployments.return_value = [
+        {
+            "id": "dep_abc",
+            "base_model": "Qwen/Qwen3-8B",
+            "base_url": "https://trainer-abc.api.baseten.co/trainer",
+            "status": {"name": "RUNNING"},
+            "user": {"email": "owner@baseten.co"},
+            "sampler": None,
+        }
+    ]
+    result = _invoke(["loops", "view", "--remote", "test_remote"], mock_remote)
+    assert result.exit_code == 0, result.output
+    assert "Owner" not in result.output
+    assert "owner@baseten.co" not in result.output
+
+
+def test_view_org_flag_owner_placeholder_when_user_missing(mock_remote):
+    # Older backend with no ``user`` field: Owner degrades to a placeholder.
+    mock_remote.api.list_loops_deployments.return_value = [
+        {
+            "id": "dep_abc",
+            "base_model": "Qwen/Qwen3-8B",
+            "base_url": "https://trainer-abc.api.baseten.co/trainer",
+            "status": {"name": "RUNNING"},
+            "sampler": None,
+        }
+    ]
+    result = _invoke(["loops", "view", "--org", "--remote", "test_remote"], mock_remote)
+    assert result.exit_code == 0, result.output
+    assert "Owner" in result.output
+    assert "dep_abc" in result.output
+
+
 def test_view_json_output_renders_null_sampler(mock_remote):
     mock_remote.api.list_loops_deployments.return_value = [
         {


### PR DESCRIPTION
## Summary
Adds `--org` to `truss loops view` so you can see **every Loops deployment in your organization — and who owns each** — not just your own.

```
truss loops view --org --remote parsed
```
- Passes `?scope=org` to `GET /v1/loops/deployments`.
- Renders an **Owner** column (the deployment's `user.email`).

Defaults are unchanged: without `--org` you get your own deployments and no Owner column.

## Why
We wanted to see, across the team, who's running Loops trainers (and thus holding the GPU nodes). The CLI/API only exposed the caller's own deployments and no owner.

## Pairs with
basetenlabs/baseten#22179, which adds `user` to `LoopsDeploymentV1` and the `?scope=org` param. This change **degrades gracefully** against an older backend: no `user` field → Owner shows `—`; `scope` ignored → you just see your own deployments.

## Backward compatibility
`list_loops_deployments(scope=None)` and `_render_loops_deployments(show_owner=False)` both default to the prior behavior, so existing callers/tests are unaffected.
