### PR TITLE
Keepalive: ping docker_server readiness endpoint

### DIFF
--- a/truss-chains/tests/test_deployment_client_watch.py
+++ b/truss-chains/tests/test_deployment_client_watch.py
@@ -255,12 +255,14 @@ def test_prepare_chainlet_models_for_watch_waits_and_starts_keepalive():
         remote_provider.fetch_auth_header,
         is_draft=True,
         deployment_id="version_id",
+        ping_path="v1/models/model",
     )
     mock_keepalive.assert_any_call(
         "https://model-def.api.baseten.co",
         remote_provider.fetch_auth_header,
         is_draft=True,
         deployment_id="version_id",
+        ping_path="v1/models/model",
     )
 
 
@@ -289,12 +291,14 @@ def test_prepare_chainlet_models_for_watch_keeps_all_chainlets_warm_with_subset(
         remote_provider.fetch_auth_header,
         is_draft=True,
         deployment_id="version_id",
+        ping_path="v1/models/model",
     )
     mock_keepalive.assert_any_call(
         "https://model-def.api.baseten.co",
         remote_provider.fetch_auth_header,
         is_draft=True,
         deployment_id="version_id",
+        ping_path="v1/models/model",
     )
 
 
@@ -352,6 +356,7 @@ def test_prepare_chainlet_models_for_watch_recovers_missing_hostname():
         remote_provider.fetch_auth_header,
         is_draft=True,
         deployment_id="version_id",
+        ping_path="v1/models/model",
     )
 
 
@@ -386,7 +391,72 @@ def test_start_keepalives_warms_ready_chainlets_including_published():
         remote_provider.fetch_auth_header,
         is_draft=False,
         deployment_id="version_id",
+        ping_path="v1/models/model",
     )
+
+
+def test_start_keepalives_uses_ping_path_override():
+    chainlets = [
+        _chainlet("LLM", status="MODEL_READY"),
+        _chainlet("Orchestrator", status="MODEL_READY"),
+    ]
+    remote_provider = MagicMock()
+    started_keepalives: dict = {}
+
+    with patch(
+        "truss_chains.deployment.deployment_client.cli_common.start_keepalive"
+    ) as mock_keepalive:
+        deployment_client._start_keepalives_for_ready_chainlets(
+            chainlets, remote_provider, started_keepalives, ping_paths={"LLM": "ready"}
+        )
+
+    # The docker_server chainlet is pinged on its readiness endpoint; the truss
+    # server chainlet keeps the default path.
+    mock_keepalive.assert_any_call(
+        "https://model-abc.api.baseten.co",
+        remote_provider.fetch_auth_header,
+        is_draft=True,
+        deployment_id="version_id",
+        ping_path="ready",
+    )
+    mock_keepalive.assert_any_call(
+        "https://model-abc.api.baseten.co",
+        remote_provider.fetch_auth_header,
+        is_draft=True,
+        deployment_id="version_id",
+        ping_path="v1/models/model",
+    )
+
+
+def test_keepalive_ping_paths_maps_docker_server_chainlets(tmp_path):
+    docker_truss_dir = tmp_path / "llm"
+    docker_truss_dir.mkdir()
+    (docker_truss_dir / "config.yaml").write_text(
+        """
+model_name: llm
+docker_server:
+  start_command: python server.py
+  server_port: 8000
+  predict_endpoint: /v1/chat/completions
+  readiness_endpoint: /ready
+  liveness_endpoint: /health
+"""
+    )
+    truss_server_dir = tmp_path / "stt"
+    truss_server_dir.mkdir()
+    (truss_server_dir / "config.yaml").write_text("model_name: stt\n")
+
+    descriptors = [
+        _descriptor(docker_truss_dir, display_name="LLM", is_truss_chainlet=True),
+        _descriptor(truss_server_dir, display_name="STT", is_truss_chainlet=True),
+        _descriptor(display_name="Orchestrator"),
+    ]
+
+    ping_paths = deployment_client._keepalive_ping_paths(descriptors)
+
+    # Framework-generated chainlets (no truss_dir) fall back to the default path
+    # via the absent key.
+    assert ping_paths == {"LLM": "ready", "STT": "v1/models/model"}
 
 
 def test_start_keepalives_is_idempotent_per_oracle_id():

--- a/truss-chains/truss_chains/deployment/deployment_client.py
+++ b/truss-chains/truss_chains/deployment/deployment_client.py
@@ -25,6 +25,7 @@ import requests
 import tenacity
 import watchfiles
 
+from truss.base import truss_config
 from truss.cli.utils import common as cli_common
 from truss.local import local_config_handler
 from truss.remote import remote_factory
@@ -323,6 +324,21 @@ def _generate_chainlet_artifacts(
     )
 
 
+def _keepalive_ping_paths(
+    chainlet_descriptors: Iterable[private_types.ChainletAPIDescriptor],
+) -> dict[str, str]:
+    """Map chainlet display name -> keepalive path. docker_server chainlets don't
+    serve the truss server's `/v1/models/model`; ping their readiness endpoint."""
+    ping_paths = {}
+    for descriptor in chainlet_descriptors:
+        if descriptor.is_truss_chainlet and descriptor.truss_dir:
+            config = truss_config.TrussConfig.from_yaml(
+                descriptor.truss_dir / "config.yaml"
+            )
+            ping_paths[descriptor.display_name] = cli_common.keepalive_ping_path(config)
+    return ping_paths
+
+
 @framework.raise_validation_errors_before
 def push(
     entrypoint: Type[private_types.ABCChainlet],
@@ -349,6 +365,9 @@ def push(
             dependency_artifacts,
             progress_bar,
             entrypoint_descriptor,
+            keepalive_ping_paths=_keepalive_ping_paths(
+                _get_ordered_dependencies([entrypoint])
+            ),
         )
     elif isinstance(options, private_types.PushOptionsLocalDocker):
         if has_engine_builder_chainlets:
@@ -508,6 +527,7 @@ class BasetenChainService(ChainService):
     _chain_deployment_handle: b10_core.ChainDeploymentHandleAtomic
     _remote: b10_remote.BasetenRemote
     _entrypoint_descriptor: Optional[private_types.ChainletAPIDescriptor]
+    _keepalive_ping_paths: Mapping[str, str]
 
     def __init__(
         self,
@@ -515,11 +535,18 @@ class BasetenChainService(ChainService):
         chain_deployment_handle: b10_core.ChainDeploymentHandleAtomic,
         remote: b10_remote.BasetenRemote,
         entrypoint_descriptor: Optional[private_types.ChainletAPIDescriptor] = None,
+        keepalive_ping_paths: Optional[Mapping[str, str]] = None,
     ) -> None:
         super().__init__(name)
         self._chain_deployment_handle = chain_deployment_handle
         self._remote = remote
         self._entrypoint_descriptor = entrypoint_descriptor
+        self._keepalive_ping_paths = keepalive_ping_paths or {}
+
+    @property
+    def keepalive_ping_paths(self) -> Mapping[str, str]:
+        """Chainlet display name -> keepalive path (see `_keepalive_ping_paths`)."""
+        return self._keepalive_ping_paths
 
     @property
     def run_remote_url(self) -> str:
@@ -611,6 +638,7 @@ def _create_baseten_chain(
     dependency_artifacts: list[b10_types.ChainletArtifact],
     progress_bar: Optional[Type["progress.Progress"]],
     entrypoint_descriptor: Optional[private_types.ChainletAPIDescriptor] = None,
+    keepalive_ping_paths: Optional[Mapping[str, str]] = None,
 ):
     logging.info(
         f"Pushing Chain '{baseten_options.chain_name}' to Baseten "
@@ -663,6 +691,7 @@ def _create_baseten_chain(
         chain_deployment_handle,
         remote_provider,
         entrypoint_descriptor,
+        keepalive_ping_paths=keepalive_ping_paths,
     )
 
 
@@ -811,6 +840,7 @@ class _Watcher:
     _error_console: "rich_console.Console"
     _show_stack_trace: bool
     _included_chainlets: set[str]
+    _keepalive_ping_paths: Mapping[str, str]
 
     def __init__(
         self,
@@ -857,6 +887,7 @@ class _Watcher:
                 chainlet_descriptors,
                 self._included_chainlets if included_chainlets else None,
             )
+            self._keepalive_ping_paths = _keepalive_ping_paths(chainlet_descriptors)
 
         resolved_chain = resolve_chain_for_watch(
             self._remote_provider, self._deployed_chain_name, provided_team_name
@@ -1084,6 +1115,7 @@ def _start_keepalives_for_ready_chainlets(
     remote_provider: b10_remote.BasetenRemote,
     started_keepalives: dict[str, threading.Event],
     resolved_hostnames: Optional[dict[str, str]] = None,
+    ping_paths: Optional[Mapping[str, str]] = None,
 ) -> None:
     """Start keepalive for each chainlet that has a usable inference endpoint.
 
@@ -1092,10 +1124,13 @@ def _start_keepalives_for_ready_chainlets(
     `/deployment/{id}/...` endpoint. Each chainlet is warmed at most once;
     ``started_keepalives`` maps already-warmed ``oracle_id`` -> stop event and is
     mutated in place so the same set can be shared across the push wait loop and
-    the subsequent watch.
+    the subsequent watch. ``ping_paths`` (chainlet display name -> path) overrides
+    the default keepalive path for docker_server chainlets.
     """
     if resolved_hostnames is None:
         resolved_hostnames = {}
+    if ping_paths is None:
+        ping_paths = {}
 
     for chainlet in chainlet_data:
         if chainlet.oracle_id in started_keepalives:
@@ -1114,6 +1149,9 @@ def _start_keepalives_for_ready_chainlets(
             remote_provider.fetch_auth_header,
             is_draft=chainlet.is_draft,
             deployment_id=chainlet.oracle_version_id,
+            ping_path=ping_paths.get(
+                chainlet.name, cli_common.KEEPALIVE_DEFAULT_PING_PATH
+            ),
         )
 
 
@@ -1124,6 +1162,7 @@ def _prepare_chainlet_models_for_watch(
     console: "rich_console.Console",
     no_sleep: bool,
     started_keepalives: Optional[dict[str, threading.Event]] = None,
+    ping_paths: Optional[Mapping[str, str]] = None,
 ) -> None:
     resolved_hostnames: dict[str, str] = {}
 
@@ -1152,6 +1191,7 @@ def _prepare_chainlet_models_for_watch(
         remote_provider,
         started_keepalives,
         resolved_hostnames=resolved_hostnames,
+        ping_paths=ping_paths,
     )
 
 
@@ -1194,6 +1234,7 @@ def watch(
         console,
         no_sleep,
         started_keepalives=started_keepalives,
+        ping_paths=patcher._keepalive_ping_paths,
     )
     patcher.watch()
 

--- a/truss/cli/chains_commands.py
+++ b/truss/cli/chains_commands.py
@@ -423,7 +423,10 @@ def push_chain(
                 live.update(table)
                 if keep_warm_during_push and remote_provider is not None:
                     deployment_client._start_keepalives_for_ready_chainlets(
-                        chainlets, remote_provider, started_keepalives
+                        chainlets,
+                        remote_provider,
+                        started_keepalives,
+                        ping_paths=service.keepalive_ping_paths,
                     )
                 num_active = sum(s == ACTIVE_STATUS for s in statuses)
                 num_deploying = sum(s in DEPLOYING_STATUSES for s in statuses)

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -1039,7 +1039,11 @@ def push(
             )
             if watch_no_sleep:
                 model_hostname = resolved_model["hostname"]
-                common.start_keepalive(model_hostname, bt_remote.fetch_auth_header)
+                common.start_keepalive(
+                    model_hostname,
+                    bt_remote.fetch_auth_header,
+                    ping_path=common.keepalive_ping_path(tr.spec.config),
+                )
             _start_watch_mode(
                 target_directory=target_directory,
                 model_name=model_name,
@@ -1476,7 +1480,11 @@ def watch(
     )
 
     if no_sleep:
-        common.start_keepalive(model_hostname, remote_provider.fetch_auth_header)
+        common.start_keepalive(
+            model_hostname,
+            remote_provider.fetch_auth_header,
+            ping_path=common.keepalive_ping_path(tr.spec.config),
+        )
 
     if tail:
         _start_tail(remote_provider, model_id, dev_version_id, in_background=True)

--- a/truss/cli/utils/common.py
+++ b/truss/cli/utils/common.py
@@ -21,6 +21,7 @@ import rich_click as click
 from rich.markup import escape
 
 import truss
+from truss.base import truss_config
 from truss.cli.utils import self_upgrade
 
 if TYPE_CHECKING:
@@ -52,6 +53,16 @@ _KEEPALIVE_INTERVAL_SEC = 30
 _KEEPALIVE_MAX_CONSECUTIVE_FAILURES = 20  # be very generous
 _KEEPALIVE_MAX_DURATION_SEC = 24 * 60 * 60  # 24 hours
 _KEEPALIVE_WARNING_BEFORE_EXIT_SEC = 30 * 60  # 30 minutes
+# Truss servers answer 200 on this route; docker_server deployments don't serve
+# it and need `keepalive_ping_path` to pick their readiness endpoint instead.
+KEEPALIVE_DEFAULT_PING_PATH = "v1/models/model"
+
+
+def keepalive_ping_path(config: truss_config.TrussConfig) -> str:
+    """Return the path the keepalive loop should ping for this deployment."""
+    if config.docker_server:
+        return config.docker_server.readiness_endpoint.lstrip("/")
+    return KEEPALIVE_DEFAULT_PING_PATH
 
 
 def set_logging_level() -> None:
@@ -325,7 +336,7 @@ def wait_for_development_model_ready(
 
 
 def _keepalive_url(
-    model_hostname: str, is_draft: bool, deployment_id: Optional[str]
+    model_hostname: str, is_draft: bool, deployment_id: Optional[str], ping_path: str
 ) -> str:
     """Build the warm-up endpoint for a deployment.
 
@@ -333,12 +344,12 @@ def _keepalive_url(
     deployments are pinged via their specific `/deployment/{id}/...` endpoint.
     """
     if is_draft:
-        return f"{model_hostname}/development/sync/v1/models/model"
+        return f"{model_hostname}/development/sync/{ping_path}"
     if not deployment_id:
         raise ValueError(
             "deployment_id is required to keep a published deployment warm."
         )
-    return f"{model_hostname}/deployment/{deployment_id}/sync/v1/models/model"
+    return f"{model_hostname}/deployment/{deployment_id}/sync/{ping_path}"
 
 
 def start_keepalive(
@@ -347,9 +358,10 @@ def start_keepalive(
     *,
     is_draft: bool = True,
     deployment_id: Optional[str] = None,
+    ping_path: str = KEEPALIVE_DEFAULT_PING_PATH,
 ) -> threading.Event:
     """Start a keepalive thread to prevent scale-to-zero. Returns the stop event."""
-    keepalive_url = _keepalive_url(model_hostname, is_draft, deployment_id)
+    keepalive_url = _keepalive_url(model_hostname, is_draft, deployment_id, ping_path)
     console.print("💤 --no-sleep enabled: keeping model warm")
     stop_event = threading.Event()
     keepalive_thread = threading.Thread(

--- a/truss/tests/cli/test_chains_cli.py
+++ b/truss/tests/cli/test_chains_cli.py
@@ -30,6 +30,7 @@ def _mock_baseten_chain_service() -> BasetenChainService:
     service = object.__new__(BasetenChainService)
     service._name = "test_chain"
     service._entrypoint_descriptor = None
+    service._keepalive_ping_paths = {}
     service._chain_deployment_handle = Mock(
         hostname="chain.api.baseten.co",
         chain_deployment_id="deployment_id",

--- a/truss/tests/cli/test_cli.py
+++ b/truss/tests/cli/test_cli.py
@@ -241,6 +241,7 @@ def _make_watch_mocks(
 
     mock_tr = Mock()
     mock_tr.spec.config.model_name = "test_model"
+    mock_tr.spec.config.docker_server = None
 
     remote_provider = MagicMock()
     remote_provider.fetch_auth_header.return_value = {
@@ -1151,7 +1152,9 @@ def test_push_watch_no_sleep_starts_keepalive(
 
     assert result.exit_code == 0
     mock_start_keepalive.assert_called_once_with(
-        "https://model.api.baseten.co", remote.fetch_auth_header
+        "https://model.api.baseten.co",
+        remote.fetch_auth_header,
+        ping_path="v1/models/model",
     )
     mock_start_watch.assert_called_once()
 

--- a/truss/tests/cli/test_cli_utils_common.py
+++ b/truss/tests/cli/test_cli_utils_common.py
@@ -2,7 +2,9 @@ import os
 from unittest.mock import patch
 
 import click
+import pytest
 
+from truss.base import truss_config
 from truss.cli.utils import common
 
 
@@ -66,6 +68,45 @@ class TestUpgradeDialogue:
             with patch.dict(os.environ, {"TRUSS_NO_UPDATE_CHECK": value}):
                 common.maybe_upgrade_dialogue()
         assert mock_notify.call_count == 3
+
+
+def test_keepalive_ping_path_truss_server_default():
+    config = truss_config.TrussConfig()
+    assert common.keepalive_ping_path(config) == "v1/models/model"
+
+
+def test_keepalive_ping_path_docker_server_uses_readiness_endpoint():
+    config = truss_config.TrussConfig(
+        docker_server=truss_config.DockerServer(
+            start_command="python server.py",
+            server_port=8000,
+            predict_endpoint="/v1/chat/completions",
+            readiness_endpoint="/ready",
+            liveness_endpoint="/health",
+        )
+    )
+    assert common.keepalive_ping_path(config) == "ready"
+
+
+def test_keepalive_url_draft():
+    url = common._keepalive_url("https://model-abc.api.baseten.co", True, None, "ready")
+    assert url == "https://model-abc.api.baseten.co/development/sync/ready"
+
+
+def test_keepalive_url_published():
+    url = common._keepalive_url(
+        "https://model-abc.api.baseten.co", False, "dep-id", "v1/models/model"
+    )
+    assert url == (
+        "https://model-abc.api.baseten.co/deployment/dep-id/sync/v1/models/model"
+    )
+
+
+def test_keepalive_url_published_requires_deployment_id():
+    with pytest.raises(ValueError):
+        common._keepalive_url(
+            "https://model-abc.api.baseten.co", False, None, "v1/models/model"
+        )
 
 
 def test_normalize_iso_timestamp_handles_nanoseconds():


### PR DESCRIPTION
## Summary

- `truss watch` / `truss chains push --watch` keepalives ping `/v1/models/model`, which docker_server deployments don't serve — every ping logs a 404 application error.
- Ping the truss config's `readiness_endpoint` for docker_server deployments instead (chains: per-chainlet via the chainlet's truss config; models: via the local truss config). Classic truss servers keep `/v1/models/model`.

## Test plan

- [x] Unit tests for `keepalive_ping_path`, `_keepalive_url`, `_keepalive_ping_paths`, and ping-path forwarding in chains keepalives.
- [x] Integration tests workflow on this branch.

Made with [Cursor](https://cursor.com)