### PR TITLE
fix(bis): Push `model_metadata` for BIS trusses

### DIFF
--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -299,6 +299,8 @@ class BasetenRemote(TrussRemote):
             body["environment_variables"] = config.environment_variables
         if config.weights:
             body["weights"] = config.weights.model_dump(exclude_none=True)
+        if config.model_metadata:
+            body["model_metadata"] = config.model_metadata
         if labels is not None:
             body["metadata"] = labels
 

--- a/truss/tests/remote/baseten/test_remote.py
+++ b/truss/tests/remote/baseten/test_remote.py
@@ -698,6 +698,9 @@ def test_push_uses_bis_llm_service_for_bis_llm(
         config={"model": "test-llm"}, version="v1"
     )
     mock_truss_handle.spec.config.environment_variables = {"HF_TOKEN": "secret"}
+    mock_truss_handle.spec.config.model_metadata = {
+        "example_model_input": {"model": "test-llm", "messages": []}
+    }
     mock_truss_handle.spec.config.weights = Weights(
         [
             WeightsSource(source="hf://model-1", mount_location="/models/base"),
@@ -747,6 +750,9 @@ def test_push_uses_bis_llm_service_for_bis_llm(
         {"source": "hf://model-2", "mount_location": "/models/adapter"},
     ]
     assert kwargs["body"]["environment_variables"] == {"HF_TOKEN": "secret"}
+    assert kwargs["body"]["model_metadata"] == {
+        "example_model_input": {"model": "test-llm", "messages": []}
+    }
     assert kwargs["body"]["metadata"] == {
         "git_sha": "abc123",
         "environment": "production",


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What
Missing plumbing to push `model_metadata` from BIS trusses; the backend already supported this via the REST API.
Enables populating the playground via truss.


<!--
  How was the change described above implemented?
-->
## :computer: How

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing


Adding

```
model_metadata:
  example_model_input:
    max_tokens: 512
    messages:
    - content: You are a helpful assistant.
      role: system
    - content: What is the capital of France?
      role: user
    model: unsloth/Llama-3.2-1B-Instruct
    stream: true
    temperature: 0.7
```

to a config.yaml.

Model input shows up in the UI
<img width="696" height="443" alt="image" src="https://github.com/user-attachments/assets/de40b916-dfac-488e-a68e-55748ac7fa6c" />
