### PR TITLE
Add request backpressure policy to truss

### DIFF
--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -627,6 +627,15 @@ class OIDC(custom_types.ConfigModel):
     )
 
 
+class RequestBackpressure(custom_types.ConfigModel):
+    """Configuration for how the deployment handles requests when at capacity."""
+
+    policy: Optional[Literal["queue_on_full", "reject_on_full"]] = pydantic.Field(
+        default=None,
+        description="queue_on_full (default) queues requests while reject_on_full returns HTTP 429 if deployment is at capacity.",
+    )
+
+
 class RemoteSSH(custom_types.ConfigModel):
     """Configuration for SSH access to running model instances."""
 
@@ -756,14 +765,9 @@ class Runtime(custom_types.ConfigModel):
         description="By default, truss servers are built from the same release as the "
         "CLI used to push. This field allows specifying a pinned/specific version instead.",
     )
-    request_backpressure_policy: Optional[
-        Literal["queue_on_full", "reject_on_full"]
-    ] = pydantic.Field(
-        default=None,
-        description=(
-            "Controls how the deployment handles requests when at capacity. "
-            "queue_on_full (default) queues requests while reject_on_full returns HTTP 429 immediately."
-        ),
+    request_backpressure: RequestBackpressure = pydantic.Field(
+        default_factory=RequestBackpressure,
+        description="Configuration for how the deployment handles requests when at capacity.",
     )
 
     config: ClassVar = pydantic.ConfigDict(validate_assignment=True)

--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -756,6 +756,15 @@ class Runtime(custom_types.ConfigModel):
         description="By default, truss servers are built from the same release as the "
         "CLI used to push. This field allows specifying a pinned/specific version instead.",
     )
+    request_backpressure_policy: Optional[
+        Literal["queue_on_full", "reject_on_full"]
+    ] = pydantic.Field(
+        default=None,
+        description=(
+            "Controls how the deployment handles requests when at capacity. "
+            "queue_on_full (default) queues requests while reject_on_full returns HTTP 429 immediately."
+        ),
+    )
 
     config: ClassVar = pydantic.ConfigDict(validate_assignment=True)
 

--- a/truss/config.schema.json
+++ b/truss/config.schema.json
@@ -995,6 +995,23 @@
           "default": null,
           "description": "By default, truss servers are built from the same release as the CLI used to push. This field allows specifying a pinned/specific version instead.",
           "title": "Truss Server Version Override"
+        },
+        "request_backpressure_policy": {
+          "anyOf": [
+            {
+              "enum": [
+                "queue_on_full",
+                "reject_on_full"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Controls how the deployment handles requests when at capacity. queue_on_full (default) queues requests while reject_on_full returns HTTP 429 immediately.",
+          "title": "Request Backpressure Policy"
         }
       },
       "title": "Runtime",

--- a/truss/config.schema.json
+++ b/truss/config.schema.json
@@ -829,6 +829,31 @@
       "title": "RemoteSSH",
       "type": "object"
     },
+    "RequestBackpressure": {
+      "additionalProperties": true,
+      "description": "Configuration for how the deployment handles requests when at capacity.",
+      "properties": {
+        "policy": {
+          "anyOf": [
+            {
+              "enum": [
+                "queue_on_full",
+                "reject_on_full"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "queue_on_full (default) queues requests while reject_on_full returns HTTP 429 if deployment is at capacity.",
+          "title": "Policy"
+        }
+      },
+      "title": "RequestBackpressure",
+      "type": "object"
+    },
     "Resources": {
       "additionalProperties": true,
       "description": "Compute resources that your model needs, including CPU, memory, and GPU resources.",
@@ -996,22 +1021,8 @@
           "description": "By default, truss servers are built from the same release as the CLI used to push. This field allows specifying a pinned/specific version instead.",
           "title": "Truss Server Version Override"
         },
-        "request_backpressure_policy": {
-          "anyOf": [
-            {
-              "enum": [
-                "queue_on_full",
-                "reject_on_full"
-              ],
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Controls how the deployment handles requests when at capacity. queue_on_full (default) queues requests while reject_on_full returns HTTP 429 immediately.",
-          "title": "Request Backpressure Policy"
+        "request_backpressure": {
+          "$ref": "#/$defs/RequestBackpressure"
         }
       },
       "title": "Runtime",


### PR DESCRIPTION
## What

Adds `request_backpressure_policy` to the `runtime` config section — a new optional field that controls how a deployment handles requests when all replicas are at capacity.

```yaml
runtime:
  request_backpressure:
    policy: queue_on_full
```

`queue_on_full` preserves existing behavior — requests queue at the activator. `reject_on_full` returns HTTP 429 immediately, allowing clients with fallback providers to route away instead of waiting.

## How

- New field on `Runtime` typed as `Optional[Literal["queue_on_full", "reject_on_full"]]` — validated at config parse time by Pydantic
- Defaults to `None` so it's omitted from serialized configs when not set, meaning all existing Truss configs are unaffected
- The backend reads `runtime.request_backpressure_policy` from the model config and enforces the org-level feature flag `ORG_ENABLE_DEPLOYMENT_ADMISSION_POLICY`; it raises `FeatureUnavailableError` if not enabled for the org

## Companion PR

basetenlabs/baseten#23872