### PR TITLE
Keep truss login API keys plaintext in trussrc instead of keyring

### DIFF
--- a/truss/cli/auth.py
+++ b/truss/cli/auth.py
@@ -87,7 +87,7 @@ def auth_status(remote: Optional[str]) -> None:
     auth_type = section.get("auth_type")
     if not auth_type:
         if "api_key" in section:
-            auth_type = "api_key (legacy plaintext)"
+            auth_type = "api_key (plaintext)"
             source = "trussrc-inline"
         else:
             raise click.ClickException(

--- a/truss/remote/remote_factory.py
+++ b/truss/remote/remote_factory.py
@@ -254,6 +254,15 @@ def _offload_secrets_from_config(remote_config: RemoteConfig) -> None:
     auth_type = configs.get("auth_type")
     if not isinstance(auth_type, str):
         return
+    # API keys are intentionally left plaintext in ~/.trussrc rather than
+    # offloaded to the OS keyring. The SSH proxy command run by the system SSH
+    # client executes under a stock Python interpreter with no keyring backend,
+    # so it can only read an api_key that lives inline in the trussrc. OAuth
+    # credentials still go to the keyring below. Existing keyring-stored api_keys
+    # remain readable via _apply_secrets_to_config; this only keeps new logins
+    # inline.
+    if auth_type == AuthType.API_KEY:
+        return
     secret_keys = _INLINE_SECRET_KEYS_BY_AUTH_TYPE.get(auth_type)
     if secret_keys is None or not all(key in configs for key in secret_keys):
         return

--- a/truss/tests/cli/test_auth_cli.py
+++ b/truss/tests/cli/test_auth_cli.py
@@ -118,24 +118,26 @@ def test_status_keyring_source(memory_keyring, trussrc):
             configs={
                 "remote_provider": "baseten",
                 "remote_url": "http://x",
-                "auth_type": "api_key",
-                "api_key": "secret",
+                "auth_type": "oauth",
+                "oauth_access_token": "access",
+                "oauth_refresh_token": "refresh",
+                "oauth_expires_at": "123",
             },
         )
     )
     result = CliRunner().invoke(truss_cli, ["auth", "status"])
     assert result.exit_code == 0, result.output
-    assert "auth_type: api_key" in result.output
+    assert "auth_type: oauth" in result.output
     assert "source: keyring" in result.output
 
 
-def test_status_legacy_plaintext(trussrc):
+def test_status_inline_plaintext(trussrc):
     trussrc.write_text(
-        "[baseten]\nremote_provider = baseten\nremote_url = http://x\napi_key = legacy\n"
+        "[baseten]\nremote_provider = baseten\nremote_url = http://x\napi_key = plain\n"
     )
     result = CliRunner().invoke(truss_cli, ["auth", "status"])
     assert result.exit_code == 0, result.output
-    assert "legacy plaintext" in result.output
+    assert "api_key (plaintext)" in result.output
     assert "source: trussrc-inline" in result.output
 
 

--- a/truss/tests/remote/test_remote_factory.py
+++ b/truss/tests/remote/test_remote_factory.py
@@ -1,3 +1,4 @@
+import json
 from unittest import mock
 
 import pytest
@@ -220,7 +221,9 @@ def test_legacy_plaintext_round_trip(trussrc):
     assert "auth_type" not in loaded.configs
 
 
-def test_keyring_offload_round_trip(memory_keyring, trussrc):
+def test_api_key_stays_plaintext(memory_keyring, trussrc):
+    # API keys are deliberately kept inline in the trussrc (never offloaded to
+    # the keyring) so the SSH proxy command can read them; only OAuth offloads.
     RemoteFactory.update_remote_config(
         RemoteConfig(
             name="baseten",
@@ -233,13 +236,57 @@ def test_keyring_offload_round_trip(memory_keyring, trussrc):
         )
     )
     text = trussrc.read_text()
-    assert "api_key = " not in text
+    assert "api_key = secret" in text
     assert "auth_type = api_key" in text
-    assert memory_keyring.get_password(KEYRING_SERVICE, "baseten") is not None
+    assert memory_keyring.get_password(KEYRING_SERVICE, "baseten") is None
 
     loaded = RemoteFactory.load_remote_config("baseten")
     assert loaded.configs["api_key"] == "secret"
     assert loaded.configs["auth_type"] == "api_key"
+
+
+def test_legacy_keyring_api_key_still_reads(memory_keyring, trussrc):
+    # API keys stored in the keyring by an older truss version (auth_type set,
+    # nothing inline) must still load for normal operations even though new
+    # logins no longer offload api_keys. SSH is the only thing that can't use
+    # these, since its proxy command reads the plaintext trussrc directly.
+    trussrc.write_text(
+        "[baseten]\n"
+        "remote_provider = baseten\n"
+        "auth_type = api_key\n"
+        "remote_url = http://x\n"
+    )
+    memory_keyring.set_password(
+        KEYRING_SERVICE,
+        "baseten",
+        json.dumps({"auth_type": "api_key", "api_key": "secret"}),
+    )
+    loaded = RemoteFactory.load_remote_config("baseten")
+    assert loaded.configs["api_key"] == "secret"
+
+
+def test_keyring_offload_round_trip(memory_keyring, trussrc):
+    RemoteFactory.update_remote_config(
+        RemoteConfig(
+            name="baseten",
+            configs={
+                "remote_provider": "baseten",
+                "auth_type": "oauth",
+                "oauth_access_token": "access",
+                "oauth_refresh_token": "refresh",
+                "oauth_expires_at": "123",
+                "remote_url": "http://x",
+            },
+        )
+    )
+    text = trussrc.read_text()
+    assert "oauth_access_token = " not in text
+    assert "auth_type = oauth" in text
+    assert memory_keyring.get_password(KEYRING_SERVICE, "baseten") is not None
+
+    loaded = RemoteFactory.load_remote_config("baseten")
+    assert loaded.configs["oauth_access_token"] == "access"
+    assert loaded.configs["auth_type"] == "oauth"
 
 
 def test_env_disabled_keeps_inline_silently(
@@ -252,18 +299,20 @@ def test_env_disabled_keeps_inline_silently(
                 name="baseten",
                 configs={
                     "remote_provider": "baseten",
-                    "auth_type": "api_key",
-                    "api_key": "secret",
+                    "auth_type": "oauth",
+                    "oauth_access_token": "access",
+                    "oauth_refresh_token": "refresh",
+                    "oauth_expires_at": "123",
                     "remote_url": "http://x",
                 },
             )
         )
     assert caplog.records == []
-    assert "api_key = secret" in trussrc.read_text()
+    assert "oauth_access_token = access" in trussrc.read_text()
     assert memory_keyring.get_password(KEYRING_SERVICE, "baseten") is None
 
     loaded = RemoteFactory.load_remote_config("baseten")
-    assert loaded.configs["api_key"] == "secret"
+    assert loaded.configs["oauth_access_token"] == "access"
 
 
 def test_unusable_backend_warns_and_keeps_inline(fail_keyring, trussrc, caplog):
@@ -273,17 +322,19 @@ def test_unusable_backend_warns_and_keeps_inline(fail_keyring, trussrc, caplog):
                 name="baseten",
                 configs={
                     "remote_provider": "baseten",
-                    "auth_type": "api_key",
-                    "api_key": "secret",
+                    "auth_type": "oauth",
+                    "oauth_access_token": "access",
+                    "oauth_refresh_token": "refresh",
+                    "oauth_expires_at": "123",
                     "remote_url": "http://x",
                 },
             )
         )
     assert any("plaintext" in r.message for r in caplog.records)
-    assert "api_key = secret" in trussrc.read_text()
+    assert "oauth_access_token = access" in trussrc.read_text()
 
     loaded = RemoteFactory.load_remote_config("baseten")
-    assert loaded.configs["api_key"] == "secret"
+    assert loaded.configs["oauth_access_token"] == "access"
 
 
 def test_load_raises_when_secret_missing_and_keyring_unavailable(fail_keyring, trussrc):
@@ -326,8 +377,10 @@ def test_remove_remote_config_drops_section_and_keyring(memory_keyring, trussrc)
             name="baseten",
             configs={
                 "remote_provider": "baseten",
-                "auth_type": "api_key",
-                "api_key": "secret",
+                "auth_type": "oauth",
+                "oauth_access_token": "access",
+                "oauth_refresh_token": "refresh",
+                "oauth_expires_at": "123",
                 "remote_url": "http://x",
             },
         )


### PR DESCRIPTION
## :rocket: What

Truss SSH requires plaintext API keys in trussrc (and doesn't work with OAuth, but new CLI can work with OAuth _and_ use keyring-based API keys). So this puts part of the behavior back to before #2399 where API keys were in trussrc. This only applies to new ones, past ones (whether plaintext or keyring) continue to work.

- `truss login --api-key` now keeps the API key plaintext in `~/.trussrc` instead of offloading it to the OS keyring (OAuth still uses the keyring).
- Restores SSH support: the SSH proxy command runs under a stock Python interpreter with no keyring backend, so it can only read a plaintext api_key.
- Forward-only: no migration, no cleanup. Existing keyring-stored api_keys still load for normal operations (just not SSH).

## :computer: How

- `_offload_secrets_from_config` returns early for `auth_type == api_key`; the read path and auth-type→keys map are untouched, so prior keyring api_keys still load.
- `auth status` label changed from `api_key (legacy plaintext)` to `api_key (plaintext)`.

## :microscope: Testing

- Added `test_api_key_stays_plaintext` and `test_legacy_keyring_api_key_still_reads` (backward-compat guard).
- Converted offload/env-disabled/unusable-backend/remove and status tests to OAuth.
- `remote_factory` + `auth_cli` suites pass (40 tests); ruff check/format clean.
