### PR TITLE
Add per-stage load telemetry to the model server (RUN-544)

### DIFF
--- a/truss/templates/server/load_telemetry.py
+++ b/truss/templates/server/load_telemetry.py
@@ -1,0 +1,136 @@
+"""Per-stage timing and torch introspection for model load.
+
+Breaks the opaque model.load() time into named stages (weights, imports,
+init, load) plus torch compile / GPU-memory attribution, emitted as one
+structured log line and OTel spans. See the "Profile container_ready
+portion of GPU Cold Start" project (RUN-544).
+
+Two invariants:
+
+- Telemetry is write-only: any internal failure degrades to missing
+  fields and a warning, never to a failed or slower load.
+- torch is never imported here. It is looked up in sys.modules, so it is
+  only observed when the customer's own code already imported it; models
+  without torch pay nothing, and the server does not spend seconds
+  importing torch on their behalf.
+"""
+
+import contextlib
+import json
+import logging
+import sys
+import time
+from typing import Dict, Iterator, Optional
+
+import opentelemetry.sdk.trace as sdk_trace
+
+
+class LoadTelemetry:
+    """Times the stages of ModelWrapper._load_impl and snapshots torch
+    compile/CUDA state around the customer's load()."""
+
+    def __init__(self, logger: logging.Logger, tracer: sdk_trace.Tracer) -> None:
+        self._logger = logger
+        self._tracer = tracer
+        self._stage_ms: Dict[str, float] = {}
+        self._pre_load_compile_s: Optional[float] = None
+        self._pre_load_gpu_mem_bytes: Optional[int] = None
+
+    @contextlib.contextmanager
+    def stage(self, name: str) -> Iterator[None]:
+        """Times a stage of the load path; also emits it as a span so the
+        breakdown reaches the trace pipeline when tracing is enabled."""
+        start = time.perf_counter()
+        with self._tracer.start_as_current_span(f"load-{name}"):
+            try:
+                yield
+            finally:
+                self._stage_ms[name] = _round_ms(time.perf_counter() - start)
+
+    def snapshot_before_model_load(self) -> None:
+        """Captures torch compile/GPU baselines right before the customer's
+        load() so finalize() can attribute deltas to it. The customer's
+        module imports have already run by this point, so torch (if used)
+        is importable state we can observe."""
+        try:
+            self._pre_load_compile_s = _torch_compile_seconds()
+            self._pre_load_gpu_mem_bytes = _gpu_memory_allocated_bytes()
+        except Exception:
+            self._logger.warning(
+                "load telemetry: pre-load snapshot failed", exc_info=True
+            )
+
+    def finalize(self, total_ms: float) -> None:
+        """Emits the load breakdown as a single structured log line."""
+        try:
+            fields: Dict[str, object] = dict(self._stage_ms)
+            fields["load_total_ms"] = round(total_ms, 1)
+
+            compile_s = _torch_compile_seconds()
+            if compile_s is not None:
+                fields["torch_compile_ms"] = _round_ms(
+                    compile_s - (self._pre_load_compile_s or 0.0)
+                )
+
+            gpu_mem_bytes = _gpu_memory_allocated_bytes()
+            if gpu_mem_bytes is not None:
+                fields["gpu_mem_allocated_gb"] = round(gpu_mem_bytes / 1024**3, 2)
+                if self._pre_load_gpu_mem_bytes is not None:
+                    fields["gpu_mem_delta_gb"] = round(
+                        (gpu_mem_bytes - self._pre_load_gpu_mem_bytes) / 1024**3, 2
+                    )
+
+            attributed_ms = sum(self._stage_ms.values())
+            fields["unattributed_ms"] = round(max(total_ms - attributed_ms, 0.0), 1)
+
+            self._logger.info(
+                f"model load telemetry: {json.dumps(fields, sort_keys=True)}"
+            )
+        except Exception:
+            self._logger.warning("load telemetry: finalize failed", exc_info=True)
+
+
+def _round_ms(seconds: float) -> float:
+    return round(seconds * 1000, 1)
+
+
+def _torch_compile_seconds() -> Optional[float]:
+    """Total torch.compile backend wall time observed so far, or None when
+    torch dynamo is absent.
+
+    compilation_time_metrics is a semi-private dict of phase name -> list
+    of durations whose keys have moved across torch versions, so everything
+    is feature-detected. Frame-level phases bound total compile wall time;
+    nested phases would double count, hence the preferred-key ladder with a
+    max-of-sums fallback rather than a grand total.
+    """
+    dynamo_utils = sys.modules.get("torch._dynamo.utils")
+    if dynamo_utils is None:
+        return None
+    metrics = getattr(dynamo_utils, "compilation_time_metrics", None)
+    if not isinstance(metrics, dict):
+        return None
+    if not metrics:
+        return 0.0
+    for frame_level_key in ("entire_frame_compile", "_compile.compile_inner"):
+        durations = metrics.get(frame_level_key)
+        if durations:
+            return float(sum(durations))
+    return float(max((sum(v) for v in metrics.values() if v), default=0.0))
+
+
+def _gpu_memory_allocated_bytes() -> Optional[int]:
+    """Total CUDA memory allocated by torch across devices, or None when
+    unobservable. Only reads state when CUDA is already initialized —
+    memory_allocated() on an uninitialized runtime would trigger CUDA init,
+    and telemetry must never alter load behavior."""
+    torch = sys.modules.get("torch")
+    if torch is None:
+        return None
+    try:
+        cuda = torch.cuda
+        if not cuda.is_initialized():
+            return None
+        return int(sum(cuda.memory_allocated(i) for i in range(cuda.device_count())))
+    except Exception:
+        return None

--- a/truss/templates/server/load_telemetry.py
+++ b/truss/templates/server/load_telemetry.py
@@ -35,6 +35,8 @@ class LoadTelemetry:
         self._stage_ms: Dict[str, float] = {}
         self._pre_load_compile_s: Optional[float] = None
         self._pre_load_gpu_mem_bytes: Optional[int] = None
+        self._pre_load_compile_phases: Dict[str, float] = {}
+        self._pre_load_counters: Dict[str, int] = {}
 
     @contextlib.contextmanager
     def stage(self, name: str) -> Iterator[None]:
@@ -55,6 +57,8 @@ class LoadTelemetry:
         try:
             self._pre_load_compile_s = _torch_compile_seconds()
             self._pre_load_gpu_mem_bytes = _gpu_memory_allocated_bytes()
+            self._pre_load_compile_phases = _torch_compile_phase_seconds()
+            self._pre_load_counters = _torch_compile_counters()
         except Exception:
             self._logger.warning(
                 "load telemetry: pre-load snapshot failed", exc_info=True
@@ -71,6 +75,26 @@ class LoadTelemetry:
                 fields["torch_compile_ms"] = _round_ms(
                     compile_s - (self._pre_load_compile_s or 0.0)
                 )
+                phases = _torch_compile_phase_seconds()
+                phase_delta = {
+                    name: _round_ms(s - self._pre_load_compile_phases.get(name, 0.0))
+                    for name, s in phases.items()
+                    if s - self._pre_load_compile_phases.get(name, 0.0) > 0.001
+                }
+                if phase_delta:
+                    # Top phases only: the full ledger can hold dozens of
+                    # nested entries and the line must stay small.
+                    fields["torch_compile_phases_ms"] = dict(
+                        sorted(phase_delta.items(), key=lambda kv: -kv[1])[
+                            :MAX_COMPILE_PHASES
+                        ]
+                    )
+                counter_delta = {
+                    name: count - self._pre_load_counters.get(name, 0)
+                    for name, count in _torch_compile_counters().items()
+                    if count - self._pre_load_counters.get(name, 0) > 0
+                }
+                fields.update(counter_delta)
 
             gpu_mem_bytes = _gpu_memory_allocated_bytes()
             if gpu_mem_bytes is not None:
@@ -88,6 +112,10 @@ class LoadTelemetry:
             )
         except Exception:
             self._logger.warning("load telemetry: finalize failed", exc_info=True)
+
+
+# Bound the per-phase compile breakdown so the log line stays small.
+MAX_COMPILE_PHASES = 5
 
 
 def _round_ms(seconds: float) -> float:
@@ -117,6 +145,54 @@ def _torch_compile_seconds() -> Optional[float]:
         if durations:
             return float(sum(durations))
     return float(max((sum(v) for v in metrics.values() if v), default=0.0))
+
+
+def _torch_compile_phase_seconds() -> Dict[str, float]:
+    """Per-phase compile wall time (dynamo tracing vs inductor codegen vs
+    autotuning, key names vary by torch version), from the same semi-private
+    ledger as _torch_compile_seconds. Empty when dynamo is absent."""
+    dynamo_utils = sys.modules.get("torch._dynamo.utils")
+    metrics = getattr(dynamo_utils, "compilation_time_metrics", None)
+    if not isinstance(metrics, dict):
+        return {}
+    out: Dict[str, float] = {}
+    for name, durations in metrics.items():
+        try:
+            out[str(name)] = float(sum(durations))
+        except (TypeError, ValueError):
+            continue
+    return out
+
+
+def _torch_compile_counters() -> Dict[str, int]:
+    """Compile-health counts from dynamo's counters, normalized to flat
+    fields. Answers *why* a compile was slow: how many distinct graphs, how
+    many graph breaks (each break splits the graph and recompiles), and
+    whether the inductor FX-graph cache hit — a miss means the compile was
+    recomputed from scratch, i.e. persistent compile caching is not working
+    for this model."""
+    dynamo_utils = sys.modules.get("torch._dynamo.utils")
+    counters = getattr(dynamo_utils, "counters", None)
+    if counters is None:
+        return {}
+    out: Dict[str, int] = {}
+    try:
+        stats = counters["stats"]
+        if "unique_graphs" in stats:
+            out["torch_unique_graphs"] = int(stats["unique_graphs"])
+        graph_breaks = counters["graph_break"]
+        if graph_breaks:
+            out["torch_graph_breaks"] = int(sum(graph_breaks.values()))
+        inductor = counters["inductor"]
+        for key, field in (
+            ("fxgraph_cache_hit", "torch_fx_cache_hits"),
+            ("fxgraph_cache_miss", "torch_fx_cache_misses"),
+        ):
+            if key in inductor:
+                out[field] = int(inductor[key])
+    except (TypeError, KeyError):
+        pass
+    return out
 
 
 def _gpu_memory_allocated_bytes() -> Optional[int]:

--- a/truss/templates/server/load_telemetry.py
+++ b/truss/templates/server/load_telemetry.py
@@ -18,8 +18,10 @@ Two invariants:
 import contextlib
 import json
 import logging
+import os
 import sys
 import time
+from pathlib import Path
 from typing import Dict, Iterator, Optional
 
 import opentelemetry.sdk.trace as sdk_trace
@@ -33,6 +35,7 @@ class LoadTelemetry:
         self._logger = logger
         self._tracer = tracer
         self._stage_ms: Dict[str, float] = {}
+        self._load_start_epoch_s = time.time()
         self._pre_load_compile_s: Optional[float] = None
         self._pre_load_gpu_mem_bytes: Optional[int] = None
         self._pre_load_compile_phases: Dict[str, float] = {}
@@ -106,6 +109,16 @@ class LoadTelemetry:
 
             attributed_ms = sum(self._stage_ms.values())
             fields["unattributed_ms"] = round(max(total_ms - attributed_ms, 0.0), 1)
+
+            process_start_s = _process_start_epoch_seconds()
+            if process_start_s is not None:
+                # Interpreter start + server imports + startup code before
+                # load() began. For standard truss images the server process
+                # is the container entrypoint, so this approximates
+                # container start -> load start.
+                fields["server_boot_ms"] = _round_ms(
+                    max(self._load_start_epoch_s - process_start_s, 0.0)
+                )
 
             self._logger.info(
                 f"model load telemetry: {json.dumps(fields, sort_keys=True)}"
@@ -193,6 +206,23 @@ def _torch_compile_counters() -> Dict[str, int]:
     except (TypeError, KeyError):
         pass
     return out
+
+
+def _process_start_epoch_seconds(proc_root: Path = Path("/proc")) -> Optional[float]:
+    """Wall-clock time this process started, from /proc (Linux only; None
+    elsewhere). starttime in /proc/self/stat is in clock ticks since boot;
+    boot time is now minus /proc/uptime."""
+    try:
+        stat = (proc_root / "self" / "stat").read_text()
+        # comm (field 2) can contain spaces/parens; fields resume after the
+        # last ')'. starttime is overall field 22 -> index 19 after comm.
+        after_comm = stat.rsplit(")", 1)[1].split()
+        starttime_ticks = float(after_comm[19])
+        uptime_s = float((proc_root / "uptime").read_text().split()[0])
+        boot_epoch_s = time.time() - uptime_s
+        return boot_epoch_s + starttime_ticks / os.sysconf("SC_CLK_TCK")
+    except Exception:
+        return None
 
 
 def _gpu_memory_allocated_bytes() -> Optional[int]:

--- a/truss/templates/server/model_wrapper.py
+++ b/truss/templates/server/model_wrapper.py
@@ -32,6 +32,7 @@ from _truss_shared.lazy_data_resolver import LazyDataResolverV2
 from _truss_shared.secrets_resolver import SecretsResolver
 from anyio import Semaphore, to_thread
 from fastapi import HTTPException, WebSocket
+from load_telemetry import LoadTelemetry
 from opentelemetry import trace
 
 MODEL_BASENAME = "model"
@@ -459,39 +460,43 @@ class ModelWrapper:
         with self._load_lock:
             self._status = ModelWrapper.Status.LOADING
             self._logger.info("Executing model.load()...")
+            telemetry = LoadTelemetry(self._logger, self._tracer)
             try:
                 start_time = time.perf_counter()
-                self._load_impl()
+                self._load_impl(telemetry)
                 self._status = ModelWrapper.Status.READY
                 self._logger.info(
                     f"Completed model.load() execution in {_elapsed_ms(start_time)} ms"
                 )
+                telemetry.finalize(_elapsed_ms(start_time))
             except Exception:
                 self._logger.exception("Exception while loading model")
                 self._status = ModelWrapper.Status.FAILED
 
-    def _load_impl(self):
-        data_dir = Path("data")
-        data_dir.mkdir(exist_ok=True)
+    def _load_impl(self, telemetry: LoadTelemetry):
+        with telemetry.stage("setup"):
+            data_dir = Path("data")
+            data_dir.mkdir(exist_ok=True)
 
-        if "bundled_packages_dir" in self._config:
-            bundled_packages_path = Path("/packages")
-            if bundled_packages_path.exists():
-                sys.path.append(str(bundled_packages_path))
+            if "bundled_packages_dir" in self._config:
+                bundled_packages_path = Path("/packages")
+                if bundled_packages_path.exists():
+                    sys.path.append(str(bundled_packages_path))
 
-        secrets = SecretsResolver.get_secrets(self._config)
-        lazy_data_resolver = LazyDataResolverV2(data_dir)
+            secrets = SecretsResolver.get_secrets(self._config)
+            lazy_data_resolver = LazyDataResolverV2(data_dir)
 
-        apply_patches(
-            self._config.get("apply_library_patches", True),
-            self._config["requirements"],
-        )
+            apply_patches(
+                self._config.get("apply_library_patches", True),
+                self._config["requirements"],
+            )
 
-        extensions = _init_extensions(
-            self._config, data_dir, secrets, lazy_data_resolver
-        )
-        for extension in extensions.values():
-            extension.load()
+        with telemetry.stage("extensions_load"):
+            extensions = _init_extensions(
+                self._config, data_dir, secrets, lazy_data_resolver
+            )
+            for extension in extensions.values():
+                extension.load()
 
         model_class_file_path = (
             Path(self._config["model_module_dir"])
@@ -514,7 +519,10 @@ class ModelWrapper:
                 raise ImportError(import_error_msg)
             module = importlib.util.module_from_spec(spec)
             try:
-                spec.loader.exec_module(module)
+                # The customer's model.py imports run here — for torch
+                # models this stage is dominated by `import torch` etc.
+                with telemetry.stage("import_model_module"):
+                    spec.loader.exec_module(module)
             except ImportError as e:
                 if "attempted relative import" in str(e):
                     raise ImportError(
@@ -536,29 +544,34 @@ class ModelWrapper:
             for ext_name, ext in extensions.items():
                 if _signature_accepts_keyword_arg(signature, ext_name):
                     model_init_params[ext_name] = ext.model_args()
-            self._maybe_model = model_class(**model_init_params)
+            with telemetry.stage("model_init"):
+                self._maybe_model = model_class(**model_init_params)
 
         elif TRT_LLM_EXTENSION_NAME in extensions:
             self._logger.info("Loading TRT LLM extension as model.")
             # trt_llm extension allows model.py to be absent. It supplies its
             # own model class in that case.
             trt_llm_extension = extensions["trt_llm"]
-            self._maybe_model = trt_llm_extension.model_override()
+            with telemetry.stage("model_init"):
+                self._maybe_model = trt_llm_extension.model_override()
         else:
             raise RuntimeError("No module class file found")
 
         self._maybe_model_descriptor = ModelDescriptor.from_model(self._model)
 
         if self._maybe_model_descriptor.setup_environment:
-            self._initialize_environment_before_load()
+            with telemetry.stage("setup_environment"):
+                self._initialize_environment_before_load()
+        telemetry.snapshot_before_model_load()
         if hasattr(self._model, "load"):
-            retry(
-                self._model.load,
-                NUM_LOAD_RETRIES,
-                self._logger.warning,
-                "Failed to load model.",
-                gap_seconds=1.0,
-            )
+            with telemetry.stage("model_load"):
+                retry(
+                    self._model.load,
+                    NUM_LOAD_RETRIES,
+                    self._logger.warning,
+                    "Failed to load model.",
+                    gap_seconds=1.0,
+                )
         lazy_data_resolver.raise_if_not_collected()
 
     def setup_polling_for_environment_updates(self):

--- a/truss/tests/templates/server/test_load_telemetry.py
+++ b/truss/tests/templates/server/test_load_telemetry.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 import sys
 import time
 from pathlib import Path
@@ -219,10 +220,10 @@ def test_torch_compile_phase_list_is_bounded(
     assert set(phases) == {f"phase_{i}" for i in range(15, 20)}
 
 
+@pytest.mark.skipif(
+    not hasattr(os, "sysconf"), reason="os.sysconf unavailable (Windows)"
+)
 def test_process_start_epoch_from_fake_proc(load_telemetry, tmp_path):
-    import os
-    import time
-
     # Fake /proc: booted 1000s ago, process started 250 ticks after boot.
     hz = os.sysconf("SC_CLK_TCK")
     (tmp_path / "self").mkdir()

--- a/truss/tests/templates/server/test_load_telemetry.py
+++ b/truss/tests/templates/server/test_load_telemetry.py
@@ -152,3 +152,68 @@ def test_finalize_never_raises(load_telemetry, monkeypatch, caplog):
     telemetry.finalize(total_ms=100.0)  # must not raise
 
     assert any("finalize failed" in r.message for r in caplog.records)
+
+
+def test_torch_compile_phase_breakdown_and_counters(
+    telemetry_and_log, load_telemetry, monkeypatch
+):
+    from collections import Counter, defaultdict
+
+    telemetry, emitted_fields = telemetry_and_log
+    counters = defaultdict(Counter)
+    counters["stats"]["unique_graphs"] = 2
+    counters["inductor"]["fxgraph_cache_miss"] = 2
+    dynamo_utils = SimpleNamespace(
+        compilation_time_metrics={
+            "entire_frame_compile": [1.0],
+            "inductor_compile": [0.6],
+        },
+        counters=counters,
+    )
+    monkeypatch.setitem(sys.modules, "torch._dynamo.utils", dynamo_utils)
+
+    telemetry.snapshot_before_model_load()
+    # load() compiles two more graphs: one cache hit, one miss, one break.
+    dynamo_utils.compilation_time_metrics["entire_frame_compile"] += [2.0, 8.0]
+    dynamo_utils.compilation_time_metrics["inductor_compile"].append(7.5)
+    dynamo_utils.compilation_time_metrics["autotuning"] = [4.0]
+    counters["stats"]["unique_graphs"] = 4
+    counters["graph_break"]["data-dependent branch"] += 1
+    counters["inductor"]["fxgraph_cache_hit"] = 1
+    counters["inductor"]["fxgraph_cache_miss"] = 3
+
+    telemetry.finalize(total_ms=20000.0)
+    fields = emitted_fields()
+
+    # Deltas, not absolutes: pre-load compile state is excluded.
+    assert fields["torch_compile_ms"] == 10000.0
+    assert fields["torch_compile_phases_ms"] == {
+        "entire_frame_compile": 10000.0,
+        "inductor_compile": 7500.0,
+        "autotuning": 4000.0,
+    }
+    assert fields["torch_unique_graphs"] == 2
+    assert fields["torch_graph_breaks"] == 1
+    assert fields["torch_fx_cache_hits"] == 1
+    assert fields["torch_fx_cache_misses"] == 1
+
+
+def test_torch_compile_phase_list_is_bounded(
+    telemetry_and_log, load_telemetry, monkeypatch
+):
+    telemetry, emitted_fields = telemetry_and_log
+    dynamo_utils = SimpleNamespace(
+        compilation_time_metrics={f"phase_{i}": [] for i in range(1, 20)}
+    )
+    monkeypatch.setitem(sys.modules, "torch._dynamo.utils", dynamo_utils)
+
+    telemetry.snapshot_before_model_load()
+    for i, name in enumerate(dynamo_utils.compilation_time_metrics, start=1):
+        dynamo_utils.compilation_time_metrics[name].append(float(i))
+    telemetry.finalize(total_ms=100.0)
+
+    fields = emitted_fields()
+    phases = fields["torch_compile_phases_ms"]
+    # The emitted line keeps only the top N phases by duration.
+    assert len(phases) == load_telemetry.MAX_COMPILE_PHASES
+    assert set(phases) == {f"phase_{i}" for i in range(15, 20)}

--- a/truss/tests/templates/server/test_load_telemetry.py
+++ b/truss/tests/templates/server/test_load_telemetry.py
@@ -217,3 +217,40 @@ def test_torch_compile_phase_list_is_bounded(
     # The emitted line keeps only the top N phases by duration.
     assert len(phases) == load_telemetry.MAX_COMPILE_PHASES
     assert set(phases) == {f"phase_{i}" for i in range(15, 20)}
+
+
+def test_process_start_epoch_from_fake_proc(load_telemetry, tmp_path):
+    import os
+    import time
+
+    # Fake /proc: booted 1000s ago, process started 250 ticks after boot.
+    hz = os.sysconf("SC_CLK_TCK")
+    (tmp_path / "self").mkdir()
+    stat_fields = ["x"] * 52
+    stat_fields[21] = str(250 * hz)  # process started 250s after boot
+    (tmp_path / "self" / "stat").write_text(
+        "42 (model (server)) " + " ".join(stat_fields[2:])
+    )
+    (tmp_path / "uptime").write_text("1000.0 800.0\n")
+
+    start = load_telemetry._process_start_epoch_seconds(proc_root=tmp_path)
+    expected = time.time() - 1000.0 + 250.0
+    assert start == pytest.approx(expected, abs=2.0)
+
+
+def test_process_start_none_when_proc_absent(load_telemetry, tmp_path):
+    assert (
+        load_telemetry._process_start_epoch_seconds(proc_root=tmp_path / "nope") is None
+    )
+
+
+def test_server_boot_ms_emitted(telemetry_and_log, load_telemetry, monkeypatch):
+    telemetry, emitted_fields = telemetry_and_log
+    # Process started 3.5s before LoadTelemetry was constructed.
+    monkeypatch.setattr(
+        load_telemetry,
+        "_process_start_epoch_seconds",
+        lambda: telemetry._load_start_epoch_s - 3.5,
+    )
+    telemetry.finalize(total_ms=100.0)
+    assert emitted_fields()["server_boot_ms"] == pytest.approx(3500.0, abs=1.0)

--- a/truss/tests/templates/server/test_load_telemetry.py
+++ b/truss/tests/templates/server/test_load_telemetry.py
@@ -1,0 +1,154 @@
+import json
+import logging
+import sys
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+import opentelemetry.sdk.trace as sdk_trace
+import pytest
+
+
+@pytest.fixture
+def load_telemetry():
+    server_dir = Path(__file__).resolve().parents[3] / "templates" / "server"
+    sys.path.insert(0, str(server_dir))
+    try:
+        import load_telemetry
+
+        yield load_telemetry
+    finally:
+        sys.path.remove(str(server_dir))
+
+
+@pytest.fixture
+def telemetry_and_log(load_telemetry, caplog):
+    caplog.set_level(logging.INFO, logger="test_load_telemetry")
+    logger = logging.getLogger("test_load_telemetry")
+    tracer = sdk_trace.TracerProvider().get_tracer(__name__)
+    telemetry = load_telemetry.LoadTelemetry(logger, tracer)
+
+    def emitted_fields() -> dict:
+        lines = [
+            r.message for r in caplog.records if "model load telemetry:" in r.message
+        ]
+        assert len(lines) == 1, f"expected one telemetry line, got {lines}"
+        return json.loads(lines[0].split("model load telemetry:", 1)[1])
+
+    return telemetry, emitted_fields
+
+
+def test_stages_and_unattributed_time(telemetry_and_log):
+    telemetry, emitted_fields = telemetry_and_log
+
+    with telemetry.stage("setup"):
+        time.sleep(0.02)
+    with telemetry.stage("model_load"):
+        time.sleep(0.05)
+    telemetry.finalize(total_ms=100.0)
+
+    fields = emitted_fields()
+    assert fields["setup"] >= 20
+    assert fields["model_load"] >= 50
+    assert fields["load_total_ms"] == 100.0
+    # unattributed = total - sum(stages); never negative
+    assert 0 <= fields["unattributed_ms"] <= 100 - 70
+    assert "torch_compile_ms" not in fields, "no torch imported -> no compile field"
+    assert "gpu_mem_allocated_gb" not in fields
+
+
+def test_stage_exception_still_records_duration_and_propagates(telemetry_and_log):
+    telemetry, _ = telemetry_and_log
+    with pytest.raises(RuntimeError):
+        with telemetry.stage("model_load"):
+            raise RuntimeError("customer load failed")
+    assert "model_load" in telemetry._stage_ms
+
+
+def test_torch_compile_delta_attributed_to_load(
+    telemetry_and_log, load_telemetry, monkeypatch
+):
+    telemetry, emitted_fields = telemetry_and_log
+    dynamo_utils = SimpleNamespace(
+        compilation_time_metrics={"entire_frame_compile": [1.0]}
+    )
+    monkeypatch.setitem(sys.modules, "torch._dynamo.utils", dynamo_utils)
+
+    # 1.0s of compile happened before load (e.g. during imports); snapshot it.
+    telemetry.snapshot_before_model_load()
+    # load() triggers 2.5s more compilation.
+    dynamo_utils.compilation_time_metrics["entire_frame_compile"].append(2.5)
+    telemetry.finalize(total_ms=5000.0)
+
+    assert emitted_fields()["torch_compile_ms"] == 2500.0
+
+
+def test_torch_compile_fallback_key_ladder(load_telemetry, monkeypatch):
+    # Unknown frame-level keys: fall back to max-of-sums, never a double
+    # counting grand total.
+    dynamo_utils = SimpleNamespace(
+        compilation_time_metrics={"phase_a": [1.0, 2.0], "phase_b": [0.5]}
+    )
+    monkeypatch.setitem(sys.modules, "torch._dynamo.utils", dynamo_utils)
+    assert load_telemetry._torch_compile_seconds() == 3.0
+
+
+def test_gpu_memory_only_read_when_cuda_initialized(load_telemetry, monkeypatch):
+    fake_torch = SimpleNamespace(
+        cuda=SimpleNamespace(
+            is_initialized=lambda: False,
+            memory_allocated=lambda i: pytest.fail(
+                "memory_allocated must not be called when CUDA is uninitialized "
+                "(it would trigger CUDA init)"
+            ),
+            device_count=lambda: 1,
+        )
+    )
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+    assert load_telemetry._gpu_memory_allocated_bytes() is None
+
+    fake_torch.cuda = SimpleNamespace(
+        is_initialized=lambda: True,
+        memory_allocated=lambda i: 2 * 1024**3,
+        device_count=lambda: 2,
+    )
+    assert load_telemetry._gpu_memory_allocated_bytes() == 4 * 1024**3
+
+
+def test_gpu_memory_delta_attributed_to_load(
+    telemetry_and_log, load_telemetry, monkeypatch
+):
+    telemetry, emitted_fields = telemetry_and_log
+    allocated = {"value": 1 * 1024**3}
+    fake_torch = SimpleNamespace(
+        cuda=SimpleNamespace(
+            is_initialized=lambda: True,
+            memory_allocated=lambda i: allocated["value"],
+            device_count=lambda: 1,
+        )
+    )
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+
+    telemetry.snapshot_before_model_load()
+    allocated["value"] = 72 * 1024**3
+    telemetry.finalize(total_ms=1000.0)
+
+    fields = emitted_fields()
+    assert fields["gpu_mem_allocated_gb"] == 72.0
+    assert fields["gpu_mem_delta_gb"] == 71.0
+
+
+def test_finalize_never_raises(load_telemetry, monkeypatch, caplog):
+    caplog.set_level(logging.WARNING, logger="test_load_telemetry")
+    logger = logging.getLogger("test_load_telemetry")
+    tracer = sdk_trace.TracerProvider().get_tracer(__name__)
+    telemetry = load_telemetry.LoadTelemetry(logger, tracer)
+    monkeypatch.setattr(
+        load_telemetry,
+        "_torch_compile_seconds",
+        lambda: (_ for _ in ()).throw(RuntimeError("introspection broke")),
+    )
+
+    telemetry.finalize(total_ms=100.0)  # must not raise
+
+    assert any("finalize failed" in r.message for r in caplog.records)

--- a/truss/tests/templates/server/test_truss_server.py
+++ b/truss/tests/templates/server/test_truss_server.py
@@ -320,6 +320,11 @@ def test_load_emits_load_telemetry_line(app_path, monkeypatch, caplog):
         SimpleNamespace(compilation_time_metrics={"entire_frame_compile": [1.5]}),
     )
 
+    # Earlier tests may have applied the server's dictConfig (e.g. via the
+    # control app), which sets the "uvicorn" logger to propagate=False —
+    # caplog captures at the root logger, so restore propagation for this test.
+    monkeypatch.setattr(logging.getLogger("uvicorn"), "propagate", True)
+
     with _clear_truss_server_modules(), _change_directory(app_path):
         model_wrapper_module = importlib.import_module("model_wrapper")
         config = yaml.safe_load((app_path / "config.yaml").read_text())

--- a/truss/tests/templates/server/test_truss_server.py
+++ b/truss/tests/templates/server/test_truss_server.py
@@ -301,3 +301,55 @@ def _is_port_available(port):
     except socket.error:
         # Port is already in use
         return False
+
+
+def test_load_emits_load_telemetry_line(app_path, monkeypatch, caplog):
+    """End-to-end through the real server load path: ModelWrapper.load()
+    against the fixture truss must emit the structured load-telemetry line
+    with per-stage timings — and the torch introspection must run (and
+    degrade cleanly) via sys.modules without torch installed."""
+    import logging
+    from types import SimpleNamespace
+
+    # Fake dynamo present before load: the wrapper must read it via
+    # sys.modules (never import torch) and emit compile fields. Pre-seeded
+    # state means the load-attributed delta is exactly zero.
+    monkeypatch.setitem(
+        sys.modules,
+        "torch._dynamo.utils",
+        SimpleNamespace(compilation_time_metrics={"entire_frame_compile": [1.5]}),
+    )
+
+    with _clear_truss_server_modules(), _change_directory(app_path):
+        model_wrapper_module = importlib.import_module("model_wrapper")
+        config = yaml.safe_load((app_path / "config.yaml").read_text())
+        wrapper = model_wrapper_module.ModelWrapper(
+            config, sdk_trace.TracerProvider().get_tracer(__name__)
+        )
+        with caplog.at_level(logging.INFO, logger="uvicorn"):
+            wrapper.load()
+
+    assert wrapper.ready, "fixture model must load successfully"
+    lines = [r.message for r in caplog.records if "model load telemetry:" in r.message]
+    assert len(lines) == 1, f"expected exactly one telemetry line, got {lines}"
+    fields = json.loads(lines[0].split("model load telemetry:", 1)[1])
+
+    # Real stage timings from the real load path.
+    for stage in ("setup", "import_model_module", "model_init", "model_load"):
+        assert stage in fields, f"missing stage {stage} in {fields}"
+        assert fields[stage] >= 0
+    assert (
+        fields["load_total_ms"]
+        >= sum(
+            fields[s]
+            for s in ("setup", "import_model_module", "model_init", "model_load")
+        )
+        - 1
+    )  # rounding slack
+    assert fields["unattributed_ms"] >= 0
+
+    # torch fields present via the sys.modules path; pre-seeded compile
+    # state is excluded from the load-attributed delta.
+    assert fields["torch_compile_ms"] == 0.0
+    # No CUDA in the test environment: GPU fields must be absent, not fake.
+    assert "gpu_mem_allocated_gb" not in fields


### PR DESCRIPTION
## :rocket: What

Breaks the opaque `model.load()` time into named, machine-readable stages, emitted once per model load as a structured log line (`model load telemetry: {...}`) and per-stage OTel spans — with zero customer code changes:

- `server_boot_ms` — process start → load start (interpreter + server imports), recovered from `/proc/self/stat`
- Stage timings: `setup`, `extensions_load` (incl. TRT-LLM), `import_model_module` (customer imports — where `import torch` lands), `model_init`, `setup_environment`, `model_load`
- torch compile attribution: `torch_compile_ms` (Dynamo ledger diffed around `load()`), `torch_compile_phases_ms` (top-5 phases), `torch_unique_graphs`, `torch_graph_breaks`, `torch_fx_cache_hits`/`_misses` (is persistent compile caching actually working?)
- `gpu_mem_allocated_gb` / `gpu_mem_delta_gb` — weights→GPU footprint
- `unattributed_ms` — total minus the sum of stages, the honesty bucket

Context: reconstruction of the fleet's worst `container_ready` cold starts (Linear: RUN-544, "Profile container_ready portion of GPU Cold Start") showed 62–91% of the worst cases is deterministic recompute (compile/warmup) — visible today only via fragile per-framework log mining. This gives every truss model a first-party breakdown.

## :computer: How

A `LoadTelemetry` context manager (`load_telemetry.py`) wraps the stages of `ModelWrapper._load_impl` and snapshots torch state before/after the customer's `load()`. Design invariants, each pinned by a test:

- **Telemetry is write-only**: internal failures degrade to missing fields + a warning, never a failed or slower load.
- **torch is never imported by the server**: it is read from `sys.modules`, so it is only observed when the customer's code already imported it. Non-torch models pay nothing.
- **`torch.compile()` is lazy** (compilation happens at first forward), so compile time is read from Dynamo's `compilation_time_metrics` ledger, snapshotted before `load()` and diffed after — feature-detected because the API is semi-private and has moved across torch versions.
- **GPU memory is only read when CUDA is already initialized**, because `memory_allocated()` would otherwise trigger CUDA init.

Cost: microseconds of clock reads + one <1 KB log line per cold start; predict path untouched; spans go through the existing (default no-op) tracer.

## :microscope: Testing

- 12 unit tests (`test_load_telemetry.py`): stage/`unattributed` arithmetic, compile-delta attribution incl. the pre-seeded-exclusion boundary, version-fallback key ladder, phase-list bounding, counter deltas, CUDA-init guard, `/proc` parsing (incl. parens-in-comm), finalize-never-raises.
- Server-level integration test (`test_truss_server.py::test_load_emits_load_telemetry_line`): real `ModelWrapper.load()` against the fixture truss → exactly one parseable line, real stage timings, torch fields via `sys.modules` without torch installed, GPU fields absent (not fabricated) without CUDA.
- Real-torch end-to-end: built the serving image locally from this branch (`TrussHandle.build_serving_docker_image`) with a probe model whose `load()` runs `torch.compile` over 3 input shapes. Observed line matched all predictions: `torch_unique_graphs: 3`, `torch_fx_cache_misses: 3`, `torch_compile_ms: 3839.6` with real Dynamo phase keys, `load_total_ms` exactly equal to the legacy "Completed model.load() in N ms" value, `unattributed_ms: 0.0`.
- Full `truss/tests/templates/server` suite green (49 tests); ruff clean.

## Notes for review

- The telemetry line is on the customer-visible log stream (deliberate — customers see their own load breakdown), landing right after "Completed model.load() execution in N ms".
- Open question: the telemetry JSON is nested inside the log record's `message`, so Loki-side extraction needs `regexp` rather than `| json`. Happy to flatten fields to the top level of the record in this PR if preferred.
- Deployed-image verification note: `truss push` builds with the released context builder, so this change reaches deployments only via a release — verified via the local image build instead; a staged probe model exists for post-release rollout verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)