### PR TITLE
feat(cli/train): add --team support to truss train workstation

### DIFF
--- a/truss-train/truss_train/public_api.py
+++ b/truss-train/truss_train/public_api.py
@@ -9,7 +9,9 @@ from truss_train.deployment import _upsert_project_and_create_job, create_traini
 
 
 @overload
-def push(config: Path, *, remote: str = "baseten") -> dict: ...
+def push(
+    config: Path, *, remote: str = "baseten", team_id: Optional[str] = None
+) -> dict: ...
 
 
 @overload
@@ -18,6 +20,7 @@ def push(
     *,
     remote: str = "baseten",
     source_dir: Optional[Path] = None,
+    team_id: Optional[str] = None,
 ) -> dict: ...
 
 
@@ -26,6 +29,7 @@ def push(
     *,
     remote: str = "baseten",
     source_dir: Optional[Path] = None,
+    team_id: Optional[str] = None,
 ) -> dict:
     """Create or update a training project and create a training job.
 
@@ -35,6 +39,9 @@ def push(
         remote: The remote provider to use. Defaults to "baseten".
         source_dir: Base directory for workspace path resolution and archiving.
             Only used when config is a TrainingProject. Defaults to Path.cwd().
+        team_id: Team to create the training project under. Required for API keys
+            that only have access to a non-default team; without it the project is
+            created under the organization's default team.
 
     Returns:
         dict: A dictionary containing the created training project and job.
@@ -45,9 +52,11 @@ def push(
 
     if isinstance(config, Path):
         with loader.import_training_project(config) as training_project:
-            return create_training_job(remote_provider, config, training_project)
+            return create_training_job(
+                remote_provider, config, training_project, team_id=team_id
+            )
     else:
         resolved_source_dir = source_dir if source_dir is not None else Path.cwd()
         return _upsert_project_and_create_job(
-            remote_provider, config, resolved_source_dir
+            remote_provider, config, resolved_source_dir, team_id=team_id
         )

--- a/truss/cli/train_commands.py
+++ b/truss/cli/train_commands.py
@@ -1246,6 +1246,13 @@ def update_capacity(
     help="Job ID to load the latest checkpoint from.",
 )
 @click.option("--remote", type=str, required=False, help="Remote to use.")
+@click.option(
+    "--team",
+    "provided_team_name",
+    type=str,
+    required=False,
+    help="Team name for the workstation project",
+)
 @click.option("--tail", is_flag=True, help="Tail for status + logs after push.")
 @common.common_options()
 def workstation(
@@ -1260,6 +1267,7 @@ def workstation(
     checkpoint_volume_size: Optional[int],
     checkpoint_from_job: Optional[str],
     remote: Optional[str],
+    provided_team_name: Optional[str],
     tail: bool,
 ):
     """Spin up an SSH workstation on Baseten training infrastructure."""
@@ -1284,6 +1292,15 @@ def workstation(
 
     if not remote:
         remote = remote_cli.inquire_remote_name()
+
+    remote_provider: BasetenRemote = cast(
+        BasetenRemote, RemoteFactory.create(remote=remote)
+    )
+    # Use config team as fallback if --team not provided
+    effective_team_name = provided_team_name or RemoteFactory.get_remote_team(remote)
+    _, team_id = _resolve_team_name(
+        remote_provider, effective_team_name, existing_project_name=project_id
+    )
 
     base_image = image or DEFAULT_BASE_IMAGE
     training_project = build_workstation_project(
@@ -1311,7 +1328,10 @@ def workstation(
         if node_count > 1:
             copy_workstation_templates(Path(tmp_dir))
         job_resp = push(
-            config=training_project, remote=remote, source_dir=Path(tmp_dir)
+            config=training_project,
+            remote=remote,
+            source_dir=Path(tmp_dir),
+            team_id=team_id,
         )
 
     job_id = job_resp["id"]
@@ -1349,9 +1369,6 @@ def workstation(
     )
 
     if tail:
-        remote_provider: BasetenRemote = cast(
-            BasetenRemote, RemoteFactory.create(remote=remote)
-        )
         project_resp_id = job_resp["training_project"]["id"]
         watcher = TrainingLogWatcher(remote_provider.api, project_resp_id, job_id)
         for log in watcher.watch():

--- a/truss/tests/cli/train/test_workstation.py
+++ b/truss/tests/cli/train/test_workstation.py
@@ -1,15 +1,20 @@
 import os
 import tempfile
 from pathlib import Path
+from unittest.mock import Mock, patch
 
 import pytest
+from click.testing import CliRunner
 
 from truss.base.constants import WORKSTATION_TEMPLATE_DIR
+from truss.cli.cli import truss_cli
 from truss.cli.train.workstation import (
     SUPPORTED_WORKSTATION_ACCELERATORS,
     build_workstation_project,
     copy_workstation_templates,
 )
+from truss.remote.baseten.custom_types import TeamType
+from truss.remote.baseten.remote import BasetenRemote
 from truss_train.definitions import (
     InteractiveSessionProvider,
     InteractiveSessionTrigger,
@@ -82,3 +87,80 @@ def test_workstation_template_dir_exists():
     assert WORKSTATION_TEMPLATE_DIR.exists()
     for name in EXPECTED_TEMPLATE_FILES:
         assert (WORKSTATION_TEMPLATE_DIR / name).exists(), f"Missing template {name}"
+
+
+class TestWorkstationTeamResolution:
+    @staticmethod
+    def _setup_mock_remote(teams, existing_projects=None):
+        mock_remote = Mock(spec=BasetenRemote)
+        mock_api = Mock()
+        mock_remote.api = mock_api
+        mock_api.get_teams.return_value = {
+            name: TeamType(**team_data) for name, team_data in teams.items()
+        }
+        mock_api.list_training_projects.return_value = existing_projects or []
+        return mock_remote
+
+    @staticmethod
+    def _invoke_workstation(runner, team_name=None):
+        args = ["train", "workstation", "--remote", "test_remote"]
+        if team_name:
+            args.extend(["--team", team_name])
+        return runner.invoke(truss_cli, args)
+
+    @patch("truss_train.public_api.push")
+    @patch("truss.cli.train_commands.RemoteFactory.get_remote_team")
+    @patch("truss.cli.train_commands.RemoteFactory.create")
+    def test_team_provided_passes_team_id_to_push(
+        self, mock_remote_factory, mock_get_remote_team, mock_push
+    ):
+        teams = {
+            "team-a": {"id": "team1", "name": "team-a", "default": True},
+            "team-b": {"id": "team2", "name": "team-b", "default": False},
+        }
+        mock_remote_factory.return_value = self._setup_mock_remote(teams)
+        mock_get_remote_team.return_value = None
+        mock_push.return_value = {
+            "id": "job123",
+            "training_project": {"id": "proj123", "name": "workstation-H100"},
+        }
+
+        result = self._invoke_workstation(CliRunner(), team_name="team-b")
+
+        assert result.exit_code == 0, result.output
+        assert mock_push.call_args[1]["team_id"] == "team2"
+
+    @patch("truss_train.public_api.push")
+    @patch("truss.cli.train_commands.RemoteFactory.get_remote_team")
+    @patch("truss.cli.train_commands.RemoteFactory.create")
+    def test_single_team_auto_resolves_without_flag(
+        self, mock_remote_factory, mock_get_remote_team, mock_push
+    ):
+        teams = {"only-team": {"id": "team9", "name": "only-team", "default": False}}
+        mock_remote_factory.return_value = self._setup_mock_remote(teams)
+        mock_get_remote_team.return_value = None
+        mock_push.return_value = {
+            "id": "job123",
+            "training_project": {"id": "proj123", "name": "workstation-H100"},
+        }
+
+        result = self._invoke_workstation(CliRunner())
+
+        assert result.exit_code == 0, result.output
+        assert mock_push.call_args[1]["team_id"] == "team9"
+
+    @patch("truss_train.public_api.push")
+    @patch("truss.cli.train_commands.RemoteFactory.get_remote_team")
+    @patch("truss.cli.train_commands.RemoteFactory.create")
+    def test_invalid_team_errors_before_push(
+        self, mock_remote_factory, mock_get_remote_team, mock_push
+    ):
+        teams = {"team-a": {"id": "team1", "name": "team-a", "default": True}}
+        mock_remote_factory.return_value = self._setup_mock_remote(teams)
+        mock_get_remote_team.return_value = None
+
+        result = self._invoke_workstation(CliRunner(), team_name="nonexistent")
+
+        assert result.exit_code == 1
+        assert "does not exist" in result.output
+        mock_push.assert_not_called()


### PR DESCRIPTION
## What

`truss train workstation` always created its project via the plain `POST /v1/training_projects` endpoint, which upserts under the org's **default team**. For API keys scoped to a non-default team, that endpoint 403s (`MANAGE_TRAINING` is checked against the default team), so workstations could not be launched at all with such keys — even though `truss train push` works fine.

## Changes

- Add `--team` to `truss train workstation`, resolved identically to `truss train push`: explicit flag → `.trussrc` remote `team` config → auto-detect from an existing project of the same name → auto-pick when the user has exactly one team → interactive prompt.
- Add a `team_id` keyword to `truss_train.public_api.push()` (both overloads), threading into the existing `team_id` params on `create_training_job` / `_upsert_project_and_create_job` so the upsert routes through `POST /v1/teams/{team_id}/training_projects`. This also unblocks SDK users hitting the same 403 programmatically.
- Reuse the remote provider in the `--tail` path instead of constructing it twice.

Team-name→id resolution (including the interactive prompt) stays in the CLI layer; the SDK only takes the resolved `team_id`, so programmatic callers never block on a prompt.

## Testing

- New CLI tests: `--team` passes the resolved `team_id` to `push`, single-team auto-resolution works with no flag, invalid team errors before any push.
- Existing `test_train_team_parameter.py` (8 resolution scenarios), `test_workstation.py`, `test_public_api.py`, `test_deployment.py` all pass.