### PR TITLE
Deprecate `truss loops runs view` in favor of `truss loops view`

### DIFF
--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -260,11 +260,15 @@ def view_loops_runs(
     reverse: bool,
     remote: Optional[str],
 ) -> None:
-    """List Loops runs visible to the caller.
+    """[DEPRECATED] Use `truss loops view` instead.
 
-    Both filters are optional and can be combined; omit both to list all
-    runs visible to the caller.
+    Lists Loops runs visible to the caller. Both filters are optional and can be
+    combined; omit both to list all runs visible to the caller.
     """
+    console.print(
+        "[DEPRECATED] `truss loops runs view` is deprecated; use `truss loops view` instead.",
+        style="yellow",
+    )
     if not remote:
         remote = remote_cli.inquire_remote_name()
 

--- a/truss/tests/cli/test_loops_cli.py
+++ b/truss/tests/cli/test_loops_cli.py
@@ -491,6 +491,14 @@ def test_runs_view_no_filters_calls_search_with_none(mock_remote):
     assert "trnr_xyz" in result.output
 
 
+def test_runs_view_prints_deprecation_notice(mock_remote):
+    mock_remote.api.list_loops_runs.return_value = []
+    result = _invoke(["loops", "runs", "view", "--remote", "test_remote"], mock_remote)
+    assert result.exit_code == 0, result.output
+    assert "DEPRECATED" in result.output
+    assert "truss loops view" in result.output
+
+
 def test_runs_view_with_run_id_filter(mock_remote):
     mock_remote.api.list_loops_runs.return_value = [
         {"id": "trnr_xyz", "session_id": "sess_abc", "base_model": "Qwen/Qwen3-8B"}


### PR DESCRIPTION
## What

`truss loops view` is now the run list, so `truss loops runs view` is redundant. Mark it deprecated:
- `[DEPRECATED]` prefix in its `--help`.
- A yellow runtime notice: *"`truss loops runs view` is deprecated; use `truss loops view` instead."*

It still works — including its `--run-id` / `--base-model` filters — so existing scripts/muscle memory keep functioning; this is just a nudge toward the primary command.

## Testing

Added a test asserting the deprecation notice; existing `runs view` tests still pass. `ruff` + `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)