### PR TITLE
fix(trt_llm): BEI max_num_tokens upgrade is a no-op

### DIFF
--- a/truss/base/trt_llm_config.py
+++ b/truss/base/trt_llm_config.py
@@ -382,9 +382,7 @@ pip install truss==0.10.8
                     logger.warning(
                         f"build.max_num_tokens={self.max_num_tokens}, upgrading to {BEI_REQUIRED_MAX_NUM_TOKENS}"
                     )
-                self = self.model_copy(
-                    update={"max_num_tokens": BEI_REQUIRED_MAX_NUM_TOKENS}
-                )
+                self.max_num_tokens = BEI_REQUIRED_MAX_NUM_TOKENS
             # set page_kv_cache and use_paged_context_fmha to false for encoder
             self.plugin_configuration.paged_kv_cache = False
             self.plugin_configuration.use_paged_context_fmha = False

--- a/truss/tests/trt_llm/test_trt_llm_config.py
+++ b/truss/tests/trt_llm/test_trt_llm_config.py
@@ -3,6 +3,7 @@ import copy
 import pydantic
 import pytest
 
+from truss.base.constants import BEI_REQUIRED_MAX_NUM_TOKENS
 from truss.base.trt_llm_config import (
     TRTLLMConfiguration,
     TRTLLMConfigurationV1,
@@ -246,3 +247,29 @@ def test_trt_llm_config_additional_fields(trtllm_config_v2):
 
     assert config.inference_stack == "v2"
     assert isinstance(config.build, TrussTRTLLMBuildConfiguration)
+
+
+def test_trt_llm_build_config_encoder_upgrades_max_num_tokens(trtllm_config):
+    """BEI requires a minimum max_num_tokens, and the encoder path enforces it.
+
+    The upgrade rebound the local `self` instead of assigning the field, so it
+    logged the upgrade while leaving max_num_tokens at the user's value.
+    """
+    build = copy.deepcopy(trtllm_config["trt_llm"]["build"])
+    build["base_model"] = "encoder"
+    build["max_num_tokens"] = 1024
+
+    build_config = TrussTRTLLMBuildConfiguration(**build)
+
+    assert build_config.max_num_tokens == BEI_REQUIRED_MAX_NUM_TOKENS
+
+
+def test_trt_llm_build_config_decoder_keeps_max_num_tokens(trtllm_config):
+    """Only the encoder path upgrades max_num_tokens."""
+    build = copy.deepcopy(trtllm_config["trt_llm"]["build"])
+    build["base_model"] = "decoder"
+    build["max_num_tokens"] = 1024
+
+    build_config = TrussTRTLLMBuildConfiguration(**build)
+
+    assert build_config.max_num_tokens == 1024


### PR DESCRIPTION
## What

`_bei_specfic_migration` logs that it is raising `max_num_tokens` to the BEI minimum, but the value never changes:

```python
TrussTRTLLMBuildConfiguration(base_model="encoder", max_num_tokens=1024, checkpoint_repository=...)
# WARNING  truss.base.trt_llm_config: build.max_num_tokens=1024, upgrading to 16384
# .max_num_tokens -> 1024
```

The upgrade rebinds the local name instead of assigning the field:

```python
self = self.model_copy(update={"max_num_tokens": BEI_REQUIRED_MAX_NUM_TOKENS})
```

`model_copy` returns a new object; rebinding `self` inside `model_post_init` discards it when the method returns.

## Why this looks like a slip rather than intent

- The **next two lines of the same method** assign fields directly and do stick:
  ```python
  self.plugin_configuration.paged_kv_cache = False
  self.plugin_configuration.use_paged_context_fmha = False
  ```
  One method, two behaviours.
- The **only other `model_copy` in the file** assigns the result back to a field:
  ```python
  self.runtime = self.runtime.model_copy(update={"webserver_default_route": route})
  ```
- The `logger.warning` announces an upgrade that then doesn't happen.

## Impact

`serving_image_builder.py` notes it is "enforcing max_num_tokens here and in engine-builder". The engine-builder half is what silently doesn't apply: the router is configured for the BEI minimum while the engine is built for the user's lower value.

## Fix

Assign the field. Verified across the paths:

| base_model | input | after |
|---|---|---|
| encoder | 1024 | 16384 ✅ |
| encoder | 8192 (default) | 16384 ✅ |
| encoder | 16384 | 16384 ✅ |
| decoder | 1024 | 1024 (unchanged) ✅ |

The adjacent `paged_kv_cache = False` still applies.

## Tests

Two cases: the encoder path upgrades, the decoder path does not. The encoder one fails on `main` and passes here. `grep max_num_tokens truss/tests/` previously returned nothing — the field had no coverage, which is why this went unnoticed.

- `pytest truss/tests/trt_llm/` — 23 passed, 1 skipped
- Full non-Docker suite — **1090 passed** (1088 baseline + 2 new), no regressions
- `uv run ruff check` / `ruff format --check` clean, per AGENTS.md

---

AI disclosure: drafted with Claude Code (Opus 4.8), including the root-cause trace and the tests. I ran the repro and the suite locally and reviewed the diff before opening.
