### PR TITLE
fix(server): decode byte chunks in the gathered generator response

### DIFF
--- a/truss/templates/server/model_wrapper.py
+++ b/truss/templates/server/model_wrapper.py
@@ -1012,9 +1012,14 @@ class ModelWrapper:
 async def _gather_generator(
     predict_result: Union[AsyncGenerator[bytes, None], Generator[bytes, None, None]],
 ) -> str:
-    return "".join(
-        [str(chunk) async for chunk in _force_async_generator(predict_result)]
-    )
+    # Join the raw bytes and decode once, so the body is the model's text (not the
+    # b'...' repr str() would produce) and a multibyte codepoint split across chunks
+    # stays intact. Some models yield str instead of bytes; coerce those first.
+    chunks = [
+        chunk if isinstance(chunk, (bytes, bytearray)) else str(chunk).encode()
+        async for chunk in _force_async_generator(predict_result)
+    ]
+    return b"".join(chunks).decode()
 
 
 def _force_async_generator(gen: Union[Generator, AsyncGenerator]) -> AsyncGenerator:

--- a/truss/tests/templates/server/test_model_wrapper.py
+++ b/truss/tests/templates/server/test_model_wrapper.py
@@ -106,6 +106,23 @@ async def test_model_wrapper_streaming_timeout(app_path):
 
 
 @pytest.mark.anyio
+async def test_gather_generator_decodes_byte_chunks(app_path):
+    if "model_wrapper" in sys.modules:
+        model_wrapper_module = sys.modules["model_wrapper"]
+        importlib.reload(model_wrapper_module)
+    else:
+        model_wrapper_module = importlib.import_module("model_wrapper")
+    gather_generator = getattr(model_wrapper_module, "_gather_generator")
+
+    async def byte_stream():
+        # A 4-byte emoji split across the chunk boundary must survive.
+        yield b"hello \xf0\x9f"
+        yield b"\x98\x80"
+
+    assert await gather_generator(byte_stream()) == "hello \U0001f600"
+
+
+@pytest.mark.anyio
 async def test_trt_llm_truss_predict(
     trt_llm_truss_container_fs, helpers, connected_request
 ):


### PR DESCRIPTION
## :rocket: What

On the gathered (non-streaming) response path, model output was silently corrupted for byte-emitting models.

`_gather_generator` builds the response body from a `bytes` generator with `str(chunk)`, so a chunk `b"hello"` becomes the literal string `"b'hello'"`. This path is taken when the request has `accept: application/json` and a non-OpenAI user agent (see `_should_gather_generator`), and the gathered string then becomes the JSON response body via `_serialize_result`, so the corrupted text reaches the client.

Example: a model that streams `b"hello "` then `b"world"` returned `"b'hello 'b'world'"` instead of `"hello world"`.

## :computer: How

Collect the chunks and decode the joined bytes once, instead of calling `str()` on each chunk:

- `b"".join(chunks).decode()` returns the real text and keeps a multibyte UTF-8 codepoint intact when it is split across two chunks, which is common for token-by-token streaming. Decoding each chunk on its own would raise `UnicodeDecodeError` on such a split.
- Some models yield `str` on this path (the streaming integration tests do), so non-bytes chunks are coerced with `str(chunk).encode()` before the join. Strict UTF-8 matches the other stream decoders in the repo.

The change is confined to the gathered branch. The byte-streaming path is untouched and the return type stays `str`.

## :microscope: Testing

- Added `test_gather_generator_decodes_byte_chunks`: it feeds a 4-byte emoji split across two chunks and asserts the decoded text, which pins both the decode and the split-codepoint case.
- Fail-without-fix confirmed: on `main` the test fails because the body comes back as the `b'...'` repr instead of the decoded text.
- `ruff check` and `ruff format --check` are clean on both files, and the full non-integration `test_model_wrapper.py` passes with no regressions.
