### PR TITLE
Support deploying Loops checkpoints by name

### DIFF
--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -16,6 +16,9 @@ from truss.cli.loops_checkpoint_viewer import (
     view_loops_checkpoint_list,
 )
 from truss.cli.train import checkpoint_viewer as checkpoint_mod
+from truss.cli.train.deploy_checkpoints.deploy_checkpoints import (
+    TRAINER_CHECKPOINT_TARGET,
+)
 from truss.cli.utils import common
 from truss.cli.utils.output import console
 from truss.remote.baseten.remote import BasetenRemote
@@ -516,8 +519,59 @@ def view_loops_checkpoints(
     )
 
 
+def _parse_comma_separated(value: Optional[str]) -> List[str]:
+    """Split a comma-separated option into a list, dropping empty entries."""
+    if not value:
+        return []
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def _resolve_loops_checkpoint_names(
+    remote_provider: BasetenRemote, run_id: str, names: List[str]
+) -> List[str]:
+    """Map Loops checkpoint names to their database IDs for the given run.
+
+    Only deployable checkpoints (non-trainer targets) are considered, mirroring
+    the interactive picker; trainer checkpoints hold training state and can't be
+    served.
+    """
+    response = remote_provider.api.list_loops_checkpoints(run_id=run_id)
+    deployable_checkpoints = [
+        checkpoint
+        for checkpoint in response.get("checkpoints", [])
+        if checkpoint.get("target") != TRAINER_CHECKPOINT_TARGET
+    ]
+    name_to_id = {
+        checkpoint["checkpoint_id"]: checkpoint["id"]
+        for checkpoint in deployable_checkpoints
+    }
+    resolved_ids = []
+    unknown_names = []
+    for name in names:
+        checkpoint_pk = name_to_id.get(name)
+        if checkpoint_pk is None:
+            unknown_names.append(name)
+        else:
+            resolved_ids.append(checkpoint_pk)
+    if unknown_names:
+        available = ", ".join(name_to_id) or "(none)"
+        raise click.UsageError(
+            f"Checkpoint name(s) {unknown_names} not found among deployable "
+            f"checkpoints for Loops run {run_id}. Available: {available}."
+        )
+    return resolved_ids
+
+
 @loops_checkpoints.command(name="deploy")
 @click.option("--run-id", type=str, required=False, help="Loops run ID.")
+@click.option(
+    "--checkpoints",
+    type=str,
+    required=False,
+    help="Comma-separated Loops checkpoint names (e.g. step-50,step-100). "
+    "Requires --run-id, since names are scoped per run. Bypasses the "
+    "interactive picker. Use `truss loops checkpoints view` to find names.",
+)
 @click.option(
     "--checkpoint-ids",
     type=str,
@@ -540,21 +594,37 @@ def view_loops_checkpoints(
 @common.common_options()
 def deploy_loops_checkpoints(
     run_id: Optional[str],
+    checkpoints: Optional[str],
     checkpoint_ids: Optional[str],
     config: Optional[str],
     dry_run: bool,
     remote: Optional[str],
 ) -> None:
-    """Deploy checkpoints from a Loops run via vLLM."""
-    if not run_id and not checkpoint_ids and not config:
+    """Deploy checkpoints from a Loops run via vLLM.
+
+    Identify checkpoints by name with --checkpoints (requires --run-id) or by
+    database ID with --checkpoint-ids, or run without them to pick
+    interactively.
+    """
+    if checkpoints and checkpoint_ids:
         raise click.UsageError(
-            "Pass --run-id, --checkpoint-ids, or --config (with "
+            "--checkpoints and --checkpoint-ids are mutually exclusive. "
+            "Deploy from one source: checkpoint names or checkpoint IDs."
+        )
+    if not run_id and not checkpoints and not checkpoint_ids and not config:
+        raise click.UsageError(
+            "Pass --run-id, --checkpoints, or --config (with "
             "loops_checkpoint_ids) to deploy Loops checkpoints."
         )
-    if checkpoint_ids and config:
+    if (checkpoints or checkpoint_ids) and config:
         raise click.UsageError(
-            "--checkpoint-ids cannot be combined with --config. "
+            "--checkpoints / --checkpoint-ids cannot be combined with --config. "
             "Pick one source of checkpoint identifiers."
+        )
+    if checkpoints and not run_id:
+        raise click.UsageError(
+            "--checkpoints requires --run-id, since checkpoint names are scoped "
+            "per run."
         )
     if checkpoint_ids and run_id:
         # Server resolves checkpoint PKs directly and ignores run_id when both
@@ -562,11 +632,13 @@ def deploy_loops_checkpoints(
         # thinking we validated their pairing.
         raise click.UsageError("--checkpoint-ids cannot be combined with --run-id.")
 
-    parsed_checkpoint_ids = (
-        [s.strip() for s in checkpoint_ids.split(",") if s.strip()]
-        if checkpoint_ids
-        else []
-    )
+    parsed_checkpoint_names = _parse_comma_separated(checkpoints)
+    if checkpoints and not parsed_checkpoint_names:
+        raise click.UsageError(
+            "--checkpoints parsed to an empty list. Provide one or more "
+            "comma-separated Loops checkpoint names."
+        )
+    parsed_checkpoint_ids = _parse_comma_separated(checkpoint_ids)
     if checkpoint_ids and not parsed_checkpoint_ids:
         raise click.UsageError(
             "--checkpoint-ids parsed to an empty list. Provide one or more "
@@ -579,6 +651,18 @@ def deploy_loops_checkpoints(
     remote_provider: BasetenRemote = cast(
         BasetenRemote, RemoteFactory.create(remote=remote)
     )
+
+    # Names are resolved to database IDs client-side, then feed the same
+    # loops_checkpoint_ids path as --checkpoint-ids. The run_id is only used
+    # for that resolution, so it is not forwarded downstream.
+    if parsed_checkpoint_names:
+        assert (
+            run_id is not None
+        )  # narrowed by the --checkpoints requires --run-id check
+        parsed_checkpoint_ids = _resolve_loops_checkpoint_names(
+            remote_provider, run_id, parsed_checkpoint_names
+        )
+        run_id = None
 
     result = train_cli.create_model_version_from_inference_template(
         remote_provider,

--- a/truss/tests/cli/test_loops_cli.py
+++ b/truss/tests/cli/test_loops_cli.py
@@ -867,6 +867,148 @@ def test_checkpoints_deploy_with_checkpoint_ids_parses_and_forwards(mock_remote)
     assert deploy_args.deploy_config_path is None
 
 
+_DEPLOYABLE_CHECKPOINTS = {
+    "checkpoints": [
+        {"id": "pk_50", "checkpoint_id": "step-50", "target": "sampler"},
+        {"id": "pk_100", "checkpoint_id": "step-100", "target": "sampler"},
+        {"id": "pk_trainer", "checkpoint_id": "step-100", "target": "trainer"},
+    ]
+}
+
+
+def test_checkpoints_deploy_with_checkpoints_resolves_names_to_ids(mock_remote):
+    mock_remote.api.list_loops_checkpoints.return_value = _DEPLOYABLE_CHECKPOINTS
+    with (
+        patch(
+            "truss.cli.loops_commands.train_cli.create_model_version_from_inference_template"
+        ) as mock_create,
+        patch(
+            "truss.cli.loops_commands.train_cli.print_deploy_checkpoints_success_message"
+        ),
+    ):
+        mock_create.return_value = Mock(deploy_config=Mock(), truss_config=None)
+        result = _invoke(
+            [
+                "loops",
+                "checkpoints",
+                "deploy",
+                "--remote",
+                "test_remote",
+                "--run-id",
+                "trnr_xyz",
+                "--checkpoints",
+                "step-50, step-100",
+                "--dry-run",
+            ],
+            mock_remote,
+        )
+    assert result.exit_code == 0, result.output
+    mock_remote.api.list_loops_checkpoints.assert_called_once_with(run_id="trnr_xyz")
+    deploy_args = mock_create.call_args[0][1]
+    # Names map to their database IDs; run_id is consumed during resolution.
+    assert deploy_args.checkpoint_ids == ["pk_50", "pk_100"]
+    assert deploy_args.run_id is None
+
+
+def test_checkpoints_deploy_checkpoints_requires_run_id(mock_remote):
+    with patch(
+        "truss.cli.loops_commands.train_cli.create_model_version_from_inference_template"
+    ) as mock_create:
+        result = _invoke(
+            [
+                "loops",
+                "checkpoints",
+                "deploy",
+                "--remote",
+                "test_remote",
+                "--checkpoints",
+                "step-50",
+            ],
+            mock_remote,
+        )
+    assert result.exit_code != 0
+    assert "requires --run-id" in result.output
+    mock_create.assert_not_called()
+
+
+def test_checkpoints_deploy_rejects_checkpoints_with_checkpoint_ids(mock_remote):
+    with patch(
+        "truss.cli.loops_commands.train_cli.create_model_version_from_inference_template"
+    ) as mock_create:
+        result = _invoke(
+            [
+                "loops",
+                "checkpoints",
+                "deploy",
+                "--remote",
+                "test_remote",
+                "--run-id",
+                "trnr_xyz",
+                "--checkpoints",
+                "step-50",
+                "--checkpoint-ids",
+                "pk_50",
+            ],
+            mock_remote,
+        )
+    assert result.exit_code != 0
+    assert "mutually exclusive" in result.output
+    mock_create.assert_not_called()
+
+
+def test_checkpoints_deploy_unknown_checkpoint_name_lists_available(mock_remote):
+    mock_remote.api.list_loops_checkpoints.return_value = _DEPLOYABLE_CHECKPOINTS
+    with patch(
+        "truss.cli.loops_commands.train_cli.create_model_version_from_inference_template"
+    ) as mock_create:
+        result = _invoke(
+            [
+                "loops",
+                "checkpoints",
+                "deploy",
+                "--remote",
+                "test_remote",
+                "--run-id",
+                "trnr_xyz",
+                "--checkpoints",
+                "step-999",
+            ],
+            mock_remote,
+        )
+    assert result.exit_code != 0
+    assert "step-999" in result.output
+    # The error lists the deployable names, excluding trainer targets.
+    assert "step-50" in result.output
+    assert "step-100" in result.output
+    mock_create.assert_not_called()
+
+
+def test_checkpoints_deploy_rejects_checkpoints_with_config(mock_remote, tmp_path):
+    config_path = tmp_path / "deploy.py"
+    config_path.write_text("")
+    with patch(
+        "truss.cli.loops_commands.train_cli.create_model_version_from_inference_template"
+    ) as mock_create:
+        result = _invoke(
+            [
+                "loops",
+                "checkpoints",
+                "deploy",
+                "--remote",
+                "test_remote",
+                "--run-id",
+                "trnr_xyz",
+                "--checkpoints",
+                "step-50",
+                "--config",
+                str(config_path),
+            ],
+            mock_remote,
+        )
+    assert result.exit_code != 0
+    mock_create.assert_not_called()
+
+
 def test_checkpoints_deploy_rejects_checkpoint_ids_with_run_id(mock_remote):
     with patch(
         "truss.cli.loops_commands.train_cli.create_model_version_from_inference_template"

--- a/truss/tests/cli/test_loops_cli.py
+++ b/truss/tests/cli/test_loops_cli.py
@@ -240,10 +240,13 @@ def _invoke(args, mock_remote):
         return runner.invoke(truss_cli, args)
 
 
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
 def _flatten(output: str) -> str:
-    """Collapse rich-click box borders and wrapping so a message substring
-    matches regardless of the render width."""
-    return " ".join(output.replace("│", " ").split())
+    """Collapse rich-click ANSI color, box borders, and wrapping so a message
+    substring matches regardless of render width or forced color (CI)."""
+    return " ".join(_ANSI_RE.sub("", output).replace("│", " ").split())
 
 
 def _run(

--- a/truss/tests/cli/test_loops_cli.py
+++ b/truss/tests/cli/test_loops_cli.py
@@ -240,6 +240,12 @@ def _invoke(args, mock_remote):
         return runner.invoke(truss_cli, args)
 
 
+def _flatten(output: str) -> str:
+    """Collapse rich-click box borders and wrapping so a message substring
+    matches regardless of the render width."""
+    return " ".join(output.replace("│", " ").split())
+
+
 def _run(
     run_id: str, status_name: str, created_at: str = "2026-07-01T00:00:00Z"
 ) -> dict:
@@ -927,7 +933,7 @@ def test_checkpoints_deploy_checkpoints_requires_run_id(mock_remote):
             mock_remote,
         )
     assert result.exit_code != 0
-    assert "requires --run-id" in result.output
+    assert "requires --run-id" in _flatten(result.output)
     mock_create.assert_not_called()
 
 
@@ -952,7 +958,7 @@ def test_checkpoints_deploy_rejects_checkpoints_with_checkpoint_ids(mock_remote)
             mock_remote,
         )
     assert result.exit_code != 0
-    assert "mutually exclusive" in result.output
+    assert "mutually exclusive" in _flatten(result.output)
     mock_create.assert_not_called()
 
 


### PR DESCRIPTION
## Summary

Adds the ability to deploy Loops checkpoints by their human-readable **name** (e.g. `step-100`), alongside the existing database-ID selection. This is purely additive — checkpoint IDs remain fully supported everywhere, and no output columns are removed.

### `truss loops checkpoints deploy` — also support deploying by name

- New `--checkpoints step-50,step-100` accepts comma-separated checkpoint **names**. It requires `--run-id`, since names are scoped per run.
- Names are resolved to database IDs **client-side** against the run's already-listed deployable checkpoints (excluding trainer-target checkpoints), then fed through the existing deploy path — no backend change.
- `--checkpoint-ids <hashids>` stays a first-class option, unchanged.
- The two selectors are mutually exclusive: deploy from one source, names or IDs.
- Error handling: `--checkpoints` without `--run-id` is rejected; an unknown name errors clearly and lists the available deployable names; either flag combined with `--config` is rejected.

### `truss loops checkpoints view` — unchanged

The checkpoint list still shows both the "Checkpoint ID" (database PK) and "Checkpoint Name" columns for Loops and training-job checkpoints. No change to any output format.

## Tests

Added CLI tests for deploy: name resolution to IDs, `--checkpoints` requires `--run-id`, mutual exclusivity between `--checkpoints` and `--checkpoint-ids`, unknown-name error listing available names, and rejection alongside `--config`. Existing `--checkpoint-ids` and view tests are retained unchanged. `ruff` and `mypy` are clean; the affected test suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
