### PR TITLE
[codex] Enable zstd decompression in performance client + fix ci

### DIFF
--- a/.github/workflows/baseten-performance-client-nodejs.yml
+++ b/.github/workflows/baseten-performance-client-nodejs.yml
@@ -163,16 +163,28 @@ jobs:
             -w /build/baseten-performance-client/node_bindings \
             ${{ matrix.settings.docker }} \
             bash -c '
+              set -euo pipefail
               if command -v apk &> /dev/null; then
-                apk add --no-cache perl openssl-dev build-base
+                apk add --no-cache curl perl openssl-dev build-base
               elif command -v apt-get &> /dev/null; then
-                apt-get update && apt-get install -y perl libssl-dev libatomic-ops-dev
+                apt-get update && apt-get install -y curl perl libssl-dev libatomic-ops-dev
               elif command -v yum &> /dev/null; then
-                yum install openssl-devel devtoolset-10-libatomic-devel perl-IPC-Cmd -y
+                yum install curl openssl-devel devtoolset-10-libatomic-devel perl-IPC-Cmd -y
               else
                 echo "Unsupported package manager. Please install perl and openssl-dev manually."
                 exit 1
               fi
+              if command -v rustup &> /dev/null; then
+                rustup update stable
+                rustup default stable
+              else
+                curl https://sh.rustup.rs -sSf --output rustup.sh
+                sh rustup.sh -y --profile minimal --default-toolchain stable
+                . "$HOME/.cargo/env"
+              fi
+              rustup target add ${{ matrix.settings.target }}
+              rustc --version
+              cargo --version
               ${{ matrix.settings.build }}
             '
       - name: Build

--- a/baseten-performance-client/Cargo.lock
+++ b/baseten-performance-client/Cargo.lock
@@ -88,6 +88,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -284,6 +296,8 @@ version = "1.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7777341816418c02e033934a09f20dc0ccaf65a5201ef8a450ae0105a573fda"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -359,6 +373,23 @@ dependencies = [
  "serde",
  "static_assertions",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "compression-core",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "concurrent-queue"
@@ -770,6 +801,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1137,6 +1179,16 @@ name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+
+[[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -1794,6 +1846,12 @@ checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -2542,13 +2600,18 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
+ "async-compression",
  "bitflags",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "iri-string",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower 0.5.2",
  "tower-layer",
  "tower-service",
@@ -3179,3 +3242,31 @@ name = "zmij"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77cc0158b0d3103d58e9e82bdbe9cf9289d80dbcf4e686ff16730eb9e5814d1a"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/baseten-performance-client/Cargo.lock
+++ b/baseten-performance-client/Cargo.lock
@@ -191,7 +191,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "baseten-performance-client"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "baseten_performance_client_core",
  "futures",
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "baseten_performance_client"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "baseten_performance_client_core",
  "futures",
@@ -245,7 +245,7 @@ dependencies = [
 
 [[package]]
 name = "baseten_performance_client_core"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "axum",
  "ctor 0.6.3",

--- a/baseten-performance-client/Cargo.toml
+++ b/baseten-performance-client/Cargo.toml
@@ -14,4 +14,4 @@ nonempty = "0.11"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
 ctor = "0.6.3"
-reqwest = { version = "0.12.26", default-features = false, features = ["blocking", "json", "stream", "http2"] }
+reqwest = { version = "0.12.26", default-features = false, features = ["blocking", "json", "stream", "http2", "zstd"] }

--- a/baseten-performance-client/README.md
+++ b/baseten-performance-client/README.md
@@ -21,7 +21,7 @@ npm install baseten-performance-client
 cargo add baseten_performance_client_core
 # Or add to your Cargo.toml:
 # [dependencies]
-# baseten_performance_client_core = "0.0.16"
+# baseten_performance_client_core = "0.1.10"
 # tokio = { version = "1.0", features = ["full"] }
 ```
 

--- a/baseten-performance-client/core/Cargo.toml
+++ b/baseten-performance-client/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "baseten_performance_client_core"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 description = "High performance HTTP client for Baseten.co and other APIs"
 license = "MIT"

--- a/baseten-performance-client/node_bindings/Cargo.toml
+++ b/baseten-performance-client/node_bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "baseten-performance-client"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 
 [lib]

--- a/baseten-performance-client/node_bindings/npm/android-arm-eabi/package.json
+++ b/baseten-performance-client/node_bindings/npm/android-arm-eabi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-android-arm-eabi",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "os": [
     "android"
   ],

--- a/baseten-performance-client/node_bindings/npm/android-arm64/package.json
+++ b/baseten-performance-client/node_bindings/npm/android-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-android-arm64",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "os": [
     "android"
   ],

--- a/baseten-performance-client/node_bindings/npm/darwin-arm64/package.json
+++ b/baseten-performance-client/node_bindings/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-darwin-arm64",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "os": [
     "darwin"
   ],

--- a/baseten-performance-client/node_bindings/npm/darwin-universal/package.json
+++ b/baseten-performance-client/node_bindings/npm/darwin-universal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-darwin-universal",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "os": [
     "darwin"
   ],

--- a/baseten-performance-client/node_bindings/npm/darwin-x64/package.json
+++ b/baseten-performance-client/node_bindings/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-darwin-x64",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "os": [
     "darwin"
   ],

--- a/baseten-performance-client/node_bindings/npm/freebsd-x64/package.json
+++ b/baseten-performance-client/node_bindings/npm/freebsd-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-freebsd-x64",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "os": [
     "freebsd"
   ],

--- a/baseten-performance-client/node_bindings/npm/linux-arm-gnueabihf/package.json
+++ b/baseten-performance-client/node_bindings/npm/linux-arm-gnueabihf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-linux-arm-gnueabihf",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "os": [
     "linux"
   ],

--- a/baseten-performance-client/node_bindings/npm/linux-arm-musleabihf/package.json
+++ b/baseten-performance-client/node_bindings/npm/linux-arm-musleabihf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-linux-arm-musleabihf",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "os": [
     "linux"
   ],

--- a/baseten-performance-client/node_bindings/npm/linux-arm64-gnu/package.json
+++ b/baseten-performance-client/node_bindings/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-linux-arm64-gnu",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "os": [
     "linux"
   ],

--- a/baseten-performance-client/node_bindings/npm/linux-arm64-musl/package.json
+++ b/baseten-performance-client/node_bindings/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-linux-arm64-musl",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "os": [
     "linux"
   ],

--- a/baseten-performance-client/node_bindings/npm/linux-riscv64-gnu/package.json
+++ b/baseten-performance-client/node_bindings/npm/linux-riscv64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-linux-riscv64-gnu",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "os": [
     "linux"
   ],

--- a/baseten-performance-client/node_bindings/npm/linux-x64-gnu/package.json
+++ b/baseten-performance-client/node_bindings/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-linux-x64-gnu",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "os": [
     "linux"
   ],

--- a/baseten-performance-client/node_bindings/npm/linux-x64-musl/package.json
+++ b/baseten-performance-client/node_bindings/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-linux-x64-musl",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "os": [
     "linux"
   ],

--- a/baseten-performance-client/node_bindings/npm/win32-arm64-msvc/package.json
+++ b/baseten-performance-client/node_bindings/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-win32-arm64-msvc",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "os": [
     "win32"
   ],

--- a/baseten-performance-client/node_bindings/npm/win32-ia32-msvc/package.json
+++ b/baseten-performance-client/node_bindings/npm/win32-ia32-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-win32-ia32-msvc",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "os": [
     "win32"
   ],

--- a/baseten-performance-client/node_bindings/npm/win32-x64-msvc/package.json
+++ b/baseten-performance-client/node_bindings/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-win32-x64-msvc",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "os": [
     "win32"
   ],

--- a/baseten-performance-client/node_bindings/package.json
+++ b/baseten-performance-client/node_bindings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "main": "index.js",
   "types": "index.d.ts",
   "napi": {

--- a/baseten-performance-client/python_bindings/Cargo.toml
+++ b/baseten-performance-client/python_bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "baseten_performance_client"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 
 [dependencies]

--- a/baseten-performance-client/python_bindings/pyproject.toml
+++ b/baseten-performance-client/python_bindings/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
   "requests"
 ]

--- a/baseten-performance-client/python_bindings/uv.lock
+++ b/baseten-performance-client/python_bindings/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "baseten-performance-client"
-version = "0.1.9"
+version = "0.1.10"
 source = { editable = "." }
 dependencies = [
     { name = "requests" },


### PR DESCRIPTION
@keer2607 this is just a version bump and dependency + fixing CI. Can please stamp?

## Summary

Enable the `reqwest` `zstd` feature for `baseten-performance-client` so HTTP responses with `Content-Encoding: zstd` are transparently decompressed by reqwest.

This is a simple deps upgrade for the performance client. @bdubayah tagging you for visibility.

## Impact

Users can receive zstd-compressed response bodies from compatible servers without adding client-side decompression code. This does not compress outgoing request bodies.

## Validation

- `cargo test -p baseten_performance_client_core`
