### PR TITLE
fix(cli): enforce exactly one of predict --data/--file

### DIFF
--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -374,6 +374,10 @@ def _extract_and_validate_model_identifier(
 
 
 def _extract_request_data(data: Optional[str], file: Optional[Path]):
+    if data is not None and file is not None:
+        raise click.UsageError(
+            "You must provide exactly one of '--data (-d)' or '--file (-f)' options."
+        )
     try:
         if data is not None:
             return json.loads(data)

--- a/truss/tests/cli/test_cli.py
+++ b/truss/tests/cli/test_cli.py
@@ -3,12 +3,13 @@ import sys
 import threading
 from unittest.mock import MagicMock, Mock, patch
 
+import click
 import pytest
 import requests
 import yaml
 from click.testing import CliRunner
 
-from truss.cli.cli import truss_cli
+from truss.cli.cli import _extract_request_data, truss_cli
 from truss.cli.utils import common
 from truss.remote.baseten.custom_types import OidcInfo, OidcTeamInfo
 from truss.remote.baseten.service import BasetenService
@@ -1757,3 +1758,31 @@ def test_model_logs_tail_with_filter_errors():
     assert result.exit_code != 0
     assert "cannot be combined" in result.output
     mock_remote.api.get_model_deployment_logs.assert_not_called()
+
+
+class TestExtractRequestData:
+    """`truss predict` request-data parsing (-d / -f)."""
+
+    def test_data_only(self):
+        assert _extract_request_data(data='{"x": 1}', file=None) == {"x": 1}
+
+    def test_file_only(self, tmp_path):
+        f = tmp_path / "req.json"
+        f.write_text('{"y": 2}')
+        assert _extract_request_data(data=None, file=f) == {"y": 2}
+
+    def test_both_provided_raises(self, tmp_path):
+        # Passing both -d and -f previously silently used -d and ignored -f;
+        # the "exactly one" contract must be enforced instead.
+        f = tmp_path / "req.json"
+        f.write_text('{"y": 2}')
+        with pytest.raises(click.UsageError, match="exactly one"):
+            _extract_request_data(data='{"x": 1}', file=f)
+
+    def test_neither_provided_raises(self):
+        with pytest.raises(click.UsageError, match="exactly one"):
+            _extract_request_data(data=None, file=None)
+
+    def test_invalid_json_raises(self):
+        with pytest.raises(click.UsageError, match="valid json"):
+            _extract_request_data(data="{not json}", file=None)


### PR DESCRIPTION
## What

`truss predict` accepts the request body via `-d/--data` (inline JSON) or `-f/--file` (JSON file). `_extract_request_data` documents these as mutually exclusive — its own error says *"You must provide **exactly one** of '--data (-d)' or '--file (-f)'"* — but it doesn't enforce that: when **both** are passed it silently returns the `--data` value and ignores `--file`, with no warning.

So a user who passes both (e.g. by mistake, or expecting `-f` to win) silently sends the wrong request body to their deployed model — a confusing, hard-to-notice failure.

## Fix

Raise the existing "exactly one" `UsageError` when both `--data` and `--file` are provided, so the mistake surfaces immediately. The single-flag and error paths are unchanged.

```python
if data is not None and file is not None:
    raise click.UsageError(
        "You must provide exactly one of '--data (-d)' or '--file (-f)' options."
    )
```

## Testing

Added `TestExtractRequestData` covering data-only, file-only, both-provided (now raises), neither-provided, and invalid-JSON. `pytest truss/tests/cli/test_cli.py::TestExtractRequestData` → **5 passed**; the both-provided test fails on `main` without this change. ruff clean.