### PR TITLE
fix(cli/train): drop Baseline column from team capacity view

### DIFF
--- a/truss/cli/train/core.py
+++ b/truss/cli/train/core.py
@@ -840,14 +840,12 @@ def display_training_capacity(remote_provider: BasetenRemote) -> None:
         )
         team_table.add_column("Team", style="cyan")
         team_table.add_column("GPU Type", style="cyan")
-        team_table.add_column("Baseline", justify="right")
         team_table.add_column("Limit", justify="right")
         team_table.add_column("Usage", justify="right")
         for item in team_gpu_capacities:
             team_table.add_row(
                 item.get("team_name", ""),
                 item.get("gpu_type", ""),
-                str(item.get("baseline", 0)),
                 str(item.get("limit", 0)),
                 str(item.get("usage_count", 0)),
             )

--- a/truss/tests/cli/train/test_train_cli_core.py
+++ b/truss/tests/cli/train/test_train_cli_core.py
@@ -509,7 +509,8 @@ def test_display_training_capacity_with_teams(capsys):
 
     assert "Team Training GPU Capacity" in out
     assert rows["H100"] == ["H100", "16", "64", "32"]
-    assert rows["ml-research"] == ["ml-research", "H100", "0", "32", "8"]
+    assert rows["ml-research"] == ["ml-research", "H100", "32", "8"]
+    assert "Baseline" not in rows["Team"]
 
 
 def test_display_training_capacity_teams_only(capsys):


### PR DESCRIPTION
## What

Removes the `Baseline` column from the **Team Training GPU Capacity** table in `truss train capacity view`.

## Why

Teams have no baseline concept — the column was always `0` and misleading. The team table now shows only the columns that make sense: `Team`, `GPU Type`, `Limit`, `Usage`.

The org-level `Training GPU Capacity` table's baseline is real and is left unchanged.

### Before
```
               Team Training GPU Capacity
╭─────────────────┬──────────┬──────────┬───────┬───────╮
│ Team            │ GPU Type │ Baseline │ Limit │ Usage │
├─────────────────┼──────────┼──────────┼───────┼───────┤
│ Johns Workspace │ B200     │        0 │    32 │     0 │
╰─────────────────┴──────────┴──────────┴───────┴───────╯
```

### After
```
          Team Training GPU Capacity
╭─────────────────┬──────────┬───────┬───────╮
│ Team            │ GPU Type │ Limit │ Usage │
├─────────────────┼──────────┼───────┼───────┤
│ Johns Workspace │ B200     │    32 │     0 │
╰─────────────────┴──────────┴───────┴───────╯
```

## Testing

`test_display_training_capacity_with_teams` updated to assert the team row no longer carries a baseline cell and the header has no `Baseline` column. All `display_training_capacity` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)