### PR TITLE
fix(ssh): scope JWT cache by remote

### DIFF
--- a/truss/cli/proxy_command.py
+++ b/truss/cli/proxy_command.py
@@ -348,7 +348,12 @@ def sign_model_certificate(rest_url, api_key, parsed, public_key, key_path):
 
 
 def _jwt_cache_path(parsed):
-    parts = [parsed.workload_type, parsed.id]
+    parts = [
+        parsed.workload_type,
+        f"remote-{parsed.remote or 'default'}",
+        f"api-{parsed.api_prefix or 'default'}",
+        parsed.id,
+    ]
     if parsed.deployment_id:
         parts.append(parsed.deployment_id)
     if parsed.replica:

--- a/truss/tests/cli/test_ssh.py
+++ b/truss/tests/cli/test_ssh.py
@@ -209,6 +209,36 @@ class TestResolveRemote:
             assert resolve_remote("dev", config) == "dev"
 
 
+class TestJwtCache:
+    def test_entries_are_scoped_by_remote_and_api_prefix(self, tmp_path):
+        dev = ParsedHostname(
+            workload_type=WORKLOAD_MODEL,
+            id="model",
+            replica=None,
+            deployment_id="deployment",
+            remote="dev",
+            api_prefix="mc-dev",
+        )
+        staging = ParsedHostname(
+            workload_type=WORKLOAD_MODEL,
+            id="model",
+            replica=None,
+            deployment_id="deployment",
+            remote="staging",
+            api_prefix="staging",
+        )
+
+        with mock.patch.object(proxy_command, "JWT_CACHE_DIR", tmp_path):
+            proxy_command.save_jwt_cache(dev, "dev-token", "dev-proxy:443")
+            proxy_command.save_jwt_cache(staging, "staging-token", "staging-proxy:443")
+
+            assert proxy_command.load_jwt_cache(dev) == ("dev-token", "dev-proxy:443")
+            assert proxy_command.load_jwt_cache(staging) == (
+                "staging-token",
+                "staging-proxy:443",
+            )
+
+
 class TestEnsureSSHKeypair:
     def test_creates_keypair_ed25519(self, tmp_path):
         key_dir = tmp_path / "ssh" / "baseten"


### PR DESCRIPTION
## What

Scope SSH proxy JWT cache entries by the parsed remote and API prefix.

## Why

The cache key previously contained only the workload type and workload IDs. Identical model or training targets on different Baseten remotes therefore shared one cache file, allowing one environment's sign step to overwrite another's token and proxy address. Concurrent SSH sessions could then read credentials for the wrong environment.

## Impact

Cache entries for different remotes and API environments no longer collide. Existing unscoped cache files are ignored and will be recreated on the next SSH connection.

## Testing

- `uv run pytest truss/tests/cli/test_ssh.py -q`
- `uv run ruff check truss/cli/proxy_command.py truss/tests/cli/test_ssh.py`
- `uv run ruff format truss/cli/proxy_command.py truss/tests/cli/test_ssh.py`
