### PR TITLE
Deprecate `truss loops samplers view` in favor of `truss loops usage`

### DIFF
--- a/truss/cli/loops_commands.py
+++ b/truss/cli/loops_commands.py
@@ -446,7 +446,14 @@ def loops_samplers() -> None:
 @click.option("--remote", type=str, required=False, help="Remote to use.")
 @common.common_options()
 def view_loops_samplers(reverse: bool, remote: Optional[str]) -> None:
-    """List Loops samplers visible to the caller."""
+    """[DEPRECATED] Use `truss loops usage` instead.
+
+    Lists Loops samplers visible to the caller.
+    """
+    console.print(
+        "[DEPRECATED] `truss loops samplers view` is deprecated; use `truss loops usage` instead.",
+        style="yellow",
+    )
     if not remote:
         remote = remote_cli.inquire_remote_name()
 

--- a/truss/tests/cli/test_loops_cli.py
+++ b/truss/tests/cli/test_loops_cli.py
@@ -563,6 +563,16 @@ def test_samplers_view_lists_samplers(mock_remote):
     assert "sampler_def" in result.output
 
 
+def test_samplers_view_prints_deprecation_notice(mock_remote):
+    mock_remote.api.list_loops_samplers.return_value = []
+    result = _invoke(
+        ["loops", "samplers", "view", "--remote", "test_remote"], mock_remote
+    )
+    assert result.exit_code == 0, result.output
+    assert "DEPRECATED" in result.output
+    assert "truss loops usage" in result.output
+
+
 def test_samplers_view_no_samplers_prints_friendly_message(mock_remote):
     mock_remote.api.list_loops_samplers.return_value = []
     result = _invoke(


### PR DESCRIPTION
## What

Marks `truss loops samplers view` as **deprecated** in favor of `truss loops usage`.

Standalone and paired samplers now surface in `truss loops usage` (as sampler-only rows and in the Sampler columns), so the standalone `samplers view` command is redundant. This mirrors the earlier deprecation of `truss loops runs view` in favor of `truss loops view`.

The command still works; it just:
- prefixes its docstring with `[DEPRECATED] Use \`truss loops usage\` instead.`, and
- prints a yellow runtime notice before its output.

## Testing

- `uv run ruff check` / `uv run mypy` clean.
- `uv run pytest truss/tests/cli/test_loops_cli.py -q` — sampler tests pass, including a new `test_samplers_view_prints_deprecation_notice`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
