### PR TITLE
fix(image_builder): fold nginx default-site removal into install layer

### DIFF
--- a/truss/templates/server.Dockerfile.jinja
+++ b/truss/templates/server.Dockerfile.jinja
@@ -129,8 +129,10 @@ ENV SERVER_START_CMD={{ config.docker_server.start_command | tojson }}
 ENTRYPOINT ["sh", "-c"]
 CMD [{{ config.docker_server.start_command | tojson }}]
 {%- else %}
+{#- Remove default site (root-only port 80) in the install layer, so no overlayfs whiteout is emitted for it. #}
 RUN {{ apt_cache_mount }}apt-get update -y && apt-get install -y --no-install-recommends \
-        curl nginx{% if not cache_mount_id %} && rm -rf /var/lib/apt/lists/*{% endif %}
+        curl nginx{% if not cache_mount_id %} && rm -rf /var/lib/apt/lists/*{% endif %} \
+        && rm -f /etc/nginx/sites-enabled/default
 COPY --chown={{ default_owner }} ./docker_server_requirements.txt ${APP_HOME}/docker_server_requirements.txt
 
 {# NB(nikhil): Use the same python version for custom server proxy as the control server, for consistency. #}
@@ -144,8 +146,6 @@ COPY --chown={{ default_owner }} ./proxy.conf {{ proxy_config_path }}
 COPY --chown={{ default_owner }} ./supervisord.conf {{ supervisor_config_path }}
 ENV SUPERVISOR_SERVER_URL="{{ supervisor_server_url }}"
 ENV SERVER_START_CMD="/docker_server/.venv/bin/supervisord -c {{ supervisor_config_path }}"
-{#- default configuration uses port 80, which requires root privileges, so we remove it #}
-RUN rm -f /etc/nginx/sites-enabled/default
 {# NB(nikhil): Ensure /dev/shm exists, but we expect this to get overwritten at runtime with volume mounts #}
 RUN mkdir -p /dev/shm
 {#- nginx writes to /var/lib/nginx, /var/log/nginx, /dev/shm, and /run directories #}

--- a/truss/tests/contexts/image_builder/test_serving_image_builder.py
+++ b/truss/tests/contexts/image_builder/test_serving_image_builder.py
@@ -251,6 +251,10 @@ def test_cache_mount_id_enabled_with_system_pkgs_ssh_and_docker_server(
         "--mount=type=cache,id=truss-apt-lib-combo,target=/var/lib/apt,sharing=locked "
         "apt-get update -y && apt-get install -y --no-install-recommends "
     ) in dockerfile
+    # The default-site removal must stay chained into the install RUN (same
+    # layer) so no overlayfs whiteout is emitted for it.
+    assert "&& rm -f /etc/nginx/sites-enabled/default" in dockerfile
+    assert "RUN rm -f /etc/nginx/sites-enabled/default" not in dockerfile
     # docker_server uv install must combine the uv cache mount with
     # `clean_uv_env`, which was extended to forward UV_CACHE_DIR / PIP_CACHE_DIR.
     assert (


### PR DESCRIPTION
Remove `/etc/nginx/sites-enabled/default` in the same `RUN` that installs nginx.

Deleting it in a later layer records an overlayfs whiteout. Some kernel + overlay-on-FUSE combinations mishandle whiteouts (the name is still listed by `readdir`, but `open()` returns `ENOENT`), which breaks nginx's `include /etc/nginx/sites-enabled/*;` and crashes startup. Same-layer removal emits no whiteout; behavior on normal overlayfs is unchanged.

Test: `uv run pytest truss/tests/contexts/image_builder/test_serving_image_builder.py`