### PR TITLE
feat(cli/train): show team capacities in capacity view

### DIFF
--- a/truss/cli/train/core.py
+++ b/truss/cli/train/core.py
@@ -800,34 +800,58 @@ def view_cache_summary_by_project(
 
 
 def display_training_capacity(remote_provider: BasetenRemote) -> None:
-    """Fetch and display GPU capacity limits and usage for the organization."""
-    gpu_capacities = remote_provider.api.get_training_capacity()
+    """Fetch and display org- and team-level GPU capacity limits and usage."""
+    capacity = remote_provider.api.get_training_capacity()
+    gpu_capacities = capacity.get("gpu_capacities", [])
+    team_gpu_capacities = capacity.get("team_gpu_capacities", [])
 
-    table = rich.table.Table(
-        show_header=True,
-        header_style="bold magenta",
-        title="Training GPU Capacity",
-        box=rich.table.box.ROUNDED,
-        border_style="blue",
-    )
-    table.add_column("GPU Type", style="cyan")
-    table.add_column("Baseline", justify="right")
-    table.add_column("Limit", justify="right")
-    table.add_column("Usage", justify="right")
-
-    if not gpu_capacities:
+    if not gpu_capacities and not team_gpu_capacities:
         console.print("No Training GPU capacity limits.")
         return
 
-    for item in gpu_capacities:
-        table.add_row(
-            item.get("gpu_type", ""),
-            str(item.get("baseline", 0)),
-            str(item.get("limit", 0)),
-            str(item.get("usage_count", 0)),
+    if gpu_capacities:
+        org_table = rich.table.Table(
+            show_header=True,
+            header_style="bold magenta",
+            title="Training GPU Capacity",
+            box=rich.table.box.ROUNDED,
+            border_style="blue",
         )
+        org_table.add_column("GPU Type", style="cyan")
+        org_table.add_column("Baseline", justify="right")
+        org_table.add_column("Limit", justify="right")
+        org_table.add_column("Usage", justify="right")
+        for item in gpu_capacities:
+            org_table.add_row(
+                item.get("gpu_type", ""),
+                str(item.get("baseline", 0)),
+                str(item.get("limit", 0)),
+                str(item.get("usage_count", 0)),
+            )
+        console.print(org_table)
 
-    console.print(table)
+    if team_gpu_capacities:
+        team_table = rich.table.Table(
+            show_header=True,
+            header_style="bold magenta",
+            title="Team Training GPU Capacity",
+            box=rich.table.box.ROUNDED,
+            border_style="blue",
+        )
+        team_table.add_column("Team", style="cyan")
+        team_table.add_column("GPU Type", style="cyan")
+        team_table.add_column("Baseline", justify="right")
+        team_table.add_column("Limit", justify="right")
+        team_table.add_column("Usage", justify="right")
+        for item in team_gpu_capacities:
+            team_table.add_row(
+                item.get("team_name", ""),
+                item.get("gpu_type", ""),
+                str(item.get("baseline", 0)),
+                str(item.get("limit", 0)),
+                str(item.get("usage_count", 0)),
+            )
+        console.print(team_table)
 
 
 def update_team_training_gpu_capacity(

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -922,9 +922,12 @@ class BasetenApi:
         )
         return resp_json["training_job"]
 
-    def get_training_capacity(self) -> list[dict]:
-        resp_json = self._rest_api_client.get("v1/training/capacity")
-        return resp_json.get("gpu_capacities", [])
+    def get_training_capacity(self) -> dict:
+        """Return the org- and team-level GPU capacity payload.
+
+        Shape: ``{"gpu_capacities": [...], "team_gpu_capacities": [...]}``.
+        """
+        return self._rest_api_client.get("v1/training/capacity")
 
     def update_team_training_gpu_capacity(
         self, team_id: str, gpu_type: str, max_gpus: int

--- a/truss/tests/cli/train/test_train_cli_core.py
+++ b/truss/tests/cli/train/test_train_cli_core.py
@@ -454,10 +454,12 @@ def test_calculate_directory_sizes_max_depth():
 def test_display_training_capacity(capsys):
     """Table is printed with GPU type, baseline, limit, and usage for each entry."""
     mock_api = Mock()
-    mock_api.get_training_capacity.return_value = [
-        {"gpu_type": "H100", "baseline": 16, "limit": 64, "usage_count": 32},
-        {"gpu_type": "A10G", "baseline": 0, "limit": 8, "usage_count": 0},
-    ]
+    mock_api.get_training_capacity.return_value = {
+        "gpu_capacities": [
+            {"gpu_type": "H100", "baseline": 16, "limit": 64, "usage_count": 32},
+            {"gpu_type": "A10G", "baseline": 0, "limit": 8, "usage_count": 0},
+        ]
+    }
     mock_remote = Mock()
     mock_remote.api = mock_api
 
@@ -474,10 +476,75 @@ def test_display_training_capacity(capsys):
     assert rows["A10G"] == ["A10G", "0", "8", "0"]
 
 
+def test_display_training_capacity_with_teams(capsys):
+    """Team capacities are rendered in a second table with a Team column."""
+    mock_api = Mock()
+    mock_api.get_training_capacity.return_value = {
+        "gpu_capacities": [
+            {"gpu_type": "H100", "baseline": 16, "limit": 64, "usage_count": 32}
+        ],
+        "team_gpu_capacities": [
+            {
+                "team_id": "team_abc",
+                "team_name": "ml-research",
+                "gpu_type": "H100",
+                "baseline": 0,
+                "limit": 32,
+                "usage_count": 8,
+            }
+        ],
+    }
+    mock_remote = Mock()
+    mock_remote.api = mock_api
+
+    display_training_capacity(mock_remote)
+
+    out = capsys.readouterr().out
+    lines = out.splitlines()
+    rows = {
+        cells[0]: cells
+        for line in lines
+        if (cells := [c.strip() for c in line.split("│") if c.strip()])
+    }
+
+    assert "Team Training GPU Capacity" in out
+    assert rows["H100"] == ["H100", "16", "64", "32"]
+    assert rows["ml-research"] == ["ml-research", "H100", "0", "32", "8"]
+
+
+def test_display_training_capacity_teams_only(capsys):
+    """A team table is shown even when there are no org-level capacities."""
+    mock_api = Mock()
+    mock_api.get_training_capacity.return_value = {
+        "gpu_capacities": [],
+        "team_gpu_capacities": [
+            {
+                "team_id": "team_abc",
+                "team_name": "ml-research",
+                "gpu_type": "H100",
+                "baseline": 0,
+                "limit": 32,
+                "usage_count": 0,
+            }
+        ],
+    }
+    mock_remote = Mock()
+    mock_remote.api = mock_api
+
+    display_training_capacity(mock_remote)
+
+    out = capsys.readouterr().out
+    assert "Team Training GPU Capacity" in out
+    assert "No Training GPU capacity limits." not in out
+
+
 def test_display_training_capacity_empty(capsys):
     """Empty state message is printed when there are no GPU capacities."""
     mock_api = Mock()
-    mock_api.get_training_capacity.return_value = []
+    mock_api.get_training_capacity.return_value = {
+        "gpu_capacities": [],
+        "team_gpu_capacities": [],
+    }
     mock_remote = Mock()
     mock_remote.api = mock_api
 


### PR DESCRIPTION
## Summary
- Extends `truss train capacity view` to also render **per-team** GPU capacity, not just org-level.
- Follow-up to #2531, which added `truss train capacity update` to set a team's ceiling but left no CLI way to read it back — `view` only showed the org table.
- Server-side needs no change: `GET v1/training/capacity` already returns `team_gpu_capacities`; this just surfaces it.

## Changes
- `BasetenApi.get_training_capacity()` now returns the full response payload (`{gpu_capacities, team_gpu_capacities}`) instead of just the org list. It had a single caller, so the contract change is contained.
- `display_training_capacity` prints the existing org table and, when team capacities exist, a second **Team Training GPU Capacity** table with a `Team` column. The "No Training GPU capacity limits." empty state now fires only when both are empty.

## Test plan
- [x] `truss/tests/cli/train/` suite (180 tests) — passing (added `with_teams` and `teams_only` display tests; updated existing mocks for the new return shape)
- [x] `ruff check` / `ruff format --check` / `mypy` — clean
- [x] Manual run against **staging** (team `ML-Perf` L4 = 10, set via `capacity update`):

```
         Training GPU Capacity
╭──────────┬──────────┬───────┬───────╮
│ GPU Type │ Baseline │ Limit │ Usage │
├──────────┼──────────┼───────┼───────┤
│ L4       │        4 │     8 │     0 │
╰──────────┴──────────┴───────┴───────╯
           Team Training GPU Capacity
╭─────────┬──────────┬──────────┬───────┬───────╮
│ Team    │ GPU Type │ Baseline │ Limit │ Usage │
├─────────┼──────────┼──────────┼───────┼───────┤
│ ML-Perf │ L4       │        0 │    10 │     0 │
╰─────────┴──────────┴──────────┴───────┴───────╯
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)