### PR TITLE
fix(cli/train): report all missing capacity update options at once

### DIFF
--- a/truss/cli/train_commands.py
+++ b/truss/cli/train_commands.py
@@ -1131,26 +1131,37 @@ def view_capacity(remote: Optional[str]):
 @capacity.command(name="update")
 @common.common_options()
 @click.option("--remote", type=str, required=False, help="Name of the remote to use")
+@click.option("--team", type=str, help="Team to update GPU capacity for.")
 @click.option(
-    "--team", type=str, required=True, help="Team to update GPU capacity for."
-)
-@click.option(
-    "--gpu-type",
-    type=str,
-    required=True,
-    help="GPU type to update capacity for (e.g. H100).",
+    "--gpu-type", type=str, help="GPU type to update capacity for (e.g. H100)."
 )
 @click.option(
     "--capacity",
     "team_capacity",
     type=int,
-    required=True,
     help="Max concurrent GPUs of this type the team may use. Org-admin only.",
 )
 def update_capacity(
-    remote: Optional[str], team: str, gpu_type: str, team_capacity: int
+    remote: Optional[str],
+    team: Optional[str],
+    gpu_type: Optional[str],
+    team_capacity: Optional[int],
 ):
     """Update a team's GPU capacity limit. Org-admin only."""
+    # Report every missing required option at once rather than one per run.
+    missing = [
+        name
+        for name, value in (
+            ("--team", team),
+            ("--gpu-type", gpu_type),
+            ("--capacity", team_capacity),
+        )
+        if value is None
+    ]
+    if missing:
+        raise click.UsageError(f"Missing required option(s): {', '.join(missing)}.")
+    assert team is not None and gpu_type is not None and team_capacity is not None
+
     if not remote:
         remote = remote_cli.inquire_remote_name()
     remote_provider: BasetenRemote = cast(

--- a/truss/tests/cli/train/test_capacity_update_args.py
+++ b/truss/tests/cli/train/test_capacity_update_args.py
@@ -1,0 +1,28 @@
+"""Tests for `truss train capacity update` required-option validation.
+
+The command should report every missing required option at once instead of
+surfacing them one at a time across repeated invocations.
+"""
+
+from click.testing import CliRunner
+
+from truss.cli.cli import truss_cli
+
+
+class TestCapacityUpdateMissingArgs:
+    def test_no_options_lists_all_missing(self):
+        result = CliRunner().invoke(truss_cli, ["train", "capacity", "update"])
+        assert result.exit_code != 0
+        out = result.output
+        assert "--team" in out
+        assert "--gpu-type" in out
+        assert "--capacity" in out
+
+    def test_partial_options_lists_only_remaining_missing(self):
+        result = CliRunner().invoke(
+            truss_cli, ["train", "capacity", "update", "--team", "some-team"]
+        )
+        assert result.exit_code != 0
+        out = result.output
+        # --team was supplied, so it should not be reported as missing.
+        assert "Missing required option(s): --gpu-type, --capacity." in out


### PR DESCRIPTION
## What

`truss train capacity update` now reports **all** missing required options in a single error, instead of surfacing them one at a time across repeated runs.

## Why

`--team`, `--gpu-type`, and `--capacity` were all `required=True`, so Click stopped at the first missing option. Users had to re-run the command repeatedly, discovering each required option only after supplying the previous one — it felt like unlocking requirements through trial and error:

```
» truss train capacity update
  Error: Missing option '--team'.
» truss train capacity update --team "Johns Workspace"
  Error: Missing option '--gpu-type'.
» truss train capacity update --team "Johns Workspace" --gpu-type H100
  Error: Missing option '--capacity'.
```

## After

```
» truss train capacity update
  Error: Missing required option(s): --team, --gpu-type, --capacity.

» truss train capacity update --team "Johns Workspace"
  Error: Missing required option(s): --gpu-type, --capacity.
```

## How

Drop `required=True` from the three options and validate them together in the command body, raising a single `click.UsageError` that lists every missing option.

## Testing

New `test_capacity_update_args.py` covers the no-options and partial-options cases via `CliRunner`. Full `truss/tests/cli/train/` suite passes (182 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)