### PR TITLE
Add TRUSS_NO_UPDATE_CHECK env var to skip update check

### DIFF
--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -176,7 +176,7 @@ def truss_cli(ctx) -> None:
     # selective run it here inline.
     if not ctx.invoked_subcommand:
         common.set_logging_level()
-        common.upgrade_dialogue()
+        common.maybe_upgrade_dialogue()
         click.echo(ctx.get_help())
 
 

--- a/truss/cli/utils/common.py
+++ b/truss/cli/utils/common.py
@@ -168,10 +168,7 @@ def _error_handling(f: Callable[..., object]) -> Callable[..., object]:
     return wrapper
 
 
-def upgrade_dialogue():
-    # Skip the update check entirely when opted out. This must precede any
-    # `user_config` access so it also avoids the config-dir/settings/state writes
-    # and trussrc read that happen while reading the update setting.
+def maybe_upgrade_dialogue():
     if os.environ.get("TRUSS_NO_UPDATE_CHECK", "").lower() in ("1", "true"):
         return
     try:
@@ -191,7 +188,7 @@ def common_options(
         def wrapper(*args: object, **kwargs: object) -> Any:
             if add_middleware:
                 set_logging_level()
-                upgrade_dialogue()
+                maybe_upgrade_dialogue()
 
             return f(*args, **kwargs)
 

--- a/truss/cli/utils/common.py
+++ b/truss/cli/utils/common.py
@@ -169,6 +169,11 @@ def _error_handling(f: Callable[..., object]) -> Callable[..., object]:
 
 
 def upgrade_dialogue():
+    # Skip the update check entirely when opted out. This must precede any
+    # `user_config` access so it also avoids the config-dir/settings/state writes
+    # and trussrc read that happen while reading the update setting.
+    if os.environ.get("TRUSS_NO_UPDATE_CHECK", "").lower() in ("1", "true"):
+        return
     try:
         self_upgrade.notify_if_outdated(truss.__version__)
     except Exception as e:

--- a/truss/tests/cli/test_cli_utils_common.py
+++ b/truss/tests/cli/test_cli_utils_common.py
@@ -1,3 +1,4 @@
+import os
 from unittest.mock import patch
 
 import click
@@ -49,6 +50,22 @@ class TestCheckIsInteractive:
         ctx = click.Context(click.Command("test"))
         with ctx:
             assert common.check_is_interactive() is True
+
+
+class TestUpgradeDialogue:
+    @patch("truss.cli.utils.common.self_upgrade.notify_if_outdated")
+    def test_skips_check_when_opted_out(self, mock_notify):
+        for value in ("1", "true", "TRUE"):
+            with patch.dict(os.environ, {"TRUSS_NO_UPDATE_CHECK": value}):
+                common.upgrade_dialogue()
+        mock_notify.assert_not_called()
+
+    @patch("truss.cli.utils.common.self_upgrade.notify_if_outdated")
+    def test_runs_check_when_not_opted_out(self, mock_notify):
+        for value in ("", "0", "false"):
+            with patch.dict(os.environ, {"TRUSS_NO_UPDATE_CHECK": value}):
+                common.upgrade_dialogue()
+        assert mock_notify.call_count == 3
 
 
 def test_normalize_iso_timestamp_handles_nanoseconds():

--- a/truss/tests/cli/test_cli_utils_common.py
+++ b/truss/tests/cli/test_cli_utils_common.py
@@ -57,14 +57,14 @@ class TestUpgradeDialogue:
     def test_skips_check_when_opted_out(self, mock_notify):
         for value in ("1", "true", "TRUE"):
             with patch.dict(os.environ, {"TRUSS_NO_UPDATE_CHECK": value}):
-                common.upgrade_dialogue()
+                common.maybe_upgrade_dialogue()
         mock_notify.assert_not_called()
 
     @patch("truss.cli.utils.common.self_upgrade.notify_if_outdated")
     def test_runs_check_when_not_opted_out(self, mock_notify):
         for value in ("", "0", "false"):
             with patch.dict(os.environ, {"TRUSS_NO_UPDATE_CHECK": value}):
-                common.upgrade_dialogue()
+                common.maybe_upgrade_dialogue()
         assert mock_notify.call_count == 3
 
 

--- a/truss/tests/cli/test_self_upgrade.py
+++ b/truss/tests/cli/test_self_upgrade.py
@@ -324,7 +324,7 @@ class TestNotifyIfOutdated:
         monkeypatch.setattr(user_config, "get_state", lambda: mock_state)
         monkeypatch.setattr(user_config, "get_settings", lambda: mock_settings)
 
-        # Exception handling moved to upgrade_dialogue() in common.py
+        # Exception handling moved to maybe_upgrade_dialogue() in common.py
         with pytest.raises(Exception, match="Network error"):
             self_upgrade.notify_if_outdated("0.11.0")
 


### PR DESCRIPTION
## :rocket: What
- Adds a `TRUSS_NO_UPDATE_CHECK` env var (`1`/`true`) that fully skips the CLI update check.
- Lets automated/embedded callers avoid the update check's side effects entirely.

## :computer: How
- Early-return at the top of `upgrade_dialogue()` before any `user_config` access, so it skips not just the PyPI version request but also the `~/.config/truss` dir creation, first-run `~/.trussrc` read, and `settings.toml`/`state.json` writes that happen while reading the update setting.
- Matches the existing CLI env-var style (`in ("1", "true")`

## :microscope: Testing
- Adds `TestUpgradeDialogue` in `test_cli_utils_common.py` covering opted-out values (`1`/`true`/`TRUE` -> no check) and not-opted-out values (empty/`0`/`false` -> check runs).