### PR TITLE
Adding visual gen support in Truss

### DIFF
--- a/truss/base/trt_llm_config.py
+++ b/truss/base/trt_llm_config.py
@@ -5,7 +5,17 @@ import logging
 import os
 import warnings
 from enum import Enum
-from typing import TYPE_CHECKING, Annotated, Any, Dict, Literal, Optional, Union
+from typing import (
+    TYPE_CHECKING,
+    Annotated,
+    Any,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    Union,
+)
 
 from huggingface_hub.errors import HFValidationError
 from huggingface_hub.utils import validate_repo_id
@@ -573,6 +583,8 @@ class VersionsOverrides(PydanticTrTBaseModel):
     bei_version: Optional[str] = None
     bei_bert_version: Optional[str] = None
     v2_llm_version: Optional[str] = None
+    # Pins the TRT-LLM release used for visual_gen deployments, e.g. `1.3.0rc20`.
+    visual_gen_version: Optional[str] = None
 
     @model_validator(mode="before")
     def version_must_start_with_number(cls, data):
@@ -581,6 +593,7 @@ class VersionsOverrides(PydanticTrTBaseModel):
             "briton_version",
             "bei_version",
             "bei_bert_version",
+            "visual_gen_version",
         ]:
             v = data.get(field)
             if v is not None and (not v or not v[0].isdigit()):
@@ -600,6 +613,142 @@ class ImageVersions(PydanticTrTBaseModel):
     )
     briton_image: str
     v2_llm_image: str
+    # Default empty: older backends do not send this field.
+    visual_gen_image: str = ""
+
+
+class _VisualGenBaseModel(PydanticTrTBaseModel):
+    """Lenient base for visual_gen sub-configs.
+
+    Unlike other truss config models, unknown keys are accepted even during
+    push-time `validate_forbid_extra` checks: the visual_gen engine schema
+    evolves with TRT-LLM releases (a config may pin a newer release via
+    `version_overrides.visual_gen_version`), and `trtllm-serve` itself
+    validates the full config strictly at startup.
+    """
+
+    @model_validator(mode="before")
+    def _maybe_forbid_extra(cls, data, info):
+        # Intentionally overrides ConfigModel._maybe_forbid_extra with a no-op.
+        return data
+
+
+class VisualGenQuantConfig(_VisualGenBaseModel):
+    # quant_algo values follow modelopt naming (FP8, NVFP4, FP8_BLOCK_SCALES, ...).
+    quant_algo: Optional[str] = None
+    # dynamic=True quantizes weights on the fly at load time and auto-selects
+    # the fastest activation-quantization kernels.
+    dynamic: Optional[bool] = None
+
+
+class VisualGenAttentionConfig(_VisualGenBaseModel):
+    backend: Literal["VANILLA", "TRTLLM", "FA4", "CUTEDSL"] = "VANILLA"
+    quant_attention_config: Optional[Dict[str, Any]] = None
+    sparse_attention_config: Optional[Dict[str, Any]] = None
+
+
+class VisualGenParallelConfig(_VisualGenBaseModel):
+    cfg_size: Annotated[int, Field(ge=1, le=2)] = 1
+    ulysses_size: Annotated[int, Field(ge=1)] = 1
+    ring_size: Annotated[int, Field(ge=1)] = 1
+    tp_size: Annotated[int, Field(ge=1)] = 1
+    attn2d_size: Optional[Tuple[int, int]] = None
+    async_ulysses: bool = False
+    parallel_vae_size: Annotated[int, Field(ge=1)] = 1
+    parallel_vae_split_dim: Literal["width", "height"] = "width"
+
+    @property
+    def n_workers(self) -> int:
+        # Mirrors ParallelConfig.n_workers in TensorRT-LLM: cfg x seq-parallel x tp,
+        # where seq-parallel is (attn2d or ring) x ulysses. parallel_vae reuses ranks.
+        attn2d_total = (
+            self.attn2d_size[0] * self.attn2d_size[1] if self.attn2d_size else 1
+        )
+        cp_size = attn2d_total if attn2d_total > 1 else self.ring_size
+        return self.cfg_size * cp_size * self.ulysses_size * self.tp_size
+
+
+class VisualGenCacheConfig(_VisualGenBaseModel):
+    cache_backend: Literal["teacache", "cache_dit"]
+
+
+class VisualGenTorchCompileConfig(_VisualGenBaseModel):
+    enable: bool = True
+    enable_fullgraph: bool = False
+    enable_autotune: bool = True
+
+
+class VisualGenCudaGraphConfig(_VisualGenBaseModel):
+    enable: bool = False
+
+
+class VisualGenCompilationConfig(_VisualGenBaseModel):
+    # Warmup shapes = Cartesian product of resolutions x num_frames.
+    resolutions: Optional[List[Tuple[int, int]]] = None
+    num_frames: Optional[List[int]] = None
+    skip_warmup: bool = False
+
+
+class VisualGenConfiguration(_VisualGenBaseModel):
+    """Top-level `visual_gen:` block for TRT-LLM Visual Gen (diffusion) deployments.
+
+    Fields mirror `VisualGenArgs` from TensorRT-LLM and are passed verbatim to
+    `trtllm-serve --visual_gen_args`. The model path comes from
+    `weights[0].mount_location` of the truss config; the serving image is
+    resolved by the backend (default or `version_overrides.visual_gen_version`).
+    """
+
+    quant_config: Optional[VisualGenQuantConfig] = None
+    attention_config: Optional[VisualGenAttentionConfig] = None
+    parallel_config: Optional[VisualGenParallelConfig] = None
+    cache_config: Optional[VisualGenCacheConfig] = None
+    torch_compile_config: Optional[VisualGenTorchCompileConfig] = None
+    cuda_graph_config: Optional[VisualGenCudaGraphConfig] = None
+    compilation_config: Optional[VisualGenCompilationConfig] = None
+    pipeline_config: Optional[Dict[str, Any]] = None
+
+    # If versions are not set, the baseten backend inserts the current default.
+    version_overrides: VersionsOverrides = Field(default_factory=VersionsOverrides)
+
+    def to_visual_gen_args_dict(self) -> Dict[str, Any]:
+        """Engine-args payload for `trtllm-serve --visual_gen_args`.
+
+        Dumps exactly the keys the user set (including unknown passthrough keys),
+        excluding truss-only fields.
+        """
+        return self.model_dump(
+            mode="json",
+            exclude={"version_overrides"},
+            exclude_unset=True,
+            exclude_none=True,
+        )
+
+
+def visual_gen_validation(config: "TrussConfig") -> "TrussConfig":
+    """Called from TrussConfig model validation (analogous to trt_llm_validation)."""
+    if config.visual_gen is None:
+        return config
+    if config.trt_llm is not None:
+        raise ValueError(
+            "`visual_gen` and `trt_llm` are mutually exclusive top-level config "
+            "blocks. Use `visual_gen` for diffusion (image/video generation) "
+            "models and `trt_llm` for LLM/embedding models."
+        )
+    if not config.weights.sources:
+        raise ValueError(
+            "`visual_gen` requires a `weights:` entry; the first source's "
+            "`mount_location` is used as the model path for trtllm-serve."
+        )
+    parallel = config.visual_gen.parallel_config
+    if parallel is not None:
+        gpu_count = config.resources.accelerator.count
+        if parallel.n_workers > gpu_count:
+            raise ValueError(
+                f"visual_gen.parallel_config requires {parallel.n_workers} GPUs "
+                f"(cfg_size x seq-parallel x tp_size), but resources.accelerator "
+                f"provides only {gpu_count}."
+            )
+    return config
 
 
 class TRTLLMConfigurationV1(PydanticTrTBaseModel):

--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -1309,6 +1309,13 @@ class TrussConfig(custom_types.ConfigModel):
         default=None,
         description="TensorRT-LLM configuration for optimized LLM inference.",
     )
+    visual_gen: Optional[trt_llm_config.VisualGenConfiguration] = pydantic.Field(
+        default=None,
+        description=(
+            "TRT-LLM Visual Gen configuration for diffusion (image/video "
+            "generation) models served with trtllm-serve."
+        ),
+    )
 
     # deploying from checkpoint
     training_checkpoints: Optional[CheckpointList] = pydantic.Field(
@@ -1515,6 +1522,10 @@ class TrussConfig(custom_types.ConfigModel):
     @pydantic.model_validator(mode="after")
     def _validate_trt_llm_resources(self) -> "TrussConfig":
         return trt_llm_config.trt_llm_validation(self)
+
+    @pydantic.model_validator(mode="after")
+    def _validate_visual_gen(self) -> "TrussConfig":
+        return trt_llm_config.visual_gen_validation(self)
 
     @pydantic.field_serializer("trt_llm")
     def _serialize_trt_llm(

--- a/truss/config.schema.json
+++ b/truss/config.schema.json
@@ -1043,7 +1043,8 @@
             "briton_version": null,
             "bei_version": null,
             "bei_bert_version": null,
-            "v2_llm_version": null
+            "v2_llm_version": null,
+            "visual_gen_version": null
           }
         }
       },
@@ -1075,7 +1076,8 @@
             "briton_version": null,
             "bei_version": null,
             "bei_bert_version": null,
-            "v2_llm_version": null
+            "v2_llm_version": null,
+            "visual_gen_version": null
           }
         }
       },
@@ -1732,9 +1734,375 @@
           ],
           "default": null,
           "title": "V2 Llm Version"
+        },
+        "visual_gen_version": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Visual Gen Version"
         }
       },
       "title": "VersionsOverrides",
+      "type": "object"
+    },
+    "VisualGenAttentionConfig": {
+      "additionalProperties": true,
+      "properties": {
+        "backend": {
+          "default": "VANILLA",
+          "enum": [
+            "VANILLA",
+            "TRTLLM",
+            "FA4",
+            "CUTEDSL"
+          ],
+          "title": "Backend",
+          "type": "string"
+        },
+        "quant_attention_config": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Quant Attention Config"
+        },
+        "sparse_attention_config": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sparse Attention Config"
+        }
+      },
+      "title": "VisualGenAttentionConfig",
+      "type": "object"
+    },
+    "VisualGenCacheConfig": {
+      "additionalProperties": true,
+      "properties": {
+        "cache_backend": {
+          "enum": [
+            "teacache",
+            "cache_dit"
+          ],
+          "title": "Cache Backend",
+          "type": "string"
+        }
+      },
+      "required": [
+        "cache_backend"
+      ],
+      "title": "VisualGenCacheConfig",
+      "type": "object"
+    },
+    "VisualGenCompilationConfig": {
+      "additionalProperties": true,
+      "properties": {
+        "resolutions": {
+          "anyOf": [
+            {
+              "items": {
+                "maxItems": 2,
+                "minItems": 2,
+                "prefixItems": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "integer"
+                  }
+                ],
+                "type": "array"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Resolutions"
+        },
+        "num_frames": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Num Frames"
+        },
+        "skip_warmup": {
+          "default": false,
+          "title": "Skip Warmup",
+          "type": "boolean"
+        }
+      },
+      "title": "VisualGenCompilationConfig",
+      "type": "object"
+    },
+    "VisualGenConfiguration": {
+      "additionalProperties": true,
+      "description": "Top-level `visual_gen:` block for TRT-LLM Visual Gen (diffusion) deployments.\n\nFields mirror `VisualGenArgs` from TensorRT-LLM and are passed verbatim to\n`trtllm-serve --visual_gen_args`. The model path comes from\n`weights[0].mount_location` of the truss config; the serving image is\nresolved by the backend (default or `version_overrides.visual_gen_version`).",
+      "properties": {
+        "quant_config": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VisualGenQuantConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "attention_config": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VisualGenAttentionConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "parallel_config": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VisualGenParallelConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "cache_config": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VisualGenCacheConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "torch_compile_config": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VisualGenTorchCompileConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "cuda_graph_config": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VisualGenCudaGraphConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "compilation_config": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VisualGenCompilationConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "pipeline_config": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Pipeline Config"
+        },
+        "version_overrides": {
+          "$ref": "#/$defs/VersionsOverrides"
+        }
+      },
+      "title": "VisualGenConfiguration",
+      "type": "object"
+    },
+    "VisualGenCudaGraphConfig": {
+      "additionalProperties": true,
+      "properties": {
+        "enable": {
+          "default": false,
+          "title": "Enable",
+          "type": "boolean"
+        }
+      },
+      "title": "VisualGenCudaGraphConfig",
+      "type": "object"
+    },
+    "VisualGenParallelConfig": {
+      "additionalProperties": true,
+      "properties": {
+        "cfg_size": {
+          "default": 1,
+          "maximum": 2,
+          "minimum": 1,
+          "title": "Cfg Size",
+          "type": "integer"
+        },
+        "ulysses_size": {
+          "default": 1,
+          "minimum": 1,
+          "title": "Ulysses Size",
+          "type": "integer"
+        },
+        "ring_size": {
+          "default": 1,
+          "minimum": 1,
+          "title": "Ring Size",
+          "type": "integer"
+        },
+        "tp_size": {
+          "default": 1,
+          "minimum": 1,
+          "title": "Tp Size",
+          "type": "integer"
+        },
+        "attn2d_size": {
+          "anyOf": [
+            {
+              "maxItems": 2,
+              "minItems": 2,
+              "prefixItems": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "integer"
+                }
+              ],
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Attn2D Size"
+        },
+        "async_ulysses": {
+          "default": false,
+          "title": "Async Ulysses",
+          "type": "boolean"
+        },
+        "parallel_vae_size": {
+          "default": 1,
+          "minimum": 1,
+          "title": "Parallel Vae Size",
+          "type": "integer"
+        },
+        "parallel_vae_split_dim": {
+          "default": "width",
+          "enum": [
+            "width",
+            "height"
+          ],
+          "title": "Parallel Vae Split Dim",
+          "type": "string"
+        }
+      },
+      "title": "VisualGenParallelConfig",
+      "type": "object"
+    },
+    "VisualGenQuantConfig": {
+      "additionalProperties": true,
+      "properties": {
+        "quant_algo": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Quant Algo"
+        },
+        "dynamic": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Dynamic"
+        }
+      },
+      "title": "VisualGenQuantConfig",
+      "type": "object"
+    },
+    "VisualGenTorchCompileConfig": {
+      "additionalProperties": true,
+      "properties": {
+        "enable": {
+          "default": true,
+          "title": "Enable",
+          "type": "boolean"
+        },
+        "enable_fullgraph": {
+          "default": false,
+          "title": "Enable Fullgraph",
+          "type": "boolean"
+        },
+        "enable_autotune": {
+          "default": true,
+          "title": "Enable Autotune",
+          "type": "boolean"
+        }
+      },
+      "title": "VisualGenTorchCompileConfig",
       "type": "object"
     },
     "WebsocketOptions": {
@@ -2162,6 +2530,18 @@
       ],
       "default": null,
       "description": "TensorRT-LLM configuration for optimized LLM inference."
+    },
+    "visual_gen": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/VisualGenConfiguration"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "TRT-LLM Visual Gen configuration for diffusion (image/video generation) models served with trtllm-serve."
     },
     "training_checkpoints": {
       "anyOf": [

--- a/truss/contexts/docker_build_setup.py
+++ b/truss/contexts/docker_build_setup.py
@@ -84,6 +84,19 @@ def _fill_trt_llm_versions(
             )
 
 
+def _fill_visual_gen_version(
+    tr: truss_handle.TrussHandle, image_versions: trt_llm_config.ImageVersions
+):
+    assert tr.spec.config.visual_gen is not None
+    if not image_versions.visual_gen_image:
+        raise ValueError(
+            "The backend did not provide a visual_gen image. The baseten "
+            "backend version may not support `visual_gen:` deployments yet."
+        )
+    print(f"Using Visual Gen image: {image_versions.visual_gen_image}")
+    tr.set_base_image(image_versions.visual_gen_image, "/usr/bin/python3")
+
+
 @click.command()
 @click.option("--truss_type", required=True)
 @click.option("--trt_llm_image_versions_json")
@@ -104,6 +117,11 @@ def docker_build_setup(
             trt_llm_image_versions_json
         )
         _fill_trt_llm_versions(tr, image_versions)
+    elif tr.spec.config.visual_gen is not None and trt_llm_image_versions_json:
+        image_versions = trt_llm_config.ImageVersions.model_validate_json(
+            trt_llm_image_versions_json
+        )
+        _fill_visual_gen_version(tr, image_versions)
 
     logging.info("Truss is loaded")
 

--- a/truss/contexts/image_builder/serving_image_builder.py
+++ b/truss/contexts/image_builder/serving_image_builder.py
@@ -99,6 +99,8 @@ BUILD_CHAINS_DIR_NAME = "truss_chains"
 BUILD_TRUSS_DIR_NAME = "truss"
 
 CONFIG_FILE = "config.yaml"
+VISUAL_GEN_CONFIG_FILENAME = "visual_gen_config.yaml"
+VISUAL_GEN_SERVER_PORT = 8000
 USER_TRUSS_IGNORE_FILE = ".truss_ignore"
 GCS_CREDENTIALS = "service_account.json"
 S3_CREDENTIALS = "s3_credentials.json"
@@ -559,6 +561,42 @@ class ServingImageBuilder(ImageBuilder):
             build_dir / CONFIG_FILE, build_dir / "standalone/truss_config.yaml"
         )
 
+    def prepare_visual_gen_build_dir(self, build_dir: Path):
+        """prepares the build directory for a TRT-LLM Visual Gen (diffusion) model"""
+        config = self._spec.config
+        assert config.visual_gen is not None, (
+            "prepare_visual_gen_build_dir should only be called for visual_gen models"
+        )
+        # Validated in visual_gen_validation; assert for mypy and safety.
+        assert config.weights.sources, "visual_gen requires a `weights:` entry"
+        model_path = config.weights.sources[0].mount_location
+
+        # Engine args are passed verbatim to `trtllm-serve --visual_gen_args`.
+        with (build_dir / VISUAL_GEN_CONFIG_FILENAME).open("w") as f:
+            yaml.safe_dump(config.visual_gen.to_visual_gen_args_dict(), f)
+
+        launch = (
+            # HF token for gated tokenizer/config fetches; weights are pre-mounted.
+            "if [ -f /secrets/hf_access_token ]; then "
+            "export HF_TOKEN=$(cat /secrets/hf_access_token); fi; "
+            f"exec trtllm-serve {model_path} "
+            f"--visual_gen_args /app/{VISUAL_GEN_CONFIG_FILENAME} "
+            f"--host 0.0.0.0 --port {VISUAL_GEN_SERVER_PORT}"
+        )
+        if config.docker_server is not None:
+            logging.warning(
+                "visual_gen is set: overriding user-supplied `docker_server` "
+                "with the generated trtllm-serve start command."
+            )
+        self._spec.config.docker_server = DockerServer(
+            start_command=f"/bin/sh -c '{launch}'",
+            server_port=VISUAL_GEN_SERVER_PORT,
+            predict_endpoint="/v1/images/generations",
+            readiness_endpoint="/health",
+            liveness_endpoint="/health",
+        )
+        copy_tree_path(DOCKER_SERVER_TEMPLATES_DIR, build_dir, ignore_patterns=[])
+
     def prepare_trtllm_bei_encoder_build_dir(self, build_dir: Path):
         """prepares the build directory for a trtllm ENCODER model to launch a Baseten Embeddings Inference (BEI) server"""
         config = self._spec.config
@@ -732,6 +770,9 @@ class ServingImageBuilder(ImageBuilder):
                     self.prepare_trtllm_bert_encoder_build_dir(build_dir=build_dir)
                 else:
                     self.prepare_trtllm_decoder_build_dir(build_dir=build_dir)
+
+        if config.visual_gen is not None:
+            self.prepare_visual_gen_build_dir(build_dir=build_dir)
 
         if _is_docker_server_build(config) and not _should_use_docker_server_slim(
             config

--- a/truss/templates/server.Dockerfile.jinja
+++ b/truss/templates/server.Dockerfile.jinja
@@ -113,6 +113,10 @@ USER {{ run_as_user_id }}
 {# before ENTRYPOINT) so that runtime-only config changes don't invalidate earlier, costly layers. #}
 {%- macro copy_config_yaml() -%}
 COPY --chown={{ run_as_user_id }}:{{ run_as_user_id }} ./config.yaml ${APP_HOME}/config.yaml
+{%- if config.visual_gen %}
+{# Engine args consumed by `trtllm-serve --visual_gen_args`; see prepare_visual_gen_build_dir. #}
+COPY --chown={{ run_as_user_id }}:{{ run_as_user_id }} ./visual_gen_config.yaml ${APP_HOME}/visual_gen_config.yaml
+{%- endif %} {#- endif config.visual_gen #}
 {%- endmacro -%}
 
 {%- if build_commands %}


### PR DESCRIPTION
This pull request introduces support for TRT-LLM Visual Gen (diffusion/image/video generation) model deployments in the Truss framework. It adds a new `visual_gen` configuration block, corresponding validation logic, schema updates, and build process integration. The changes ensure that Visual Gen deployments are mutually exclusive with LLM deployments, validate configuration correctness, and properly prepare the serving environment.

The most important changes are:

**Visual Gen Configuration Support**
* Added the `VisualGenConfiguration` class and related sub-configs (quantization, attention, parallelism, cache, compilation, etc.) to `trt_llm_config.py`, allowing users to specify detailed Visual Gen deployment options. These models are lenient to allow forward compatibility with backend schema changes.
* Updated `truss_config.py` to include a top-level, mutually exclusive `visual_gen` field and added validation to prevent both `trt_llm` and `visual_gen` from being set simultaneously. [[1]](diffhunk://#diff-bd2e56a7fb17062c4ddbeb577e8577de55d55c946ee3d8d63bf690dd969e6162R1312-R1318) [[2]](diffhunk://#diff-bd2e56a7fb17062c4ddbeb577e8577de55d55c946ee3d8d63bf690dd969e6162R1526-R1529)

**Version Pinning and Schema Updates**
* Extended the `VersionsOverrides` model and JSON schema to support a `visual_gen_version` field for pinning backend releases, and updated validation to include this new field. [[1]](diffhunk://#diff-46ef452528530de706caaea1d0903cc5bc7a713f398c36e9410f257f11e0034cR586-R587) [[2]](diffhunk://#diff-46ef452528530de706caaea1d0903cc5bc7a713f398c36e9410f257f11e0034cR596) [[3]](diffhunk://#diff-ed1a86b36921ceb570bcde5e6217641524eb6d6d0454215eb7d4f44abf6d0890L1046-R1047) [[4]](diffhunk://#diff-ed1a86b36921ceb570bcde5e6217641524eb6d6d0454215eb7d4f44abf6d0890L1078-R1080) [[5]](diffhunk://#diff-ed1a86b36921ceb570bcde5e6217641524eb6d6d0454215eb7d4f44abf6d0890R1737-R2107)
* Updated `ImageVersions` to include a `visual_gen_image` field for backend-provided serving images.

**Build and Serving Integration**
* Added logic to the Docker build setup (`docker_build_setup.py`) to handle Visual Gen deployments, including filling the correct image version and asserting backend support. [[1]](diffhunk://#diff-515e5eae1b91a5c7be03d7f671a9ffa92f4a48705b3eb32fb13f10de21256b04R87-R99) [[2]](diffhunk://#diff-515e5eae1b91a5c7be03d7f671a9ffa92f4a48705b3eb32fb13f10de21256b04R120-R124)
* Implemented `prepare_visual_gen_build_dir` in `serving_image_builder.py` to serialize the configuration, set up the launch command for `trtllm-serve`, and override user-supplied server commands as needed. [[1]](diffhunk://#diff-fcc20c8c80a4959f2008aa68b35e52e9d7708ec8bf6a4525d3a2ef7bbcaf53c8R102-R103) [[2]](diffhunk://#diff-fcc20c8c80a4959f2008aa68b35e52e9d7708ec8bf6a4525d3a2ef7bbcaf53c8R564-R599)

These changes collectively enable first-class support for deploying TRT-LLM Visual Gen models with Truss, including configuration, validation, schema enforcement, and serving orchestration.