### PR TITLE
feat(cli/train): show capacity type (spot/on-demand) in train view

### DIFF
--- a/truss/cli/train/core.py
+++ b/truss/cli/train/core.py
@@ -36,6 +36,20 @@ ACTIVE_JOB_STATUSES = [
     "TRAINING_JOB_DEPLOYING",
 ]
 
+# Display labels for a job's `availability_model`. The backend serializes
+# "dedicated" (non-preemptible on-demand capacity) or "spot" (interruptible);
+# an absent value predates the field and reads as on-demand.
+_AVAILABILITY_MODEL_LABELS = {"dedicated": "On-demand", "spot": "Spot"}
+
+
+def _format_capacity_type(job: dict) -> str:
+    availability_model = job.get("availability_model")
+    if not availability_model:
+        return "On-demand"
+    return _AVAILABILITY_MODEL_LABELS.get(
+        availability_model, availability_model.title()
+    )
+
 
 def _get_job_by_job_id(remote_provider: BasetenRemote, job_id: str) -> dict:
     jobs = remote_provider.api.search_training_jobs(job_id=job_id)
@@ -114,6 +128,7 @@ def display_training_jobs(jobs, remote_url: str, title="Training Job Details"):
     table.add_column("Project")
     table.add_column("Status")
     table.add_column("Instance Type")
+    table.add_column("Capacity Type")
     table.add_column("Created By")
     table.add_column("Created")
     table.add_column("Job Page", style="bold yellow")
@@ -125,6 +140,7 @@ def display_training_jobs(jobs, remote_url: str, title="Training Job Details"):
             job["training_project"]["name"],
             job["current_status"],
             job["instance_type"]["name"],
+            _format_capacity_type(job),
             job.get("user", {}).get("email", ""),
             cli_common.format_localized_time(job["created_at"]),
             cli_common.format_link(
@@ -224,6 +240,7 @@ def display_queued_jobs(jobs: list[dict], remote_url: str) -> None:
     table.add_column("Job Name")
     table.add_column("Project")
     table.add_column("Instance Type")
+    table.add_column("Capacity Type")
     table.add_column("Priority")
     table.add_column("Created By")
     table.add_column("Queued At")
@@ -239,6 +256,7 @@ def display_queued_jobs(jobs: list[dict], remote_url: str) -> None:
             job["name"],
             job["training_project"]["name"],
             job["instance_type"]["name"],
+            _format_capacity_type(job),
             str(job.get("priority") or 0),
             job.get("user", {}).get("email", ""),
             cli_common.format_localized_time(job["created_at"]),

--- a/truss/cli/train/core.py
+++ b/truss/cli/train/core.py
@@ -26,7 +26,11 @@ from truss.cli.utils import common as cli_common
 from truss.cli.utils.output import console
 from truss.remote.baseten.remote import BasetenRemote
 from truss_train import loader
-from truss_train.definitions import CheckpointList, DeployCheckpointsConfig
+from truss_train.definitions import (
+    AvailabilityModel,
+    CheckpointList,
+    DeployCheckpointsConfig,
+)
 
 QUEUED_JOB_STATUSES = ["TRAINING_JOB_PENDING"]
 
@@ -36,19 +40,23 @@ ACTIVE_JOB_STATUSES = [
     "TRAINING_JOB_DEPLOYING",
 ]
 
-# Display labels for a job's `availability_model`. The backend serializes
-# "dedicated" (non-preemptible on-demand capacity) or "spot" (interruptible);
-# an absent value predates the field and reads as on-demand.
-_AVAILABILITY_MODEL_LABELS = {"dedicated": "On-demand", "spot": "Spot"}
+# Human-readable labels for a job's `availability_model`. DEDICATED is
+# non-preemptible on-demand capacity (and the default when the field is absent,
+# which predates it); SPOT is interruptible.
+_AVAILABILITY_MODEL_LABELS = {
+    AvailabilityModel.DEDICATED: "On-demand",
+    AvailabilityModel.SPOT: "Spot",
+}
 
 
 def _format_capacity_type(job: dict) -> str:
-    availability_model = job.get("availability_model")
-    if not availability_model:
-        return "On-demand"
-    return _AVAILABILITY_MODEL_LABELS.get(
-        availability_model, availability_model.title()
-    )
+    raw = job.get("availability_model") or AvailabilityModel.DEDICATED
+    try:
+        model = AvailabilityModel(raw)
+    except ValueError:
+        # Unknown future value: surface it rather than dropping it.
+        return str(raw).title()
+    return _AVAILABILITY_MODEL_LABELS.get(model, model.value.title())
 
 
 def _get_job_by_job_id(remote_provider: BasetenRemote, job_id: str) -> dict:

--- a/truss/tests/cli/train/test_train_cli_core.py
+++ b/truss/tests/cli/train/test_train_cli_core.py
@@ -9,7 +9,10 @@ from truss.cli.train.cache import (
     create_file_summary_with_directory_sizes,
 )
 from truss.cli.train.core import (
+    _format_capacity_type,
+    display_queued_jobs,
     display_training_capacity,
+    display_training_jobs,
     update_team_training_gpu_capacity,
     view_training_job_metrics,
 )
@@ -640,3 +643,65 @@ def test_update_team_training_gpu_capacity_unknown_team_raises():
         )
 
     mock_api.update_team_training_gpu_capacity.assert_not_called()
+
+
+def test_format_capacity_type():
+    """availability_model maps to human-readable labels; absent reads as on-demand."""
+    assert _format_capacity_type({"availability_model": "spot"}) == "Spot"
+    assert _format_capacity_type({"availability_model": "dedicated"}) == "On-demand"
+    # Absent / null predates the field and reads as on-demand.
+    assert _format_capacity_type({}) == "On-demand"
+    assert _format_capacity_type({"availability_model": None}) == "On-demand"
+    # An unknown future value is surfaced rather than dropped.
+    assert _format_capacity_type({"availability_model": "reserved"}) == "Reserved"
+
+
+def _make_job(job_id, availability_model=None, **overrides):
+    job = {
+        "id": job_id,
+        "name": f"{job_id}-name",
+        "training_project": {"id": "proj1", "name": "proj"},
+        "instance_type": {"name": "H100"},
+        "current_status": "TRAINING_JOB_RUNNING",
+        "priority": 0,
+        "created_at": "2026-07-13T00:00:00Z",
+        "user": {"email": "a@b.co"},
+    }
+    if availability_model is not None:
+        job["availability_model"] = availability_model
+    job.update(overrides)
+    return job
+
+
+def test_display_queued_jobs_shows_capacity_type(capsys):
+    """Queued jobs table includes a Capacity Type column mapped from availability_model."""
+    jobs = [
+        _make_job("spotjob", availability_model="spot"),
+        _make_job("dedjob", availability_model="dedicated"),
+        _make_job("oldjob"),  # no availability_model -> on-demand
+    ]
+
+    # Render wide so the extra column isn't truncated at the default 80 cols.
+    with patch("truss.cli.train.core.console", Console(width=200)):
+        display_queued_jobs(jobs, "https://app.baseten.co")
+
+    out = capsys.readouterr().out
+    assert "Capacity Type" in out
+    assert "Spot" in out
+    assert "On-demand" in out
+
+
+def test_display_training_jobs_shows_capacity_type(capsys):
+    """Active jobs table includes a Capacity Type column mapped from availability_model."""
+    jobs = [
+        _make_job("spotjob", availability_model="spot"),
+        _make_job("dedjob", availability_model="dedicated"),
+    ]
+
+    with patch("truss.cli.train.core.console", Console(width=200)):
+        display_training_jobs(jobs, "https://app.baseten.co")
+
+    out = capsys.readouterr().out
+    assert "Capacity Type" in out
+    assert "Spot" in out
+    assert "On-demand" in out

--- a/truss/tests/cli/train/test_train_cli_core.py
+++ b/truss/tests/cli/train/test_train_cli_core.py
@@ -673,8 +673,17 @@ def _make_job(job_id, availability_model=None, **overrides):
     return job
 
 
+def _rows_by_first_cell(out: str) -> dict:
+    """Parse a rendered rich table into {first_cell: [cells...]} for exact assertions."""
+    return {
+        cells[0]: cells
+        for line in out.splitlines()
+        if (cells := [c.strip() for c in line.split("│") if c.strip()])
+    }
+
+
 def test_display_queued_jobs_shows_capacity_type(capsys):
-    """Queued jobs table includes a Capacity Type column mapped from availability_model."""
+    """Queued jobs table maps each job's availability_model to its Capacity Type cell."""
     jobs = [
         _make_job("spotjob", availability_model="spot"),
         _make_job("dedjob", availability_model="dedicated"),
@@ -686,13 +695,16 @@ def test_display_queued_jobs_shows_capacity_type(capsys):
         display_queued_jobs(jobs, "https://app.baseten.co")
 
     out = capsys.readouterr().out
-    assert "Capacity Type" in out
-    assert "Spot" in out
-    assert "On-demand" in out
+    rows = _rows_by_first_cell(out)
+    # Columns: Job ID, Job Name, Project, Instance Type, Capacity Type, ...
+    assert rows["Job ID"][4] == "Capacity Type"
+    assert rows["spotjob"][4] == "Spot"
+    assert rows["dedjob"][4] == "On-demand"
+    assert rows["oldjob"][4] == "On-demand"
 
 
 def test_display_training_jobs_shows_capacity_type(capsys):
-    """Active jobs table includes a Capacity Type column mapped from availability_model."""
+    """Active jobs table maps each job's availability_model to its Capacity Type cell."""
     jobs = [
         _make_job("spotjob", availability_model="spot"),
         _make_job("dedjob", availability_model="dedicated"),
@@ -702,6 +714,8 @@ def test_display_training_jobs_shows_capacity_type(capsys):
         display_training_jobs(jobs, "https://app.baseten.co")
 
     out = capsys.readouterr().out
-    assert "Capacity Type" in out
-    assert "Spot" in out
-    assert "On-demand" in out
+    rows = _rows_by_first_cell(out)
+    # Columns: Job ID, Job Name, Project, Status, Instance Type, Capacity Type, ...
+    assert rows["Job ID"][5] == "Capacity Type"
+    assert rows["spotjob"][5] == "Spot"
+    assert rows["dedjob"][5] == "On-demand"


### PR DESCRIPTION
## What

Adds a **Capacity Type** column to both tables in `truss train view` (queued jobs and active jobs), showing whether each training job runs on **Spot** or **On-demand** capacity.

Before, there was no way to tell from the CLI which capacity class a job was scheduled on — the last of the spot-support gaps in the train views.

## How

Each job returned by the jobs API already carries `availability_model` (`"spot"` / `"dedicated"`, serialized by `TrainingJobV1` on the backend). This PR maps it to a human-readable label via a small `_format_capacity_type` helper:

- `spot` → `Spot`
- `dedicated` → `On-demand` (matching the backend's "dedicated = non-preemptible on-demand capacity" definition)
- absent/null (predates the field) → `On-demand`
- any unknown future value → title-cased, rather than dropped

This is a **client-only** change — no backend work required.

## Example

```
                              Active Training Jobs
│ Job ID │ Job Name │ Project │ Status               │ Instance Type │ Capacity Type │ ...
│ j1     │ sft-run  │ llama   │ TRAINING_JOB_RUNNING │ H100          │ Spot          │ ...
│ j3     │ old-run  │ llama   │ TRAINING_JOB_RUNNING │ A10G          │ On-demand     │ ...
```

## Testing

- New unit tests for `_format_capacity_type` (spot/dedicated/absent/unknown) and for the rendered `Capacity Type` column in both the queued and active tables.
- `uv run pytest truss/tests/cli/train/test_train_cli_core.py` → 17 passed (rebased on latest `main`).

Coverage is happy-path plus the field-absent and unknown-value branches. The realistic values come from the backend's `V1AvailabilityModel` enum (`backend/training/services.py`), which only ever serializes `dedicated` or `spot`; the unknown-value case is deliberately adversarial, guarding against a future enum member the client hasn't shipped support for yet.

## Context

Closes the CLI-visibility work for TRN-1280. The sibling gap called out when this PR was first opened — `truss train capacity view` showing a single `Usage` number — has since shipped: backend `#23291` (splits usage into dedicated vs spot) and truss `#2547` (On-Demand / Spot columns). This PR is the remaining piece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
