### PR TITLE
fix(image_builder): stop corrupting slim SERVER_START_CMD ENV values (RUN-564)

### DIFF
--- a/truss/templates/server.Dockerfile.jinja
+++ b/truss/templates/server.Dockerfile.jinja
@@ -123,7 +123,7 @@ RUN {% for secret,path in config.build.secret_to_path_mapping.items() %} --mount
 
 {%- if config.docker_server %}
 {%- if docker_server_slim %}
-ENV SERVER_START_CMD={{ config.docker_server.start_command | tojson }}
+ENV SERVER_START_CMD={{ config.docker_server.start_command | dockerfile_env_value }}
 {{ chown_and_switch_to_regular_user_if_enabled() }}
 {{ copy_config_yaml() }}
 ENTRYPOINT ["sh", "-c"]

--- a/truss/tests/contexts/image_builder/test_serving_image_builder.py
+++ b/truss/tests/contexts/image_builder/test_serving_image_builder.py
@@ -27,6 +27,7 @@ from truss.contexts.image_builder.serving_image_builder import (
 from truss.tests.test_testing_utilities_for_other_tests import ensure_kill_all
 from truss.truss_handle.build import init_directory
 from truss.truss_handle.truss_handle import TrussHandle
+from truss.util.jinja import dockerfile_env_value
 
 BASE_DIR = Path(__file__).parent
 
@@ -1069,14 +1070,19 @@ def test_nginx_config_disables_disk_writes(tmp_path):
 
 
 class TestDockerServerSlimBuild:
-    def _make_docker_server_truss(self, tmp_path, transport_kind="http"):
+    def _make_docker_server_truss(
+        self,
+        tmp_path,
+        transport_kind="http",
+        start_command="python main.py --port 8000",
+    ):
         truss_dir = tmp_path / f"docker_server_truss_{transport_kind}"
         th = TrussHandle(init_directory(truss_dir))
         th.update_python_version("py311")
         th.set_base_image("python:3.11-slim", "/usr/local/bin/python3")
         config = th.spec.config
         config.docker_server = DockerServer(
-            start_command="python main.py --port 8000",
+            start_command=start_command,
             server_port=8000,
             predict_endpoint="/predict",
             readiness_endpoint="/health",
@@ -1107,6 +1113,36 @@ class TestDockerServerSlimBuild:
         assert not (build_dir / "proxy.conf").exists()
         assert not (build_dir / "supervisord.conf").exists()
         assert not (build_dir / "docker_server_requirements.txt").exists()
+
+    def test_slim_dockerfile_start_cmd_env_preserves_quotes(self, tmp_path):
+        start_command = (
+            'sh -c "vllm serve /app/model'
+            ' --hf-overrides \'{"text_config": {"sliding_window": 4096}}\''
+            ' --port $PORT"'
+        )
+        truss_dir = self._make_docker_server_truss(
+            tmp_path, start_command=start_command
+        )
+        with patch.dict(os.environ, {"BT_USE_DOCKER_SERVER_SLIM": "true"}):
+            builder = ServingImageBuilderContext.run(truss_dir)
+            build_dir = tmp_path / "build_quoted_start_cmd"
+            builder.prepare_image_build_dir(build_dir)
+
+        dockerfile = (build_dir / "Dockerfile").read_text()
+        env_line = next(
+            line
+            for line in dockerfile.splitlines()
+            if line.startswith("ENV SERVER_START_CMD=")
+        )
+        # tojson would have baked \u0027 (') into ENV, which the Dockerfile
+        # parser keeps verbatim. CMD may keep \uXXXX: JSON exec form decodes it.
+        assert "\\u00" not in env_line
+        assert env_line == "ENV SERVER_START_CMD=" + dockerfile_env_value(start_command)
+
+        cmd_line = next(
+            line for line in dockerfile.splitlines() if line.startswith("CMD [")
+        )
+        assert json.loads(cmd_line[len("CMD ") :]) == [start_command]
 
     def test_legacy_dockerfile_unchanged_when_flag_off(self, tmp_path):
         truss_dir = self._make_docker_server_truss(tmp_path)

--- a/truss/tests/util/test_jinja.py
+++ b/truss/tests/util/test_jinja.py
@@ -1,0 +1,35 @@
+import pytest
+
+from truss.util.jinja import dockerfile_env_value
+
+
+def test_plain_value_is_double_quoted():
+    assert dockerfile_env_value("python main.py --port 8000") == (
+        '"python main.py --port 8000"'
+    )
+
+
+def test_single_quotes_kept_verbatim():
+    # tojson escaped these to \u0027, which the Dockerfile ENV parser keeps
+    # verbatim; the filter must keep them as-is instead.
+    value = "vllm serve --hf-overrides '{\"a\": 1}'"
+    assert dockerfile_env_value(value) == (
+        '"vllm serve --hf-overrides \'{\\"a\\": 1}\'"'
+    )
+
+
+def test_html_sensitive_chars_kept_verbatim():
+    assert dockerfile_env_value("a < b > c & d") == '"a < b > c & d"'
+
+
+def test_dollar_escaped_to_defer_expansion_to_runtime():
+    assert dockerfile_env_value("serve --host $HOST") == '"serve --host \\$HOST"'
+
+
+def test_backslash_and_double_quote_escaped():
+    assert dockerfile_env_value('a\\b "c"') == '"a\\\\b \\"c\\""'
+
+
+def test_newline_rejected():
+    with pytest.raises(ValueError, match="newline"):
+        dockerfile_env_value("line1\nline2")

--- a/truss/tests/util/test_jinja.py
+++ b/truss/tests/util/test_jinja.py
@@ -30,6 +30,8 @@ def test_backslash_and_double_quote_escaped():
     assert dockerfile_env_value('a\\b "c"') == '"a\\\\b \\"c\\""'
 
 
-def test_newline_rejected():
-    with pytest.raises(ValueError, match="newline"):
-        dockerfile_env_value("line1\nline2")
+@pytest.mark.parametrize("value", ["line1\nline2", "line1\rline2", "line1\r\nline2"])
+def test_line_breaks_rejected_without_echoing_value(value):
+    with pytest.raises(ValueError, match="line break") as exc_info:
+        dockerfile_env_value(value)
+    assert "line1" not in str(exc_info.value)

--- a/truss/util/jinja.py
+++ b/truss/util/jinja.py
@@ -5,7 +5,10 @@ from jinja2 import Environment, FileSystemLoader, Template
 
 def dockerfile_env_value(value: str) -> str:
     """Quote a string as a Dockerfile ENV value. Unlike `tojson`, whose
-    \\uXXXX escapes for ' < > & the ENV parser keeps verbatim."""
+    \\uXXXX escapes for ' < > & the ENV parser keeps verbatim.
+
+    Escapes exactly the special set of buildkit's double-quoted ENV grammar,
+    {" $ \\} (shell/lex.go processDoubleQuote); all else passes verbatim."""
     if "\n" in value:
         raise ValueError(f"Dockerfile ENV values cannot contain newlines: {value!r}")
     # Escaping $ defers env expansion from image build time to runtime.

--- a/truss/util/jinja.py
+++ b/truss/util/jinja.py
@@ -3,7 +3,18 @@ from pathlib import Path
 from jinja2 import Environment, FileSystemLoader, Template
 
 
+def dockerfile_env_value(value: str) -> str:
+    """Quote a string as a Dockerfile ENV value. Unlike `tojson`, whose
+    \\uXXXX escapes for ' < > & the ENV parser keeps verbatim."""
+    if "\n" in value:
+        raise ValueError(f"Dockerfile ENV values cannot contain newlines: {value!r}")
+    # Escaping $ defers env expansion from image build time to runtime.
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"').replace("$", "\\$")
+    return f'"{escaped}"'
+
+
 def read_template_from_fs(base_dir: Path, template_file_name: str) -> Template:
     template_loader = FileSystemLoader(str(base_dir))
     template_env = Environment(loader=template_loader)
+    template_env.filters["dockerfile_env_value"] = dockerfile_env_value
     return template_env.get_template(template_file_name)

--- a/truss/util/jinja.py
+++ b/truss/util/jinja.py
@@ -9,8 +9,9 @@ def dockerfile_env_value(value: str) -> str:
 
     Escapes exactly the special set of buildkit's double-quoted ENV grammar,
     {" $ \\} (shell/lex.go processDoubleQuote); all else passes verbatim."""
-    if "\n" in value:
-        raise ValueError(f"Dockerfile ENV values cannot contain newlines: {value!r}")
+    if "\n" in value or "\r" in value:
+        # Deliberately not echoing the value: start commands can embed secrets.
+        raise ValueError("Dockerfile ENV values cannot contain line breaks.")
     # Escaping $ defers env expansion from image build time to runtime.
     escaped = value.replace("\\", "\\\\").replace('"', '\\"').replace("$", "\\$")
     return f'"{escaped}"'


### PR DESCRIPTION
## Summary

- `tojson` escapes `' < > &` to `\uXXXX`; the Dockerfile ENV parser keeps those verbatim (only JSON exec-form instructions decode them), so any slim `docker_server.start_command` containing those characters was baked corrupted into `SERVER_START_CMD` (RUN-564).
- Add a `dockerfile_env_value` Jinja filter that double-quotes the value and escapes `\ " $` (the `$` escape defers env expansion to runtime, matching the exec-form CMD), and use it for the slim `ENV SERVER_START_CMD` line. `CMD` keeps `tojson` (valid there).
- Escape semantics verified against BuildKit via `docker build` + `docker inspect` round-trips, including single quotes, nested double quotes, backslashes, and `$`.

## Test plan

- [x] New unit tests for the filter (`truss/tests/util/test_jinja.py`).
- [x] New slim build-dir test asserting the rendered `ENV` line is escape-free and `CMD` round-trips.
- [x] Manual: built the generated slim context, `docker inspect` shows byte-exact `SERVER_START_CMD`, and `eval "$SERVER_START_CMD"` in-container starts a server with quoted args intact.

Made with [Cursor](https://cursor.com)