### PR TITLE
Polish truss loops usage display: Created column + collapsed statuses

### DIFF
--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -645,7 +645,7 @@ def _render_loops_usage(
     table.add_column("Trainer Status")
     table.add_column("Sampler GPU")
     table.add_column("Sampler Status")
-    table.add_column("Since")
+    table.add_column("Created")
     for deployment in deployments:
         sampler = deployment.get("sampler")
         created_at = deployment.get("created_at") or ""

--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -247,7 +247,23 @@ _SCALED_TO_ZERO_STATUS = "SCALED_TO_ZERO"
 # Dead sampler states (DeploymentStatusV1) — hold no live GPUs; standalone
 # samplers in these states are hidden from the usage view unless --all.
 _TERMINAL_SAMPLER_STATUSES = frozenset(
-    {"INACTIVE", "FAILED", "DEPLOY_FAILED", "BUILD_FAILED", "BUILD_STOPPED"}
+    {
+        "INACTIVE",
+        "FAILED",
+        "DEPLOY_FAILED",
+        "BUILD_FAILED",
+        "BUILD_STOPPED",
+        "UNHEALTHY",
+        "DEACTIVATING",
+    }
+)
+# The usage table collapses raw backend statuses into the same buckets the UI
+# (truss loops view) shows: trainer is ACTIVE/INACTIVE (scaled-to-zero, stopped,
+# and failed all read INACTIVE); sampler adds SCALED_TO_ZERO. These are the
+# statuses that read as ACTIVE — serving or coming up; anything else is INACTIVE.
+_TRAINER_ACTIVE_STATUSES = frozenset({"CREATED", "DEPLOYING", "RUNNING"})
+_SAMPLER_ACTIVE_STATUSES = frozenset(
+    {"ACTIVE", "WAKING_UP", "UPDATING", "BUILDING", "DEPLOYING", "LOADING_MODEL"}
 )
 
 
@@ -610,6 +626,24 @@ def _row_holds_live_gpus(row: Dict[str, Any]) -> bool:
     return trainer_live or sampler_live
 
 
+def _trainer_status_label(status: str) -> str:
+    """Collapse a raw trainer status to ACTIVE/INACTIVE (scaled-to-zero, stopped,
+    and failed all read INACTIVE), or "—" for a standalone-sampler row."""
+    if status == _NO_TRAINER_STATUS:
+        return _NO_TRAINER_STATUS
+    return "ACTIVE" if status in _TRAINER_ACTIVE_STATUSES else "INACTIVE"
+
+
+def _sampler_status_label(status: Optional[str]) -> str:
+    """Collapse a raw sampler status to ACTIVE/SCALED_TO_ZERO/INACTIVE, or "—"
+    when there is no sampler."""
+    if not status:
+        return "—"
+    if status == _SCALED_TO_ZERO_STATUS:
+        return _SCALED_TO_ZERO_STATUS
+    return "ACTIVE" if status in _SAMPLER_ACTIVE_STATUSES else "INACTIVE"
+
+
 def _render_loops_usage(
     deployments: List[Dict[str, Any]],
     summary: Dict[str, int],
@@ -649,8 +683,10 @@ def _render_loops_usage(
     for deployment in deployments:
         sampler = deployment.get("sampler")
         created_at = deployment.get("created_at") or ""
-        since = common.format_localized_time(created_at) if created_at else "—"
-        sampler_status = ((sampler or {}).get("status") or {}).get("name") or "—"
+        created = common.format_localized_time(created_at) if created_at else "—"
+        sampler_status = _sampler_status_label(
+            ((sampler or {}).get("status") or {}).get("name")
+        )
         # Active-or-latest: idle (scaled-to-zero/stopped) deployments have no
         # active run but still expose their most recent run as a usable handle.
         run_id = deployment.get("active_run_id") or deployment.get("latest_run_id")
@@ -663,13 +699,13 @@ def _render_loops_usage(
                 _format_gpu_cell(
                     deployment.get("instance_type"), deployment.get("node_count") or 1
                 ),
-                deployment["status"]["name"],
+                _trainer_status_label(deployment["status"]["name"]),
                 _format_gpu_cell(
                     sampler.get("instance_type") if sampler else None,
                     (sampler.get("node_count") or 1) if sampler else 1,
                 ),
                 sampler_status,
-                since,
+                created,
             ]
         )
         table.add_row(*row)
@@ -685,11 +721,13 @@ def _render_loops_usage_json(deployments: List[Dict[str, Any]]) -> None:
             "active_run_id": deployment.get("active_run_id"),
             "latest_run_id": deployment.get("latest_run_id"),
             "base_model": deployment.get("base_model", ""),
-            "status": deployment["status"]["name"],
+            "status": _trainer_status_label(deployment["status"]["name"]),
             "owner": (deployment.get("user") or {}).get("email"),
             "trainer_instance_type": deployment.get("instance_type"),
             "trainer_node_count": deployment.get("node_count"),
-            "sampler_status": (sampler.get("status") or {}).get("name"),
+            "sampler_status": _sampler_status_label(
+                (sampler.get("status") or {}).get("name")
+            ),
             "sampler_instance_type": sampler.get("instance_type"),
             "sampler_node_count": sampler.get("node_count"),
             "created_at": deployment.get("created_at") or "",

--- a/truss/tests/cli/test_loops_cli.py
+++ b/truss/tests/cli/test_loops_cli.py
@@ -1431,10 +1431,47 @@ def test_usage_renders_gpu_statuses_and_owner(mock_remote):
     # Multi-node trainer allocation shows the node-count suffix.
     assert "H100:8 ×2" in flat
     assert "H100:2" in flat
-    assert "RUNNING" in flat
+    # Raw statuses (RUNNING) collapse to the UI buckets (ACTIVE/INACTIVE).
+    assert "RUNNING" not in flat
     assert "ACTIVE" in flat
     # Org-wide is the default.
     mock_remote.api.list_loops_deployments.assert_called_once_with(scope="org")
+
+
+def test_usage_collapses_statuses_to_ui_buckets(mock_remote):
+    # Trainer scaled-to-zero reads INACTIVE (mimics the run status); a coming-up
+    # sampler (WAKING_UP) reads ACTIVE.
+    mock_remote.api.list_loops_deployments.return_value = [
+        _usage_deployment(
+            "dep_a",
+            status_name="SCALED_TO_ZERO",
+            active_run_id=None,
+            latest_run_id="run_a",
+            sampler_status="WAKING_UP",
+            sampler_gpu={"gpu_type": "L4", "gpu_count": 1, "node_count": 1},
+        )
+    ]
+    result = _invoke(
+        ["loops", "usage", "--remote", "test_remote", "-o", "json"], mock_remote
+    )
+    assert result.exit_code == 0, result.output
+    record = _parse_jsonl(result.output)[0]
+    assert record["status"] == "INACTIVE"  # trainer SCALED_TO_ZERO -> INACTIVE
+    assert record["sampler_status"] == "ACTIVE"  # sampler WAKING_UP -> ACTIVE
+
+
+def test_usage_all_shows_failed_sampler_as_inactive(mock_remote):
+    # A failed/unhealthy sampler collapses to INACTIVE (shown with --all).
+    mock_remote.api.list_loops_deployments.return_value = []
+    mock_remote.api.list_loops_samplers.return_value = [
+        _standalone_sampler("samp_bad", status_name="DEPLOY_FAILED")
+    ]
+    result = _invoke(
+        ["loops", "usage", "--all", "--remote", "test_remote", "-o", "json"],
+        mock_remote,
+    )
+    assert result.exit_code == 0, result.output
+    assert _parse_jsonl(result.output)[0]["sampler_status"] == "INACTIVE"
 
 
 def test_usage_mine_drops_owner_and_uses_caller_scope(mock_remote):
@@ -1649,7 +1686,7 @@ def test_usage_json_output_shape(mock_remote):
             "active_run_id": "run_xyz",
             "latest_run_id": None,
             "base_model": "Qwen/Qwen3-8B",
-            "status": "RUNNING",
+            "status": "ACTIVE",
             "owner": "owner@baseten.co",
             "trainer_instance_type": {"gpu_type": "H100", "gpu_count": 8},
             "trainer_node_count": 2,
@@ -1693,7 +1730,7 @@ def test_usage_json_output_renders_null_gpu_and_sampler(mock_remote):
     records = _parse_jsonl(result.output)
     assert records[0]["active_run_id"] is None
     assert records[0]["trainer_instance_type"] is None
-    assert records[0]["sampler_status"] is None
+    assert records[0]["sampler_status"] == "—"  # no sampler
     assert records[0]["sampler_instance_type"] is None
 
 


### PR DESCRIPTION
## What

Polish for the `truss loops usage` display:

1. **Rename `Since` → `Created`.** The column shows each allocation's creation timestamp, so `Created` names it more clearly.

2. **Collapse the status columns to the UI's buckets** (mirroring `truss loops view`), instead of showing raw backend statuses:
   - **Trainer Status** → `ACTIVE` / `INACTIVE` (scaled-to-zero, stopped, and failed all read `INACTIVE`).
   - **Sampler Status** → `ACTIVE` / `SCALED_TO_ZERO` / `INACTIVE` (serving + coming-up states like `WAKING_UP`/`BUILDING` read `ACTIVE`; failed/unhealthy/deactivating read `INACTIVE`).

   The raw backend vocabularies were inconsistent side by side (a serving trainer said `RUNNING` while a serving sampler said `ACTIVE`) and noisy (13 possible sampler values). `UNHEALTHY`/`DEACTIVATING` were also added to the dead-sampler set so the summary's in-use/idle math agrees with the collapsed labels.

Applies to both the table and `-o json`.

## Testing

- `uv run ruff check` / `uv run mypy` clean.
- `uv run pytest truss/tests/cli/test_loops_cli.py -q` — 102 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
