### PR TITLE
docs: fix stale `truss chains deploy` references and inaccurate watch prose

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,15 +204,6 @@ If you stopped the watch session, you can re-attach with:
 uvx truss watch
 ```
 
-This creates a production deployment with its own endpoint. The API URL changes from `/environments/development/` to `/environments/production/`:
-
-```python
-client = OpenAI(
-    api_key=os.environ["BASETEN_API_KEY"],
-    base_url="https://model-{model_id}.api.baseten.co/environments/production/sync/v1",
-)
-```
-
 Your model ID is the string after `/models/` in the logs URL from `uvx truss push`. You can also find it in your [Baseten dashboard](https://app.baseten.co/models/).
 
 # IDE support

--- a/truss-chains/examples/audio-transcription/transcribe.py
+++ b/truss-chains/examples/audio-transcription/transcribe.py
@@ -15,7 +15,7 @@ IMAGE = chains.DockerImage(
 )
 
 
-# Deploy the Whisper model with `truss chains deploy whisper_chainlet.py`:
+# Deploy the Whisper model with `truss chains push whisper_chainlet.py`:
 # And insert the predict URL here. You can get it from the CLI output or
 # the status page, e.g. "https://model-6wgeygoq.api.baseten.co/production/predict"
 

--- a/truss/remote/baseten/utils/status.py
+++ b/truss/remote/baseten/utils/status.py
@@ -31,7 +31,7 @@ def get_displayable_status(status: str) -> str:
     """
     TODO: Remove this method once Chains is supported in the REST API
 
-    This is used by the `truss chains deploy` command right now to
+    This is used by the `truss chains push` command right now to
     print the right status. Once Chains are supported by the REST API, the
     Baseten REST API will return status strings matching the ones here, so we don't
     need to do any mapping.


### PR DESCRIPTION
First-time PR. Small docs-only cleanup. The `truss chains deploy` command no longer exists — the `chains` group only exposes `push`, `watch`, and `init` — but a few references to it remained. Also fixes an inaccurate line in the README about `truss watch`.

No actual code touched