### PR TITLE
feat: add fabric requirement config

### DIFF
--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -96,6 +96,10 @@ class Accelerator(str, enum.Enum):
     B300 = "B300"
 
 
+class Fabric(str, enum.Enum):
+    INFINIBAND = "infiniband"
+
+
 class AcceleratorSpec(custom_types.ConfigModel):
     model_config = pydantic.ConfigDict(validate_assignment=True)
 
@@ -886,6 +890,11 @@ class Resources(custom_types.ConfigModel):
             default=None, description="Number of nodes for multi-node deployments."
         )
     )
+    fabrics: Optional[list[Fabric]] = pydantic.Field(
+        default=None,
+        description="Ordered high-bandwidth fabric preferences. M2 supports infiniband.",
+        examples=[["infiniband"]],
+    )
 
     _MILLI_CPU_REGEX: ClassVar[re.Pattern] = re.compile(r"^[0-9.]*m$")
     _MEMORY_REGEX: ClassVar[re.Pattern] = re.compile(r"^[0-9.]*([a-zA-Z]+)?$")
@@ -928,6 +937,15 @@ class Resources(custom_types.ConfigModel):
             data.pop("use_gpu", None)
         return data
 
+    @pydantic.field_validator("fabrics")
+    @classmethod
+    def validate_unique_fabrics(
+        cls, fabrics: Optional[list[Fabric]]
+    ) -> Optional[list[Fabric]]:
+        if fabrics is not None and len(fabrics) != len(set(fabrics)):
+            raise ValueError("resources.fabrics must not contain duplicate entries")
+        return fabrics
+
     @pydantic.field_validator("cpu")
     def _validate_cpu(cls, cpu_spec: str) -> str:
         if _is_numeric(cpu_spec):
@@ -958,12 +976,14 @@ class Resources(custom_types.ConfigModel):
         handler: core_schema.SerializerFunctionWrapHandler,
         info: core_schema.SerializationInfo,
     ) -> dict:
-        """Custom omission of `node_count` and `instance_type` if at default."""
+        """Custom omission of optional resource fields when unset."""
         result = handler(self)
         if not self.node_count:
             result.pop("node_count", None)
         if not self.instance_type:
             result.pop("instance_type", None)
+        if not self.fabrics:
+            result.pop("fabrics", None)
         return result
 
 

--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -896,7 +896,7 @@ class Resources(custom_types.ConfigModel):
     )
     fabrics: Optional[list[Fabric]] = pydantic.Field(
         default=None,
-        description="Ordered high-bandwidth fabric preferences. M2 supports infiniband.",
+        description="Ordered NIC fabric preferences.",
         examples=[["infiniband"]],
     )
 
@@ -1507,26 +1507,9 @@ class TrussConfig(custom_types.ConfigModel):
 
     @pydantic.model_validator(mode="after")
     def _validate_fabric_requirements(self) -> "TrussConfig":
-        has_fabric_requirement = self.resources.rdma is not None or bool(
-            self.resources.fabrics
-        )
-        if not has_fabric_requirement:
-            return self
-
         if self.resources.rdma is not None and self.resources.fabrics:
             raise ValueError(
                 "Please specify only one of `resources.rdma` and `resources.fabrics`"
-            )
-
-        is_disaggregated = (
-            self.bis_llm is not None
-            and self.bis_llm.config is not None
-            and self.bis_llm.config.get("is_disaggregated") is True
-        )
-        if not is_disaggregated:
-            raise ValueError(
-                "`resources.rdma` and `resources.fabrics` are currently supported "
-                "only for disaggregated BIS LLM deployments"
             )
 
         return self

--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -890,6 +890,10 @@ class Resources(custom_types.ConfigModel):
             default=None, description="Number of nodes for multi-node deployments."
         )
     )
+    rdma: Optional[bool] = pydantic.Field(
+        default=None,
+        description="Whether this deployment requires an available RDMA fabric.",
+    )
     fabrics: Optional[list[Fabric]] = pydantic.Field(
         default=None,
         description="Ordered high-bandwidth fabric preferences. M2 supports infiniband.",
@@ -982,6 +986,8 @@ class Resources(custom_types.ConfigModel):
             result.pop("node_count", None)
         if not self.instance_type:
             result.pop("instance_type", None)
+        if self.rdma is None:
+            result.pop("rdma", None)
         if not self.fabrics:
             result.pop("fabrics", None)
         return result
@@ -1497,6 +1503,32 @@ class TrussConfig(custom_types.ConfigModel):
                 "docker_server.run_as_user_id. SSH requires the default "
                 "'app' user (uid 60000)."
             )
+        return self
+
+    @pydantic.model_validator(mode="after")
+    def _validate_fabric_requirements(self) -> "TrussConfig":
+        has_fabric_requirement = self.resources.rdma is not None or bool(
+            self.resources.fabrics
+        )
+        if not has_fabric_requirement:
+            return self
+
+        if self.resources.rdma is not None and self.resources.fabrics:
+            raise ValueError(
+                "Please specify only one of `resources.rdma` and `resources.fabrics`"
+            )
+
+        is_disaggregated = (
+            self.bis_llm is not None
+            and self.bis_llm.config is not None
+            and self.bis_llm.config.get("is_disaggregated") is True
+        )
+        if not is_disaggregated:
+            raise ValueError(
+                "`resources.rdma` and `resources.fabrics` are currently supported "
+                "only for disaggregated BIS LLM deployments"
+            )
+
         return self
 
     @pydantic.model_validator(mode="after")

--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -866,12 +866,11 @@ class FabricRequirement(custom_types.ConfigModel):
     """Network fabric requirements for a deployment."""
 
     use_rdma: Optional[bool] = pydantic.Field(
-        default=None,
-        description="Whether this deployment requires an available RDMA fabric.",
+        default=None, description="Whether to use RDMA with any supported fabric."
     )
     preferences: Optional[list[Fabric]] = pydantic.Field(
         default=None,
-        description="Ordered NIC fabric preferences.",
+        description="Exhaustive list of acceptable network fabrics, in preference order.",
         examples=[["infiniband"]],
     )
 
@@ -892,9 +891,9 @@ class FabricRequirement(custom_types.ConfigModel):
 
     @pydantic.model_validator(mode="after")
     def validate_requirement(self) -> "FabricRequirement":
-        if self.use_rdma is not None and self.preferences is not None:
+        if self.use_rdma is False and self.preferences is not None:
             raise ValueError(
-                "Please specify only one of `resources.fabric.use_rdma` and "
+                "`resources.fabric.use_rdma: false` cannot be combined with "
                 "`resources.fabric.preferences`"
             )
         return self
@@ -908,7 +907,7 @@ class FabricRequirement(custom_types.ConfigModel):
         result = handler(self)
         if self.use_rdma is None:
             result.pop("use_rdma", None)
-        if not self.preferences:
+        if self.preferences is None:
             result.pop("preferences", None)
         return result
 

--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -96,10 +96,6 @@ class Accelerator(str, enum.Enum):
     B300 = "B300"
 
 
-class Fabric(str, enum.Enum):
-    INFINIBAND = "infiniband"
-
-
 class AcceleratorSpec(custom_types.ConfigModel):
     model_config = pydantic.ConfigDict(validate_assignment=True)
 
@@ -868,35 +864,14 @@ class FabricRequirement(custom_types.ConfigModel):
     use_rdma: Optional[bool] = pydantic.Field(
         default=None, description="Whether to use RDMA with any supported fabric."
     )
-    preferences: Optional[list[Fabric]] = pydantic.Field(
+    preferences: Optional[list[str]] = pydantic.Field(
         default=None,
-        description="Exhaustive list of acceptable network fabrics, in preference order.",
+        description=(
+            "Exhaustive list of acceptable network fabrics, in preference order. "
+            "An empty list requires no fabric."
+        ),
         examples=[["infiniband"]],
     )
-
-    @pydantic.field_validator("preferences")
-    @classmethod
-    def validate_unique_preferences(
-        cls, preferences: Optional[list[Fabric]]
-    ) -> Optional[list[Fabric]]:
-        if preferences is None:
-            return preferences
-        if not preferences:
-            raise ValueError("resources.fabric.preferences must be a non-empty list")
-        if len(preferences) != len(set(preferences)):
-            raise ValueError(
-                "resources.fabric.preferences must not contain duplicate entries"
-            )
-        return preferences
-
-    @pydantic.model_validator(mode="after")
-    def validate_requirement(self) -> "FabricRequirement":
-        if self.use_rdma is False and self.preferences is not None:
-            raise ValueError(
-                "`resources.fabric.use_rdma: false` cannot be combined with "
-                "`resources.fabric.preferences`"
-            )
-        return self
 
     @pydantic.model_serializer(mode="wrap")
     def _serialize(

--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -865,7 +865,7 @@ class Build(custom_types.ConfigModel):
 class FabricRequirement(custom_types.ConfigModel):
     """Network fabric requirements for a deployment."""
 
-    rdma: Optional[bool] = pydantic.Field(
+    use_rdma: Optional[bool] = pydantic.Field(
         default=None,
         description="Whether this deployment requires an available RDMA fabric.",
     )
@@ -892,9 +892,9 @@ class FabricRequirement(custom_types.ConfigModel):
 
     @pydantic.model_validator(mode="after")
     def validate_requirement(self) -> "FabricRequirement":
-        if self.rdma is not None and self.preferences is not None:
+        if self.use_rdma is not None and self.preferences is not None:
             raise ValueError(
-                "Please specify only one of `resources.fabric.rdma` and "
+                "Please specify only one of `resources.fabric.use_rdma` and "
                 "`resources.fabric.preferences`"
             )
         return self
@@ -906,8 +906,8 @@ class FabricRequirement(custom_types.ConfigModel):
         info: core_schema.SerializationInfo,
     ) -> dict:
         result = handler(self)
-        if self.rdma is None:
-            result.pop("rdma", None)
+        if self.use_rdma is None:
+            result.pop("use_rdma", None)
         if not self.preferences:
             result.pop("preferences", None)
         return result

--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -862,6 +862,57 @@ class Build(custom_types.ConfigModel):
         return self
 
 
+class FabricRequirement(custom_types.ConfigModel):
+    """Network fabric requirements for a deployment."""
+
+    rdma: Optional[bool] = pydantic.Field(
+        default=None,
+        description="Whether this deployment requires an available RDMA fabric.",
+    )
+    preferences: Optional[list[Fabric]] = pydantic.Field(
+        default=None,
+        description="Ordered NIC fabric preferences.",
+        examples=[["infiniband"]],
+    )
+
+    @pydantic.field_validator("preferences")
+    @classmethod
+    def validate_unique_preferences(
+        cls, preferences: Optional[list[Fabric]]
+    ) -> Optional[list[Fabric]]:
+        if preferences is None:
+            return preferences
+        if not preferences:
+            raise ValueError("resources.fabric.preferences must be a non-empty list")
+        if len(preferences) != len(set(preferences)):
+            raise ValueError(
+                "resources.fabric.preferences must not contain duplicate entries"
+            )
+        return preferences
+
+    @pydantic.model_validator(mode="after")
+    def validate_requirement(self) -> "FabricRequirement":
+        if self.rdma is not None and self.preferences is not None:
+            raise ValueError(
+                "Please specify only one of `resources.fabric.rdma` and "
+                "`resources.fabric.preferences`"
+            )
+        return self
+
+    @pydantic.model_serializer(mode="wrap")
+    def _serialize(
+        self,
+        handler: core_schema.SerializerFunctionWrapHandler,
+        info: core_schema.SerializationInfo,
+    ) -> dict:
+        result = handler(self)
+        if self.rdma is None:
+            result.pop("rdma", None)
+        if not self.preferences:
+            result.pop("preferences", None)
+        return result
+
+
 class Resources(custom_types.ConfigModel):
     """Compute resources that your model needs, including CPU, memory, and GPU resources."""
 
@@ -890,14 +941,8 @@ class Resources(custom_types.ConfigModel):
             default=None, description="Number of nodes for multi-node deployments."
         )
     )
-    rdma: Optional[bool] = pydantic.Field(
-        default=None,
-        description="Whether this deployment requires an available RDMA fabric.",
-    )
-    fabrics: Optional[list[Fabric]] = pydantic.Field(
-        default=None,
-        description="Ordered NIC fabric preferences.",
-        examples=[["infiniband"]],
+    fabric: Optional[FabricRequirement] = pydantic.Field(
+        default=None, description="Network fabric requirements for this deployment."
     )
 
     _MILLI_CPU_REGEX: ClassVar[re.Pattern] = re.compile(r"^[0-9.]*m$")
@@ -941,15 +986,6 @@ class Resources(custom_types.ConfigModel):
             data.pop("use_gpu", None)
         return data
 
-    @pydantic.field_validator("fabrics")
-    @classmethod
-    def validate_unique_fabrics(
-        cls, fabrics: Optional[list[Fabric]]
-    ) -> Optional[list[Fabric]]:
-        if fabrics is not None and len(fabrics) != len(set(fabrics)):
-            raise ValueError("resources.fabrics must not contain duplicate entries")
-        return fabrics
-
     @pydantic.field_validator("cpu")
     def _validate_cpu(cls, cpu_spec: str) -> str:
         if _is_numeric(cpu_spec):
@@ -986,10 +1022,8 @@ class Resources(custom_types.ConfigModel):
             result.pop("node_count", None)
         if not self.instance_type:
             result.pop("instance_type", None)
-        if self.rdma is None:
-            result.pop("rdma", None)
-        if not self.fabrics:
-            result.pop("fabrics", None)
+        if self.fabric is None:
+            result.pop("fabric", None)
         return result
 
 
@@ -1507,11 +1541,19 @@ class TrussConfig(custom_types.ConfigModel):
 
     @pydantic.model_validator(mode="after")
     def _validate_fabric_requirements(self) -> "TrussConfig":
-        if self.resources.rdma is not None and self.resources.fabrics:
-            raise ValueError(
-                "Please specify only one of `resources.rdma` and `resources.fabrics`"
-            )
+        if self.resources.fabric is None:
+            return self
 
+        is_disaggregated = (
+            self.bis_llm is not None
+            and self.bis_llm.config is not None
+            and self.bis_llm.config.get("is_disaggregated") is True
+        )
+        if not is_disaggregated:
+            raise ValueError(
+                "`resources.fabric` is currently only supported for "
+                "disaggregated BIS LLM deployments"
+            )
         return self
 
     @pydantic.model_validator(mode="after")

--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -1540,23 +1540,6 @@ class TrussConfig(custom_types.ConfigModel):
         return self
 
     @pydantic.model_validator(mode="after")
-    def _validate_fabric_requirements(self) -> "TrussConfig":
-        if self.resources.fabric is None:
-            return self
-
-        is_disaggregated = (
-            self.bis_llm is not None
-            and self.bis_llm.config is not None
-            and self.bis_llm.config.get("is_disaggregated") is True
-        )
-        if not is_disaggregated:
-            raise ValueError(
-                "`resources.fabric` is currently only supported for "
-                "disaggregated BIS LLM deployments"
-            )
-        return self
-
-    @pydantic.model_validator(mode="after")
     def _validate_config(self) -> "TrussConfig":
         if self.requirements and self.requirements_file:
             raise ValueError(

--- a/truss/config.schema.json
+++ b/truss/config.schema.json
@@ -879,6 +879,19 @@
           "description": "Number of nodes for multi-node deployments.",
           "title": "Node Count"
         },
+        "rdma": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Whether this deployment requires an available RDMA fabric.",
+          "title": "Rdma"
+        },
         "fabrics": {
           "anyOf": [
             {

--- a/truss/config.schema.json
+++ b/truss/config.schema.json
@@ -529,6 +529,13 @@
       "title": "ExternalDataItem",
       "type": "object"
     },
+    "Fabric": {
+      "enum": [
+        "infiniband"
+      ],
+      "title": "Fabric",
+      "type": "string"
+    },
     "GRPCOptions": {
       "properties": {
         "kind": {
@@ -871,6 +878,27 @@
           "default": null,
           "description": "Number of nodes for multi-node deployments.",
           "title": "Node Count"
+        },
+        "fabrics": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/Fabric"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Ordered high-bandwidth fabric preferences. M2 supports infiniband.",
+          "examples": [
+            [
+              "infiniband"
+            ]
+          ],
+          "title": "Fabrics"
         }
       },
       "title": "Resources",

--- a/truss/config.schema.json
+++ b/truss/config.schema.json
@@ -905,7 +905,7 @@
             }
           ],
           "default": null,
-          "description": "Ordered high-bandwidth fabric preferences. M2 supports infiniband.",
+          "description": "Ordered NIC fabric preferences.",
           "examples": [
             [
               "infiniband"

--- a/truss/config.schema.json
+++ b/truss/config.schema.json
@@ -550,7 +550,7 @@
             }
           ],
           "default": null,
-          "description": "Whether this deployment requires an available RDMA fabric.",
+          "description": "Whether to use RDMA with any supported fabric.",
           "title": "Use Rdma"
         },
         "preferences": {
@@ -566,7 +566,7 @@
             }
           ],
           "default": null,
-          "description": "Ordered NIC fabric preferences.",
+          "description": "Exhaustive list of acceptable network fabrics, in preference order.",
           "examples": [
             [
               "infiniband"

--- a/truss/config.schema.json
+++ b/truss/config.schema.json
@@ -540,7 +540,7 @@
       "additionalProperties": true,
       "description": "Network fabric requirements for a deployment.",
       "properties": {
-        "rdma": {
+        "use_rdma": {
           "anyOf": [
             {
               "type": "boolean"
@@ -551,7 +551,7 @@
           ],
           "default": null,
           "description": "Whether this deployment requires an available RDMA fabric.",
-          "title": "Rdma"
+          "title": "Use Rdma"
         },
         "preferences": {
           "anyOf": [

--- a/truss/config.schema.json
+++ b/truss/config.schema.json
@@ -536,6 +536,48 @@
       "title": "Fabric",
       "type": "string"
     },
+    "FabricRequirement": {
+      "additionalProperties": true,
+      "description": "Network fabric requirements for a deployment.",
+      "properties": {
+        "rdma": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Whether this deployment requires an available RDMA fabric.",
+          "title": "Rdma"
+        },
+        "preferences": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/Fabric"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Ordered NIC fabric preferences.",
+          "examples": [
+            [
+              "infiniband"
+            ]
+          ],
+          "title": "Preferences"
+        }
+      },
+      "title": "FabricRequirement",
+      "type": "object"
+    },
     "GRPCOptions": {
       "properties": {
         "kind": {
@@ -879,39 +921,17 @@
           "description": "Number of nodes for multi-node deployments.",
           "title": "Node Count"
         },
-        "rdma": {
+        "fabric": {
           "anyOf": [
             {
-              "type": "boolean"
+              "$ref": "#/$defs/FabricRequirement"
             },
             {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Whether this deployment requires an available RDMA fabric.",
-          "title": "Rdma"
-        },
-        "fabrics": {
-          "anyOf": [
-            {
-              "items": {
-                "$ref": "#/$defs/Fabric"
-              },
-              "type": "array"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Ordered NIC fabric preferences.",
-          "examples": [
-            [
-              "infiniband"
-            ]
-          ],
-          "title": "Fabrics"
+          "description": "Network fabric requirements for this deployment."
         }
       },
       "title": "Resources",

--- a/truss/config.schema.json
+++ b/truss/config.schema.json
@@ -529,13 +529,6 @@
       "title": "ExternalDataItem",
       "type": "object"
     },
-    "Fabric": {
-      "enum": [
-        "infiniband"
-      ],
-      "title": "Fabric",
-      "type": "string"
-    },
     "FabricRequirement": {
       "additionalProperties": true,
       "description": "Network fabric requirements for a deployment.",
@@ -557,7 +550,7 @@
           "anyOf": [
             {
               "items": {
-                "$ref": "#/$defs/Fabric"
+                "type": "string"
               },
               "type": "array"
             },
@@ -566,7 +559,7 @@
             }
           ],
           "default": null,
-          "description": "Exhaustive list of acceptable network fabrics, in preference order.",
+          "description": "Exhaustive list of acceptable network fabrics, in preference order. An empty list requires no fabric.",
           "examples": [
             [
               "infiniband"

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -290,9 +290,19 @@ class BasetenRemote(TrussRemote):
         model_id: Optional[str],
         labels: Optional[Dict[str, Any]],
     ) -> Dict[str, Any]:
-        body: Dict[str, Any] = {
-            "resources": config.resources.model_dump(exclude_none=True)
-        }
+        resources = config.resources.model_dump(exclude_none=True)
+        has_explicit_fabric_requirement = config.resources.rdma is not None or bool(
+            config.resources.fabrics
+        )
+        is_disaggregated = (
+            config.bis_llm is not None
+            and config.bis_llm.config is not None
+            and config.bis_llm.config.get("is_disaggregated") is True
+        )
+        if is_disaggregated and not has_explicit_fabric_requirement:
+            resources["rdma"] = True
+
+        body: Dict[str, Any] = {"resources": resources}
         if model_id is None:
             body["name"] = model_name
         if config.environment_variables:

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -26,7 +26,7 @@ from truss.base.constants import (
     DEFAULT_REMOTE_NAME,
     PRODUCTION_ENVIRONMENT_NAME,
 )
-from truss.base.truss_config import Fabric, ModelServer
+from truss.base.truss_config import ModelServer
 from truss.local.local_config_handler import LocalConfigHandler
 from truss.remote.baseten import custom_types
 from truss.remote.baseten import custom_types as b10_types
@@ -68,7 +68,6 @@ if TYPE_CHECKING:
 
 # Server-side cap on raw config.yaml; payloads larger than this are dropped.
 RAW_CONFIG_MAX_BYTES = 100 * 1024
-DEFAULT_RDMA_FABRICS = (Fabric.INFINIBAND,)
 
 
 class PatchStatus(enum.Enum):
@@ -80,36 +79,6 @@ class PatchStatus(enum.Enum):
 class PatchResult(NamedTuple):
     status: PatchStatus
     message: str
-
-
-def _is_disaggregated(config: Any) -> bool:
-    return (
-        config.bis_llm is not None
-        and config.bis_llm.config is not None
-        and config.bis_llm.config.get("is_disaggregated") is True
-    )
-
-
-def _effective_fabric_preferences(config: Any) -> Optional[list[str]]:
-    requirement = config.resources.fabric
-    if requirement is not None:
-        if requirement.preferences is not None:
-            return [fabric.value for fabric in requirement.preferences]
-        if requirement.use_rdma is False:
-            return []
-        if requirement.use_rdma is True:
-            return [fabric.value for fabric in DEFAULT_RDMA_FABRICS]
-    if _is_disaggregated(config):
-        return [fabric.value for fabric in DEFAULT_RDMA_FABRICS]
-    return None
-
-
-def _compile_fabric_requirement(resources: Dict[str, Any], config: Any) -> None:
-    preferences = _effective_fabric_preferences(config)
-    if preferences is None:
-        resources.pop("fabric", None)
-        return
-    resources["fabric"] = {"preferences": preferences}
 
 
 def retry_patch(
@@ -321,10 +290,9 @@ class BasetenRemote(TrussRemote):
         model_id: Optional[str],
         labels: Optional[Dict[str, Any]],
     ) -> Dict[str, Any]:
-        resources = config.resources.model_dump(mode="json", exclude_none=True)
-        _compile_fabric_requirement(resources, config)
-
-        body: Dict[str, Any] = {"resources": resources}
+        body: Dict[str, Any] = {
+            "resources": config.resources.model_dump(mode="json", exclude_none=True)
+        }
         if model_id is None:
             body["name"] = model_name
         if config.environment_variables:
@@ -432,11 +400,9 @@ class BasetenRemote(TrussRemote):
 
         config.validate_forbid_extra()
         config_dict = config.to_dict()
-        config_for_validation = base64_encoded_json_str(config_dict)
-        if config.bis_llm is None:
-            validate_truss_config_against_backend(self._api, config_for_validation)
-        _compile_fabric_requirement(config_dict["resources"], config)
         encoded_config_str = base64_encoded_json_str(config_dict)
+        if config.bis_llm is None:
+            validate_truss_config_against_backend(self._api, encoded_config_str)
         default_config = (truss_handle.truss_dir / CONFIG_FILE).resolve()
         config_yaml_override: Optional[bytes] = None
         if truss_handle.spec.config_path.resolve() != default_config:

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -26,7 +26,7 @@ from truss.base.constants import (
     DEFAULT_REMOTE_NAME,
     PRODUCTION_ENVIRONMENT_NAME,
 )
-from truss.base.truss_config import ModelServer
+from truss.base.truss_config import Fabric, ModelServer
 from truss.local.local_config_handler import LocalConfigHandler
 from truss.remote.baseten import custom_types
 from truss.remote.baseten import custom_types as b10_types
@@ -68,6 +68,7 @@ if TYPE_CHECKING:
 
 # Server-side cap on raw config.yaml; payloads larger than this are dropped.
 RAW_CONFIG_MAX_BYTES = 100 * 1024
+DEFAULT_RDMA_FABRICS = (Fabric.INFINIBAND,)
 
 
 class PatchStatus(enum.Enum):
@@ -79,6 +80,36 @@ class PatchStatus(enum.Enum):
 class PatchResult(NamedTuple):
     status: PatchStatus
     message: str
+
+
+def _is_disaggregated(config: Any) -> bool:
+    return (
+        config.bis_llm is not None
+        and config.bis_llm.config is not None
+        and config.bis_llm.config.get("is_disaggregated") is True
+    )
+
+
+def _effective_fabric_preferences(config: Any) -> Optional[list[str]]:
+    requirement = config.resources.fabric
+    if requirement is not None:
+        if requirement.preferences is not None:
+            return [fabric.value for fabric in requirement.preferences]
+        if requirement.use_rdma is False:
+            return []
+        if requirement.use_rdma is True:
+            return [fabric.value for fabric in DEFAULT_RDMA_FABRICS]
+    if _is_disaggregated(config):
+        return [fabric.value for fabric in DEFAULT_RDMA_FABRICS]
+    return None
+
+
+def _compile_fabric_requirement(resources: Dict[str, Any], config: Any) -> None:
+    preferences = _effective_fabric_preferences(config)
+    if preferences is None:
+        resources.pop("fabric", None)
+        return
+    resources["fabric"] = {"preferences": preferences}
 
 
 def retry_patch(
@@ -290,19 +321,8 @@ class BasetenRemote(TrussRemote):
         model_id: Optional[str],
         labels: Optional[Dict[str, Any]],
     ) -> Dict[str, Any]:
-        resources = config.resources.model_dump(exclude_none=True)
-        fabric_requirement = config.resources.fabric
-        has_explicit_fabric_requirement = fabric_requirement is not None and (
-            fabric_requirement.use_rdma is not None
-            or bool(fabric_requirement.preferences)
-        )
-        is_disaggregated = (
-            config.bis_llm is not None
-            and config.bis_llm.config is not None
-            and config.bis_llm.config.get("is_disaggregated") is True
-        )
-        if is_disaggregated and not has_explicit_fabric_requirement:
-            resources["fabric"] = {"use_rdma": True}
+        resources = config.resources.model_dump(mode="json", exclude_none=True)
+        _compile_fabric_requirement(resources, config)
 
         body: Dict[str, Any] = {"resources": resources}
         if model_id is None:
@@ -411,9 +431,12 @@ class BasetenRemote(TrussRemote):
             raise ValueError("disable-truss-download can only be used for new models")
 
         config.validate_forbid_extra()
-        encoded_config_str = base64_encoded_json_str(config.to_dict())
+        config_dict = config.to_dict()
+        config_for_validation = base64_encoded_json_str(config_dict)
         if config.bis_llm is None:
-            validate_truss_config_against_backend(self._api, encoded_config_str)
+            validate_truss_config_against_backend(self._api, config_for_validation)
+        _compile_fabric_requirement(config_dict["resources"], config)
+        encoded_config_str = base64_encoded_json_str(config_dict)
         default_config = (truss_handle.truss_dir / CONFIG_FILE).resolve()
         config_yaml_override: Optional[bytes] = None
         if truss_handle.spec.config_path.resolve() != default_config:

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -291,7 +291,7 @@ class BasetenRemote(TrussRemote):
         labels: Optional[Dict[str, Any]],
     ) -> Dict[str, Any]:
         body: Dict[str, Any] = {
-            "resources": config.resources.model_dump(mode="json", exclude_none=True)
+            "resources": config.resources.model_dump(exclude_none=True)
         }
         if model_id is None:
             body["name"] = model_name

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -291,8 +291,9 @@ class BasetenRemote(TrussRemote):
         labels: Optional[Dict[str, Any]],
     ) -> Dict[str, Any]:
         resources = config.resources.model_dump(exclude_none=True)
-        has_explicit_fabric_requirement = config.resources.rdma is not None or bool(
-            config.resources.fabrics
+        fabric_requirement = config.resources.fabric
+        has_explicit_fabric_requirement = fabric_requirement is not None and (
+            fabric_requirement.rdma is not None or bool(fabric_requirement.preferences)
         )
         is_disaggregated = (
             config.bis_llm is not None
@@ -300,7 +301,7 @@ class BasetenRemote(TrussRemote):
             and config.bis_llm.config.get("is_disaggregated") is True
         )
         if is_disaggregated and not has_explicit_fabric_requirement:
-            resources["rdma"] = True
+            resources["fabric"] = {"rdma": True}
 
         body: Dict[str, Any] = {"resources": resources}
         if model_id is None:

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -293,7 +293,8 @@ class BasetenRemote(TrussRemote):
         resources = config.resources.model_dump(exclude_none=True)
         fabric_requirement = config.resources.fabric
         has_explicit_fabric_requirement = fabric_requirement is not None and (
-            fabric_requirement.rdma is not None or bool(fabric_requirement.preferences)
+            fabric_requirement.use_rdma is not None
+            or bool(fabric_requirement.preferences)
         )
         is_disaggregated = (
             config.bis_llm is not None
@@ -301,7 +302,7 @@ class BasetenRemote(TrussRemote):
             and config.bis_llm.config.get("is_disaggregated") is True
         )
         if is_disaggregated and not has_explicit_fabric_requirement:
-            resources["fabric"] = {"rdma": True}
+            resources["fabric"] = {"use_rdma": True}
 
         body: Dict[str, Any] = {"resources": resources}
         if model_id is None:

--- a/truss/tests/remote/baseten/test_remote.py
+++ b/truss/tests/remote/baseten/test_remote.py
@@ -691,14 +691,27 @@ def test_push_raised_validation_error_for_extra_fields(tmp_path, remote):
             remote.push(th, "model_name", th.truss_dir)
 
 
+@pytest.mark.parametrize(
+    ("resource_config", "expected_resource_config"),
+    [
+        ({"rdma": True}, {"rdma": True}),
+        ({"rdma": False}, {"rdma": False}),
+        ({"fabrics": [Fabric.INFINIBAND]}, {"fabrics": ["infiniband"]}),
+    ],
+)
 def test_push_uses_bis_llm_service_for_bis_llm(
-    remote, mock_upload_truss, mock_truss_handle
+    remote,
+    mock_upload_truss,
+    mock_truss_handle,
+    resource_config,
+    expected_resource_config,
 ):
     mock_truss_handle.spec.config.bis_llm = BISLLM(
-        config={"model": "test-llm"}, version="v1"
+        config={"model": "test-llm", "is_disaggregated": True}, version="v1"
     )
     mock_truss_handle.spec.config.environment_variables = {"HF_TOKEN": "secret"}
-    mock_truss_handle.spec.config.resources.fabrics = [Fabric.INFINIBAND]
+    for field, value in resource_config.items():
+        setattr(mock_truss_handle.spec.config.resources, field, value)
     mock_truss_handle.spec.config.weights = Weights(
         [
             WeightsSource(source="hf://model-1", mount_location="/models/base"),
@@ -741,7 +754,10 @@ def test_push_uses_bis_llm_service_for_bis_llm(
     _, kwargs = mock_create_bis_llm_service.call_args
     assert kwargs["model_id"] == "bis-llm-model-id"
     assert kwargs["team_id"] is None
-    assert kwargs["body"]["llm_config"] == {"model": "test-llm"}
+    assert kwargs["body"]["llm_config"] == {
+        "model": "test-llm",
+        "is_disaggregated": True,
+    }
     assert kwargs["body"]["llm_version"] == "v1"
     assert kwargs["body"]["weights"] == [
         {"source": "hf://model-1", "mount_location": "/models/base"},
@@ -753,7 +769,11 @@ def test_push_uses_bis_llm_service_for_bis_llm(
         "environment": "production",
     }
     assert isinstance(kwargs["body"]["resources"], dict)
-    assert kwargs["body"]["resources"]["fabrics"] == ["infiniband"]
+    for field in ("rdma", "fabrics"):
+        if field in expected_resource_config:
+            assert kwargs["body"]["resources"][field] == expected_resource_config[field]
+        else:
+            assert field not in kwargs["body"]["resources"]
     assert "name" not in kwargs["body"]
     assert service.model_id == "bis-llm-model-id"
     assert service.model_version_id == "bis-llm-deployment-id"

--- a/truss/tests/remote/baseten/test_remote.py
+++ b/truss/tests/remote/baseten/test_remote.py
@@ -695,6 +695,9 @@ def test_push_raised_validation_error_for_extra_fields(tmp_path, remote):
     ("is_disaggregated", "resource_config", "expected_resource_config"),
     [
         (False, {}, {}),
+        (False, {"rdma": True}, {"rdma": True}),
+        (False, {"rdma": False}, {"rdma": False}),
+        (False, {"fabrics": [Fabric.INFINIBAND]}, {"fabrics": ["infiniband"]}),
         (True, {}, {"rdma": True}),
         (True, {"rdma": True}, {"rdma": True}),
         (True, {"rdma": False}, {"rdma": False}),

--- a/truss/tests/remote/baseten/test_remote.py
+++ b/truss/tests/remote/baseten/test_remote.py
@@ -6,7 +6,7 @@ import pydantic
 import pytest
 import requests_mock
 
-from truss.base.truss_config import BISLLM, Weights, WeightsSource
+from truss.base.truss_config import BISLLM, Fabric, Weights, WeightsSource
 from truss.remote.baseten import custom_types as b10_types
 from truss.remote.baseten.core import (
     ModelId,
@@ -698,6 +698,7 @@ def test_push_uses_bis_llm_service_for_bis_llm(
         config={"model": "test-llm"}, version="v1"
     )
     mock_truss_handle.spec.config.environment_variables = {"HF_TOKEN": "secret"}
+    mock_truss_handle.spec.config.resources.fabrics = [Fabric.INFINIBAND]
     mock_truss_handle.spec.config.weights = Weights(
         [
             WeightsSource(source="hf://model-1", mount_location="/models/base"),
@@ -752,6 +753,7 @@ def test_push_uses_bis_llm_service_for_bis_llm(
         "environment": "production",
     }
     assert isinstance(kwargs["body"]["resources"], dict)
+    assert kwargs["body"]["resources"]["fabrics"] == ["infiniband"]
     assert "name" not in kwargs["body"]
     assert service.model_id == "bis-llm-model-id"
     assert service.model_version_id == "bis-llm-deployment-id"

--- a/truss/tests/remote/baseten/test_remote.py
+++ b/truss/tests/remote/baseten/test_remote.py
@@ -692,22 +692,25 @@ def test_push_raised_validation_error_for_extra_fields(tmp_path, remote):
 
 
 @pytest.mark.parametrize(
-    ("resource_config", "expected_resource_config"),
+    ("is_disaggregated", "resource_config", "expected_resource_config"),
     [
-        ({"rdma": True}, {"rdma": True}),
-        ({"rdma": False}, {"rdma": False}),
-        ({"fabrics": [Fabric.INFINIBAND]}, {"fabrics": ["infiniband"]}),
+        (False, {}, {}),
+        (True, {}, {"rdma": True}),
+        (True, {"rdma": True}, {"rdma": True}),
+        (True, {"rdma": False}, {"rdma": False}),
+        (True, {"fabrics": [Fabric.INFINIBAND]}, {"fabrics": ["infiniband"]}),
     ],
 )
 def test_push_uses_bis_llm_service_for_bis_llm(
     remote,
     mock_upload_truss,
     mock_truss_handle,
+    is_disaggregated,
     resource_config,
     expected_resource_config,
 ):
     mock_truss_handle.spec.config.bis_llm = BISLLM(
-        config={"model": "test-llm", "is_disaggregated": True}, version="v1"
+        config={"model": "test-llm", "is_disaggregated": is_disaggregated}, version="v1"
     )
     mock_truss_handle.spec.config.environment_variables = {"HF_TOKEN": "secret"}
     for field, value in resource_config.items():
@@ -756,7 +759,7 @@ def test_push_uses_bis_llm_service_for_bis_llm(
     assert kwargs["team_id"] is None
     assert kwargs["body"]["llm_config"] == {
         "model": "test-llm",
-        "is_disaggregated": True,
+        "is_disaggregated": is_disaggregated,
     }
     assert kwargs["body"]["llm_version"] == "v1"
     assert kwargs["body"]["weights"] == [

--- a/truss/tests/remote/baseten/test_remote.py
+++ b/truss/tests/remote/baseten/test_remote.py
@@ -6,7 +6,13 @@ import pydantic
 import pytest
 import requests_mock
 
-from truss.base.truss_config import BISLLM, Fabric, Weights, WeightsSource
+from truss.base.truss_config import (
+    BISLLM,
+    Fabric,
+    FabricRequirement,
+    Weights,
+    WeightsSource,
+)
 from truss.remote.baseten import custom_types as b10_types
 from truss.remote.baseten.core import (
     ModelId,
@@ -694,14 +700,11 @@ def test_push_raised_validation_error_for_extra_fields(tmp_path, remote):
 @pytest.mark.parametrize(
     ("is_disaggregated", "resource_config", "expected_resource_config"),
     [
-        (False, {}, {}),
-        (False, {"rdma": True}, {"rdma": True}),
-        (False, {"rdma": False}, {"rdma": False}),
-        (False, {"fabrics": [Fabric.INFINIBAND]}, {"fabrics": ["infiniband"]}),
-        (True, {}, {"rdma": True}),
+        (False, None, None),
+        (True, None, {"rdma": True}),
         (True, {"rdma": True}, {"rdma": True}),
         (True, {"rdma": False}, {"rdma": False}),
-        (True, {"fabrics": [Fabric.INFINIBAND]}, {"fabrics": ["infiniband"]}),
+        (True, {"preferences": [Fabric.INFINIBAND]}, {"preferences": ["infiniband"]}),
     ],
 )
 def test_push_uses_bis_llm_service_for_bis_llm(
@@ -716,8 +719,10 @@ def test_push_uses_bis_llm_service_for_bis_llm(
         config={"model": "test-llm", "is_disaggregated": is_disaggregated}, version="v1"
     )
     mock_truss_handle.spec.config.environment_variables = {"HF_TOKEN": "secret"}
-    for field, value in resource_config.items():
-        setattr(mock_truss_handle.spec.config.resources, field, value)
+    if resource_config is not None:
+        mock_truss_handle.spec.config.resources.fabric = (
+            FabricRequirement.model_validate(resource_config)
+        )
     mock_truss_handle.spec.config.weights = Weights(
         [
             WeightsSource(source="hf://model-1", mount_location="/models/base"),
@@ -775,11 +780,10 @@ def test_push_uses_bis_llm_service_for_bis_llm(
         "environment": "production",
     }
     assert isinstance(kwargs["body"]["resources"], dict)
-    for field in ("rdma", "fabrics"):
-        if field in expected_resource_config:
-            assert kwargs["body"]["resources"][field] == expected_resource_config[field]
-        else:
-            assert field not in kwargs["body"]["resources"]
+    if expected_resource_config is None:
+        assert "fabric" not in kwargs["body"]["resources"]
+    else:
+        assert kwargs["body"]["resources"]["fabric"] == expected_resource_config
     assert "name" not in kwargs["body"]
     assert service.model_id == "bis-llm-model-id"
     assert service.model_version_id == "bis-llm-deployment-id"

--- a/truss/tests/remote/baseten/test_remote.py
+++ b/truss/tests/remote/baseten/test_remote.py
@@ -1,3 +1,5 @@
+import base64
+import json
 import re
 from unittest import mock
 from unittest.mock import MagicMock, patch
@@ -6,13 +8,7 @@ import pydantic
 import pytest
 import requests_mock
 
-from truss.base.truss_config import (
-    BISLLM,
-    Fabric,
-    FabricRequirement,
-    Weights,
-    WeightsSource,
-)
+from truss.base.truss_config import BISLLM, FabricRequirement, Weights, WeightsSource
 from truss.remote.baseten import custom_types as b10_types
 from truss.remote.baseten.core import (
     ModelId,
@@ -701,10 +697,15 @@ def test_push_raised_validation_error_for_extra_fields(tmp_path, remote):
     ("is_disaggregated", "resource_config", "expected_resource_config"),
     [
         (False, None, None),
-        (True, None, {"use_rdma": True}),
-        (True, {"use_rdma": True}, {"use_rdma": True}),
-        (True, {"use_rdma": False}, {"use_rdma": False}),
-        (True, {"preferences": [Fabric.INFINIBAND]}, {"preferences": ["infiniband"]}),
+        (True, None, {"preferences": ["infiniband"]}),
+        (True, {"use_rdma": True}, {"preferences": ["infiniband"]}),
+        (True, {"use_rdma": False}, {"preferences": []}),
+        (True, {"preferences": ["infiniband"]}, {"preferences": ["infiniband"]}),
+        (
+            True,
+            {"use_rdma": True, "preferences": ["infiniband"]},
+            {"preferences": ["infiniband"]},
+        ),
     ],
 )
 def test_push_uses_bis_llm_service_for_bis_llm(
@@ -788,6 +789,41 @@ def test_push_uses_bis_llm_service_for_bis_llm(
     assert service.model_id == "bis-llm-model-id"
     assert service.model_version_id == "bis-llm-deployment-id"
     assert service._url_config == URLConfig.BIS_LLM
+
+
+@pytest.mark.parametrize(
+    ("resource_config", "expected_resource_config"),
+    [
+        ({"use_rdma": True}, {"preferences": ["infiniband"]}),
+        ({"use_rdma": False}, {"preferences": []}),
+        ({"preferences": ["infiniband"]}, {"preferences": ["infiniband"]}),
+        (
+            {"use_rdma": True, "preferences": ["infiniband"]},
+            {"preferences": ["infiniband"]},
+        ),
+    ],
+)
+def test_push_compiles_fabric_requirement_for_non_bis_deployments(
+    remote,
+    mock_baseten_requests,
+    mock_upload_truss,
+    mock_create_truss_service,
+    mock_truss_handle,
+    resource_config,
+    expected_resource_config,
+):
+    mock_truss_handle.spec.config.resources.fabric = FabricRequirement.model_validate(
+        resource_config
+    )
+
+    remote.push(
+        mock_truss_handle, "model_name", mock_truss_handle.truss_dir, publish=True
+    )
+
+    _, kwargs = mock_create_truss_service.call_args
+    config = json.loads(base64.b64decode(kwargs["config"]))
+    assert config["resources"]["fabric"] == expected_resource_config
+    assert "use_rdma" not in config["resources"]["fabric"]
 
 
 @pytest.mark.parametrize(

--- a/truss/tests/remote/baseten/test_remote.py
+++ b/truss/tests/remote/baseten/test_remote.py
@@ -701,9 +701,9 @@ def test_push_raised_validation_error_for_extra_fields(tmp_path, remote):
     ("is_disaggregated", "resource_config", "expected_resource_config"),
     [
         (False, None, None),
-        (True, None, {"rdma": True}),
-        (True, {"rdma": True}, {"rdma": True}),
-        (True, {"rdma": False}, {"rdma": False}),
+        (True, None, {"use_rdma": True}),
+        (True, {"use_rdma": True}, {"use_rdma": True}),
+        (True, {"use_rdma": False}, {"use_rdma": False}),
         (True, {"preferences": [Fabric.INFINIBAND]}, {"preferences": ["infiniband"]}),
     ],
 )

--- a/truss/tests/remote/baseten/test_remote.py
+++ b/truss/tests/remote/baseten/test_remote.py
@@ -697,14 +697,14 @@ def test_push_raised_validation_error_for_extra_fields(tmp_path, remote):
     ("is_disaggregated", "resource_config", "expected_resource_config"),
     [
         (False, None, None),
-        (True, None, {"preferences": ["infiniband"]}),
-        (True, {"use_rdma": True}, {"preferences": ["infiniband"]}),
-        (True, {"use_rdma": False}, {"preferences": []}),
+        (True, None, None),
+        (True, {"use_rdma": True}, {"use_rdma": True}),
+        (True, {"use_rdma": False}, {"use_rdma": False}),
         (True, {"preferences": ["infiniband"]}, {"preferences": ["infiniband"]}),
         (
             True,
             {"use_rdma": True, "preferences": ["infiniband"]},
-            {"preferences": ["infiniband"]},
+            {"use_rdma": True, "preferences": ["infiniband"]},
         ),
     ],
 )
@@ -794,16 +794,16 @@ def test_push_uses_bis_llm_service_for_bis_llm(
 @pytest.mark.parametrize(
     ("resource_config", "expected_resource_config"),
     [
-        ({"use_rdma": True}, {"preferences": ["infiniband"]}),
-        ({"use_rdma": False}, {"preferences": []}),
+        ({"use_rdma": True}, {"use_rdma": True}),
+        ({"use_rdma": False}, {"use_rdma": False}),
         ({"preferences": ["infiniband"]}, {"preferences": ["infiniband"]}),
         (
             {"use_rdma": True, "preferences": ["infiniband"]},
-            {"preferences": ["infiniband"]},
+            {"use_rdma": True, "preferences": ["infiniband"]},
         ),
     ],
 )
-def test_push_compiles_fabric_requirement_for_non_bis_deployments(
+def test_push_forwards_fabric_requirement_for_non_bis_deployments(
     remote,
     mock_baseten_requests,
     mock_upload_truss,
@@ -823,7 +823,6 @@ def test_push_compiles_fabric_requirement_for_non_bis_deployments(
     _, kwargs = mock_create_truss_service.call_args
     config = json.loads(base64.b64decode(kwargs["config"]))
     assert config["resources"]["fabric"] == expected_resource_config
-    assert "use_rdma" not in config["resources"]["fabric"]
 
 
 @pytest.mark.parametrize(

--- a/truss/tests/test_config.py
+++ b/truss/tests/test_config.py
@@ -22,6 +22,7 @@ from truss.base.truss_config import (
     DockerAuthType,
     DockerServer,
     EgressRestrictions,
+    Fabric,
     HTTPOptions,
     ModelCache,
     ModelRepo,
@@ -166,6 +167,19 @@ def test_instance_type_not_serialized_when_none():
     resources = Resources()
     result = resources.to_dict(verbose=True)
     assert "instance_type" not in result
+
+
+def test_parse_resource_fabrics():
+    resources = Resources.model_validate({"fabrics": ["infiniband"]})
+
+    assert resources.fabrics == [Fabric.INFINIBAND]
+    assert resources.to_dict()["fabrics"] == ["infiniband"]
+
+
+@pytest.mark.parametrize("fabrics", [["roce"], ["infiniband", "infiniband"]])
+def test_parse_resource_fabrics_rejects_unsupported_or_duplicate_values(fabrics):
+    with pytest.raises(pydantic.ValidationError):
+        Resources.model_validate({"fabrics": fabrics})
 
 
 @pytest.mark.parametrize(

--- a/truss/tests/test_config.py
+++ b/truss/tests/test_config.py
@@ -182,6 +182,63 @@ def test_parse_resource_fabrics_rejects_unsupported_or_duplicate_values(fabrics)
         Resources.model_validate({"fabrics": fabrics})
 
 
+@pytest.mark.parametrize("rdma", [True, False])
+def test_parse_resource_rdma_preserves_explicit_value(rdma):
+    resources = Resources.model_validate({"rdma": rdma})
+
+    assert resources.rdma is rdma
+    assert resources.to_dict()["rdma"] is rdma
+
+
+def test_resource_rdma_not_serialized_when_unset():
+    assert "rdma" not in Resources().to_dict(verbose=True)
+
+
+@pytest.mark.parametrize(
+    "resources", [{"rdma": True}, {"rdma": False}, {"fabrics": ["infiniband"]}]
+)
+def test_fabric_requirements_require_disaggregated_bis(resources):
+    with pytest.raises(
+        pydantic.ValidationError,
+        match="currently supported only for disaggregated BIS LLM deployments",
+    ):
+        TrussConfig.model_validate({"resources": resources})
+
+    with pytest.raises(
+        pydantic.ValidationError,
+        match="currently supported only for disaggregated BIS LLM deployments",
+    ):
+        TrussConfig.model_validate(
+            {"resources": resources, "bis_llm": {"config": {"is_disaggregated": False}}}
+        )
+
+
+@pytest.mark.parametrize(
+    "resources", [{"rdma": True}, {"rdma": False}, {"fabrics": ["infiniband"]}]
+)
+def test_fabric_requirements_allow_disaggregated_bis(resources):
+    config = TrussConfig.model_validate(
+        {"resources": resources, "bis_llm": {"config": {"is_disaggregated": True}}}
+    )
+
+    serialized_resources = config.resources.to_dict()
+    for field, expected_value in resources.items():
+        assert serialized_resources[field] == expected_value
+
+
+def test_rdma_and_fabrics_are_mutually_exclusive():
+    with pytest.raises(
+        pydantic.ValidationError,
+        match="Please specify only one of `resources.rdma` and `resources.fabrics`",
+    ):
+        TrussConfig.model_validate(
+            {
+                "resources": {"rdma": True, "fabrics": ["infiniband"]},
+                "bis_llm": {"config": {"is_disaggregated": True}},
+            }
+        )
+
+
 @pytest.mark.parametrize(
     "cpu_spec, expected_valid",
     [

--- a/truss/tests/test_config.py
+++ b/truss/tests/test_config.py
@@ -197,29 +197,19 @@ def test_resource_rdma_not_serialized_when_unset():
 @pytest.mark.parametrize(
     "resources", [{"rdma": True}, {"rdma": False}, {"fabrics": ["infiniband"]}]
 )
-def test_fabric_requirements_require_disaggregated_bis(resources):
-    with pytest.raises(
-        pydantic.ValidationError,
-        match="currently supported only for disaggregated BIS LLM deployments",
-    ):
-        TrussConfig.model_validate({"resources": resources})
-
-    with pytest.raises(
-        pydantic.ValidationError,
-        match="currently supported only for disaggregated BIS LLM deployments",
-    ):
-        TrussConfig.model_validate(
-            {"resources": resources, "bis_llm": {"config": {"is_disaggregated": False}}}
-        )
-
-
 @pytest.mark.parametrize(
-    "resources", [{"rdma": True}, {"rdma": False}, {"fabrics": ["infiniband"]}]
+    "bis_llm",
+    [
+        None,
+        {"config": {"is_disaggregated": False}},
+        {"config": {"is_disaggregated": True}},
+    ],
 )
-def test_fabric_requirements_allow_disaggregated_bis(resources):
-    config = TrussConfig.model_validate(
-        {"resources": resources, "bis_llm": {"config": {"is_disaggregated": True}}}
-    )
+def test_fabric_requirements_are_not_restricted_by_deployment_type(resources, bis_llm):
+    config_dict = {"resources": resources}
+    if bis_llm is not None:
+        config_dict["bis_llm"] = bis_llm
+    config = TrussConfig.model_validate(config_dict)
 
     serialized_resources = config.resources.to_dict()
     for field, expected_value in resources.items():

--- a/truss/tests/test_config.py
+++ b/truss/tests/test_config.py
@@ -223,16 +223,26 @@ def test_fabric_requirements_allow_all_deployment_types(fabric_requirement, bis_
     )
 
 
-def test_use_rdma_and_fabric_preferences_are_mutually_exclusive():
+def test_use_rdma_true_and_fabric_preferences_can_be_combined():
+    resources = Resources.model_validate(
+        {"fabric": {"use_rdma": True, "preferences": ["infiniband"]}}
+    )
+
+    assert resources.fabric is not None
+    assert resources.fabric.use_rdma is True
+    assert resources.fabric.preferences == [Fabric.INFINIBAND]
+
+
+def test_use_rdma_false_and_fabric_preferences_cannot_be_combined():
     with pytest.raises(
         pydantic.ValidationError,
         match=(
-            "Please specify only one of `resources.fabric.use_rdma` and "
+            "`resources.fabric.use_rdma: false` cannot be combined with "
             "`resources.fabric.preferences`"
         ),
     ):
         Resources.model_validate(
-            {"fabric": {"use_rdma": True, "preferences": ["infiniband"]}}
+            {"fabric": {"use_rdma": False, "preferences": ["infiniband"]}}
         )
 
 

--- a/truss/tests/test_config.py
+++ b/truss/tests/test_config.py
@@ -203,32 +203,20 @@ def test_resource_fabric_not_serialized_when_unset():
     "fabric_requirement",
     [{"use_rdma": True}, {"use_rdma": False}, {"preferences": ["infiniband"]}],
 )
-@pytest.mark.parametrize("bis_llm", [None, {"config": {"is_disaggregated": False}}])
-def test_fabric_requirements_reject_non_disaggregated_configs(
-    fabric_requirement, bis_llm
-):
+@pytest.mark.parametrize(
+    "bis_llm",
+    [
+        None,
+        {"config": {"is_disaggregated": False}},
+        {"config": {"is_disaggregated": True}},
+    ],
+)
+def test_fabric_requirements_allow_all_deployment_types(fabric_requirement, bis_llm):
     config_dict = {"resources": {"fabric": fabric_requirement}}
     if bis_llm is not None:
         config_dict["bis_llm"] = bis_llm
 
-    with pytest.raises(
-        pydantic.ValidationError,
-        match="currently only supported for disaggregated BIS LLM deployments",
-    ):
-        TrussConfig.model_validate(config_dict)
-
-
-@pytest.mark.parametrize(
-    "fabric_requirement",
-    [{"use_rdma": True}, {"use_rdma": False}, {"preferences": ["infiniband"]}],
-)
-def test_fabric_requirements_allow_disaggregated_bis(fabric_requirement):
-    config = TrussConfig.model_validate(
-        {
-            "resources": {"fabric": fabric_requirement},
-            "bis_llm": {"config": {"is_disaggregated": True}},
-        }
-    )
+    config = TrussConfig.model_validate(config_dict)
 
     assert config.resources.fabric == FabricRequirement.model_validate(
         fabric_requirement

--- a/truss/tests/test_config.py
+++ b/truss/tests/test_config.py
@@ -22,7 +22,6 @@ from truss.base.truss_config import (
     DockerAuthType,
     DockerServer,
     EgressRestrictions,
-    Fabric,
     FabricRequirement,
     HTTPOptions,
     ModelCache,
@@ -174,16 +173,16 @@ def test_parse_resource_fabric_preferences():
     resources = Resources.model_validate({"fabric": {"preferences": ["infiniband"]}})
 
     assert resources.fabric is not None
-    assert resources.fabric.preferences == [Fabric.INFINIBAND]
+    assert resources.fabric.preferences == ["infiniband"]
     assert resources.to_dict()["fabric"]["preferences"] == ["infiniband"]
 
 
 @pytest.mark.parametrize("preferences", [[], ["roce"], ["infiniband", "infiniband"]])
-def test_parse_resource_fabric_rejects_unsupported_or_duplicate_preferences(
-    preferences,
-):
-    with pytest.raises(pydantic.ValidationError):
-        Resources.model_validate({"fabric": {"preferences": preferences}})
+def test_parse_resource_fabric_defers_preference_validation_to_server(preferences):
+    resources = Resources.model_validate({"fabric": {"preferences": preferences}})
+
+    assert resources.fabric is not None
+    assert resources.fabric.preferences == preferences
 
 
 @pytest.mark.parametrize("use_rdma", [True, False])
@@ -230,20 +229,17 @@ def test_use_rdma_true_and_fabric_preferences_can_be_combined():
 
     assert resources.fabric is not None
     assert resources.fabric.use_rdma is True
-    assert resources.fabric.preferences == [Fabric.INFINIBAND]
+    assert resources.fabric.preferences == ["infiniband"]
 
 
-def test_use_rdma_false_and_fabric_preferences_cannot_be_combined():
-    with pytest.raises(
-        pydantic.ValidationError,
-        match=(
-            "`resources.fabric.use_rdma: false` cannot be combined with "
-            "`resources.fabric.preferences`"
-        ),
-    ):
-        Resources.model_validate(
-            {"fabric": {"use_rdma": False, "preferences": ["infiniband"]}}
-        )
+def test_use_rdma_false_and_fabric_preferences_defer_validation_to_server():
+    resources = Resources.model_validate(
+        {"fabric": {"use_rdma": False, "preferences": ["infiniband"]}}
+    )
+
+    assert resources.fabric is not None
+    assert resources.fabric.use_rdma is False
+    assert resources.fabric.preferences == ["infiniband"]
 
 
 @pytest.mark.parametrize(

--- a/truss/tests/test_config.py
+++ b/truss/tests/test_config.py
@@ -186,13 +186,13 @@ def test_parse_resource_fabric_rejects_unsupported_or_duplicate_preferences(
         Resources.model_validate({"fabric": {"preferences": preferences}})
 
 
-@pytest.mark.parametrize("rdma", [True, False])
-def test_parse_resource_rdma_preserves_explicit_value(rdma):
-    resources = Resources.model_validate({"fabric": {"rdma": rdma}})
+@pytest.mark.parametrize("use_rdma", [True, False])
+def test_parse_resource_use_rdma_preserves_explicit_value(use_rdma):
+    resources = Resources.model_validate({"fabric": {"use_rdma": use_rdma}})
 
     assert resources.fabric is not None
-    assert resources.fabric.rdma is rdma
-    assert resources.to_dict()["fabric"]["rdma"] is rdma
+    assert resources.fabric.use_rdma is use_rdma
+    assert resources.to_dict()["fabric"]["use_rdma"] is use_rdma
 
 
 def test_resource_fabric_not_serialized_when_unset():
@@ -201,7 +201,7 @@ def test_resource_fabric_not_serialized_when_unset():
 
 @pytest.mark.parametrize(
     "fabric_requirement",
-    [{"rdma": True}, {"rdma": False}, {"preferences": ["infiniband"]}],
+    [{"use_rdma": True}, {"use_rdma": False}, {"preferences": ["infiniband"]}],
 )
 @pytest.mark.parametrize("bis_llm", [None, {"config": {"is_disaggregated": False}}])
 def test_fabric_requirements_reject_non_disaggregated_configs(
@@ -220,7 +220,7 @@ def test_fabric_requirements_reject_non_disaggregated_configs(
 
 @pytest.mark.parametrize(
     "fabric_requirement",
-    [{"rdma": True}, {"rdma": False}, {"preferences": ["infiniband"]}],
+    [{"use_rdma": True}, {"use_rdma": False}, {"preferences": ["infiniband"]}],
 )
 def test_fabric_requirements_allow_disaggregated_bis(fabric_requirement):
     config = TrussConfig.model_validate(
@@ -235,16 +235,16 @@ def test_fabric_requirements_allow_disaggregated_bis(fabric_requirement):
     )
 
 
-def test_rdma_and_fabric_preferences_are_mutually_exclusive():
+def test_use_rdma_and_fabric_preferences_are_mutually_exclusive():
     with pytest.raises(
         pydantic.ValidationError,
         match=(
-            "Please specify only one of `resources.fabric.rdma` and "
+            "Please specify only one of `resources.fabric.use_rdma` and "
             "`resources.fabric.preferences`"
         ),
     ):
         Resources.model_validate(
-            {"fabric": {"rdma": True, "preferences": ["infiniband"]}}
+            {"fabric": {"use_rdma": True, "preferences": ["infiniband"]}}
         )
 
 

--- a/truss/tests/test_config.py
+++ b/truss/tests/test_config.py
@@ -23,6 +23,7 @@ from truss.base.truss_config import (
     DockerServer,
     EgressRestrictions,
     Fabric,
+    FabricRequirement,
     HTTPOptions,
     ModelCache,
     ModelRepo,
@@ -169,63 +170,81 @@ def test_instance_type_not_serialized_when_none():
     assert "instance_type" not in result
 
 
-def test_parse_resource_fabrics():
-    resources = Resources.model_validate({"fabrics": ["infiniband"]})
+def test_parse_resource_fabric_preferences():
+    resources = Resources.model_validate({"fabric": {"preferences": ["infiniband"]}})
 
-    assert resources.fabrics == [Fabric.INFINIBAND]
-    assert resources.to_dict()["fabrics"] == ["infiniband"]
+    assert resources.fabric is not None
+    assert resources.fabric.preferences == [Fabric.INFINIBAND]
+    assert resources.to_dict()["fabric"]["preferences"] == ["infiniband"]
 
 
-@pytest.mark.parametrize("fabrics", [["roce"], ["infiniband", "infiniband"]])
-def test_parse_resource_fabrics_rejects_unsupported_or_duplicate_values(fabrics):
+@pytest.mark.parametrize("preferences", [[], ["roce"], ["infiniband", "infiniband"]])
+def test_parse_resource_fabric_rejects_unsupported_or_duplicate_preferences(
+    preferences,
+):
     with pytest.raises(pydantic.ValidationError):
-        Resources.model_validate({"fabrics": fabrics})
+        Resources.model_validate({"fabric": {"preferences": preferences}})
 
 
 @pytest.mark.parametrize("rdma", [True, False])
 def test_parse_resource_rdma_preserves_explicit_value(rdma):
-    resources = Resources.model_validate({"rdma": rdma})
+    resources = Resources.model_validate({"fabric": {"rdma": rdma}})
 
-    assert resources.rdma is rdma
-    assert resources.to_dict()["rdma"] is rdma
+    assert resources.fabric is not None
+    assert resources.fabric.rdma is rdma
+    assert resources.to_dict()["fabric"]["rdma"] is rdma
 
 
-def test_resource_rdma_not_serialized_when_unset():
-    assert "rdma" not in Resources().to_dict(verbose=True)
+def test_resource_fabric_not_serialized_when_unset():
+    assert "fabric" not in Resources().to_dict(verbose=True)
 
 
 @pytest.mark.parametrize(
-    "resources", [{"rdma": True}, {"rdma": False}, {"fabrics": ["infiniband"]}]
+    "fabric_requirement",
+    [{"rdma": True}, {"rdma": False}, {"preferences": ["infiniband"]}],
 )
-@pytest.mark.parametrize(
-    "bis_llm",
-    [
-        None,
-        {"config": {"is_disaggregated": False}},
-        {"config": {"is_disaggregated": True}},
-    ],
-)
-def test_fabric_requirements_are_not_restricted_by_deployment_type(resources, bis_llm):
-    config_dict = {"resources": resources}
+@pytest.mark.parametrize("bis_llm", [None, {"config": {"is_disaggregated": False}}])
+def test_fabric_requirements_reject_non_disaggregated_configs(
+    fabric_requirement, bis_llm
+):
+    config_dict = {"resources": {"fabric": fabric_requirement}}
     if bis_llm is not None:
         config_dict["bis_llm"] = bis_llm
-    config = TrussConfig.model_validate(config_dict)
 
-    serialized_resources = config.resources.to_dict()
-    for field, expected_value in resources.items():
-        assert serialized_resources[field] == expected_value
-
-
-def test_rdma_and_fabrics_are_mutually_exclusive():
     with pytest.raises(
         pydantic.ValidationError,
-        match="Please specify only one of `resources.rdma` and `resources.fabrics`",
+        match="currently only supported for disaggregated BIS LLM deployments",
     ):
-        TrussConfig.model_validate(
-            {
-                "resources": {"rdma": True, "fabrics": ["infiniband"]},
-                "bis_llm": {"config": {"is_disaggregated": True}},
-            }
+        TrussConfig.model_validate(config_dict)
+
+
+@pytest.mark.parametrize(
+    "fabric_requirement",
+    [{"rdma": True}, {"rdma": False}, {"preferences": ["infiniband"]}],
+)
+def test_fabric_requirements_allow_disaggregated_bis(fabric_requirement):
+    config = TrussConfig.model_validate(
+        {
+            "resources": {"fabric": fabric_requirement},
+            "bis_llm": {"config": {"is_disaggregated": True}},
+        }
+    )
+
+    assert config.resources.fabric == FabricRequirement.model_validate(
+        fabric_requirement
+    )
+
+
+def test_rdma_and_fabric_preferences_are_mutually_exclusive():
+    with pytest.raises(
+        pydantic.ValidationError,
+        match=(
+            "Please specify only one of `resources.fabric.rdma` and "
+            "`resources.fabric.preferences`"
+        ),
+    ):
+        Resources.model_validate(
+            {"fabric": {"rdma": True, "preferences": ["infiniband"]}}
         )
 
 

--- a/truss/tests/test_config.py
+++ b/truss/tests/test_config.py
@@ -232,16 +232,6 @@ def test_use_rdma_true_and_fabric_preferences_can_be_combined():
     assert resources.fabric.preferences == ["infiniband"]
 
 
-def test_use_rdma_false_and_fabric_preferences_defer_validation_to_server():
-    resources = Resources.model_validate(
-        {"fabric": {"use_rdma": False, "preferences": ["infiniband"]}}
-    )
-
-    assert resources.fabric is not None
-    assert resources.fabric.use_rdma is False
-    assert resources.fabric.preferences == ["infiniband"]
-
-
 @pytest.mark.parametrize(
     "cpu_spec, expected_valid",
     [


### PR DESCRIPTION
## :rocket: What

Add optional deployment fabric intent to Truss:

- `resources.fabric.use_rdma: true` requests any supported RDMA fabric.
- `resources.fabric.use_rdma: false` explicitly requests no RDMA fabric.
- `resources.fabric.preferences` supplies an ordered list of acceptable fabrics; an empty list requests no fabric.

These fields work for BIS and ordinary Truss deployments. 

## :computer: How

- Add `Resources.fabric` with optional `use_rdma` and `preferences` fields.
- Preserve omission when `resources.fabric` is not configured, including for disaggregated deployments.
- Defer validation, mutual exclusivity, defaults, and RDMA-to-fabric resolution to the server.

The config validation is in basetenlabs/baseten#24852. 

## :microscope: Testing

- `uv run pytest truss/tests/test_config.py truss/tests/remote/baseten/test_remote.py -q`: 290 passed
- `uv run ruff check truss/base/truss_config.py truss/remote/baseten/remote.py truss/tests/test_config.py truss/tests/remote/baseten/test_remote.py`
- `uv run python bin/generate_truss_config_schema.py --check`

Coverage verifies omitted, `use_rdma: true`, `use_rdma: false`, explicit preferences, and pass-through behavior for BIS and ordinary Truss pushes.

## :ship: Release requirements

- **Pre-release:** None. The new fields are inert until the server consumes them.
- **Before advertising the feature:** Land the backend validator and MCM scheduler changes linked above.
- **Post-release:** None.
