### PR TITLE
Add RTX_PRO_6000_48GB accelerator type (RTX PRO 6000 MIG 2g.48gb slice)

### DIFF
--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -93,6 +93,7 @@ class Accelerator(str, enum.Enum):
     B200 = "B200"
     L40S = "L40S"
     RTX_PRO_6000 = "RTX_PRO_6000"
+    RTX_PRO_6000_48GB = "RTX_PRO_6000_48GB"
     B300 = "B300"
     GB300 = "GB300"
 

--- a/truss/contexts/docker_build_setup.py
+++ b/truss/contexts/docker_build_setup.py
@@ -63,6 +63,7 @@ def _fill_trt_llm_versions(
                 Accelerator.V100: "turing-",
                 Accelerator.B200: "blackwell-",
                 Accelerator.RTX_PRO_6000: "blackwell-",
+                Accelerator.RTX_PRO_6000_48GB: "blackwell-",
                 Accelerator.B300: "blackwell-",
                 Accelerator.GB300: "blackwell-",
                 None: "unsupported none please upgrade truss",

--- a/truss/tests/test_config.py
+++ b/truss/tests/test_config.py
@@ -230,6 +230,10 @@ def test_validate_mem_spec(mem_spec, expected_valid, memory_in_bytes):
             "RTX_PRO_6000",
             AcceleratorSpec(accelerator=Accelerator.RTX_PRO_6000, count=1),
         ),
+        (
+            "RTX_PRO_6000_48GB",
+            AcceleratorSpec(accelerator=Accelerator.RTX_PRO_6000_48GB, count=1),
+        ),
         ("B300", AcceleratorSpec(accelerator=Accelerator.B300, count=1)),
         ("GB300:4", AcceleratorSpec(accelerator=Accelerator.GB300, count=4)),
     ],


### PR DESCRIPTION
## Summary

Adds a new `Accelerator` enum value `RTX_PRO_6000_48GB` for the RTX PRO 6000 MIG `2g.48gb` profile (half of a 96GB RTX PRO 6000).

- Naming follows the existing MIG-slice convention (`H100_40GB`, `A100_40GB`): base GPU + slice memory.
- Modeled on the `RTX_PRO_6000` addition (#2395): enum value + BEI-BERT docker image suffix mapping (`blackwell-`, same as the full card).
- No `trt_llm_config.py` change needed — Blackwell parts pass the current FP8/FP4 validation by default.

## Testing

- `pytest truss/tests/test_config.py` — 218 passed, including a new `test_acc_spec_from_str` case for the new accelerator.
- `ruff check` / `ruff format --check` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)