### PR TITLE
Add RTX_PRO_6000_48GB_GFX accelerator type (RTX PRO 6000 MIG 2g.48gb+gfx slice)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "truss"
-version = "0.18.23"
+version = "0.18.25rc0"
 description = "A seamless bridge from model development to model delivery"
 authors = [
     { name = "Pankaj Gupta", email = "no-reply@baseten.co" },

--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -93,6 +93,7 @@ class Accelerator(str, enum.Enum):
     B200 = "B200"
     L40S = "L40S"
     RTX_PRO_6000 = "RTX_PRO_6000"
+    RTX_PRO_6000_48GB_GFX = "RTX_PRO_6000_48GB_GFX"
     B300 = "B300"
     GB300 = "GB300"
 

--- a/truss/contexts/docker_build_setup.py
+++ b/truss/contexts/docker_build_setup.py
@@ -63,6 +63,7 @@ def _fill_trt_llm_versions(
                 Accelerator.V100: "turing-",
                 Accelerator.B200: "blackwell-",
                 Accelerator.RTX_PRO_6000: "blackwell-",
+                Accelerator.RTX_PRO_6000_48GB_GFX: "blackwell-",
                 Accelerator.B300: "blackwell-",
                 Accelerator.GB300: "blackwell-",
                 None: "unsupported none please upgrade truss",

--- a/truss/tests/test_config.py
+++ b/truss/tests/test_config.py
@@ -230,6 +230,10 @@ def test_validate_mem_spec(mem_spec, expected_valid, memory_in_bytes):
             "RTX_PRO_6000",
             AcceleratorSpec(accelerator=Accelerator.RTX_PRO_6000, count=1),
         ),
+        (
+            "RTX_PRO_6000_48GB_GFX",
+            AcceleratorSpec(accelerator=Accelerator.RTX_PRO_6000_48GB_GFX, count=1),
+        ),
         ("B300", AcceleratorSpec(accelerator=Accelerator.B300, count=1)),
         ("GB300:4", AcceleratorSpec(accelerator=Accelerator.GB300, count=4)),
     ],

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.9, <3.15"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -3632,7 +3632,7 @@ wheels = [
 
 [[package]]
 name = "truss"
-version = "0.18.23"
+version = "0.18.25rc0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

Adds a new `Accelerator` enum value `RTX_PRO_6000_48GB_GFX` for the RTX PRO 6000 MIG `2g.48gb+gfx` profile (half of a 96GB RTX PRO 6000).

- Naming follows the existing MIG-slice convention (`H100_40GB`, `A100_40GB`): base GPU + slice memory.
- The `_GFX` suffix distinguishes the graphics-enabled MIG profile (`2g.48gb+gfx`) from compute-only profiles.
- Modeled on the `RTX_PRO_6000` addition (#2395): enum value + BEI-BERT docker image suffix mapping (`blackwell-`, same as the full card).
- No `trt_llm_config.py` change needed — Blackwell parts pass the current FP8/FP4 validation by default.

## Testing

- `pytest truss/tests/test_config.py` — 218 passed, including a new `test_acc_spec_from_str` case for the new accelerator.
- `ruff check` / `ruff format --check` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
