### PR TITLE
Handle binary Content-Type parameters in model server

### DIFF
--- a/truss/templates/server/truss_server.py
+++ b/truss/templates/server/truss_server.py
@@ -367,10 +367,9 @@ class BasetenEndpoints:
 
     @staticmethod
     def is_binary(request: Request):
-        return (
-            "Content-Type" in request.headers
-            and request.headers["Content-Type"] == "application/octet-stream"
-        )
+        content_type = request.headers.get("Content-Type", "")
+        media_type = content_type.partition(";")[0].strip().lower()
+        return media_type == "application/octet-stream"
 
 
 class TrussServer:

--- a/truss/tests/templates/server/test_truss_server.py
+++ b/truss/tests/templates/server/test_truss_server.py
@@ -14,6 +14,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import opentelemetry.sdk.trace as sdk_trace
 import pytest
 import yaml
+from starlette.datastructures import Headers
+
+from truss.templates.shared import serialization
 
 
 @pytest.fixture
@@ -116,6 +119,27 @@ async def test_execute_request_sets_none_when_no_request_id_header(app_path):
         )
 
         mock_request_id_context.set.assert_called_once_with(None)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "content_type",
+    ["application/octet-stream; charset=binary", "Application/Octet-Stream"],
+)
+async def test_binary_request_accepts_content_type_variants(app_path, content_type):
+    mock_request = _make_connected_request()
+    mock_request.headers = Headers({"Content-Type": content_type})
+    body = serialization.truss_msgpack_serialize({})
+
+    with _clear_truss_server_modules(), _change_directory(app_path):
+        endpoints = _get_endpoints(app_path)
+        response = await endpoints.predict(
+            model_name="model", request=mock_request, body_raw=body
+        )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/octet-stream"
+    assert serialization.truss_msgpack_deserialize(response.body) == {"predictions": []}
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## What

Binary msgpack requests were only recognized when `Content-Type` exactly matched `application/octet-stream`. Headers with parameters or different casing were treated as JSON, so the request failed before reaching the model.

## How

Normalize the header before checking it by taking the media type before `;`, trimming whitespace, and comparing it case-insensitively.

Added a regression test covering a parameterized and a mixed-case header through the full msgpack request and response path.

## Testing

- `uv run pytest truss/tests/templates/server/test_truss_server.py::test_binary_request_accepts_content_type_variants -q`
- `uv run pytest truss/tests -m 'not integration' -q` (1320 passed, 11 skipped, 221 deselected)
- `uv run pre-commit run --files truss/templates/server/truss_server.py truss/tests/templates/server/test_truss_server.py`
- `uv run ruff check .`
- `uv run ruff format . --check`
