### PR TITLE
fix(loops/cli): show checkpoints across all runs of a base model

### DIFF
--- a/truss/cli/loops_checkpoint_viewer.py
+++ b/truss/cli/loops_checkpoint_viewer.py
@@ -1,4 +1,5 @@
 import sys
+from typing import Optional
 
 from truss.cli.train.checkpoint_viewer import (
     OUTPUT_FORMAT_CLI_TABLE,
@@ -20,29 +21,38 @@ from truss.remote.baseten.remote import BasetenRemote
 
 def view_loops_checkpoint_list(
     remote_provider: BasetenRemote,
-    run_id: str,
+    run_id: Optional[str] = None,
+    base_model: Optional[str] = None,
     sort_by: str = SORT_BY_CREATED,
     order: str = SORT_ORDER_ASC,
     output_format: str = OUTPUT_FORMAT_CLI_TABLE,
 ) -> None:
-    """View checkpoints for a Loops run.
+    """View Loops checkpoints for a single run or across all runs of a base model.
 
     Mirrors `view_checkpoint_list` for training jobs but hits the Loops
-    checkpoint endpoint. Interactive file drill-down is not yet supported
-    because Loops files are listed per-checkpoint rather than per-run.
+    checkpoint endpoint, which returns each checkpoint's own run id so a
+    base-model query can span multiple runs. Interactive file drill-down is
+    not yet supported because Loops files are listed per-checkpoint rather
+    than per-run.
     """
+    scope_kind = ScopeKind.RUN if run_id is not None else ScopeKind.BASE_MODEL
+    scope_id = run_id if run_id is not None else base_model
+    assert scope_id is not None  # caller validates exactly one is set
+
     viewer: CheckpointListViewer
     if output_format == OUTPUT_FORMAT_CSV:
-        viewer = CSVCheckpointViewer(scope_kind=ScopeKind.RUN)
+        viewer = CSVCheckpointViewer(scope_kind=scope_kind)
     elif output_format == OUTPUT_FORMAT_JSON:
-        viewer = JSONCheckpointViewer(scope_kind=ScopeKind.RUN)
+        viewer = JSONCheckpointViewer(scope_kind=scope_kind)
     elif output_format == OUTPUT_FORMAT_CLI_TABLE:
-        viewer = CLITableCheckpointViewer(scope_kind=ScopeKind.RUN)
+        viewer = CLITableCheckpointViewer(scope_kind=scope_kind)
     else:
         raise ValueError(f"Invalid output format: {output_format}")
 
     try:
-        raw = remote_provider.api.list_loops_checkpoints(run_id=run_id)
+        raw = remote_provider.api.list_loops_checkpoints(
+            run_id=run_id, base_model=base_model
+        )
         checkpoints = raw.get("checkpoints", [])
 
         reverse = order == SORT_ORDER_DESC
@@ -50,9 +60,9 @@ def view_loops_checkpoint_list(
         checkpoints.sort(key=sort_key, reverse=reverse)
 
         if not checkpoints:
-            viewer.output_no_checkpoints_message(run_id)
+            viewer.output_no_checkpoints_message(scope_id)
         else:
-            viewer.output_checkpoints(checkpoints, run_id)
+            viewer.output_checkpoints(checkpoints, scope_id)
     except Exception as e:
         # Keep stdout clean for json/csv consumers (jq pipelines, spreadsheets);
         # only the CLI table format gets a styled error.
@@ -61,14 +71,3 @@ def view_loops_checkpoint_list(
         else:
             console.print(f"Error fetching checkpoints: {e}", style="red")
         raise
-
-
-def resolve_most_recent_run_for_base_model(
-    remote_provider: BasetenRemote, base_model: str
-) -> str:
-    """Return the most recently created Loops run for the given base model."""
-    runs = remote_provider.api.list_loops_runs(base_model=base_model)
-    if not runs:
-        raise ValueError(f"No Loops runs found for base model: {base_model}")
-    runs = sorted(runs, key=lambda r: r.get("created_at") or "", reverse=True)
-    return runs[0]["id"]

--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -11,10 +11,7 @@ from truss.cli.cli import truss_cli
 from truss.cli.logs import utils as cli_log_utils
 from truss.cli.logs.loops_deployment_log_watcher import LoopsDeploymentLogWatcher
 from truss.cli.logs.model_log_watcher import ModelDeploymentLogWatcher
-from truss.cli.loops_checkpoint_viewer import (
-    resolve_most_recent_run_for_base_model,
-    view_loops_checkpoint_list,
-)
+from truss.cli.loops_checkpoint_viewer import view_loops_checkpoint_list
 from truss.cli.train import checkpoint_viewer as checkpoint_mod
 from truss.cli.utils import common
 from truss.cli.utils.output import console
@@ -409,7 +406,7 @@ def loops_checkpoints() -> None:
     "--base-model",
     type=str,
     required=False,
-    help="Base model name. Resolves to the most recent Loops run for that model.",
+    help="Base model name. Shows checkpoints across all your runs of that model.",
 )
 @click.option(
     "--sort",
@@ -455,8 +452,8 @@ def view_loops_checkpoints(
 ) -> None:
     """List checkpoints for a Loops run.
 
-    Identify the run with --run-id, or pass --base-model to pick the most
-    recent run for that base model.
+    Identify a single run with --run-id, or pass --base-model to list
+    checkpoints across all your runs of that base model.
     """
     if run_id and base_model:
         raise click.UsageError("Pass either --run-id or --base-model, not both.")
@@ -470,20 +467,10 @@ def view_loops_checkpoints(
         BasetenRemote, RemoteFactory.create(remote=remote)
     )
 
-    if run_id:
-        resolved_run_id = run_id
-    else:
-        try:
-            assert base_model is not None  # narrowed by the validation above
-            resolved_run_id = resolve_most_recent_run_for_base_model(
-                remote_provider, base_model
-            )
-        except ValueError as e:
-            raise click.UsageError(str(e))
-
     view_loops_checkpoint_list(
         remote_provider=remote_provider,
-        run_id=resolved_run_id,
+        run_id=run_id,
+        base_model=base_model,
         sort_by=sort,
         order=order,
         output_format=output_format,

--- a/truss/cli/train/checkpoint_viewer.py
+++ b/truss/cli/train/checkpoint_viewer.py
@@ -36,6 +36,36 @@ class ScopeKind(str, Enum):
 
     JOB = "job"
     RUN = "run"
+    BASE_MODEL = "base_model"
+
+    @property
+    def title_noun(self) -> str:
+        return "base model" if self is ScopeKind.BASE_MODEL else self.value
+
+    @property
+    def row_id_column(self) -> str:
+        return "Job ID" if self is ScopeKind.JOB else "Run ID"
+
+    @property
+    def shows_target(self) -> bool:
+        return self in (ScopeKind.RUN, ScopeKind.BASE_MODEL)
+
+    @property
+    def scope_json_key(self) -> str:
+        """Top-level identifier key in JSON output."""
+        if self is ScopeKind.BASE_MODEL:
+            return "base_model"
+        return f"{self.value}_id"
+
+    def row_scope_id(self, ckpt: dict, scope_id: str) -> str:
+        """The id shown in a checkpoint's scope column.
+
+        Job-scoped views share one job id; run/base-model views show each
+        checkpoint's own run so a base-model query can span multiple runs.
+        """
+        if self is ScopeKind.JOB:
+            return scope_id
+        return ckpt.get("run_id") or scope_id
 
 
 # Sort constants
@@ -97,7 +127,7 @@ class CLITableCheckpointViewer(CheckpointListViewer):
 
     def output_checkpoints(self, checkpoints: list[dict], scope_id: str) -> None:
         table = rich.table.Table(
-            title=f"Checkpoints for {self.scope_kind.value}: {scope_id}",
+            title=f"Checkpoints for {self.scope_kind.title_noun}: {scope_id}",
             show_header=True,
             header_style="bold magenta",
             box=rich.table.box.ROUNDED,
@@ -107,8 +137,8 @@ class CLITableCheckpointViewer(CheckpointListViewer):
         # no-underscore, e.g. `vL3pQrS8`) and a human step-name
         # (`checkpoint_id`, e.g. `checkpoint-100` / `step-100`). Show the
         # parent scope, then both identifiers.
-        scope_column = "Run ID" if self.scope_kind == ScopeKind.RUN else "Job ID"
-        show_target = self.scope_kind == ScopeKind.RUN
+        scope_column = self.scope_kind.row_id_column
+        show_target = self.scope_kind.shows_target
         table.add_column(scope_column, style="cyan")
         table.add_column("Checkpoint ID", style="cyan")
         table.add_column("Checkpoint Name", style="cyan")
@@ -124,7 +154,11 @@ class CLITableCheckpointViewer(CheckpointListViewer):
                 ckpt.get("size_bytes", 0)
             )
             created_str = cli_common.format_localized_time(ckpt.get("created_at", ""))
-            row = [scope_id, ckpt.get("id", ""), ckpt.get("checkpoint_id", "")]
+            row = [
+                self.scope_kind.row_scope_id(ckpt, scope_id),
+                ckpt.get("id", ""),
+                ckpt.get("checkpoint_id", ""),
+            ]
             if show_target:
                 row.append(ckpt.get("target", "") or "")
             row.extend(
@@ -141,7 +175,7 @@ class CLITableCheckpointViewer(CheckpointListViewer):
 
     def output_no_checkpoints_message(self, scope_id: str) -> None:
         console.print(
-            f"No checkpoints found for {self.scope_kind.value}: {scope_id}.",
+            f"No checkpoints found for {self.scope_kind.title_noun}: {scope_id}.",
             style="yellow",
         )
 
@@ -150,9 +184,9 @@ class CSVCheckpointViewer(CheckpointListViewer):
     """Viewer that outputs checkpoint list in CSV format."""
 
     def _header(self) -> list[str]:
-        scope_column = "Run ID" if self.scope_kind == ScopeKind.RUN else "Job ID"
+        scope_column = self.scope_kind.row_id_column
         header = [scope_column, "Checkpoint ID", "Checkpoint Name"]
-        if self.scope_kind == ScopeKind.RUN:
+        if self.scope_kind.shows_target:
             header.append("Target")
         header.extend(
             [
@@ -168,13 +202,17 @@ class CSVCheckpointViewer(CheckpointListViewer):
     def output_checkpoints(self, checkpoints: list[dict], scope_id: str) -> None:
         writer = csv.writer(sys.stdout)
         writer.writerow(self._header())
-        show_target = self.scope_kind == ScopeKind.RUN
+        show_target = self.scope_kind.shows_target
         for ckpt in checkpoints:
             size_str = cli_common.format_bytes_to_human_readable(
                 ckpt.get("size_bytes", 0)
             )
             created_str = cli_common.format_localized_time(ckpt.get("created_at", ""))
-            row = [scope_id, ckpt.get("id", ""), ckpt.get("checkpoint_id", "")]
+            row = [
+                self.scope_kind.row_scope_id(ckpt, scope_id),
+                ckpt.get("id", ""),
+                ckpt.get("checkpoint_id", ""),
+            ]
             if show_target:
                 row.append(ckpt.get("target", "") or "")
             row.extend(
@@ -197,7 +235,7 @@ class JSONCheckpointViewer(CheckpointListViewer):
     """Viewer that outputs checkpoint list in JSON format."""
 
     def output_checkpoints(self, checkpoints: list[dict], scope_id: str) -> None:
-        scope_id_key = f"{self.scope_kind.value}_id"
+        row_id_key = "job_id" if self.scope_kind is ScopeKind.JOB else "run_id"
         checkpoints_data = []
         for ckpt in checkpoints:
             size_str = cli_common.format_bytes_to_human_readable(
@@ -205,11 +243,11 @@ class JSONCheckpointViewer(CheckpointListViewer):
             )
             created_str = cli_common.format_localized_time(ckpt.get("created_at", ""))
             entry: dict[str, Any] = {
-                scope_id_key: scope_id,
+                row_id_key: self.scope_kind.row_scope_id(ckpt, scope_id),
                 "id": ckpt.get("id", ""),
                 "checkpoint_id": ckpt.get("checkpoint_id", ""),
             }
-            if self.scope_kind == ScopeKind.RUN:
+            if self.scope_kind.shows_target:
                 entry["target"] = ckpt.get("target", "") or ""
             entry.update(
                 {
@@ -225,7 +263,7 @@ class JSONCheckpointViewer(CheckpointListViewer):
             checkpoints_data.append(entry)
 
         output = {
-            f"{self.scope_kind.value}_id": scope_id,
+            self.scope_kind.scope_json_key: scope_id,
             "total_checkpoints": len(checkpoints),
             "checkpoints": checkpoints_data,
         }
@@ -233,7 +271,7 @@ class JSONCheckpointViewer(CheckpointListViewer):
 
     def output_no_checkpoints_message(self, scope_id: str) -> None:
         output = {
-            f"{self.scope_kind.value}_id": scope_id,
+            self.scope_kind.scope_json_key: scope_id,
             "total_checkpoints": 0,
             "checkpoints": [],
         }

--- a/truss/tests/cli/test_loops_cli.py
+++ b/truss/tests/cli/test_loops_cli.py
@@ -748,17 +748,63 @@ def test_checkpoints_view_with_run_id_calls_list_loops_checkpoints(mock_remote):
         mock_remote,
     )
     assert result.exit_code == 0, result.output
-    mock_remote.api.list_loops_checkpoints.assert_called_once_with(run_id="trnr_xyz")
+    mock_remote.api.list_loops_checkpoints.assert_called_once_with(
+        run_id="trnr_xyz", base_model=None
+    )
     assert "step-100" in result.output  # checkpoint name
     assert "vL3pQrS8" in result.output  # Loops checkpoint PK
     assert "trnr_xyz" in result.output  # table title shows the run id
 
 
-def test_checkpoints_view_with_base_model_picks_most_recent_run(mock_remote):
-    mock_remote.api.list_loops_runs.return_value = [
-        {"id": "trnr_old", "created_at": "2026-05-01T00:00:00Z"},
-        {"id": "trnr_new", "created_at": "2026-05-07T00:00:00Z"},
-    ]
+def test_checkpoints_view_with_base_model_lists_all_runs(mock_remote):
+    mock_remote.api.list_loops_checkpoints.return_value = {
+        "checkpoints": [
+            {
+                "id": "ckptOld",
+                "checkpoint_id": "step-50",
+                "run_id": "trnr_old",
+                "checkpoint_type": "lora",
+                "base_model": "Qwen/Qwen3-8B",
+                "size_bytes": 1234,
+                "created_at": "2026-05-01T00:00:00Z",
+            },
+            {
+                "id": "ckptNew",
+                "checkpoint_id": "step-100",
+                "run_id": "trnr_new",
+                "checkpoint_type": "lora",
+                "base_model": "Qwen/Qwen3-8B",
+                "size_bytes": 5678,
+                "created_at": "2026-05-07T00:00:00Z",
+            },
+        ]
+    }
+    result = _invoke(
+        [
+            "loops",
+            "checkpoints",
+            "view",
+            "--remote",
+            "test_remote",
+            "--base-model",
+            "Qwen/Qwen3-8B",
+        ],
+        mock_remote,
+    )
+    assert result.exit_code == 0, result.output
+    # base_model is passed straight through; runs are not resolved client-side.
+    mock_remote.api.list_loops_checkpoints.assert_called_once_with(
+        run_id=None, base_model="Qwen/Qwen3-8B"
+    )
+    mock_remote.api.list_loops_runs.assert_not_called()
+    # Checkpoints from every run for the base model are shown, each with its run.
+    assert "trnr_old" in result.output
+    assert "trnr_new" in result.output
+    assert "step-50" in result.output
+    assert "step-100" in result.output
+
+
+def test_checkpoints_view_base_model_no_checkpoints(mock_remote):
     mock_remote.api.list_loops_checkpoints.return_value = {"checkpoints": []}
     result = _invoke(
         [
@@ -773,26 +819,10 @@ def test_checkpoints_view_with_base_model_picks_most_recent_run(mock_remote):
         mock_remote,
     )
     assert result.exit_code == 0, result.output
-    mock_remote.api.list_loops_runs.assert_called_once_with(base_model="Qwen/Qwen3-8B")
-    mock_remote.api.list_loops_checkpoints.assert_called_once_with(run_id="trnr_new")
-
-
-def test_checkpoints_view_base_model_no_runs(mock_remote):
-    mock_remote.api.list_loops_runs.return_value = []
-    result = _invoke(
-        [
-            "loops",
-            "checkpoints",
-            "view",
-            "--remote",
-            "test_remote",
-            "--base-model",
-            "Qwen/Qwen3-8B",
-        ],
-        mock_remote,
+    mock_remote.api.list_loops_checkpoints.assert_called_once_with(
+        run_id=None, base_model="Qwen/Qwen3-8B"
     )
-    assert result.exit_code != 0
-    mock_remote.api.list_loops_checkpoints.assert_not_called()
+    assert "Qwen/Qwen3-8B" in result.output
 
 
 def test_checkpoints_view_json_format_emits_run_id_key(mock_remote):


### PR DESCRIPTION
## :rocket: What

`truss loops checkpoints view --base-model <model>` only showed checkpoints from the **single most-recent run** for that base model, silently hiding every other run. This makes it show checkpoints across **all** of the caller's runs of that base model.

## :computer: How

The bug was client-side. The command resolved `--base-model` to one run id (`resolve_most_recent_run_for_base_model` → fetch all runs, sort by `created_at`, take `[0]`) and then queried checkpoints for just that run.

But the backend's `GET /v1/loops/checkpoints` already supports a `base_model` query filter that returns *all checkpoints across the caller's runs of that base model*, and each `LoopsCheckpointV1` carries its own `run_id`. So the fix is to stop resolving to a single run:

- `view_loops_checkpoint_list` now takes `run_id` **or** `base_model` and passes both straight to `list_loops_checkpoints(...)`.
- Added `ScopeKind.BASE_MODEL` to the shared checkpoint viewer so a base-model query labels each row with the checkpoint's own run id (the per-row "Run ID" column / JSON `run_id`), while the title/top-level JSON key reflects the base model. The single-run (`--run-id`) and training-job (`JOB`) paths are unchanged.
- Removed the now-dead `resolve_most_recent_run_for_base_model` helper and its `list_loops_runs` round-trip.
- Updated the `--base-model` help text (was "Resolves to the most recent Loops run for that model").

## :microscope: Testing

- Rewrote `test_checkpoints_view_with_base_model_picks_most_recent_run` (which asserted the buggy single-run behavior) into `test_checkpoints_view_with_base_model_lists_all_runs`, verifying `base_model` is passed through, `list_loops_runs` is **not** called, and checkpoints + run ids from multiple runs all appear.
- `truss/tests/cli/test_loops_cli.py` (50) and `truss/tests/cli/train/test_checkpoint_viewer.py` (56) pass.
- `ruff check`, `ruff format --check`, and `mypy` clean on the changed files.