### PR TITLE
feat(cli/train): support setting team GPU capacity

### DIFF
--- a/truss/cli/train/core.py
+++ b/truss/cli/train/core.py
@@ -14,6 +14,7 @@ import rich
 from InquirerPy import inquirer
 from rich.text import Text
 
+from truss.cli import remote_cli
 from truss.cli.train import common, deploy_checkpoints
 from truss.cli.train.metrics_watcher import MetricsWatcher
 from truss.cli.train.types import (
@@ -827,3 +828,19 @@ def display_training_capacity(remote_provider: BasetenRemote) -> None:
         )
 
     console.print(table)
+
+
+def update_team_training_gpu_capacity(
+    remote_provider: BasetenRemote, team_name: str, gpu_type: str, capacity: int
+) -> Dict[str, Any]:
+    """Set the max concurrent GPUs of a given type a team may use. Org-admin only."""
+    existing_teams = remote_provider.api.get_teams()
+    team = existing_teams.get(team_name)
+    if team is None:
+        raise click.ClickException(
+            f"Team '{team_name}' does not exist. "
+            f"Available teams: {remote_cli.format_available_teams(existing_teams)}"
+        )
+    return remote_provider.api.update_team_training_gpu_capacity(
+        team_id=team.id, gpu_type=gpu_type, max_gpus=capacity
+    )

--- a/truss/cli/train_commands.py
+++ b/truss/cli/train_commands.py
@@ -1128,15 +1128,17 @@ def view_capacity(remote: Optional[str]):
     train_cli.display_training_capacity(remote_provider)
 
 
-@capacity.command(name="set")
+@capacity.command(name="update")
 @common.common_options()
 @click.option("--remote", type=str, required=False, help="Name of the remote to use")
-@click.option("--team", type=str, required=True, help="Team to set GPU capacity for.")
+@click.option(
+    "--team", type=str, required=True, help="Team to update GPU capacity for."
+)
 @click.option(
     "--gpu-type",
     type=str,
     required=True,
-    help="GPU type to set capacity for (e.g. H100).",
+    help="GPU type to update capacity for (e.g. H100).",
 )
 @click.option(
     "--capacity",
@@ -1145,8 +1147,10 @@ def view_capacity(remote: Optional[str]):
     required=True,
     help="Max concurrent GPUs of this type the team may use. Org-admin only.",
 )
-def set_capacity(remote: Optional[str], team: str, gpu_type: str, team_capacity: int):
-    """Set a team's GPU capacity limit. Org-admin only."""
+def update_capacity(
+    remote: Optional[str], team: str, gpu_type: str, team_capacity: int
+):
+    """Update a team's GPU capacity limit. Org-admin only."""
     if not remote:
         remote = remote_cli.inquire_remote_name()
     remote_provider: BasetenRemote = cast(
@@ -1165,7 +1169,7 @@ def set_capacity(remote: Optional[str], team: str, gpu_type: str, team_capacity:
         error_console.print(f"Failed to update team capacity: {str(e)}")
         sys.exit(1)
     console.print(
-        f"Set {item['team_name']}'s {item['gpu_type']} capacity to {item['limit']}.",
+        f"Updated {item['team_name']}'s {item['gpu_type']} capacity to {item['limit']}.",
         style="green",
     )
 

--- a/truss/cli/train_commands.py
+++ b/truss/cli/train_commands.py
@@ -1157,7 +1157,7 @@ def update_capacity(
         BasetenRemote, RemoteFactory.create(remote=remote)
     )
     try:
-        item = train_cli.update_team_training_gpu_capacity(
+        updated_capacity = train_cli.update_team_training_gpu_capacity(
             remote_provider=remote_provider,
             team_name=team,
             gpu_type=gpu_type,
@@ -1169,7 +1169,8 @@ def update_capacity(
         error_console.print(f"Failed to update team capacity: {str(e)}")
         sys.exit(1)
     console.print(
-        f"Updated {item['team_name']}'s {item['gpu_type']} capacity to {item['limit']}.",
+        f"Updated {updated_capacity['team_name']}'s {updated_capacity['gpu_type']} "
+        f"capacity to {updated_capacity['limit']}.",
         style="green",
     )
 

--- a/truss/cli/train_commands.py
+++ b/truss/cli/train_commands.py
@@ -1113,13 +1113,62 @@ def _patch_sessions(
 @train.command(name="capacity")
 @common.common_options()
 @click.option("--remote", type=str, required=False, help="Name of the remote to use")
-def capacity(remote: Optional[str]):
-    """Show GPU capacity limits and current usage for the organization."""
+@click.option("--team", type=str, required=False, help="Team to set GPU capacity for.")
+@click.option(
+    "--gpu-type",
+    type=str,
+    required=False,
+    help="GPU type to set capacity for (e.g. H100).",
+)
+@click.option(
+    "--capacity",
+    "team_capacity",
+    type=int,
+    required=False,
+    help="Max concurrent GPUs of this type the team may use. Org-admin only.",
+)
+def capacity(
+    remote: Optional[str],
+    team: Optional[str],
+    gpu_type: Optional[str],
+    team_capacity: Optional[int],
+):
+    """Show GPU capacity limits and current usage for the organization.
+
+    Pass --team, --gpu-type, and --capacity together to set a team's GPU capacity limit.
+    """
+    is_update = team or gpu_type or team_capacity is not None
+    if is_update and not (team and gpu_type and team_capacity is not None):
+        raise click.UsageError(
+            "--team, --gpu-type, and --capacity must all be provided together."
+        )
+
     if not remote:
         remote = remote_cli.inquire_remote_name()
     remote_provider: BasetenRemote = cast(
         BasetenRemote, RemoteFactory.create(remote=remote)
     )
+
+    if is_update:
+        assert team and gpu_type and team_capacity is not None
+        try:
+            item = train_cli.update_team_training_gpu_capacity(
+                remote_provider=remote_provider,
+                team_name=team,
+                gpu_type=gpu_type,
+                capacity=team_capacity,
+            )
+        except click.ClickException:
+            raise
+        except Exception as e:
+            error_console.print(f"Failed to update team capacity: {str(e)}")
+            sys.exit(1)
+        console.print(
+            f"Set {item['team_name']}'s {item['gpu_type']} capacity to {item['limit']}.",
+            style="green",
+        )
+        return
+
     train_cli.display_training_capacity(remote_provider)
 
 

--- a/truss/cli/train_commands.py
+++ b/truss/cli/train_commands.py
@@ -1110,66 +1110,64 @@ def _patch_sessions(
     return messages
 
 
-@train.command(name="capacity")
+@train.group(name="capacity")
+def capacity():
+    """Capacity-related subcommands for truss train"""
+
+
+@capacity.command(name="view")
 @common.common_options()
 @click.option("--remote", type=str, required=False, help="Name of the remote to use")
-@click.option("--team", type=str, required=False, help="Team to set GPU capacity for.")
+def view_capacity(remote: Optional[str]):
+    """Show GPU capacity limits and current usage for the organization."""
+    if not remote:
+        remote = remote_cli.inquire_remote_name()
+    remote_provider: BasetenRemote = cast(
+        BasetenRemote, RemoteFactory.create(remote=remote)
+    )
+    train_cli.display_training_capacity(remote_provider)
+
+
+@capacity.command(name="set")
+@common.common_options()
+@click.option("--remote", type=str, required=False, help="Name of the remote to use")
+@click.option("--team", type=str, required=True, help="Team to set GPU capacity for.")
 @click.option(
     "--gpu-type",
     type=str,
-    required=False,
+    required=True,
     help="GPU type to set capacity for (e.g. H100).",
 )
 @click.option(
     "--capacity",
     "team_capacity",
     type=int,
-    required=False,
+    required=True,
     help="Max concurrent GPUs of this type the team may use. Org-admin only.",
 )
-def capacity(
-    remote: Optional[str],
-    team: Optional[str],
-    gpu_type: Optional[str],
-    team_capacity: Optional[int],
-):
-    """Show GPU capacity limits and current usage for the organization.
-
-    Pass --team, --gpu-type, and --capacity together to set a team's GPU capacity limit.
-    """
-    is_update = team or gpu_type or team_capacity is not None
-    if is_update and not (team and gpu_type and team_capacity is not None):
-        raise click.UsageError(
-            "--team, --gpu-type, and --capacity must all be provided together."
-        )
-
+def set_capacity(remote: Optional[str], team: str, gpu_type: str, team_capacity: int):
+    """Set a team's GPU capacity limit. Org-admin only."""
     if not remote:
         remote = remote_cli.inquire_remote_name()
     remote_provider: BasetenRemote = cast(
         BasetenRemote, RemoteFactory.create(remote=remote)
     )
-
-    if is_update:
-        assert team and gpu_type and team_capacity is not None
-        try:
-            item = train_cli.update_team_training_gpu_capacity(
-                remote_provider=remote_provider,
-                team_name=team,
-                gpu_type=gpu_type,
-                capacity=team_capacity,
-            )
-        except click.ClickException:
-            raise
-        except Exception as e:
-            error_console.print(f"Failed to update team capacity: {str(e)}")
-            sys.exit(1)
-        console.print(
-            f"Set {item['team_name']}'s {item['gpu_type']} capacity to {item['limit']}.",
-            style="green",
+    try:
+        item = train_cli.update_team_training_gpu_capacity(
+            remote_provider=remote_provider,
+            team_name=team,
+            gpu_type=gpu_type,
+            capacity=team_capacity,
         )
-        return
-
-    train_cli.display_training_capacity(remote_provider)
+    except click.ClickException:
+        raise
+    except Exception as e:
+        error_console.print(f"Failed to update team capacity: {str(e)}")
+        sys.exit(1)
+    console.print(
+        f"Set {item['team_name']}'s {item['gpu_type']} capacity to {item['limit']}.",
+        style="green",
+    )
 
 
 @train.command(name="workstation")

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -926,6 +926,15 @@ class BasetenApi:
         resp_json = self._rest_api_client.get("v1/training/capacity")
         return resp_json.get("gpu_capacities", [])
 
+    def update_team_training_gpu_capacity(
+        self, team_id: str, gpu_type: str, max_gpus: int
+    ) -> dict:
+        resp_json = self._rest_api_client.patch(
+            "v1/training/capacity",
+            body={"team_id": team_id, "gpu_type": gpu_type, "max_gpus": max_gpus},
+        )
+        return resp_json["team_gpu_capacity"]
+
     def list_training_job_checkpoints(self, project_id: str, job_id: str):
         resp_json = self._rest_api_client.get(
             f"v1/training_projects/{project_id}/jobs/{job_id}/checkpoints"

--- a/truss/tests/cli/train/test_train_cli_core.py
+++ b/truss/tests/cli/train/test_train_cli_core.py
@@ -1,11 +1,18 @@
 from unittest.mock import Mock, patch
 
+import click
+import pytest
+
 from truss.cli.train.cache import (
     calculate_directory_sizes,
     create_file_summary_with_directory_sizes,
 )
-from truss.cli.train.core import display_training_capacity, view_training_job_metrics
-from truss.remote.baseten.custom_types import FileSummary
+from truss.cli.train.core import (
+    display_training_capacity,
+    update_team_training_gpu_capacity,
+    view_training_job_metrics,
+)
+from truss.remote.baseten.custom_types import FileSummary, TeamType
 
 
 @patch("truss.cli.train.metrics_watcher.time.sleep")
@@ -477,3 +484,47 @@ def test_display_training_capacity_empty(capsys):
     display_training_capacity(mock_remote)
 
     assert "No Training GPU capacity limits." in capsys.readouterr().out
+
+
+def test_update_team_training_gpu_capacity_resolves_team_and_calls_api():
+    """Team name is resolved to a team_id before calling the update API."""
+    mock_api = Mock()
+    mock_api.get_teams.return_value = {
+        "ml-research": TeamType(id="team_abc", name="ml-research", default=False)
+    }
+    mock_api.update_team_training_gpu_capacity.return_value = {
+        "team_id": "team_abc",
+        "team_name": "ml-research",
+        "gpu_type": "H100",
+        "baseline": 0,
+        "limit": 32,
+        "usage_count": 0,
+    }
+    mock_remote = Mock()
+    mock_remote.api = mock_api
+
+    result = update_team_training_gpu_capacity(
+        mock_remote, team_name="ml-research", gpu_type="H100", capacity=32
+    )
+
+    mock_api.update_team_training_gpu_capacity.assert_called_once_with(
+        team_id="team_abc", gpu_type="H100", max_gpus=32
+    )
+    assert result["limit"] == 32
+
+
+def test_update_team_training_gpu_capacity_unknown_team_raises():
+    """An unknown team name raises a ClickException listing the available teams."""
+    mock_api = Mock()
+    mock_api.get_teams.return_value = {
+        "ml-research": TeamType(id="team_abc", name="ml-research", default=False)
+    }
+    mock_remote = Mock()
+    mock_remote.api = mock_api
+
+    with pytest.raises(click.ClickException, match="ml-research"):
+        update_team_training_gpu_capacity(
+            mock_remote, team_name="does-not-exist", gpu_type="H100", capacity=32
+        )
+
+    mock_api.update_team_training_gpu_capacity.assert_not_called()


### PR DESCRIPTION
## Summary
- Adds `truss train capacity` as a subcommand group: `view` (existing read-only capacity table, unchanged) and `update` (new).
- `truss train capacity update --team --gpu-type --capacity` lets org admins set a team's GPU training capacity ceiling from the CLI. All three flags are required (click-native `required=True`, no manual flag-combination validation).
- Calls a new `PATCH v1/training/capacity` endpoint (org-admin only, server-side).

## Test plan
- [x] Unit tests for `update_team_training_gpu_capacity` (resolves team, raises on unknown team) — passing
- [x] Full `truss/tests/cli/train/` suite (178 tests) — passing, no regressions
- [x] `ruff check` / `ruff format` / `mypy` — clean
- [x] Manual `truss train capacity view --help`, `truss train capacity update --help`, and missing-required-flag smoke checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)