### PR TITLE
Fail fast in checkpoint deploy when non-interactive

### DIFF
--- a/truss/cli/train/deploy_checkpoints/deploy_checkpoints.py
+++ b/truss/cli/train/deploy_checkpoints/deploy_checkpoints.py
@@ -38,6 +38,21 @@ CHECKPOINT_PATTERN = re.compile(r".*checkpoint-\d+(?:-\d+)?$")
 ALLOWED_DEPLOYMENT_NAMES = re.compile(r"^[0-9a-zA-Z_\-\.]*$")
 
 
+def _guard_interactive(missing_value: str) -> None:
+    """Fail fast with a clear message instead of prompting when non-interactive.
+
+    The helpers below fall back to InquirerPy when a value is missing. In a
+    non-TTY or under ``--non-interactive`` that prompt would raise an opaque
+    ``OSError``/``EOFError``, so we surface which value still needs providing.
+    """
+    if not cli_common.check_is_interactive():
+        raise click.UsageError(
+            f"{missing_value} is required but was not provided, and interactive "
+            "prompts are disabled (non-interactive context or --non-interactive). "
+            "Provide the missing value via --config (DeployCheckpointsConfig) and retry."
+        )
+
+
 def create_model_version_from_inference_template(
     remote_provider: BasetenRemote,
     checkpoint_deploy_config: DeployCheckpointsConfig,
@@ -266,6 +281,7 @@ def _get_model_name(
         else ""
     )
 
+    _guard_interactive("Model name (model_name)")
     return inquirer.text(
         message=f"Enter the model name for your {model_weight_format.value} model.",
         validate=lambda s: s and s.strip(),
@@ -342,6 +358,7 @@ def _hydrate_deploy_config(
                 if checkpoint_model_ref
                 else ""
             )
+            _guard_interactive("Model name (model_name)")
             model_name = inquirer.text(
                 message="Enter the model name.",
                 validate=lambda s: s and s.strip(),
@@ -551,6 +568,9 @@ def _get_checkpoint_ids_to_deploy(
 
 def _select_multiple_checkpoints(checkpoint_id_options: List[str]) -> List[str]:
     """Select multiple checkpoints using interactive checkbox."""
+    _guard_interactive(
+        "Checkpoint selection (--checkpoint-ids, or checkpoint_details in --config)"
+    )
     checkpoint_ids = inquirer.checkbox(
         message="Use spacebar to select/deselect checkpoints to deploy. Press enter when done.",
         choices=checkpoint_id_options,
@@ -594,6 +614,7 @@ def _get_accelerator_if_specified(
         return Compute(cpu_count=0, memory="0Mi", accelerator=None)
 
     # prompt user for accelerator
+    _guard_interactive("Compute / accelerator (compute in --config)")
     gpu_type = inquirer.select(
         message="Select the GPU type to use for deployment. Select None for CPU.",
         choices=choices,
@@ -649,6 +670,7 @@ def _get_base_model_id(user_input: Optional[str], checkpoint: dict) -> Optional[
     elif checkpoint.get("checkpoint_type") == ModelWeightsFormat.WHISPER.value.lower():
         return None
     else:
+        _guard_interactive("Base model id (base_model_id)")
         base_model_id = inquirer.text(message="Enter the base model id.").execute()
     if not base_model_id:
         raise click.UsageError(
@@ -740,6 +762,9 @@ def get_hf_secret_name(user_input: Union[str, SecretReference, None]) -> str:
     """Get HuggingFace secret name from user input or prompt for it."""
     if not user_input:
         # prompt user for hf secret name
+        _guard_interactive(
+            "HuggingFace secret name (runtime.environment_variables.HF_TOKEN in --config)"
+        )
         hf_secret_name = inquirer.select(
             message="Enter the huggingface secret name.",
             choices=["hf_access_token", None, "custom"],

--- a/truss/tests/cli/test_loops_cli.py
+++ b/truss/tests/cli/test_loops_cli.py
@@ -966,3 +966,38 @@ def test_checkpoints_deploy_rejects_checkpoint_ids_with_config(mock_remote, tmp_
         )
     assert result.exit_code != 0
     mock_create.assert_not_called()
+
+
+def test_checkpoints_deploy_non_interactive_fails_without_prompting(mock_remote):
+    """A non-TTY (or --non-interactive) deploy that is missing prompted values
+    should fail fast with a clear message instead of crashing in a prompt."""
+    mock_remote.api.list_loops_runs.return_value = [
+        {"id": "trnr_xyz", "base_model": "Qwen/Qwen3-0.6B"}
+    ]
+    # A single deployable checkpoint skips the checkpoint picker, so the first
+    # value we still need to prompt for is the model name.
+    mock_remote.api.list_loops_checkpoints.return_value = {
+        "checkpoints": [
+            {"id": "ckpt_pk_1", "checkpoint_id": "checkpoint-100", "target": "sampler"}
+        ]
+    }
+
+    result = _invoke(
+        [
+            "loops",
+            "checkpoints",
+            "deploy",
+            "--remote",
+            "test_remote",
+            "--run-id",
+            "trnr_xyz",
+            "--non-interactive",
+        ],
+        mock_remote,
+    )
+
+    assert result.exit_code != 0
+    assert "non-interactive" in result.output.lower()
+    assert "Model name" in result.output
+    # We must not have reached the deploy mutation.
+    mock_remote.api.create_model_version_from_inference_template.assert_not_called()

--- a/truss/tests/cli/train/test_deploy_checkpoints.py
+++ b/truss/tests/cli/train/test_deploy_checkpoints.py
@@ -20,6 +20,16 @@ from truss.cli.train.deploy_checkpoints.deploy_whisper_checkpoints import (
 from truss_train.definitions import ModelWeightsFormat
 
 
+@pytest.fixture(autouse=True)
+def assume_interactive():
+    """These tests exercise the interactive prompt helpers, so simulate a human
+    at a TTY. Non-interactive fail-fast behavior is covered in test_loops_cli.py."""
+    with patch(
+        "truss.cli.utils.common.check_is_interactive", return_value=True
+    ) as mock:
+        yield mock
+
+
 @pytest.fixture
 def mock_remote():
     mock = MagicMock()


### PR DESCRIPTION
## Problem

`truss loops checkpoints deploy` (and the shared `truss train deploy_checkpoints`) ignored non-interactive contexts. When required config values were missing, the code fell straight into InquirerPy prompts. In a non-TTY or under `--non-interactive`, those prompts crash with an opaque `OSError`/`EOFError` instead of a clear error telling the user what's missing.

## Root cause

The prompt helpers in `deploy_checkpoints.py` called `inquirer.*` directly without ever consulting `check_is_interactive()` — the existing helper that already accounts for both non-TTY stdin/stdout **and** the `--non-interactive` flag.

## Fix

- Add a `_guard_interactive(missing_value)` helper that raises a clear `click.UsageError` naming the missing value when `check_is_interactive()` is `False`.
- Apply it at every reachable prompt site in the deploy flow: model name (both the Loops and training-job paths), checkpoint multi-select, compute/accelerator, base model id, and the HuggingFace secret name. Downstream prompts (GPU count, custom-secret text) are only reachable after a guarded prompt, so they're covered transitively.

## Tests

- New `test_checkpoints_deploy_non_interactive_fails_without_prompting`: a `--non-interactive` deploy missing the model name exits non-zero with a clear message and never reaches the deploy mutation.
- Existing `deploy_checkpoints` unit tests exercise the interactive prompt helpers directly, so an autouse `assume_interactive` fixture simulates a human at a TTY for that module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)