### PR TITLE
fix(cli/train): bound the training log fetch with a deadline

### DIFF
--- a/truss/remote/baseten/core.py
+++ b/truss/remote/baseten/core.py
@@ -3,6 +3,7 @@ import json
 import logging
 import pathlib
 import textwrap
+import time
 from typing import IO, TYPE_CHECKING, Any, Dict, List, NamedTuple, Optional, Tuple, Type
 
 import requests
@@ -35,6 +36,11 @@ NO_ENVIRONMENTS_EXIST_ERROR_MESSAGING = (
 # Maximum number of iterations to prevent infinite loops when paginating logs
 MAX_ITERATIONS = 10_000
 MIN_BATCH_SIZE = 100
+
+# Wall-clock bound on the whole forward scan. A chatty job needs one request per
+# MAX_BATCH_SIZE lines, so without a deadline the scan outlives any CI step
+# timeout and the caller reports its own timeout instead of the job's logs.
+DEFAULT_LOG_FETCH_TIMEOUT_SEC = 60.0
 
 # LIMIT for the number of logs to fetch per request defined by the server
 MAX_BATCH_SIZE = 1000
@@ -625,14 +631,11 @@ def _process_batch_logs(
         Tuple of (should_continue, next_start_time, next_end_time)
     """
 
-    # If no logs returned, we're done
+    # An empty window ends the scan. A short-but-non-empty batch does not: the
+    # window is capped at 2h, so a job that outlives one window still has logs
+    # past its end.
     if not batch_logs:
         logging.info(f"No logs returned for job {job_id} at iteration {iteration}")
-        return False, None, None
-
-    # If we got fewer logs than the batch size, we've reached the end
-    if len(batch_logs) == 0:
-        logging.info(f"Reached end of logs for job {job_id} at iteration {iteration}")
         return False, None, None
 
     # Timestamp returned in nanoseconds for the last log in this batch converted
@@ -662,6 +665,7 @@ class BatchedTrainingLogsFetcher:
         project_id: str,
         job_id: str,
         batch_size: int = MAX_BATCH_SIZE,
+        timeout_sec: float = DEFAULT_LOG_FETCH_TIMEOUT_SEC,
     ):
         self.api = api
         self.project_id = project_id
@@ -670,6 +674,8 @@ class BatchedTrainingLogsFetcher:
         self.iteration = 0
         self.current_start_time = None
         self.current_end_time = None
+        self.truncated = False
+        self._deadline = time.monotonic() + timeout_sec
         self._initialize_time_window()
 
     def _initialize_time_window(self):
@@ -684,9 +690,19 @@ class BatchedTrainingLogsFetcher:
 
     def __next__(self) -> List[Any]:
         if self.iteration >= MAX_ITERATIONS:
+            self.truncated = True
             logging.warning(
                 f"Reached maximum iteration limit ({MAX_ITERATIONS}) while paginating "
                 f"training job logs for project_id={self.project_id}, job_id={self.job_id}."
+            )
+            raise StopIteration
+
+        if time.monotonic() >= self._deadline:
+            self.truncated = True
+            logging.warning(
+                f"Timed out after {self.iteration} batches while paginating training job "
+                f"logs for project_id={self.project_id}, job_id={self.job_id}. "
+                "Returning the logs fetched so far."
             )
             raise StopIteration
 
@@ -741,23 +757,39 @@ class BatchedTrainingLogsFetcher:
 
 
 def get_training_job_logs_with_pagination(
-    api: BasetenApi, project_id: str, job_id: str, batch_size: int = MAX_BATCH_SIZE
+    api: BasetenApi,
+    project_id: str,
+    job_id: str,
+    batch_size: int = MAX_BATCH_SIZE,
+    timeout_sec: float = DEFAULT_LOG_FETCH_TIMEOUT_SEC,
 ) -> List[Any]:
     """
     This method implements forward time-based pagination by starting from the earliest
     available log and working forward in time. It uses the timestamp of the newest log in
     each batch as the start time for the next request.
 
+    The scan is bounded by ``timeout_sec``; on expiry it returns the logs fetched so far
+    and warns, rather than blocking the caller indefinitely.
+
     Returns:
         List of all logs in chronological order (oldest first)
     """
     all_logs = []
 
-    logs_iterator = BatchedTrainingLogsFetcher(api, project_id, job_id, batch_size)
+    logs_iterator = BatchedTrainingLogsFetcher(
+        api, project_id, job_id, batch_size, timeout_sec=timeout_sec
+    )
 
     for batch_logs in logs_iterator:
         all_logs.extend(batch_logs)
 
     logging.info(f"Completed pagination for job {job_id}. Total logs: {len(all_logs)}")
+
+    if logs_iterator.truncated:
+        console.print(
+            f"Warning: stopped fetching logs early; showing the first "
+            f"{len(all_logs)} lines only.",
+            style="yellow",
+        )
 
     return all_logs

--- a/truss/tests/remote/baseten/test_core.py
+++ b/truss/tests/remote/baseten/test_core.py
@@ -1,3 +1,4 @@
+import itertools
 import json
 from tempfile import NamedTemporaryFile
 from unittest import mock
@@ -1100,3 +1101,33 @@ def test_create_bis_llm_service_creates_model_version():
     api.create_bis_llm_model_version.assert_called_once_with(
         model_id="bis-llm-model-id", body=body
     )
+
+
+def test_get_training_job_logs_with_pagination_stops_at_timeout(baseten_api):
+    """A chatty job needs one request per batch of lines, so an unbounded scan
+    outlives the caller. The deadline must return the logs fetched so far."""
+    counter = itertools.count()
+    baseten_api._fetch_log_batch = mock.Mock(
+        side_effect=lambda *_: [
+            {
+                "timestamp": str(1640995200000000000 + 60_000_000_000 * next(counter)),
+                "message": "Log",
+            }
+        ]
+    )
+    baseten_api.get_training_job = mock.Mock(
+        return_value={"training_job": {"created_at": "2022-01-01T00:00:00Z"}}
+    )
+
+    # Deadline is set at construction and still unbreached for the first batch;
+    # every later reading is past it. Batches never run out on their own.
+    readings = iter([0.0, 0.0])
+    with mock.patch(
+        "truss.remote.baseten.core.time.monotonic", lambda: next(readings, 999.0)
+    ):
+        result = get_training_job_logs_with_pagination(
+            baseten_api, "project-123", "job-456", batch_size=1, timeout_sec=30.0
+        )
+
+    assert len(result) == 1
+    assert baseten_api._fetch_log_batch.call_count == 1


### PR DESCRIPTION
## What

`truss train logs` (without `--tail`) could run essentially forever. It now stops at a deadline and returns the logs it has.

## Why

The non-tail path paginates forward from the job's first log, one request per `MAX_BATCH_SIZE` (1000) lines, with no wall-clock bound (`get_training_job_logs_with_pagination`). A chatty job needs many sequential requests, so the command outruns whatever timeout the caller imposed, and the caller reports *its own* timeout instead of the job's logs.

This is not hypothetical. `basetenlabs/ml-cookbook`'s training smoke tests have been red every scheduled run since 2026-06-23, and the only error visible in any of those runs is:

```
FAIL: Command '['uv', 'run', 'truss', 'train', 'logs', '--job-id', 'w5ov4mq', ...]' timed out after 300 seconds
subprocess.TimeoutExpired
```

The actual failure (an HF weights download returning 403, so `train.py` died with `OSError: Can't load the model for 'Qwen/Qwen3-0.6B'`) never made it to CI output. Six weeks of failures all looked identical and none of them named the cause. I had to pull the logs out of Loki by hand to find it.

## How

- Add `timeout_sec` (default 60s) to `BatchedTrainingLogsFetcher` and `get_training_job_logs_with_pagination`. On expiry the iterator stops, the caller gets the logs collected so far, and a yellow warning says the view is partial.
- Drop a dead termination branch: `if len(batch_logs) == 0` duplicated the `if not batch_logs` check immediately above it, so the "fewer logs than the batch size means we've reached the end" intent stated in its comment never actually ran. Terminating on a short batch would be wrong regardless, since the query window is capped at 2h and a longer-running job still has logs past it, so I corrected the comment to describe what the code does rather than making the code match the old comment.

## Testing

- `uv run pytest truss/tests/remote/ -q` — 207 passed.
- New test `test_get_training_job_logs_with_pagination_stops_at_timeout` drives a fetcher whose batches never run out and asserts the deadline ends the scan with the first batch's logs intact.

## Follow-ups (not in this PR)

Two things I noticed and deliberately left alone:

- `test_get_training_job_logs_with_pagination_max_iterations` asserts that a repeated, non-advancing batch produces `MAX_ITERATIONS * batch_size` logs from 10,000 identical API calls. That encodes a pathological case as expected behavior. A guard that stops when the window fails to advance would be the real fix, but it changes that test's contract, so it belongs in its own PR.
- Some existing tests in this area use millisecond timestamps in their fixtures while `_process_batch_logs` divides by `NANOSECONDS_PER_MILLISECOND`, i.e. they exercise a window arithmetic that production never produces.

Separately, for triaging a *failed* job the forward `direction: "asc"` scan is backwards: you read startup noise first and the error you want is last. A `--last N` mode using `direction: "desc"` in a single request would make failure triage instant. Happy to file that if it sounds useful.