### PR TITLE
fix: make insufficient-revision error message actionable

### DIFF
--- a/truss/tests/util/test_requirements.py
+++ b/truss/tests/util/test_requirements.py
@@ -6,6 +6,7 @@ from truss.util.requirements import (
     _is_valid_requirement,
     parse_requirement_string,
     parse_requirements_from_pyproject,
+    raise_insufficent_revision,
 )
 
 
@@ -174,3 +175,19 @@ def test_parse_requirement_string_filtered():
     assert parse_requirement_string("") is None
     assert parse_requirement_string("# comment") is None
     assert parse_requirement_string("   ") is None
+
+
+def test_raise_insufficent_revision_message_is_actionable():
+    with pytest.raises(ValueError) as exc_info:
+        raise_insufficent_revision("org/model", "main")
+
+    message = str(exc_info.value)
+    assert "org/model" in message
+    assert "main" in message
+    # The message must actually tell the user what to do (it previously read
+    # "Please a suitable commit sha under this", missing a verb).
+    assert "provide a suitable commit sha" in message
+    # And it must surface a plain, usable link rather than the old malformed
+    # literal markdown `[link](...)` that rendered verbatim in the CLI error.
+    assert "https://huggingface.co/org/model/commits/main" in message
+    assert "[link]" not in message

--- a/truss/util/requirements.py
+++ b/truss/util/requirements.py
@@ -41,6 +41,6 @@ def raise_insufficent_revision(repo_id_huggingface: str, revision: str):
     """
     raise ValueError(
         f"Revision '{revision}' is insufficient for repo '{repo_id_huggingface}'. "
-        "Please a suitable commit sha under this "
-        f"`[link](https://huggingface.co/{repo_id_huggingface}/commits/main)`"
+        "Please provide a suitable commit sha; you can find one at "
+        f"https://huggingface.co/{repo_id_huggingface}/commits/main"
     )


### PR DESCRIPTION
`raise_insufficent_revision` produced a broken CLI error. The sentence *"Please a suitable commit sha under this"* is missing a verb, and the commits link was emitted as literal markdown — `` `[link](...)` `` — which renders verbatim in a terminal instead of as a usable URL.

## Fix

Reword to *"Please provide a suitable commit sha; you can find one at <url>"* with a plain link.

Before:
```
Revision 'main' is insufficient for repo 'org/model'. Please a suitable commit sha under this `[link](https://huggingface.co/org/model/commits/main)`
```
After:
```
Revision 'main' is insufficient for repo 'org/model'. Please provide a suitable commit sha; you can find one at https://huggingface.co/org/model/commits/main
```

This message is raised from `_check_v2_requirements` when a Hugging Face `model_cache` repo uses `use_volume=True` without a `revision`.

## Tests

Adds a regression test in `truss/tests/util/test_requirements.py` asserting the message names the repo and revision, tells the user to *provide* a commit sha, and surfaces a plain URL (no literal `[link]`). Verified it fails on the old message and passes on the fix; `pytest truss/tests/util/test_requirements.py` → 22 passed, `ruff check`/`format` clean.

(Minor: the function name is also misspelled — `insufficent`. Left as-is to keep this change focused on the user-facing message; happy to rename in a follow-up if you'd like.)
