### PR TITLE
feat(sidecar): truss CLI changes in support of runtime OIDC

### DIFF
--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -617,6 +617,16 @@ Transport = Annotated[
 ]
 
 
+class OIDC(custom_types.ConfigModel):
+    """Configuration for runtime-mounting of an OIDC bearer token"""
+
+    # NOTE: This field assumes trinary logic: 'true' -> enabled, 'false' -> disabled, 'None' -> default (operator setting)
+    enabled: Optional[bool] = pydantic.Field(
+        default=None,
+        description="If true, mounts an OIDC bearer token for your model to access at runtime.",
+    )
+
+
 class RemoteSSH(custom_types.ConfigModel):
     """Configuration for SSH access to running model instances."""
 
@@ -724,6 +734,12 @@ class Runtime(custom_types.ConfigModel):
         default_factory=HealthChecks,
         description="Custom health check configuration for your deployments.",
     )
+
+    oidc: OIDC = pydantic.Field(
+        default_factory=OIDC,
+        description="Configuration for runtime-mounting of an OIDC bearer token.",
+    )
+
     remote_ssh: RemoteSSH = pydantic.Field(
         default_factory=RemoteSSH,
         description="Configuration for SSH access to running model instances.",

--- a/truss/config.schema.json
+++ b/truss/config.schema.json
@@ -794,6 +794,27 @@
       "title": "ModelServer",
       "type": "string"
     },
+    "OIDC": {
+      "additionalProperties": true,
+      "description": "Configuration for runtime-mounting of an OIDC bearer token",
+      "properties": {
+        "enabled": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "If true, mounts an OIDC bearer token for your model to access at runtime.",
+          "title": "Enabled"
+        }
+      },
+      "title": "OIDC",
+      "type": "object"
+    },
     "RemoteSSH": {
       "additionalProperties": true,
       "description": "Configuration for SSH access to running model instances.",
@@ -942,6 +963,10 @@
         },
         "health_checks": {
           "$ref": "#/$defs/HealthChecks"
+        },
+        "oidc": {
+          "$ref": "#/$defs/OIDC",
+          "description": "Configuration for runtime-mounting of an OIDC bearer token."
         },
         "remote_ssh": {
           "$ref": "#/$defs/RemoteSSH"


### PR DESCRIPTION
Create a new field `runtime.oidc.enabled` in the Truss `config.yaml` in support of runtime OIDC.