### PR TITLE
perf(client): lower min request timeout to 100ms and hedge delay to 60ms

### DIFF
--- a/baseten-performance-client/Cargo.lock
+++ b/baseten-performance-client/Cargo.lock
@@ -191,7 +191,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "baseten-performance-client"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "baseten_performance_client_core",
  "futures",
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "baseten_performance_client"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "baseten_performance_client_core",
  "futures",
@@ -245,7 +245,7 @@ dependencies = [
 
 [[package]]
 name = "baseten_performance_client_core"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "axum",
  "ctor 0.6.3",

--- a/baseten-performance-client/README.md
+++ b/baseten-performance-client/README.md
@@ -21,7 +21,7 @@ npm install baseten-performance-client
 cargo add baseten_performance_client_core
 # Or add to your Cargo.toml:
 # [dependencies]
-# baseten_performance_client_core = "0.1.11"
+# baseten_performance_client_core = "0.1.12"
 # tokio = { version = "1.0", features = ["full"] }
 ```
 
@@ -128,7 +128,7 @@ preference = RequestProcessingPreference(
     max_concurrent_requests=32,
     timeout_s=360,
     max_chars_per_request=10000,  # Character-based batching (50-256,000)
-    hedge_delay=0.5,  # Request hedging delay in seconds (min 0.2s)
+    hedge_delay=0.5,  # Request hedging delay in seconds (min 0.045s)
     total_timeout_s=600,  # Total timeout for all batched requests
     extra_headers={"x-custom-header": "value"}  # Custom headers
 )
@@ -169,7 +169,7 @@ Note: The embed method is versatile and can be used with any embeddings service,
 #### Advanced Parameters
 
 - **`max_chars_per_request`**: Character-based batching limit (50-256,000 characters). When set, requests are batched by character count rather than just input count, helping optimize for services with character-based pricing or processing limits.
-- **`hedge_delay`**: Request hedging delay in seconds (minimum 0.2s). Enables sending duplicate requests after a delay to improve latency if the original request is slow. Limited by a 5% budget to prevent excessive resource usage.
+- **`hedge_delay`**: Request hedging delay in seconds (minimum 0.045s). Enables sending duplicate requests after a delay to improve latency if the original request is slow. Limited by a 5% budget to prevent excessive resource usage.
 - **`total_timeout_s`**: Total timeout for the entire operation in seconds. Unlike `timeout_s` (which is per-request), this sets an upper bound on the total time for all batched requests combined. Must be >= `timeout_s` if both are set. If not set, there is no upper bound on the total time for all batched requests.
 
 #### Asynchronous Embedding

--- a/baseten-performance-client/core/Cargo.toml
+++ b/baseten-performance-client/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "baseten_performance_client_core"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2021"
 description = "High performance HTTP client for Baseten.co and other APIs"
 license = "MIT"

--- a/baseten-performance-client/core/src/constants.rs
+++ b/baseten-performance-client/core/src/constants.rs
@@ -1,6 +1,6 @@
 // Request timeout constants
 pub const DEFAULT_REQUEST_TIMEOUT_S: f64 = 3600.0;
-pub(crate) const MIN_REQUEST_TIMEOUT_S: f64 = 0.5;
+pub(crate) const MIN_REQUEST_TIMEOUT_S: f64 = 0.1;
 pub(crate) const MAX_REQUEST_TIMEOUT_S: f64 = 3600.0;
 
 // Concurrency constants
@@ -12,7 +12,7 @@ pub(crate) const MIN_CHARACTERS_PER_REQUEST: usize = 50;
 pub(crate) const MAX_CHARACTERS_PER_REQUEST: usize = 256000;
 
 // hedging settings:
-pub(crate) const MIN_HEDGE_DELAY_S: f64 = 0.2;
+pub(crate) const MIN_HEDGE_DELAY_S: f64 = 0.045;
 
 // Batch size constants
 pub(crate) const MAX_BATCH_SIZE: usize = 1024;

--- a/baseten-performance-client/node_bindings/Cargo.toml
+++ b/baseten-performance-client/node_bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "baseten-performance-client"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2021"
 
 [lib]

--- a/baseten-performance-client/node_bindings/npm/android-arm-eabi/package.json
+++ b/baseten-performance-client/node_bindings/npm/android-arm-eabi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-android-arm-eabi",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "os": [
     "android"
   ],

--- a/baseten-performance-client/node_bindings/npm/android-arm64/package.json
+++ b/baseten-performance-client/node_bindings/npm/android-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-android-arm64",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "os": [
     "android"
   ],

--- a/baseten-performance-client/node_bindings/npm/darwin-arm64/package.json
+++ b/baseten-performance-client/node_bindings/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-darwin-arm64",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "os": [
     "darwin"
   ],

--- a/baseten-performance-client/node_bindings/npm/darwin-universal/package.json
+++ b/baseten-performance-client/node_bindings/npm/darwin-universal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-darwin-universal",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "os": [
     "darwin"
   ],

--- a/baseten-performance-client/node_bindings/npm/darwin-x64/package.json
+++ b/baseten-performance-client/node_bindings/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-darwin-x64",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "os": [
     "darwin"
   ],

--- a/baseten-performance-client/node_bindings/npm/freebsd-x64/package.json
+++ b/baseten-performance-client/node_bindings/npm/freebsd-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-freebsd-x64",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "os": [
     "freebsd"
   ],

--- a/baseten-performance-client/node_bindings/npm/linux-arm-gnueabihf/package.json
+++ b/baseten-performance-client/node_bindings/npm/linux-arm-gnueabihf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-linux-arm-gnueabihf",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "os": [
     "linux"
   ],

--- a/baseten-performance-client/node_bindings/npm/linux-arm-musleabihf/package.json
+++ b/baseten-performance-client/node_bindings/npm/linux-arm-musleabihf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-linux-arm-musleabihf",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "os": [
     "linux"
   ],

--- a/baseten-performance-client/node_bindings/npm/linux-arm64-gnu/package.json
+++ b/baseten-performance-client/node_bindings/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-linux-arm64-gnu",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "os": [
     "linux"
   ],

--- a/baseten-performance-client/node_bindings/npm/linux-arm64-musl/package.json
+++ b/baseten-performance-client/node_bindings/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-linux-arm64-musl",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "os": [
     "linux"
   ],

--- a/baseten-performance-client/node_bindings/npm/linux-riscv64-gnu/package.json
+++ b/baseten-performance-client/node_bindings/npm/linux-riscv64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-linux-riscv64-gnu",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "os": [
     "linux"
   ],

--- a/baseten-performance-client/node_bindings/npm/linux-x64-gnu/package.json
+++ b/baseten-performance-client/node_bindings/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-linux-x64-gnu",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "os": [
     "linux"
   ],

--- a/baseten-performance-client/node_bindings/npm/linux-x64-musl/package.json
+++ b/baseten-performance-client/node_bindings/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-linux-x64-musl",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "os": [
     "linux"
   ],

--- a/baseten-performance-client/node_bindings/npm/win32-arm64-msvc/package.json
+++ b/baseten-performance-client/node_bindings/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-win32-arm64-msvc",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "os": [
     "win32"
   ],

--- a/baseten-performance-client/node_bindings/npm/win32-ia32-msvc/package.json
+++ b/baseten-performance-client/node_bindings/npm/win32-ia32-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-win32-ia32-msvc",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "os": [
     "win32"
   ],

--- a/baseten-performance-client/node_bindings/npm/win32-x64-msvc/package.json
+++ b/baseten-performance-client/node_bindings/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-win32-x64-msvc",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "os": [
     "win32"
   ],

--- a/baseten-performance-client/node_bindings/package.json
+++ b/baseten-performance-client/node_bindings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "main": "index.js",
   "types": "index.d.ts",
   "napi": {

--- a/baseten-performance-client/python_bindings/Cargo.toml
+++ b/baseten-performance-client/python_bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "baseten_performance_client"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2021"
 
 [dependencies]

--- a/baseten-performance-client/python_bindings/pyproject.toml
+++ b/baseten-performance-client/python_bindings/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
   "requests"
 ]


### PR DESCRIPTION
## Summary

Lowers the performance client's validation floors to be less restrictive for low-latency workloads.

- `MIN_REQUEST_TIMEOUT_S`: `0.5` -> `0.1` (100ms) — applies to both per-request `timeout_s` and `total_timeout_s`
- `MIN_HEDGE_DELAY_S`: `0.2` -> `0.06` (60ms)

## Context

Customer reported the 500ms minimum as too restrictive. The 100ms floor still guards against misconfiguration while allowing sub-500ms timeouts for fast endpoints (e.g. local/embedding). The 60ms hedge delay floor aligns with the new timeout floor.

## Validation

Both constants are enforced in:
- `core/src/client.rs` (`validate_and_get_timeout_duration`)
- `core/src/split_policy.rs` (`validate_parameters`)

Existing tests pass (`cargo test -p baseten_performance_client_core`).