### PR TITLE
feat(loops): add time-range and limit flags to truss loops logs

### DIFF
--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -1075,49 +1075,7 @@ def push(
     is_flag=True,
     help="Stream new logs as they arrive. Cannot be combined with the time-range or filter flags.",
 )
-@click.option(
-    "--start",
-    type=click.DateTime(
-        formats=[
-            "%Y-%m-%d",
-            "%Y-%m-%dT%H:%M:%S",
-            "%Y-%m-%d %H:%M:%S",
-            "%Y-%m-%dT%H:%M:%S%z",
-            "%Y-%m-%d %H:%M:%S%z",
-        ]
-    ),
-    default=None,
-    help=(
-        "Start of the log time range (ISO 8601). No-timezone values are local. "
-        "Defaults to a short look-back ending at --end. Window must be <= 7 days."
-    ),
-)
-@click.option(
-    "--end",
-    type=click.DateTime(
-        formats=[
-            "%Y-%m-%d",
-            "%Y-%m-%dT%H:%M:%S",
-            "%Y-%m-%d %H:%M:%S",
-            "%Y-%m-%dT%H:%M:%S%z",
-            "%Y-%m-%d %H:%M:%S%z",
-        ]
-    ),
-    default=None,
-    help=(
-        "End of the log time range (ISO 8601). No-timezone values are local. "
-        "Defaults to now. Window must be <= 7 days."
-    ),
-)
-@click.option(
-    "--since",
-    type=str,
-    default=None,
-    help=(
-        "Logs from a relative time ago until now, as <N><unit> with unit "
-        "s/m/h/d (e.g. '90s', '2h', '3d'). Max '7d'. Excludes --start/--end."
-    ),
-)
+@cli_log_utils.log_time_range_options
 @click.option(
     "--min-level",
     type=click.Choice(["debug", "info", "warning", "error"], case_sensitive=False),

--- a/truss/cli/logs/loops_deployment_log_watcher.py
+++ b/truss/cli/logs/loops_deployment_log_watcher.py
@@ -30,7 +30,10 @@ class LoopsDeploymentLogWatcher(LogWatcher):
     def fetch_logs(
         self, start_epoch_millis: Optional[int], end_epoch_millis: Optional[int]
     ) -> List[Any]:
-        return self.api.get_loops_deployment_logs(
+        # Deliberately the single-page fetch: tail polls re-fetch
+        # overlapping windows every few seconds and want the newest lines
+        # of each, not a multi-request crawl of the whole window.
+        return self.api.get_loops_deployment_logs_page(
             self._loops_deployment_id, start_epoch_millis, end_epoch_millis
         )
 

--- a/truss/cli/logs/utils.py
+++ b/truss/cli/logs/utils.py
@@ -13,6 +13,69 @@ MAX_LOG_RANGE = timedelta(days=7)
 _SINCE_RE = re.compile(r"^(\d+)([smhd])$")
 _SINCE_UNIT_TO_SECONDS = {"s": 1, "m": 60, "h": 3600, "d": 86400}
 
+# The sub-second form is what truncation resume hints emit (see
+# format_flag_datetime); it must stay in _LOG_DATETIME_FORMATS so hint output
+# is always parseable by --start/--end.
+LOG_RESUME_FORMAT = "%Y-%m-%dT%H:%M:%S.%f%z"
+
+_LOG_DATETIME_FORMATS = [
+    "%Y-%m-%d",
+    "%Y-%m-%dT%H:%M:%S",
+    "%Y-%m-%d %H:%M:%S",
+    "%Y-%m-%dT%H:%M:%S%z",
+    "%Y-%m-%d %H:%M:%S%z",
+    LOG_RESUME_FORMAT,
+]
+
+
+def format_flag_datetime(epoch_ms: int) -> str:
+    """Render an epoch-ms value as a --start/--end flag value.
+
+    Timezone-aware (immune to DST fall-back ambiguity), millisecond
+    precision. Parse-back error is at most 1ms and only ever downward:
+    safe for --start values as-is; --end values must be biased +1ms by the
+    caller so the error cannot clip the window's tail.
+    """
+    dt = datetime.fromtimestamp(epoch_ms / 1000, tz=timezone.utc).astimezone()
+    return dt.strftime(LOG_RESUME_FORMAT)
+
+
+def log_time_range_options(f):
+    """Add the shared --start/--end/--since options to a logs command.
+
+    The three values are meant to be resolved together via
+    resolve_log_time_range(). Options are applied in reverse so they render
+    in --help as --start, --end, --since.
+    """
+    f = click.option(
+        "--since",
+        type=str,
+        default=None,
+        help=(
+            "Logs from a relative time ago until now, as <N><unit> with unit "
+            "s/m/h/d (e.g. '90s', '2h', '3d'). Max '7d'. Excludes --start/--end."
+        ),
+    )(f)
+    f = click.option(
+        "--end",
+        type=click.DateTime(formats=_LOG_DATETIME_FORMATS),
+        default=None,
+        help=(
+            "End of the log time range (ISO 8601). No-timezone values are local. "
+            "Defaults to now. Window must be <= 7 days."
+        ),
+    )(f)
+    f = click.option(
+        "--start",
+        type=click.DateTime(formats=_LOG_DATETIME_FORMATS),
+        default=None,
+        help=(
+            "Start of the log time range (ISO 8601). No-timezone values are local. "
+            "Defaults to a short look-back ending at --end. Window must be <= 7 days."
+        ),
+    )(f)
+    return f
+
 
 class ParsedLog(pydantic.BaseModel):
     timestamp: str

--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -1,5 +1,6 @@
 import json
-from typing import Any, Dict, List, Optional, cast
+from datetime import datetime
+from typing import Any, Dict, Iterable, List, Optional, cast
 
 import rich.table
 import rich_click as click
@@ -18,8 +19,14 @@ from truss.cli.loops_checkpoint_viewer import (
 from truss.cli.train import checkpoint_viewer as checkpoint_mod
 from truss.cli.utils import common
 from truss.cli.utils.output import console
+from truss.remote.baseten.api import LOOPS_LOGS_MAX_LINES
 from truss.remote.baseten.remote import BasetenRemote
 from truss.remote.remote_factory import RemoteFactory
+
+# Default cap on lines fetched per `truss loops logs` invocation. The 7-day
+# window bounds how far back you can look, not how much one call may pull;
+# past this, the CLI prints a resume hint instead of buffering more.
+DEFAULT_LOGS_LINE_LIMIT = 10_000
 
 
 @click.group()
@@ -577,6 +584,39 @@ def deploy_loops_checkpoints(
         train_cli.print_deploy_checkpoints_success_message(result.deploy_config)
 
 
+_MAX_LOG_RANGE_MS = int(cli_log_utils.MAX_LOG_RANGE.total_seconds() * 1000)
+
+
+def _logs_truncation_hint(
+    resume_ms: Optional[int], max_lines: int, end_ms: Optional[int]
+) -> str:
+    """Build the hint shown when a windowed fetch was cut at --limit."""
+    prefix = f"Showing the first {max_lines:,} lines of the window."
+    raise_part = ", or raise --limit" if max_lines < LOOPS_LOGS_MAX_LINES else ""
+
+    if resume_ms is None:
+        return (
+            f"{prefix} All shown lines share one millisecond, which "
+            f"--start cannot advance past{raise_part}."
+        )
+
+    end_part = ""
+    if end_ms is not None:
+        # Keep the pasted command inside the 7-day window check (the --end
+        # bias below plus --start parse-back slack could push an
+        # exactly-7-day window over the limit).
+        resume_ms = max(resume_ms, end_ms + 2 - _MAX_LOG_RANGE_MS)
+        # +1ms bias: --end parse-back error is downward, so biasing up means
+        # the resumed window can only extend past the original end, never
+        # clip its tail.
+        end_part = f' --end "{cli_log_utils.format_flag_datetime(end_ms + 1)}"'
+    resume = cli_log_utils.format_flag_datetime(resume_ms)
+    return (
+        f'{prefix} Continue with --start "{resume}"{end_part}, narrow the '
+        f"window{raise_part}."
+    )
+
+
 def _resolve_sampler_model_id(
     remote_provider: BasetenRemote, sampler_deployment_id: str
 ) -> str:
@@ -623,7 +663,21 @@ def _resolve_sampler_model_id(
     "--tail",
     is_flag=True,
     default=False,
-    help="Continue polling for new log lines until the deployment goes inactive (or Ctrl+C).",
+    help=(
+        "Continue polling for new log lines until the deployment goes inactive "
+        "(or Ctrl+C). Cannot be combined with the time-range flags or --limit."
+    ),
+)
+@cli_log_utils.log_time_range_options
+@click.option(
+    "--limit",
+    type=click.IntRange(1, LOOPS_LOGS_MAX_LINES),
+    default=None,
+    help=(
+        f"Max lines per invocation (default {DEFAULT_LOGS_LINE_LIMIT:,}); when the "
+        "window holds more, the oldest lines are shown with a hint to resume. "
+        "Only applies to --loops-deployment-id windowed fetches."
+    ),
 )
 @click.option("--remote", type=str, required=False, help="Remote to use.")
 @common.common_options()
@@ -631,6 +685,10 @@ def view_loops_logs(
     loops_deployment_id: Optional[str],
     sampler_deployment_id: Optional[str],
     tail: bool,
+    start: Optional[datetime],
+    end: Optional[datetime],
+    since: Optional[str],
+    limit: Optional[int],
     remote: Optional[str],
 ) -> None:
     """Fetch logs from one half of a Loops deployment.
@@ -638,11 +696,27 @@ def view_loops_logs(
     Pass exactly one of ``--loops-deployment-id`` (the Loops deployment) or
     ``--sampler-deployment-id`` (the sampler's inference deployment). The
     two sides have separate log streams; pick the one you're debugging.
+
+    Defaults to a short look-back window. Use --start/--end or --since to
+    look further back (max 7 days), or --tail to stream live logs by polling
+    the API -- so the stream survives trainer/replica restarts.
     """
     if bool(loops_deployment_id) == bool(sampler_deployment_id):
         raise click.UsageError(
             "Pass exactly one of --loops-deployment-id or --sampler-deployment-id."
         )
+    if tail and (
+        start is not None or end is not None or since is not None or limit is not None
+    ):
+        raise click.UsageError(
+            "--tail cannot be combined with --start/--end/--since/--limit."
+        )
+    if limit is not None and sampler_deployment_id:
+        raise click.UsageError(
+            "--limit only applies to --loops-deployment-id fetches; sampler "
+            "logs come back as a single server-capped page."
+        )
+    start_ms, end_ms = cli_log_utils.resolve_log_time_range(start, end, since)
 
     if not remote:
         remote = remote_cli.inquire_remote_name()
@@ -650,31 +724,46 @@ def view_loops_logs(
         BasetenRemote, RemoteFactory.create(remote=remote)
     )
 
+    truncation_hint: Optional[str] = None
+    parsed_logs: Iterable[cli_log_utils.ParsedLog]
     if loops_deployment_id is not None:
         if tail:
-            loops_watcher = LoopsDeploymentLogWatcher(
+            parsed_logs = LoopsDeploymentLogWatcher(
                 remote_provider.api, loops_deployment_id
+            ).watch()
+        elif start_ms is None and end_ms is None and limit is None:
+            # No window or limit flags: one request for the newest server
+            # page. Pagination and resume hints are for explicit windows.
+            parsed_logs = cli_log_utils.parse_logs(
+                remote_provider.api.get_loops_deployment_logs_page(loops_deployment_id)
             )
-            for log in loops_watcher.watch():
-                cli_log_utils.output_log(log)
         else:
-            logs = remote_provider.api.get_loops_deployment_logs(loops_deployment_id)
-            for log in cli_log_utils.parse_logs(logs):
-                cli_log_utils.output_log(log)
-        return
-
-    # --sampler-deployment-id path: reuse the existing model-deployment log machinery.
-    assert sampler_deployment_id is not None  # narrowed by the XOR check above
-    model_id = _resolve_sampler_model_id(remote_provider, sampler_deployment_id)
-    if tail:
-        model_watcher = ModelDeploymentLogWatcher(
-            remote_provider.api, model_id, sampler_deployment_id
-        )
-        for log in model_watcher.watch():
-            cli_log_utils.output_log(log)
+            max_lines = limit if limit is not None else DEFAULT_LOGS_LINE_LIMIT
+            window = remote_provider.api.get_loops_deployment_logs(
+                loops_deployment_id, start_ms, end_ms, max_lines=max_lines
+            )
+            parsed_logs = cli_log_utils.parse_logs(window.logs)
+            if window.truncated:
+                truncation_hint = _logs_truncation_hint(
+                    window.resume_start_epoch_millis, max_lines, end_ms
+                )
     else:
-        logs = remote_provider.api.get_model_deployment_logs(
-            model_id, sampler_deployment_id
-        )
-        for log in cli_log_utils.parse_logs(logs):
-            cli_log_utils.output_log(log)
+        # --sampler-deployment-id path: reuse the existing model-deployment
+        # log machinery. The model id is narrowed by the XOR check above.
+        assert sampler_deployment_id is not None
+        model_id = _resolve_sampler_model_id(remote_provider, sampler_deployment_id)
+        if tail:
+            parsed_logs = ModelDeploymentLogWatcher(
+                remote_provider.api, model_id, sampler_deployment_id
+            ).watch()
+        else:
+            parsed_logs = cli_log_utils.parse_logs(
+                remote_provider.api.get_model_deployment_logs(
+                    model_id, sampler_deployment_id, start_ms, end_ms
+                )
+            )
+
+    for log in parsed_logs:
+        cli_log_utils.output_log(log)
+    if truncation_hint:
+        console.print(truncation_hint, style="yellow")

--- a/truss/remote/baseten/api.py
+++ b/truss/remote/baseten/api.py
@@ -1,6 +1,8 @@
 import base64
 import json
 import logging
+import time
+from collections import Counter
 from enum import Enum
 from typing import Any, Dict, List, Mapping, Optional
 
@@ -18,6 +20,36 @@ from truss.remote.baseten.utils.transfer import base64_encoded_json_str
 
 logger = logging.getLogger(__name__)
 PARAMS_INDENT = "\n                    "
+
+# Server-side max page size for the Loops deployment /logs endpoint.
+LOOPS_LOGS_PAGE_LIMIT = 1000
+# Ceiling for a caller-requested max_lines (the CLI's --limit IntRange).
+LOOPS_LOGS_MAX_LINES = 100_000
+# Backstop on pages fetched per call: 2x the pages the line ceiling needs,
+# since boundary-dedupe repeats consume page slots without adding lines.
+LOOPS_LOGS_MAX_PAGES = 2 * LOOPS_LOGS_MAX_LINES // LOOPS_LOGS_PAGE_LIMIT
+# Padding added to a client-computed window end, absorbing clock skew and
+# log-ingest delay (like the tail watcher's clock-skew buffer).
+LOOPS_LOGS_END_PIN_BUFFER_MS = 60_000
+
+
+def _loops_log_key(log: Dict[str, Any]) -> tuple:
+    """Full identity of a loops log line, matching ParsedLog's fields."""
+    return (log["timestamp"], log.get("message"), log.get("replica"))
+
+
+class LoopsLogsWindow(SafeModel):
+    """Result of a windowed (paginated) Loops log fetch."""
+
+    logs: List[Dict[str, Any]]
+    # True when the fetch stopped before exhausting the window (max_lines
+    # reached, or the page backstop fired).
+    truncated: bool
+    # Millisecond cursor a follow-up fetch can start from (inclusive; the
+    # boundary millisecond is re-fetched). None when not truncated, or when
+    # no cursor can make progress because a single millisecond holds more
+    # lines than were returned.
+    resume_start_epoch_millis: Optional[int]
 
 
 class ChainAWSCredential(SafeModel):
@@ -1147,29 +1179,156 @@ class BasetenApi:
         # NB(nikhil): reverse order so latest logs are at the end
         return resp_json["logs"][::-1]
 
-    def get_loops_deployment_logs(
+    def get_loops_deployment_logs_page(
         self,
         loops_deployment_id: str,
         start_epoch_millis: Optional[int] = None,
         end_epoch_millis: Optional[int] = None,
     ):
-        """Fetch logs for a Loops deployment.
+        """Fetch a single (newest) page of logs for a Loops deployment.
 
-        Backend endpoint is GET-only — uses query params, not a request body
-        like the training-job / model-deployment endpoints.
+        One request for the newest lines of the window (the server's default
+        page size), returned oldest-first. Used by the tail watcher, whose
+        poll loop re-fetches overlapping windows and wants the newest lines
+        of each — for full-window fetches use get_loops_deployment_logs,
+        which paginates.
         """
-        params: Dict[str, str] = {}
-        if start_epoch_millis:
+        # direction is pinned explicitly because the reversal below (and the
+        # tail watcher's correctness) depend on newest-first responses.
+        params: Dict[str, str] = {"direction": "desc"}
+        if start_epoch_millis is not None:
             params["start_epoch_millis"] = str(start_epoch_millis)
-        if end_epoch_millis:
+        if end_epoch_millis is not None:
             params["end_epoch_millis"] = str(end_epoch_millis)
 
         resp_json = self._rest_api_client.get(
             f"v1/loops/deployments/{loops_deployment_id}/logs", url_params=params
         )
-        # Reverse so latest logs are at the end (matches the training-job /
-        # model-deployment helpers above).
+        # Server default order is newest-first; reverse so latest logs are
+        # at the end, matching the other log helpers.
         return resp_json["logs"][::-1]
+
+    def get_loops_deployment_logs(
+        self,
+        loops_deployment_id: str,
+        start_epoch_millis: Optional[int] = None,
+        end_epoch_millis: Optional[int] = None,
+        max_lines: Optional[int] = None,
+    ) -> LoopsLogsWindow:
+        """Fetch logs for a Loops deployment, paginating across the whole
+        [start_epoch_millis, end_epoch_millis) window.
+
+        The GET endpoint returns at most one page (server max 1000 lines)
+        with no truncation signal, so we page in ascending order, treating a
+        full page as "maybe more". Timestamps are nanoseconds but the
+        endpoint filters at millisecond granularity, so each follow-up
+        request restarts from the last line's millisecond and the boundary
+        repeats are dropped. Logs are oldest-first. When max_lines is set,
+        the oldest max_lines of the window are returned and the result
+        carries whether the window was cut and where to resume. For a
+        single newest-page fetch (tail polling) use
+        get_loops_deployment_logs_page.
+        """
+        logs: List[Dict[str, Any]] = []
+        # Multiset of the lines already fetched for the millisecond the next
+        # request starts at -- only these can come back again. Keyed on the
+        # full line identity and counted, so neither distinct same-timestamp
+        # lines nor genuine duplicates straddling a page cut are over-dropped.
+        boundary_counts: Counter = Counter()
+        cursor = start_epoch_millis
+        truncated = False
+        resume_ms: Optional[int] = None
+
+        for _ in range(LOOPS_LOGS_MAX_PAGES):
+            params: Dict[str, str] = {
+                "limit": str(LOOPS_LOGS_PAGE_LIMIT),
+                "direction": "asc",
+            }
+            if cursor is not None:
+                params["start_epoch_millis"] = str(cursor)
+            if end_epoch_millis is not None:
+                params["end_epoch_millis"] = str(end_epoch_millis)
+
+            resp_json = self._rest_api_client.get(
+                f"v1/loops/deployments/{loops_deployment_id}/logs", url_params=params
+            )
+            page = resp_json["logs"]
+            new_logs = []
+            for log in page:
+                key = _loops_log_key(log)
+                if boundary_counts[key]:
+                    boundary_counts[key] -= 1
+                else:
+                    new_logs.append(log)
+            logs.extend(new_logs)
+
+            if max_lines is not None and len(logs) > max_lines:
+                # The first hidden line's millisecond is an exact resume
+                # cursor: start_epoch_millis is inclusive server-side.
+                truncated = True
+                resume_ms = int(logs[max_lines]["timestamp"]) // 1_000_000
+                logs = logs[:max_lines]
+                break
+
+            if len(page) < LOOPS_LOGS_PAGE_LIMIT:
+                break  # short page -- caught up to `end` (or to "now")
+
+            last_millis = int(page[-1]["timestamp"]) // 1_000_000
+
+            if end_epoch_millis is None:
+                # Pin an open window end before paginating so follow-up
+                # pages don't chase a server-side "now" that advances with
+                # every request; the max() guards against a lagging client
+                # clock inverting the window below the cursor.
+                end_epoch_millis = (
+                    max(int(time.time() * 1000), last_millis + 1)
+                    + LOOPS_LOGS_END_PIN_BUFFER_MS
+                )
+            if new_logs:
+                cursor = last_millis
+                boundary_counts = Counter(
+                    _loops_log_key(log)
+                    for log in page
+                    if int(log["timestamp"]) // 1_000_000 == last_millis
+                )
+            else:
+                # A full page with nothing new: a single millisecond holds at
+                # least a full page of lines, so restarting from it can never
+                # advance. Skip past it; any of its lines beyond the first
+                # page are unreachable through this endpoint.
+                logger.warning(
+                    "Loops deployment %s has a full page (%d) of log lines "
+                    "in one millisecond; some of its lines may be omitted.",
+                    loops_deployment_id,
+                    LOOPS_LOGS_PAGE_LIMIT,
+                )
+                cursor = last_millis + 1
+                boundary_counts = Counter()
+        else:
+            truncated = True
+            resume_ms = cursor  # where the next page would have started
+            logger.warning(
+                "Reached maximum page limit (%d) fetching logs for Loops "
+                "deployment %s; output may be truncated. Narrow the "
+                "requested time range.",
+                LOOPS_LOGS_MAX_PAGES,
+                loops_deployment_id,
+            )
+
+        if (
+            truncated
+            and resume_ms is not None
+            and logs
+            and int(logs[0]["timestamp"]) // 1_000_000 >= resume_ms
+        ):
+            # Every returned line sits at or past the resume millisecond: a
+            # follow-up fetch from it would re-return them all first, so no
+            # cursor can make progress at this max_lines.
+            resume_ms = None
+
+        return LoopsLogsWindow(
+            logs=logs, truncated=truncated, resume_start_epoch_millis=resume_ms
+        )
 
     def create_model_version_from_inference_template(self, request_data: dict):
         """

--- a/truss/tests/cli/test_logs_utils.py
+++ b/truss/tests/cli/test_logs_utils.py
@@ -3,7 +3,13 @@ from datetime import datetime, timedelta, timezone
 import pytest
 import rich_click as click
 
-from truss.cli.logs.utils import MAX_LOG_RANGE, parse_since, resolve_log_time_range
+from truss.cli.logs.utils import (
+    LOG_RESUME_FORMAT,
+    MAX_LOG_RANGE,
+    format_flag_datetime,
+    parse_since,
+    resolve_log_time_range,
+)
 
 
 def test_parse_since_minutes():
@@ -72,6 +78,8 @@ def test_resolve_since_sets_window_ending_now():
 
 def test_resolve_only_start_leaves_end_none():
     # Omitted --end is deferred to the server (sent as None), not backfilled.
+    # Paginated fetches pin their own end internally (see
+    # get_loops_deployment_logs), so the resolver stays a pure translation.
     start = datetime(2026, 5, 14, 0, 0, 0, tzinfo=timezone.utc)
     start_ms, end_ms = resolve_log_time_range(start, None, None)
     assert start_ms == int(start.timestamp() * 1000)
@@ -80,11 +88,24 @@ def test_resolve_only_start_leaves_end_none():
 
 def test_resolve_only_start_skips_window_check():
     # With end deferred, a far-past start is not rejected client-side; the
-    # server enforces the window once it backfills end.
+    # server enforces the 7-day window.
     start = datetime(2020, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
     start_ms, end_ms = resolve_log_time_range(start, None, None)
     assert start_ms == int(start.timestamp() * 1000)
     assert end_ms is None
+
+
+def test_format_flag_datetime_round_trip_error_is_bounded_downward():
+    # Hint callers bias by +/-1ms in their safe direction; that only works
+    # if the render->parse round trip loses at most 1ms and never gains.
+    # Samples include a known float-truncation case (2150399568319) and a
+    # DST fall-back-hour epoch (1762065000000), which the %z-aware format
+    # must round-trip without the 1-hour ambiguity.
+    for epoch_ms in (1782968142946, 2150399568319, 1762065000000):
+        rendered = format_flag_datetime(epoch_ms)
+        parsed = datetime.strptime(rendered, LOG_RESUME_FORMAT)
+        delta = int(parsed.timestamp() * 1000) - epoch_ms
+        assert -1 <= delta <= 0
 
 
 def test_resolve_only_end_leaves_start_none():

--- a/truss/tests/cli/test_loops_cli.py
+++ b/truss/tests/cli/test_loops_cli.py
@@ -976,10 +976,20 @@ def test_checkpoints_deploy_rejects_checkpoint_ids_with_config(mock_remote, tmp_
     mock_create.assert_not_called()
 
 
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _plain(result):
+    # Rich styles flag tokens with ANSI codes when color is on (e.g. on CI)
+    # and wraps output to the terminal width; strip codes and collapse
+    # whitespace so assertions on message text are environment-independent.
+    return " ".join(_ANSI_RE.sub("", result.output).split())
+
+
 def test_logs_requires_exactly_one_deployment_id(mock_remote):
     result = _invoke(["loops", "logs", "--remote", "test_remote"], mock_remote)
     assert result.exit_code != 0
-    assert "exactly one" in result.output
+    assert "exactly one" in _plain(result)
 
     result = _invoke(
         [
@@ -995,7 +1005,7 @@ def test_logs_requires_exactly_one_deployment_id(mock_remote):
         mock_remote,
     )
     assert result.exit_code != 0
-    assert "exactly one" in result.output
+    assert "exactly one" in _plain(result)
 
 
 def test_logs_tail_rejects_time_range_flags(mock_remote):
@@ -1014,7 +1024,7 @@ def test_logs_tail_rejects_time_range_flags(mock_remote):
         mock_remote,
     )
     assert result.exit_code != 0
-    assert "--tail cannot be combined" in result.output
+    assert "--tail cannot be combined" in _plain(result)
     mock_remote.api.get_loops_deployment_logs.assert_not_called()
 
 
@@ -1031,8 +1041,8 @@ def test_logs_bare_invocation_uses_single_newest_page(mock_remote):
     assert result.exit_code == 0, result.output
     mock_remote.api.get_loops_deployment_logs_page.assert_called_once_with("dep-1")
     mock_remote.api.get_loops_deployment_logs.assert_not_called()
-    assert "hello world" in result.output
-    assert "Showing the first" not in result.output
+    assert "hello world" in _plain(result)
+    assert "Showing the first" not in _plain(result)
 
 
 def test_logs_since_passes_resolved_time_range(mock_remote):
@@ -1112,11 +1122,11 @@ def test_logs_limit_truncation_prints_resume_hint(mock_remote):
     mock_remote.api.get_loops_deployment_logs.assert_called_once_with(
         "dep-1", None, None, max_lines=2
     )
-    assert "two" in result.output
-    assert "Showing the first 2 lines" in result.output
-    assert "--start" in result.output
+    assert "two" in _plain(result)
+    assert "Showing the first 2 lines" in _plain(result)
+    assert "--start" in _plain(result)
     # No explicit window end was given, so the hint must not suggest --end.
-    assert "--end" not in result.output
+    assert "--end" not in _plain(result)
 
 
 def test_logs_exact_fit_prints_no_hint(mock_remote):
@@ -1144,7 +1154,7 @@ def test_logs_exact_fit_prints_no_hint(mock_remote):
         mock_remote,
     )
     assert result.exit_code == 0, result.output
-    assert "Showing the first" not in result.output
+    assert "Showing the first" not in _plain(result)
 
 
 def test_logs_truncation_hint_preserves_window_end(mock_remote):
@@ -1174,8 +1184,8 @@ def test_logs_truncation_hint_preserves_window_end(mock_remote):
         mock_remote,
     )
     assert result.exit_code == 0, result.output
-    assert "Showing the first 2 lines" in result.output
-    assert '--end "' in result.output
+    assert "Showing the first 2 lines" in _plain(result)
+    assert '--end "' in _plain(result)
 
 
 def test_logs_stuck_millisecond_hint_omits_unusable_resume(mock_remote):
@@ -1203,9 +1213,9 @@ def test_logs_stuck_millisecond_hint_omits_unusable_resume(mock_remote):
         mock_remote,
     )
     assert result.exit_code == 0, result.output
-    assert "share one millisecond" in result.output
-    assert "--start" not in result.output.replace("--start cannot", "")
-    assert "raise --limit" in result.output
+    assert "share one millisecond" in _plain(result)
+    assert "--start" not in _plain(result).replace("--start cannot", "")
+    assert "raise --limit" in _plain(result)
 
 
 @patch("truss.cli.loops_commands.LOOPS_LOGS_MAX_LINES", 2)
@@ -1232,8 +1242,8 @@ def test_logs_hint_drops_raise_limit_clause_at_ceiling(mock_remote):
         mock_remote,
     )
     assert result.exit_code == 0, result.output
-    assert "Showing the first 2 lines" in result.output
-    assert "raise --limit" not in result.output
+    assert "Showing the first 2 lines" in _plain(result)
+    assert "raise --limit" not in _plain(result)
 
 
 def test_logs_limit_rejected_with_tail(mock_remote):
@@ -1252,7 +1262,7 @@ def test_logs_limit_rejected_with_tail(mock_remote):
         mock_remote,
     )
     assert result.exit_code != 0
-    assert "--tail cannot be combined" in result.output
+    assert "--tail cannot be combined" in _plain(result)
 
 
 def test_logs_limit_rejected_with_sampler(mock_remote):
@@ -1270,7 +1280,7 @@ def test_logs_limit_rejected_with_sampler(mock_remote):
         mock_remote,
     )
     assert result.exit_code != 0
-    assert "--limit only applies" in result.output
+    assert "--limit only applies" in _plain(result)
 
 
 def test_logs_truncation_hint_command_survives_seven_day_check():

--- a/truss/tests/cli/test_loops_cli.py
+++ b/truss/tests/cli/test_loops_cli.py
@@ -3,12 +3,20 @@
 import json
 import os
 import re
+from datetime import datetime
 from unittest.mock import Mock, patch
 
 import pytest
 from click.testing import CliRunner
 
 from truss.cli.cli import truss_cli
+from truss.cli.logs.utils import (
+    LOG_RESUME_FORMAT,
+    MAX_LOG_RANGE,
+    resolve_log_time_range,
+)
+from truss.cli.loops_commands import _logs_truncation_hint
+from truss.remote.baseten.api import LoopsLogsWindow
 
 _LOCALIZED_TIMESTAMP_RE = re.compile(r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}")
 
@@ -966,3 +974,317 @@ def test_checkpoints_deploy_rejects_checkpoint_ids_with_config(mock_remote, tmp_
         )
     assert result.exit_code != 0
     mock_create.assert_not_called()
+
+
+def test_logs_requires_exactly_one_deployment_id(mock_remote):
+    result = _invoke(["loops", "logs", "--remote", "test_remote"], mock_remote)
+    assert result.exit_code != 0
+    assert "exactly one" in result.output
+
+    result = _invoke(
+        [
+            "loops",
+            "logs",
+            "--remote",
+            "test_remote",
+            "--loops-deployment-id",
+            "dep-1",
+            "--sampler-deployment-id",
+            "samp-1",
+        ],
+        mock_remote,
+    )
+    assert result.exit_code != 0
+    assert "exactly one" in result.output
+
+
+def test_logs_tail_rejects_time_range_flags(mock_remote):
+    result = _invoke(
+        [
+            "loops",
+            "logs",
+            "--remote",
+            "test_remote",
+            "--loops-deployment-id",
+            "dep-1",
+            "--tail",
+            "--since",
+            "1h",
+        ],
+        mock_remote,
+    )
+    assert result.exit_code != 0
+    assert "--tail cannot be combined" in result.output
+    mock_remote.api.get_loops_deployment_logs.assert_not_called()
+
+
+def test_logs_bare_invocation_uses_single_newest_page(mock_remote):
+    # No window flags: one request for the newest server page, no
+    # pagination, no hint.
+    mock_remote.api.get_loops_deployment_logs_page.return_value = [
+        {"timestamp": "1700000000000000000", "message": "hello world", "replica": None}
+    ]
+    result = _invoke(
+        ["loops", "logs", "--remote", "test_remote", "--loops-deployment-id", "dep-1"],
+        mock_remote,
+    )
+    assert result.exit_code == 0, result.output
+    mock_remote.api.get_loops_deployment_logs_page.assert_called_once_with("dep-1")
+    mock_remote.api.get_loops_deployment_logs.assert_not_called()
+    assert "hello world" in result.output
+    assert "Showing the first" not in result.output
+
+
+def test_logs_since_passes_resolved_time_range(mock_remote):
+    mock_remote.api.get_loops_deployment_logs.return_value = LoopsLogsWindow(
+        logs=[], truncated=False, resume_start_epoch_millis=None
+    )
+    result = _invoke(
+        [
+            "loops",
+            "logs",
+            "--remote",
+            "test_remote",
+            "--loops-deployment-id",
+            "dep-1",
+            "--since",
+            "1h",
+        ],
+        mock_remote,
+    )
+    assert result.exit_code == 0, result.output
+    _, start_ms, end_ms = mock_remote.api.get_loops_deployment_logs.call_args[0]
+    assert end_ms - start_ms == 3600 * 1000
+
+
+def test_logs_sampler_path_passes_time_range(mock_remote):
+    mock_remote.api.list_loops_deployments.return_value = [
+        {"sampler": {"deployment_id": "samp-1", "model_id": "model-9"}}
+    ]
+    mock_remote.api.get_model_deployment_logs.return_value = []
+    result = _invoke(
+        [
+            "loops",
+            "logs",
+            "--remote",
+            "test_remote",
+            "--sampler-deployment-id",
+            "samp-1",
+            "--since",
+            "2h",
+        ],
+        mock_remote,
+    )
+    assert result.exit_code == 0, result.output
+    model_id, deployment_id, start_ms, end_ms = (
+        mock_remote.api.get_model_deployment_logs.call_args[0]
+    )
+    assert model_id == "model-9"
+    assert deployment_id == "samp-1"
+    assert end_ms - start_ms == 2 * 3600 * 1000
+
+
+def test_logs_limit_truncation_prints_resume_hint(mock_remote):
+    # The pager reports truncation and the exact resume cursor; the hint
+    # renders it as a ready-to-paste --start value.
+    mock_remote.api.get_loops_deployment_logs.return_value = LoopsLogsWindow(
+        logs=[
+            {"timestamp": "1700000000000000000", "message": "one", "replica": None},
+            {"timestamp": "1700000060000000000", "message": "two", "replica": None},
+        ],
+        truncated=True,
+        resume_start_epoch_millis=1700000120000,
+    )
+    result = _invoke(
+        [
+            "loops",
+            "logs",
+            "--remote",
+            "test_remote",
+            "--loops-deployment-id",
+            "dep-1",
+            "--limit",
+            "2",
+        ],
+        mock_remote,
+    )
+    assert result.exit_code == 0, result.output
+    mock_remote.api.get_loops_deployment_logs.assert_called_once_with(
+        "dep-1", None, None, max_lines=2
+    )
+    assert "two" in result.output
+    assert "Showing the first 2 lines" in result.output
+    assert "--start" in result.output
+    # No explicit window end was given, so the hint must not suggest --end.
+    assert "--end" not in result.output
+
+
+def test_logs_exact_fit_prints_no_hint(mock_remote):
+    # A window holding exactly --limit lines comes back not truncated: no
+    # hint.
+    mock_remote.api.get_loops_deployment_logs.return_value = LoopsLogsWindow(
+        logs=[
+            {"timestamp": "1700000000000000000", "message": "one", "replica": None},
+            {"timestamp": "1700000060000000000", "message": "two", "replica": None},
+        ],
+        truncated=False,
+        resume_start_epoch_millis=None,
+    )
+    result = _invoke(
+        [
+            "loops",
+            "logs",
+            "--remote",
+            "test_remote",
+            "--loops-deployment-id",
+            "dep-1",
+            "--limit",
+            "2",
+        ],
+        mock_remote,
+    )
+    assert result.exit_code == 0, result.output
+    assert "Showing the first" not in result.output
+
+
+def test_logs_truncation_hint_preserves_window_end(mock_remote):
+    # With an explicit window (--since resolves an end), the resume hint must
+    # carry --end so the resumed fetch stays inside the original window.
+    mock_remote.api.get_loops_deployment_logs.return_value = LoopsLogsWindow(
+        logs=[
+            {"timestamp": "1700000000000000000", "message": "one", "replica": None},
+            {"timestamp": "1700000060000000000", "message": "two", "replica": None},
+        ],
+        truncated=True,
+        resume_start_epoch_millis=1700000120000,
+    )
+    result = _invoke(
+        [
+            "loops",
+            "logs",
+            "--remote",
+            "test_remote",
+            "--loops-deployment-id",
+            "dep-1",
+            "--since",
+            "1h",
+            "--limit",
+            "2",
+        ],
+        mock_remote,
+    )
+    assert result.exit_code == 0, result.output
+    assert "Showing the first 2 lines" in result.output
+    assert '--end "' in result.output
+
+
+def test_logs_stuck_millisecond_hint_omits_unusable_resume(mock_remote):
+    # The pager reports truncation with no usable cursor (one millisecond
+    # holds more lines than --limit); the hint must not offer a resume.
+    mock_remote.api.get_loops_deployment_logs.return_value = LoopsLogsWindow(
+        logs=[
+            {"timestamp": "1700000000000000100", "message": "a", "replica": None},
+            {"timestamp": "1700000000000000200", "message": "b", "replica": None},
+        ],
+        truncated=True,
+        resume_start_epoch_millis=None,
+    )
+    result = _invoke(
+        [
+            "loops",
+            "logs",
+            "--remote",
+            "test_remote",
+            "--loops-deployment-id",
+            "dep-1",
+            "--limit",
+            "2",
+        ],
+        mock_remote,
+    )
+    assert result.exit_code == 0, result.output
+    assert "share one millisecond" in result.output
+    assert "--start" not in result.output.replace("--start cannot", "")
+    assert "raise --limit" in result.output
+
+
+@patch("truss.cli.loops_commands.LOOPS_LOGS_MAX_LINES", 2)
+def test_logs_hint_drops_raise_limit_clause_at_ceiling(mock_remote):
+    mock_remote.api.get_loops_deployment_logs.return_value = LoopsLogsWindow(
+        logs=[
+            {"timestamp": "1700000000000000000", "message": "one", "replica": None},
+            {"timestamp": "1700000060000000000", "message": "two", "replica": None},
+        ],
+        truncated=True,
+        resume_start_epoch_millis=1700000120000,
+    )
+    result = _invoke(
+        [
+            "loops",
+            "logs",
+            "--remote",
+            "test_remote",
+            "--loops-deployment-id",
+            "dep-1",
+            "--limit",
+            "2",
+        ],
+        mock_remote,
+    )
+    assert result.exit_code == 0, result.output
+    assert "Showing the first 2 lines" in result.output
+    assert "raise --limit" not in result.output
+
+
+def test_logs_limit_rejected_with_tail(mock_remote):
+    result = _invoke(
+        [
+            "loops",
+            "logs",
+            "--remote",
+            "test_remote",
+            "--loops-deployment-id",
+            "dep-1",
+            "--tail",
+            "--limit",
+            "100",
+        ],
+        mock_remote,
+    )
+    assert result.exit_code != 0
+    assert "--tail cannot be combined" in result.output
+
+
+def test_logs_limit_rejected_with_sampler(mock_remote):
+    result = _invoke(
+        [
+            "loops",
+            "logs",
+            "--remote",
+            "test_remote",
+            "--sampler-deployment-id",
+            "samp-1",
+            "--limit",
+            "100",
+        ],
+        mock_remote,
+    )
+    assert result.exit_code != 0
+    assert "--limit only applies" in result.output
+
+
+def test_logs_truncation_hint_command_survives_seven_day_check():
+    # Pasting the hint's --start/--end back must never fail window
+    # validation, even when the original window was exactly 7 days and the
+    # resume cursor sits at its very start (the --end bias would otherwise
+    # widen the span past the limit).
+    end_ms = 1782968142946
+    resume_ms = end_ms - int(MAX_LOG_RANGE.total_seconds() * 1000)
+    hint = _logs_truncation_hint(resume_ms, max_lines=3, end_ms=end_ms)
+
+    start_str = hint.split('--start "')[1].split('"')[0]
+    end_str = hint.split('--end "')[1].split('"')[0]
+    start_dt = datetime.strptime(start_str, LOG_RESUME_FORMAT)
+    end_dt = datetime.strptime(end_str, LOG_RESUME_FORMAT)
+    _, resolved_end = resolve_log_time_range(start_dt, end_dt, None)  # no raise
+    assert resolved_end >= end_ms

--- a/truss/tests/remote/baseten/test_api.py
+++ b/truss/tests/remote/baseten/test_api.py
@@ -824,3 +824,283 @@ def test_get_model_deployment_logs_omits_unset_filters(baseten_api):
     )
 
     assert mock_rest_client.post.call_args[1]["body"] == {}
+
+
+def _loops_log(timestamp_ns, message, replica=None):
+    return {"timestamp": str(timestamp_ns), "message": message, "replica": replica}
+
+
+def _loops_logs_request_starts(mock_rest_client):
+    return [
+        call[1]["url_params"].get("start_epoch_millis")
+        for call in mock_rest_client.get.call_args_list
+    ]
+
+
+def test_get_loops_deployment_logs_single_page(baseten_api):
+    logs = [_loops_log(1_000_000, "a"), _loops_log(2_000_000, "b")]
+    mock_rest_client = mock.Mock()
+    mock_rest_client.get.return_value = {"logs": logs}
+    baseten_api._rest_api_client = mock_rest_client
+
+    result = baseten_api.get_loops_deployment_logs("loop-1")
+
+    assert result.logs == logs
+    assert result.truncated is False
+    assert result.resume_start_epoch_millis is None
+    mock_rest_client.get.assert_called_once_with(
+        "v1/loops/deployments/loop-1/logs",
+        url_params={"limit": "1000", "direction": "asc"},
+    )
+
+
+def test_get_loops_deployment_logs_passes_time_range(baseten_api):
+    mock_rest_client = mock.Mock()
+    mock_rest_client.get.return_value = {"logs": []}
+    baseten_api._rest_api_client = mock_rest_client
+
+    baseten_api.get_loops_deployment_logs(
+        "loop-1", start_epoch_millis=1000, end_epoch_millis=2000
+    )
+
+    assert mock_rest_client.get.call_args[1]["url_params"] == {
+        "limit": "1000",
+        "direction": "asc",
+        "start_epoch_millis": "1000",
+        "end_epoch_millis": "2000",
+    }
+
+
+@mock.patch("truss.remote.baseten.api.LOOPS_LOGS_PAGE_LIMIT", 3)
+def test_get_loops_deployment_logs_paginates_without_dropping_boundary_lines(
+    baseten_api,
+):
+    # Millisecond 5 spans the first page boundary: x2 did not fit in page 1,
+    # so page 2 must restart from millisecond 5 (not 6) to pick it up, and the
+    # re-fetched x1 must not be duplicated in the result.
+    a = _loops_log(1_000_000, "a")
+    b = _loops_log(2_000_000, "b")
+    x1 = _loops_log(5_000_000, "x1")
+    x2 = _loops_log(5_000_100, "x2")
+    c = _loops_log(6_000_000, "c")
+
+    mock_rest_client = mock.Mock()
+    mock_rest_client.get.side_effect = [
+        {"logs": [a, b, x1]},
+        {"logs": [x1, x2, c]},
+        {"logs": [c]},
+    ]
+    baseten_api._rest_api_client = mock_rest_client
+
+    result = baseten_api.get_loops_deployment_logs("loop-1", start_epoch_millis=1)
+
+    assert result.logs == [a, b, x1, x2, c]
+    assert result.truncated is False
+    assert _loops_logs_request_starts(mock_rest_client) == ["1", "5", "6"]
+
+
+@mock.patch("truss.remote.baseten.api.LOOPS_LOGS_PAGE_LIMIT", 2)
+def test_get_loops_deployment_logs_skips_past_oversized_millisecond(baseten_api):
+    # Millisecond 5 fills an entire page, so restarting from it can never
+    # advance. The pager must skip to millisecond 6 instead of looping or
+    # giving up on everything after it.
+    x1 = _loops_log(5_000_000, "x1")
+    x2 = _loops_log(5_000_100, "x2")
+    c = _loops_log(6_000_000, "c")
+
+    mock_rest_client = mock.Mock()
+    mock_rest_client.get.side_effect = [
+        {"logs": [x1, x2]},
+        {"logs": [x1, x2]},
+        {"logs": [c]},
+    ]
+    baseten_api._rest_api_client = mock_rest_client
+
+    result = baseten_api.get_loops_deployment_logs("loop-1")
+
+    assert result.logs == [x1, x2, c]
+    assert result.truncated is False
+    assert _loops_logs_request_starts(mock_rest_client) == [None, "5", "6"]
+
+
+@mock.patch("truss.remote.baseten.api.LOOPS_LOGS_MAX_PAGES", 3)
+@mock.patch("truss.remote.baseten.api.LOOPS_LOGS_PAGE_LIMIT", 1)
+def test_get_loops_deployment_logs_stops_at_max_pages(baseten_api):
+    pages = [
+        {"logs": [_loops_log(ms * 1_000_000, f"line-{ms}")]} for ms in (1, 2, 3, 4)
+    ]
+    mock_rest_client = mock.Mock()
+    mock_rest_client.get.side_effect = pages
+    baseten_api._rest_api_client = mock_rest_client
+
+    result = baseten_api.get_loops_deployment_logs("loop-1")
+
+    assert mock_rest_client.get.call_count == 3
+    assert [log["message"] for log in result.logs] == ["line-1", "line-2", "line-3"]
+    # The backstop is a truncation the caller can see and resume from.
+    assert result.truncated is True
+    assert result.resume_start_epoch_millis == 3
+
+
+@mock.patch("truss.remote.baseten.api.LOOPS_LOGS_PAGE_LIMIT", 3)
+def test_get_loops_deployment_logs_keeps_distinct_replica_lines(baseten_api):
+    # Two replicas emit the same message with the same ns timestamp in the
+    # boundary millisecond; the dedupe key includes replica, so the second
+    # replica's line must survive the boundary re-fetch.
+    a = _loops_log(1_000_000, "a")
+    b = _loops_log(2_000_000, "b")
+    x1 = _loops_log(5_000_000, "x", replica="r1")
+    x2 = _loops_log(5_000_000, "x", replica="r2")
+    c = _loops_log(6_000_000, "c")
+
+    mock_rest_client = mock.Mock()
+    mock_rest_client.get.side_effect = [
+        {"logs": [a, b, x1]},
+        {"logs": [x1, x2, c]},
+        {"logs": [c]},
+    ]
+    baseten_api._rest_api_client = mock_rest_client
+
+    result = baseten_api.get_loops_deployment_logs("loop-1", start_epoch_millis=1)
+
+    assert result.logs == [a, b, x1, x2, c]
+
+
+@mock.patch("truss.remote.baseten.api.LOOPS_LOGS_PAGE_LIMIT", 3)
+def test_get_loops_deployment_logs_preserves_duplicate_lines_across_page_cut(
+    baseten_api,
+):
+    # Millisecond 5 holds three genuinely identical lines, two of which fit in
+    # page 1. The boundary dedupe counts multiplicity, so the third identical
+    # copy in the re-fetched page is kept rather than collapsed away.
+    a = _loops_log(1_000_000, "a")
+    d = _loops_log(5_000_000, "dup")
+    e = _loops_log(6_000_000, "e")
+
+    mock_rest_client = mock.Mock()
+    mock_rest_client.get.side_effect = [
+        {"logs": [a, d, d]},
+        {"logs": [d, d, d]},
+        {"logs": [d, d, d]},
+        {"logs": [e]},
+    ]
+    baseten_api._rest_api_client = mock_rest_client
+
+    result = baseten_api.get_loops_deployment_logs("loop-1", start_epoch_millis=1)
+
+    assert result.logs == [a, d, d, d, e]
+    assert _loops_logs_request_starts(mock_rest_client) == ["1", "5", "5", "6"]
+
+
+@mock.patch("truss.remote.baseten.api.LOOPS_LOGS_PAGE_LIMIT", 3)
+def test_get_loops_deployment_logs_stops_at_max_lines(baseten_api):
+    # max_lines=4 with 3-line pages: the second page tops up past the cap, so
+    # fetching stops after two requests and the result is trimmed to the cap.
+    lines = [_loops_log(ms * 1_000_000, f"line-{ms}") for ms in range(1, 8)]
+    mock_rest_client = mock.Mock()
+    mock_rest_client.get.side_effect = [
+        {"logs": lines[0:3]},
+        {"logs": lines[2:5]},  # re-serves the boundary line at ms 3
+        {"logs": lines[4:7]},
+    ]
+    baseten_api._rest_api_client = mock_rest_client
+
+    result = baseten_api.get_loops_deployment_logs(
+        "loop-1", start_epoch_millis=1, max_lines=4
+    )
+
+    assert mock_rest_client.get.call_count == 2
+    assert [log["message"] for log in result.logs] == [
+        "line-1",
+        "line-2",
+        "line-3",
+        "line-4",
+    ]
+    assert result.truncated is True
+    # The first hidden line (line-5, ms 5) gives the exact resume cursor.
+    assert result.resume_start_epoch_millis == 5
+
+
+@mock.patch("truss.remote.baseten.api.LOOPS_LOGS_PAGE_LIMIT", 2)
+def test_get_loops_deployment_logs_pins_open_end_once_paginating(baseten_api):
+    # With no end given, the first request leaves end open (server default
+    # window), but follow-up pages carry a pinned end so the fetch can't
+    # chase a server-side "now" that advances with every request.
+    mock_rest_client = mock.Mock()
+    mock_rest_client.get.side_effect = [
+        {"logs": [_loops_log(1_000_000, "a"), _loops_log(2_000_000, "b")]},
+        {"logs": [_loops_log(3_000_000, "c")]},
+    ]
+    baseten_api._rest_api_client = mock_rest_client
+
+    baseten_api.get_loops_deployment_logs("loop-1")
+
+    first_params = mock_rest_client.get.call_args_list[0][1]["url_params"]
+    second_params = mock_rest_client.get.call_args_list[1][1]["url_params"]
+    assert "end_epoch_millis" not in first_params
+    assert "end_epoch_millis" in second_params
+
+
+def test_get_loops_deployment_logs_page_is_single_request(baseten_api):
+    # The tail watcher's fetch: exactly one request, server defaults (no
+    # limit/direction params), response reversed to oldest-first.
+    a = _loops_log(2_000_000, "newer")
+    b = _loops_log(1_000_000, "older")
+    mock_rest_client = mock.Mock()
+    mock_rest_client.get.return_value = {"logs": [a, b]}
+    baseten_api._rest_api_client = mock_rest_client
+
+    result = baseten_api.get_loops_deployment_logs_page("loop-1", 1000, 2000)
+
+    assert result == [b, a]
+    mock_rest_client.get.assert_called_once_with(
+        "v1/loops/deployments/loop-1/logs",
+        url_params={
+            "direction": "desc",
+            "start_epoch_millis": "1000",
+            "end_epoch_millis": "2000",
+        },
+    )
+
+
+@mock.patch("truss.remote.baseten.api.LOOPS_LOGS_PAGE_LIMIT", 3)
+def test_get_loops_deployment_logs_exact_fit_is_not_truncated(baseten_api):
+    # A window holding exactly max_lines lines that ends on a full page is
+    # ambiguous after page 1; the pager disambiguates with one more request
+    # and reports the window complete rather than truncated.
+    a, b, c = (_loops_log(ms * 1_000_000, f"line-{ms}") for ms in (1, 2, 3))
+    mock_rest_client = mock.Mock()
+    mock_rest_client.get.side_effect = [
+        {"logs": [a, b, c]},
+        {"logs": [c]},  # only the boundary repeat: nothing hidden
+    ]
+    baseten_api._rest_api_client = mock_rest_client
+
+    result = baseten_api.get_loops_deployment_logs(
+        "loop-1", start_epoch_millis=1, max_lines=3
+    )
+
+    assert result.logs == [a, b, c]
+    assert result.truncated is False
+    assert result.resume_start_epoch_millis is None
+
+
+@mock.patch("truss.remote.baseten.api.LOOPS_LOGS_PAGE_LIMIT", 3)
+def test_get_loops_deployment_logs_reports_unresumable_millisecond(baseten_api):
+    # All returned lines share the resume millisecond, so a follow-up fetch
+    # from it would re-return them first: the pager reports truncation with
+    # no usable resume cursor.
+    x1 = _loops_log(5_000_000, "x1")
+    x2 = _loops_log(5_000_100, "x2")
+    x3 = _loops_log(5_000_200, "x3")
+    mock_rest_client = mock.Mock()
+    mock_rest_client.get.return_value = {"logs": [x1, x2, x3]}
+    baseten_api._rest_api_client = mock_rest_client
+
+    result = baseten_api.get_loops_deployment_logs(
+        "loop-1", start_epoch_millis=1, max_lines=2
+    )
+
+    assert result.logs == [x1, x2]
+    assert result.truncated is True
+    assert result.resume_start_epoch_millis is None


### PR DESCRIPTION
## :rocket: What

`truss loops logs` could only return a single server-default page (the newest ~500 lines), silently dropping everything else — which made debugging a trainer that logs heavily very painful. This PR adds windowed fetching:

- `--start` / `--end` / `--since` scope a window up to 7 days (options shared with `truss model-logs` via a new `log_time_range_options` decorator).
- `--limit` caps lines per invocation (default 10,000, max 100,000); when a window holds more, the CLI shows the oldest lines and prints a ready-to-paste resume command.
- `--tail` and bare invocations keep their exact previous behavior.

**Behavior scope:** all changes are confined to windowed `truss loops logs` fetches. `--tail`, flag-less invocations, and other commands are byte-identical to main, with one strictly-additive exception: `model-logs --start/--end` now also accept millisecond-precision timezone-aware values (the format resume hints emit).

## :computer: How

- `BasetenApi.get_loops_deployment_logs` paginates ascending across the window. The endpoint filters at millisecond granularity while timestamps are nanoseconds, so each follow-up request restarts from the last line's millisecond and boundary repeats are deduped by full line identity (a Counter multiset, so neither distinct same-timestamp lines nor genuine duplicates are over-dropped). Open window ends are pinned (with a clock-skew buffer) once pagination starts, so the fetch never chases an advancing server-side "now".
- The pager returns a `LoopsLogsWindow` (`logs`, `truncated`, `resume_start_epoch_millis`) so truncation knowledge stays at the layer that produces it — including backstop truncation and the "one millisecond holds more lines than the limit" case, which is reported as unresumable instead of hinting a resume that would loop forever.
- The truncation hint preserves the user's `--end`, emits timezone-aware millisecond-precision values (immune to DST-fold ambiguity; parse round-trip error is ≤1ms and downward-only, biased in the safe direction per bound), and is clamped so a pasted command from an exactly-7-day window always passes validation.
- Tail polling uses a separate `get_loops_deployment_logs_page` (single request, `direction` pinned explicitly, newest page reversed to oldest-first) — the watcher's poll loop wants the newest lines of overlapping windows, not a full-window crawl.

## :microscope: Testing

- Unit tests for the pager (boundary-line preservation, duplicate multiplicity across page cuts, replica-distinct lines, exact-fit vs truncated windows, unresumable milliseconds, backstop reporting, open-end pinning, max-lines trimming) and the CLI (flag conflicts, hint content/suppression, resume-command 7-day round-trip). Full unit suite passes (1,301).
- Live-verified against a real Loops deployment: a 7-day window fetched 3,389 lines over 4 requests with zero duplicates and stable ordering; resume hints paste back and continue without gaps; `--tail` and bare invocations confirmed unchanged. Server contract verified live: `limit` is validated with max 1000, `direction` is honored, `start_epoch_millis` is millisecond-inclusive.

Follow-ups (intentionally out of scope):
- The training-logs fetcher in `core.py` advances its cursor `last_ms + 1` and can skip same-millisecond boundary lines — same bug class this PR fixes for loops; fix there or extract a shared cursor helper.
- `base_watcher`'s 60s overlap re-fetch per poll could use `_last_log_time_ms` to skip re-downloading seen data, but only if log ingestion guarantees no late-arriving older timestamps — needs a backend answer.
- Client-side window validation for `--start`-only invocations (currently deferred to the server's 400) could be added deliberately for all log commands at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)