### PR TITLE
fix(ssh): actionable error for missing Python SSL root certs

### DIFF
--- a/truss/cli/proxy_command.py
+++ b/truss/cli/proxy_command.py
@@ -65,6 +65,15 @@ def error(msg):
     sys.exit(1)
 
 
+def tls_cert_error(exc):
+    """Exit with an actionable message for TLS certificate verification failures."""
+    error(
+        f"TLS certificate verification failed ({exc}). The Python running this "
+        f"script ({sys.executable}) may have no SSL root certificates installed. "
+        "See https://docs.baseten.co/training/ssh#missing-python-certificates"
+    )
+
+
 def find_key_path():
     """Find the SSH private key (ed25519 or RSA fallback)."""
     for name in ("id_ed25519", "id_rsa"):
@@ -281,6 +290,8 @@ def api_request(url, api_key, method="GET", body=None, extra_headers=None):
             msg = e.reason
         error(f"API error ({e.code}): {msg}")
     except urllib.error.URLError as e:
+        if isinstance(e.reason, ssl.SSLCertVerificationError):
+            tls_cert_error(e.reason)
         error(f"Cannot reach API: {e.reason}")
 
 
@@ -429,7 +440,10 @@ def connect_proxy(proxy_address, jwt_token):
         tls_sock = raw_sock
     else:
         ctx = ssl.create_default_context()
-        tls_sock = ctx.wrap_socket(raw_sock, server_hostname=host)
+        try:
+            tls_sock = ctx.wrap_socket(raw_sock, server_hostname=host)
+        except ssl.SSLCertVerificationError as e:
+            tls_cert_error(e)
 
     # Send length-prefixed JWT
     jwt_bytes = jwt_token.encode()

--- a/truss/tests/cli/test_ssh.py
+++ b/truss/tests/cli/test_ssh.py
@@ -1,4 +1,7 @@
 import configparser
+import ssl
+import sys
+import urllib.error
 from unittest import mock
 
 import pytest
@@ -287,6 +290,13 @@ class TestInstallProxyCommandScript:
 
 
 class TestSetupSSHConfig:
+    @pytest.fixture(autouse=True)
+    def _stub_resolve_python(self):
+        with mock.patch.object(
+            ssh_mod, "_resolve_python", return_value="/usr/bin/python3"
+        ):
+            yield
+
     def test_creates_new_config(self, tmp_path):
         ssh_config = tmp_path / "config"
         key_dir = tmp_path / "baseten"
@@ -427,3 +437,22 @@ class TestIsSetupComplete:
     def test_returns_false_without_key(self, tmp_path):
         (tmp_path / "proxy-command.py").touch()
         assert is_setup_complete(tmp_path) is False
+
+
+class TestTlsCertError:
+    def test_message_names_interpreter_and_docs(self, capsys):
+        with pytest.raises(SystemExit):
+            proxy_command.tls_cert_error(Exception("boom"))
+        err = capsys.readouterr().err
+        assert "TLS certificate verification failed" in err
+        assert sys.executable in err
+        assert "docs.baseten.co" in err
+
+    def test_api_request_routes_cert_failures(self, capsys):
+        exc = urllib.error.URLError(
+            ssl.SSLCertVerificationError("CERTIFICATE_VERIFY_FAILED")
+        )
+        with mock.patch("urllib.request.urlopen", side_effect=exc):
+            with pytest.raises(SystemExit):
+                proxy_command.api_request("https://api.baseten.co/v1/x", "key")
+        assert "TLS certificate verification failed" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

Fixes [SEC-947](https://linear.app/baseten/issue/SEC-947/detect-missing-python-certs-during-workstation-setup): on macOS, python.org installs ship with an empty SSL trust store until `Install Certificates.command` is run, so the first `ssh` through the proxy script died with a raw `CERTIFICATE_VERIFY_FAILED` traceback buried in ssh stderr.

## Changes

Minimal by design (an earlier revision probed interpreters' trust stores at setup time, but the detection heuristic had platform-dependent false positives — e.g. Debian/Ubuntu's lazily-loaded hashed cert dirs report 0 CAs while verifying fine — so we opted for catching the real failure instead):

- `truss/cli/proxy_command.py`: catch `SSLCertVerificationError` in both TLS paths (signing API via `urllib`, proxy tunnel via `wrap_socket`) and exit with one actionable line naming the interpreter and linking to the troubleshooting docs.
- Docs ([companion PR in docs.baseten.co](PLACEHOLDER)): new "Missing Python certificates" section — install certs for that Python, or re-run `truss ssh setup --python $(which python3.12)`.

Failure behavior verified: cert verification fails at handshake (fast, no timeout), `Match exec` stderr is shown to the user, and `*.ssh.baseten.co` doesn't resolve publicly, so the user sees our message followed by an immediate resolve error rather than a hang.

## Testing

- Unit tests for the error message and the `api_request` cert-failure routing in `truss/tests/cli/test_ssh.py`; `TestSetupSSHConfig` also made hermetic (stubs `_resolve_python` instead of depending on host interpreters).