### PR TITLE
feat(performance-client): support msgpack bin in untyped responses

### DIFF
--- a/baseten-performance-client/Cargo.lock
+++ b/baseten-performance-client/Cargo.lock
@@ -199,6 +199,7 @@ dependencies = [
  "napi-build",
  "napi-derive",
  "once_cell",
+ "rmpv",
  "serde",
  "serde_json",
  "tokio",
@@ -238,6 +239,7 @@ dependencies = [
  "pyo3",
  "pyo3-async-runtimes",
  "pythonize",
+ "rmpv",
  "serde",
  "serde_json",
  "tokio",
@@ -256,6 +258,7 @@ dependencies = [
  "rand",
  "reqwest",
  "rmp-serde",
+ "rmpv",
  "serde",
  "serde_json",
  "tokio",
@@ -2038,6 +2041,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmpv"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a4e1d4b9b938a26d2996af33229f0ca0956c652c1375067f0b45291c1df8417"
+dependencies = [
+ "rmp",
+ "serde",
+ "serde_bytes",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2169,6 +2183,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/baseten-performance-client/Cargo.lock
+++ b/baseten-performance-client/Cargo.lock
@@ -238,7 +238,6 @@ dependencies = [
  "pyo3",
  "pyo3-async-runtimes",
  "pythonize",
- "rmpv",
  "serde",
  "serde_json",
  "tokio",

--- a/baseten-performance-client/Cargo.lock
+++ b/baseten-performance-client/Cargo.lock
@@ -191,7 +191,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "baseten-performance-client"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "baseten_performance_client_core",
  "futures",
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "baseten_performance_client"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "baseten_performance_client_core",
  "futures",
@@ -245,7 +245,7 @@ dependencies = [
 
 [[package]]
 name = "baseten_performance_client_core"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "axum",
  "ctor 0.6.3",

--- a/baseten-performance-client/Cargo.lock
+++ b/baseten-performance-client/Cargo.lock
@@ -199,7 +199,6 @@ dependencies = [
  "napi-build",
  "napi-derive",
  "once_cell",
- "rmpv",
  "serde",
  "serde_json",
  "tokio",

--- a/baseten-performance-client/Cargo.toml
+++ b/baseten-performance-client/Cargo.toml
@@ -16,3 +16,4 @@ tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
 ctor = "0.6.3"
 reqwest = { version = "0.12.26", default-features = false, features = ["blocking", "json", "stream", "http2", "zstd"] }
 rmp-serde = "1.3.0"
+rmpv = { version = "1.3", features = ["with-serde"] }

--- a/baseten-performance-client/README.md
+++ b/baseten-performance-client/README.md
@@ -21,7 +21,7 @@ npm install baseten-performance-client
 cargo add baseten_performance_client_core
 # Or add to your Cargo.toml:
 # [dependencies]
-# baseten_performance_client_core = "0.1.12"
+# baseten_performance_client_core = "0.1.13"
 # tokio = { version = "1.0", features = ["full"] }
 ```
 

--- a/baseten-performance-client/core/Cargo.toml
+++ b/baseten-performance-client/core/Cargo.toml
@@ -17,6 +17,7 @@ openssl = { version = "0.10.75", features = ["vendored"], optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 rmp-serde = { workspace = true }
+rmpv = { workspace = true }
 futures = { workspace = true }
 once_cell = { workspace = true }
 rand = { workspace = true }

--- a/baseten-performance-client/core/Cargo.toml
+++ b/baseten-performance-client/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "baseten_performance_client_core"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2021"
 description = "High performance HTTP client for Baseten.co and other APIs"
 license = "MIT"

--- a/baseten-performance-client/core/src/client.rs
+++ b/baseten-performance-client/core/src/client.rs
@@ -751,7 +751,7 @@ impl PerformanceClientCore {
         payloads_json: Vec<serde_json::Value>,
         preference: &RequestProcessingPreference,
         method: crate::http::HttpMethod,
-    ) -> Result<(Vec<(ResponseValue, HeaderMap, Duration)>, Duration), ClientError> {
+    ) -> Result<(Vec<(rmpv::Value, HeaderMap, Duration)>, Duration), ClientError> {
         let start_time = std::time::Instant::now();
         let total_payloads = payloads_json.len();
 
@@ -771,9 +771,9 @@ impl PerformanceClientCore {
 
         // JoinSetGuard automatically aborts all tasks and sets cancel_token on drop
         let mut join_set: JoinSetGuard<
-            Result<(usize, ResponseValue, HeaderMap, Duration), ClientError>,
+            Result<(usize, rmpv::Value, HeaderMap, Duration), ClientError>,
         > = JoinSetGuard::with_cancel_token(config.cancel_token.clone());
-        let mut indexed_results: Vec<(usize, ResponseValue, HeaderMap, Duration)> =
+        let mut indexed_results: Vec<(usize, rmpv::Value, HeaderMap, Duration)> =
             Vec::with_capacity(total_payloads);
 
         for (index, payload_item_json) in payloads_json.into_iter().enumerate() {
@@ -867,7 +867,7 @@ impl PerformanceClientCore {
 
         indexed_results.sort_by_key(|&(original_index, _, _, _)| original_index);
 
-        let final_results: Vec<(ResponseValue, HeaderMap, Duration)> = indexed_results
+        let final_results: Vec<(rmpv::Value, HeaderMap, Duration)> = indexed_results
             .into_iter()
             .map(|(_, val, headers, dur)| (val, headers, dur))
             .collect();

--- a/baseten-performance-client/core/src/client.rs
+++ b/baseten-performance-client/core/src/client.rs
@@ -751,7 +751,7 @@ impl PerformanceClientCore {
         payloads_json: Vec<serde_json::Value>,
         preference: &RequestProcessingPreference,
         method: crate::http::HttpMethod,
-    ) -> Result<(Vec<(serde_json::Value, HeaderMap, Duration)>, Duration), ClientError> {
+    ) -> Result<(Vec<(ResponseValue, HeaderMap, Duration)>, Duration), ClientError> {
         let start_time = std::time::Instant::now();
         let total_payloads = payloads_json.len();
 
@@ -771,9 +771,9 @@ impl PerformanceClientCore {
 
         // JoinSetGuard automatically aborts all tasks and sets cancel_token on drop
         let mut join_set: JoinSetGuard<
-            Result<(usize, serde_json::Value, HeaderMap, Duration), ClientError>,
+            Result<(usize, ResponseValue, HeaderMap, Duration), ClientError>,
         > = JoinSetGuard::with_cancel_token(config.cancel_token.clone());
-        let mut indexed_results: Vec<(usize, serde_json::Value, HeaderMap, Duration)> =
+        let mut indexed_results: Vec<(usize, ResponseValue, HeaderMap, Duration)> =
             Vec::with_capacity(total_payloads);
 
         for (index, payload_item_json) in payloads_json.into_iter().enumerate() {
@@ -867,7 +867,7 @@ impl PerformanceClientCore {
 
         indexed_results.sort_by_key(|&(original_index, _, _, _)| original_index);
 
-        let final_results: Vec<(serde_json::Value, HeaderMap, Duration)> = indexed_results
+        let final_results: Vec<(ResponseValue, HeaderMap, Duration)> = indexed_results
             .into_iter()
             .map(|(_, val, headers, dur)| (val, headers, dur))
             .collect();

--- a/baseten-performance-client/core/src/http_client.rs
+++ b/baseten-performance-client/core/src/http_client.rs
@@ -82,6 +82,33 @@ where
     Ok((response_data, headers_map))
 }
 
+/// Untyped response body: JSON as `serde_json::Value`, msgpack as `rmpv::Value`
+/// (bin-capable, unlike `serde_json::Value`).
+#[derive(Debug, Clone)]
+pub enum ResponseValue {
+    Json(serde_json::Value),
+    Msgpack(rmpv::Value),
+}
+
+impl ResponseValue {
+    pub fn empty() -> Self {
+        ResponseValue::Json(serde_json::Value::Object(serde_json::Map::new()))
+    }
+
+    pub fn to_json(&self) -> Result<serde_json::Value, serde_json::Error> {
+        serde_json::to_value(self)
+    }
+}
+
+impl serde::Serialize for ResponseValue {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            ResponseValue::Json(j) => j.serialize(serializer),
+            ResponseValue::Msgpack(m) => m.serialize(serializer),
+        }
+    }
+}
+
 // Unified HTTP request helper with headers extraction
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn send_http_request_with_headers<T>(
@@ -93,7 +120,7 @@ pub(crate) async fn send_http_request_with_headers<T>(
     config: &RequestProcessingConfig,
     customer_request_id: CustomerRequestId,
     method: crate::http::HttpMethod,
-) -> Result<(serde_json::Value, std::collections::HashMap<String, String>), ClientError>
+) -> Result<(ResponseValue, std::collections::HashMap<String, String>), ClientError>
 where
     T: serde::Serialize,
 {
@@ -135,14 +162,14 @@ where
         );
     }
 
-    let response_json_value: serde_json::Value =
+    let response_value: ResponseValue =
         if method.has_body() || matches!(method, crate::http::HttpMethod::GET) {
-            parse_response_body(successful_response).await?
+            parse_response_value(successful_response).await?
         } else {
-            serde_json::Value::Object(serde_json::Map::new())
+            ResponseValue::empty()
         };
 
-    Ok((response_json_value, headers_map))
+    Ok((response_value, headers_map))
 }
 
 fn add_response_negotiation_headers(
@@ -184,6 +211,27 @@ where
     response
         .json::<R>()
         .await
+        .map_err(|e| ClientError::Serialization(format!("Failed to parse response JSON: {}", e)))
+}
+
+pub(crate) async fn parse_response_value(
+    response: reqwest::Response,
+) -> Result<ResponseValue, ClientError> {
+    if is_msgpack_response(&response) {
+        let bytes = response.bytes().await.map_err(|e| {
+            ClientError::Serialization(format!("Failed to read MessagePack response body: {}", e))
+        })?;
+        return rmp_serde::from_slice::<rmpv::Value>(&bytes)
+            .map(ResponseValue::Msgpack)
+            .map_err(|e| {
+                ClientError::Serialization(format!("Failed to parse response MessagePack: {}", e))
+            });
+    }
+
+    response
+        .json::<serde_json::Value>()
+        .await
+        .map(ResponseValue::Json)
         .map_err(|e| ClientError::Serialization(format!("Failed to parse response JSON: {}", e)))
 }
 
@@ -492,5 +540,65 @@ fn is_retryable_status(status: u16, config: &RequestProcessingConfig) -> bool {
         400..=499 => false,
         // Unexpected status codes
         _ => false,
+    }
+}
+
+#[cfg(test)]
+mod response_value_tests {
+    use super::*;
+
+    fn encoder_wire_payload() -> Vec<u8> {
+        // mirrors mm_encoder raw-bytes layout: fixmap {mm_embeds: bin, grid_thws: bin, length: int}
+        let mut buf = Vec::new();
+        buf.push(0x83);
+        buf.extend(b"\xa9mm_embeds");
+        buf.extend([0xc4, 0x04, 0xde, 0xad, 0xbe, 0xef]);
+        buf.extend(b"\xa9grid_thws");
+        buf.extend([0xc4, 0x02, 0x01, 0x02]);
+        buf.extend(b"\xa6length");
+        buf.push(0x10);
+        buf
+    }
+
+    #[test]
+    fn msgpack_bin_payload_decodes() {
+        let value: rmpv::Value = rmp_serde::from_slice(&encoder_wire_payload()).unwrap();
+        let map = value.as_map().unwrap();
+        let get = |k: &str| {
+            map.iter()
+                .find(|(key, _)| key.as_str() == Some(k))
+                .map(|(_, v)| v)
+                .unwrap()
+        };
+        assert_eq!(get("length").as_i64(), Some(16));
+        assert_eq!(get("mm_embeds").as_slice(), Some(&[0xde, 0xad, 0xbe, 0xef][..]));
+        assert_eq!(get("grid_thws").as_slice(), Some(&[0x01, 0x02][..]));
+    }
+
+    #[test]
+    fn msgpack_bin_payload_fails_as_json_value() {
+        // the pre-fix behavior: serde_json::Value cannot represent bin
+        let err = rmp_serde::from_slice::<serde_json::Value>(&encoder_wire_payload()).unwrap_err();
+        assert!(err.to_string().contains("byte array"));
+    }
+
+    #[test]
+    fn msgpack_without_bin_serializes_identically_to_json() {
+        // b64-mode responses (strings/ints only) must keep producing the same JSON
+        let payload =
+            rmp_serde::to_vec_named(&serde_json::json!({"success": true, "length": 16, "data": "QUJD"}))
+                .unwrap();
+        let via_rmpv: rmpv::Value = rmp_serde::from_slice(&payload).unwrap();
+        let via_json: serde_json::Value = rmp_serde::from_slice(&payload).unwrap();
+        assert_eq!(
+            serde_json::to_value(ResponseValue::Msgpack(via_rmpv)).unwrap(),
+            via_json
+        );
+    }
+
+    #[test]
+    fn json_variant_serializes_passthrough() {
+        let j = serde_json::json!({"a": [1, 2, 3]});
+        assert_eq!(serde_json::to_value(ResponseValue::Json(j.clone())).unwrap(), j);
     }
 }

--- a/baseten-performance-client/core/src/http_client.rs
+++ b/baseten-performance-client/core/src/http_client.rs
@@ -82,7 +82,6 @@ where
     Ok((response_data, headers_map))
 }
 
-
 // Unified HTTP request helper with headers extraction
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn send_http_request_with_headers<T>(
@@ -138,9 +137,9 @@ where
 
     let response_value: rmpv::Value =
         if method.has_body() || matches!(method, crate::http::HttpMethod::GET) {
-            parse_response_value(successful_response).await?
+            parse_response_body(successful_response).await?
         } else {
-            rmpv::Value::Map(vec![])
+            rmpv::Value::Map(Vec::new())
         };
 
     Ok((response_value, headers_map))
@@ -184,24 +183,6 @@ where
 
     response
         .json::<R>()
-        .await
-        .map_err(|e| ClientError::Serialization(format!("Failed to parse response JSON: {}", e)))
-}
-
-pub(crate) async fn parse_response_value(
-    response: reqwest::Response,
-) -> Result<rmpv::Value, ClientError> {
-    if is_msgpack_response(&response) {
-        let bytes = response.bytes().await.map_err(|e| {
-            ClientError::Serialization(format!("Failed to read MessagePack response body: {}", e))
-        })?;
-        return rmp_serde::from_slice::<rmpv::Value>(&bytes).map_err(|e| {
-            ClientError::Serialization(format!("Failed to parse response MessagePack: {}", e))
-        });
-    }
-
-    response
-        .json::<rmpv::Value>()
         .await
         .map_err(|e| ClientError::Serialization(format!("Failed to parse response JSON: {}", e)))
 }
@@ -511,63 +492,5 @@ fn is_retryable_status(status: u16, config: &RequestProcessingConfig) -> bool {
         400..=499 => false,
         // Unexpected status codes
         _ => false,
-    }
-}
-
-#[cfg(test)]
-mod response_value_tests {
-    use super::*;
-
-    fn encoder_wire_payload() -> Vec<u8> {
-        // mirrors mm_encoder raw-bytes layout: fixmap {mm_embeds: bin, grid_thws: bin, length: int}
-        let mut buf = Vec::new();
-        buf.push(0x83);
-        buf.extend(b"\xa9mm_embeds");
-        buf.extend([0xc4, 0x04, 0xde, 0xad, 0xbe, 0xef]);
-        buf.extend(b"\xa9grid_thws");
-        buf.extend([0xc4, 0x02, 0x01, 0x02]);
-        buf.extend(b"\xa6length");
-        buf.push(0x10);
-        buf
-    }
-
-    #[test]
-    fn msgpack_bin_payload_decodes() {
-        let value: rmpv::Value = rmp_serde::from_slice(&encoder_wire_payload()).unwrap();
-        let map = value.as_map().unwrap();
-        let get = |k: &str| {
-            map.iter()
-                .find(|(key, _)| key.as_str() == Some(k))
-                .map(|(_, v)| v)
-                .unwrap()
-        };
-        assert_eq!(get("length").as_i64(), Some(16));
-        assert_eq!(get("mm_embeds").as_slice(), Some(&[0xde, 0xad, 0xbe, 0xef][..]));
-        assert_eq!(get("grid_thws").as_slice(), Some(&[0x01, 0x02][..]));
-    }
-
-    #[test]
-    fn msgpack_bin_payload_fails_as_json_value() {
-        // serde_json::Value cannot represent bin
-        let err = rmp_serde::from_slice::<serde_json::Value>(&encoder_wire_payload()).unwrap_err();
-        assert!(err.to_string().contains("byte array"));
-    }
-
-    #[test]
-    fn msgpack_without_bin_serializes_identically_to_json() {
-        // b64-mode responses (strings/ints only) must keep producing the same JSON
-        let payload =
-            rmp_serde::to_vec_named(&serde_json::json!({"success": true, "length": 16, "data": "QUJD"}))
-                .unwrap();
-        let via_rmpv: rmpv::Value = rmp_serde::from_slice(&payload).unwrap();
-        let via_json: serde_json::Value = rmp_serde::from_slice(&payload).unwrap();
-        assert_eq!(serde_json::to_value(&via_rmpv).unwrap(), via_json);
-    }
-
-    #[test]
-    fn json_response_serializes_passthrough() {
-        let j = serde_json::json!({"a": [1, 2, 3]});
-        let via_rmpv: rmpv::Value = serde_json::from_value(j.clone()).unwrap();
-        assert_eq!(serde_json::to_value(&via_rmpv).unwrap(), j);
     }
 }

--- a/baseten-performance-client/core/src/http_client.rs
+++ b/baseten-performance-client/core/src/http_client.rs
@@ -82,32 +82,6 @@ where
     Ok((response_data, headers_map))
 }
 
-/// Untyped response body: JSON as `serde_json::Value`, msgpack as `rmpv::Value`
-/// (bin-capable, unlike `serde_json::Value`).
-#[derive(Debug, Clone)]
-pub enum ResponseValue {
-    Json(serde_json::Value),
-    Msgpack(rmpv::Value),
-}
-
-impl ResponseValue {
-    pub fn empty() -> Self {
-        ResponseValue::Json(serde_json::Value::Object(serde_json::Map::new()))
-    }
-
-    pub fn to_json(&self) -> Result<serde_json::Value, serde_json::Error> {
-        serde_json::to_value(self)
-    }
-}
-
-impl serde::Serialize for ResponseValue {
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        match self {
-            ResponseValue::Json(j) => j.serialize(serializer),
-            ResponseValue::Msgpack(m) => m.serialize(serializer),
-        }
-    }
-}
 
 // Unified HTTP request helper with headers extraction
 #[allow(clippy::too_many_arguments)]
@@ -120,7 +94,7 @@ pub(crate) async fn send_http_request_with_headers<T>(
     config: &RequestProcessingConfig,
     customer_request_id: CustomerRequestId,
     method: crate::http::HttpMethod,
-) -> Result<(ResponseValue, std::collections::HashMap<String, String>), ClientError>
+) -> Result<(rmpv::Value, std::collections::HashMap<String, String>), ClientError>
 where
     T: serde::Serialize,
 {
@@ -162,11 +136,11 @@ where
         );
     }
 
-    let response_value: ResponseValue =
+    let response_value: rmpv::Value =
         if method.has_body() || matches!(method, crate::http::HttpMethod::GET) {
             parse_response_value(successful_response).await?
         } else {
-            ResponseValue::empty()
+            rmpv::Value::Map(vec![])
         };
 
     Ok((response_value, headers_map))
@@ -216,22 +190,19 @@ where
 
 pub(crate) async fn parse_response_value(
     response: reqwest::Response,
-) -> Result<ResponseValue, ClientError> {
+) -> Result<rmpv::Value, ClientError> {
     if is_msgpack_response(&response) {
         let bytes = response.bytes().await.map_err(|e| {
             ClientError::Serialization(format!("Failed to read MessagePack response body: {}", e))
         })?;
-        return rmp_serde::from_slice::<rmpv::Value>(&bytes)
-            .map(ResponseValue::Msgpack)
-            .map_err(|e| {
-                ClientError::Serialization(format!("Failed to parse response MessagePack: {}", e))
-            });
+        return rmp_serde::from_slice::<rmpv::Value>(&bytes).map_err(|e| {
+            ClientError::Serialization(format!("Failed to parse response MessagePack: {}", e))
+        });
     }
 
     response
-        .json::<serde_json::Value>()
+        .json::<rmpv::Value>()
         .await
-        .map(ResponseValue::Json)
         .map_err(|e| ClientError::Serialization(format!("Failed to parse response JSON: {}", e)))
 }
 
@@ -577,7 +548,7 @@ mod response_value_tests {
 
     #[test]
     fn msgpack_bin_payload_fails_as_json_value() {
-        // the pre-fix behavior: serde_json::Value cannot represent bin
+        // serde_json::Value cannot represent bin
         let err = rmp_serde::from_slice::<serde_json::Value>(&encoder_wire_payload()).unwrap_err();
         assert!(err.to_string().contains("byte array"));
     }
@@ -590,15 +561,13 @@ mod response_value_tests {
                 .unwrap();
         let via_rmpv: rmpv::Value = rmp_serde::from_slice(&payload).unwrap();
         let via_json: serde_json::Value = rmp_serde::from_slice(&payload).unwrap();
-        assert_eq!(
-            serde_json::to_value(ResponseValue::Msgpack(via_rmpv)).unwrap(),
-            via_json
-        );
+        assert_eq!(serde_json::to_value(&via_rmpv).unwrap(), via_json);
     }
 
     #[test]
-    fn json_variant_serializes_passthrough() {
+    fn json_response_serializes_passthrough() {
         let j = serde_json::json!({"a": [1, 2, 3]});
-        assert_eq!(serde_json::to_value(ResponseValue::Json(j.clone())).unwrap(), j);
+        let via_rmpv: rmpv::Value = serde_json::from_value(j.clone()).unwrap();
+        assert_eq!(serde_json::to_value(&via_rmpv).unwrap(), j);
     }
 }

--- a/baseten-performance-client/core/src/lib.rs
+++ b/baseten-performance-client/core/src/lib.rs
@@ -20,7 +20,6 @@ pub use endpoint_routing::{
 };
 pub use errors::ClientError;
 pub use http::*;
-pub use http_client::ResponseValue;
 pub use split_policy::RequestProcessingPreference;
 pub use utils::*;
 

--- a/baseten-performance-client/core/src/lib.rs
+++ b/baseten-performance-client/core/src/lib.rs
@@ -20,7 +20,7 @@ pub use endpoint_routing::{
 };
 pub use errors::ClientError;
 pub use http::*;
-// http_client is internal only - not reexported
+pub use http_client::ResponseValue;
 pub use split_policy::RequestProcessingPreference;
 pub use utils::*;
 

--- a/baseten-performance-client/core/tests/integration_test.rs
+++ b/baseten-performance-client/core/tests/integration_test.rs
@@ -460,7 +460,7 @@ async fn test_batch_post_decodes_msgpack_response() {
         .expect("batch_post msgpack response should parse");
 
     assert_eq!(responses.len(), 1);
-    let body = responses[0].0.to_json().expect("msgpack response converts to json");
+    let body = serde_json::to_value(&responses[0].0).expect("msgpack response converts to json");
     assert_eq!(body["format"], "msgpack");
     assert_eq!(body["received"], json!({"value": 42}));
     assert!(body["accept"]

--- a/baseten-performance-client/core/tests/integration_test.rs
+++ b/baseten-performance-client/core/tests/integration_test.rs
@@ -387,12 +387,22 @@ async fn test_msgpack_handler(
         .unwrap_or_default()
         .to_string();
 
-    let response = json!({
-        "format": "msgpack",
-        "accept": accept,
-        "accept_encoding": accept_encoding,
-        "received": request,
-    });
+    let response = rmpv::Value::Map(vec![
+        (rmpv::Value::from("format"), rmpv::Value::from("msgpack")),
+        (rmpv::Value::from("accept"), rmpv::Value::from(accept)),
+        (
+            rmpv::Value::from("accept_encoding"),
+            rmpv::Value::from(accept_encoding),
+        ),
+        (
+            rmpv::Value::from("received"),
+            serde_json::from_value(request).expect("request should convert to msgpack value"),
+        ),
+        (
+            rmpv::Value::from("bin"),
+            rmpv::Value::Binary(vec![0xde, 0xad, 0xbe, 0xef]),
+        ),
+    ]);
     let body = rmp_serde::to_vec_named(&response).expect("test msgpack body should serialize");
 
     let mut headers = AxumHeaderMap::new();
@@ -460,6 +470,14 @@ async fn test_batch_post_decodes_msgpack_response() {
         .expect("batch_post msgpack response should parse");
 
     assert_eq!(responses.len(), 1);
+    let msgpack_map = responses[0].0.as_map().expect("msgpack response is a map");
+    assert_eq!(
+        msgpack_map
+            .iter()
+            .find(|(key, _)| key.as_str() == Some("bin"))
+            .map(|(_, value)| value.as_slice()),
+        Some(Some(&[0xde, 0xad, 0xbe, 0xef][..]))
+    );
     let body = serde_json::to_value(&responses[0].0).expect("msgpack response converts to json");
     assert_eq!(body["format"], "msgpack");
     assert_eq!(body["received"], json!({"value": 42}));

--- a/baseten-performance-client/core/tests/integration_test.rs
+++ b/baseten-performance-client/core/tests/integration_test.rs
@@ -460,12 +460,13 @@ async fn test_batch_post_decodes_msgpack_response() {
         .expect("batch_post msgpack response should parse");
 
     assert_eq!(responses.len(), 1);
-    assert_eq!(responses[0].0["format"], "msgpack");
-    assert_eq!(responses[0].0["received"], json!({"value": 42}));
-    assert!(responses[0].0["accept"]
+    let body = responses[0].0.to_json().expect("msgpack response converts to json");
+    assert_eq!(body["format"], "msgpack");
+    assert_eq!(body["received"], json!({"value": 42}));
+    assert!(body["accept"]
         .as_str()
         .is_some_and(|accept| accept.contains("application/msgpack")));
-    assert!(responses[0].0["accept_encoding"]
+    assert!(body["accept_encoding"]
         .as_str()
         .is_some_and(|accept_encoding| accept_encoding.contains("zstd")));
     assert_eq!(

--- a/baseten-performance-client/node_bindings/Cargo.toml
+++ b/baseten-performance-client/node_bindings/Cargo.toml
@@ -12,7 +12,6 @@ napi = { version = "2.16", features = ["napi4", "serde-json","tokio_rt"] }
 napi-derive = "2.16"
 serde = { workspace = true }
 serde_json = { workspace = true }
-rmpv = { workspace = true }
 tokio = { workspace = true }
 futures = { workspace = true }
 once_cell = { workspace = true }

--- a/baseten-performance-client/node_bindings/Cargo.toml
+++ b/baseten-performance-client/node_bindings/Cargo.toml
@@ -12,6 +12,7 @@ napi = { version = "2.16", features = ["napi4", "serde-json","tokio_rt"] }
 napi-derive = "2.16"
 serde = { workspace = true }
 serde_json = { workspace = true }
+rmpv = { workspace = true }
 tokio = { workspace = true }
 futures = { workspace = true }
 once_cell = { workspace = true }

--- a/baseten-performance-client/node_bindings/Cargo.toml
+++ b/baseten-performance-client/node_bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "baseten-performance-client"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2021"
 
 [lib]

--- a/baseten-performance-client/node_bindings/npm/android-arm-eabi/package.json
+++ b/baseten-performance-client/node_bindings/npm/android-arm-eabi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-android-arm-eabi",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "os": [
     "android"
   ],

--- a/baseten-performance-client/node_bindings/npm/android-arm64/package.json
+++ b/baseten-performance-client/node_bindings/npm/android-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-android-arm64",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "os": [
     "android"
   ],

--- a/baseten-performance-client/node_bindings/npm/darwin-arm64/package.json
+++ b/baseten-performance-client/node_bindings/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-darwin-arm64",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "os": [
     "darwin"
   ],

--- a/baseten-performance-client/node_bindings/npm/darwin-universal/package.json
+++ b/baseten-performance-client/node_bindings/npm/darwin-universal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-darwin-universal",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "os": [
     "darwin"
   ],

--- a/baseten-performance-client/node_bindings/npm/darwin-x64/package.json
+++ b/baseten-performance-client/node_bindings/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-darwin-x64",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "os": [
     "darwin"
   ],

--- a/baseten-performance-client/node_bindings/npm/freebsd-x64/package.json
+++ b/baseten-performance-client/node_bindings/npm/freebsd-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-freebsd-x64",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "os": [
     "freebsd"
   ],

--- a/baseten-performance-client/node_bindings/npm/linux-arm-gnueabihf/package.json
+++ b/baseten-performance-client/node_bindings/npm/linux-arm-gnueabihf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-linux-arm-gnueabihf",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "os": [
     "linux"
   ],

--- a/baseten-performance-client/node_bindings/npm/linux-arm-musleabihf/package.json
+++ b/baseten-performance-client/node_bindings/npm/linux-arm-musleabihf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-linux-arm-musleabihf",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "os": [
     "linux"
   ],

--- a/baseten-performance-client/node_bindings/npm/linux-arm64-gnu/package.json
+++ b/baseten-performance-client/node_bindings/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-linux-arm64-gnu",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "os": [
     "linux"
   ],

--- a/baseten-performance-client/node_bindings/npm/linux-arm64-musl/package.json
+++ b/baseten-performance-client/node_bindings/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-linux-arm64-musl",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "os": [
     "linux"
   ],

--- a/baseten-performance-client/node_bindings/npm/linux-riscv64-gnu/package.json
+++ b/baseten-performance-client/node_bindings/npm/linux-riscv64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-linux-riscv64-gnu",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "os": [
     "linux"
   ],

--- a/baseten-performance-client/node_bindings/npm/linux-x64-gnu/package.json
+++ b/baseten-performance-client/node_bindings/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-linux-x64-gnu",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "os": [
     "linux"
   ],

--- a/baseten-performance-client/node_bindings/npm/linux-x64-musl/package.json
+++ b/baseten-performance-client/node_bindings/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-linux-x64-musl",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "os": [
     "linux"
   ],

--- a/baseten-performance-client/node_bindings/npm/win32-arm64-msvc/package.json
+++ b/baseten-performance-client/node_bindings/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-win32-arm64-msvc",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "os": [
     "win32"
   ],

--- a/baseten-performance-client/node_bindings/npm/win32-ia32-msvc/package.json
+++ b/baseten-performance-client/node_bindings/npm/win32-ia32-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-win32-ia32-msvc",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "os": [
     "win32"
   ],

--- a/baseten-performance-client/node_bindings/npm/win32-x64-msvc/package.json
+++ b/baseten-performance-client/node_bindings/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client-win32-x64-msvc",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "os": [
     "win32"
   ],

--- a/baseten-performance-client/node_bindings/package.json
+++ b/baseten-performance-client/node_bindings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basetenlabs/performance-client",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "main": "index.js",
   "types": "index.d.ts",
   "files": [

--- a/baseten-performance-client/node_bindings/src/lib.rs
+++ b/baseten-performance-client/node_bindings/src/lib.rs
@@ -614,6 +614,7 @@ impl PerformanceClient {
       .map_err(|e| create_napi_error(&format!("Serialization error: {}", e)))
   }
 
+
   #[napi]
   pub async fn batch_post(
     &self,
@@ -645,7 +646,7 @@ impl PerformanceClient {
     let mut individual_request_times = Vec::new();
 
     for (json_value, headers, duration) in results {
-      data.push(json_value);
+      data.push(response_value_to_json(json_value)?);
       response_headers.push(headers);
       individual_request_times.push(duration.as_secs_f64());
     }
@@ -659,5 +660,50 @@ impl PerformanceClient {
 
     serde_json::to_value(response)
       .map_err(|e| create_napi_error(&format!("Serialization error: {}", e)))
+  }
+}
+
+fn rmpv_to_json(value: rmpv::Value) -> napi::Result<JsonValue> {
+  match value {
+    rmpv::Value::Nil => Ok(JsonValue::Null),
+    rmpv::Value::Boolean(b) => Ok(JsonValue::Bool(b)),
+    rmpv::Value::Integer(i) => {
+      if let Some(v) = i.as_i64() {
+        Ok(JsonValue::from(v))
+      } else if let Some(v) = i.as_u64() {
+        Ok(JsonValue::from(v))
+      } else {
+        Err(create_napi_error("unrepresentable msgpack integer"))
+      }
+    }
+    rmpv::Value::F32(f) => Ok(JsonValue::from(f as f64)),
+    rmpv::Value::F64(f) => Ok(JsonValue::from(f)),
+    rmpv::Value::String(s) => Ok(JsonValue::from(s.into_str().unwrap_or_default())),
+    rmpv::Value::Array(items) => Ok(JsonValue::Array(
+      items.into_iter().map(rmpv_to_json).collect::<napi::Result<Vec<_>>>()?,
+    )),
+    rmpv::Value::Map(entries) => {
+      let mut map = serde_json::Map::with_capacity(entries.len());
+      for (k, v) in entries {
+        let key = match k {
+          rmpv::Value::String(s) => s.into_str().unwrap_or_default(),
+          other => other.to_string(),
+        };
+        map.insert(key, rmpv_to_json(v)?);
+      }
+      Ok(JsonValue::Object(map))
+    }
+    rmpv::Value::Binary(_) | rmpv::Value::Ext(..) => Err(create_napi_error(
+      "msgpack binary payloads are not supported by the node bindings",
+    )),
+  }
+}
+
+fn response_value_to_json(
+  value: baseten_performance_client_core::ResponseValue,
+) -> napi::Result<JsonValue> {
+  match value {
+    baseten_performance_client_core::ResponseValue::Json(j) => Ok(j),
+    baseten_performance_client_core::ResponseValue::Msgpack(m) => rmpv_to_json(m),
   }
 }

--- a/baseten-performance-client/node_bindings/src/lib.rs
+++ b/baseten-performance-client/node_bindings/src/lib.rs
@@ -699,11 +699,6 @@ fn rmpv_to_json(value: rmpv::Value) -> napi::Result<JsonValue> {
   }
 }
 
-fn response_value_to_json(
-  value: baseten_performance_client_core::ResponseValue,
-) -> napi::Result<JsonValue> {
-  match value {
-    baseten_performance_client_core::ResponseValue::Json(j) => Ok(j),
-    baseten_performance_client_core::ResponseValue::Msgpack(m) => rmpv_to_json(m),
-  }
+fn response_value_to_json(value: rmpv::Value) -> napi::Result<JsonValue> {
+  rmpv_to_json(value)
 }

--- a/baseten-performance-client/node_bindings/src/lib.rs
+++ b/baseten-performance-client/node_bindings/src/lib.rs
@@ -614,8 +614,9 @@ impl PerformanceClient {
       .map_err(|e| create_napi_error(&format!("Serialization error: {}", e)))
   }
 
-  // TODO: This JSON-compatible return type cannot preserve MessagePack binary values.
-  // The API return type is subject to change when binary responses are exposed as Buffers.
+  // TODO: This JSON-compatible return type cannot preserve MessagePack binary, invalid UTF-8
+  // strings, or maps with non-string keys. The API return type is subject to change when those
+  // values are exposed through native JavaScript types.
   #[napi]
   pub async fn batch_post(
     &self,

--- a/baseten-performance-client/node_bindings/src/lib.rs
+++ b/baseten-performance-client/node_bindings/src/lib.rs
@@ -614,7 +614,6 @@ impl PerformanceClient {
       .map_err(|e| create_napi_error(&format!("Serialization error: {}", e)))
   }
 
-
   #[napi]
   pub async fn batch_post(
     &self,
@@ -646,7 +645,10 @@ impl PerformanceClient {
     let mut individual_request_times = Vec::new();
 
     for (json_value, headers, duration) in results {
-      data.push(response_value_to_json(json_value)?);
+      data.push(
+        serde_json::to_value(json_value)
+          .map_err(|e| create_napi_error(&format!("Serialization error: {}", e)))?,
+      );
       response_headers.push(headers);
       individual_request_times.push(duration.as_secs_f64());
     }
@@ -661,44 +663,4 @@ impl PerformanceClient {
     serde_json::to_value(response)
       .map_err(|e| create_napi_error(&format!("Serialization error: {}", e)))
   }
-}
-
-fn rmpv_to_json(value: rmpv::Value) -> napi::Result<JsonValue> {
-  match value {
-    rmpv::Value::Nil => Ok(JsonValue::Null),
-    rmpv::Value::Boolean(b) => Ok(JsonValue::Bool(b)),
-    rmpv::Value::Integer(i) => {
-      if let Some(v) = i.as_i64() {
-        Ok(JsonValue::from(v))
-      } else if let Some(v) = i.as_u64() {
-        Ok(JsonValue::from(v))
-      } else {
-        Err(create_napi_error("unrepresentable msgpack integer"))
-      }
-    }
-    rmpv::Value::F32(f) => Ok(JsonValue::from(f as f64)),
-    rmpv::Value::F64(f) => Ok(JsonValue::from(f)),
-    rmpv::Value::String(s) => Ok(JsonValue::from(s.into_str().unwrap_or_default())),
-    rmpv::Value::Array(items) => Ok(JsonValue::Array(
-      items.into_iter().map(rmpv_to_json).collect::<napi::Result<Vec<_>>>()?,
-    )),
-    rmpv::Value::Map(entries) => {
-      let mut map = serde_json::Map::with_capacity(entries.len());
-      for (k, v) in entries {
-        let key = match k {
-          rmpv::Value::String(s) => s.into_str().unwrap_or_default(),
-          other => other.to_string(),
-        };
-        map.insert(key, rmpv_to_json(v)?);
-      }
-      Ok(JsonValue::Object(map))
-    }
-    rmpv::Value::Binary(_) | rmpv::Value::Ext(..) => Err(create_napi_error(
-      "msgpack binary payloads are not supported by the node bindings",
-    )),
-  }
-}
-
-fn response_value_to_json(value: rmpv::Value) -> napi::Result<JsonValue> {
-  rmpv_to_json(value)
 }

--- a/baseten-performance-client/node_bindings/src/lib.rs
+++ b/baseten-performance-client/node_bindings/src/lib.rs
@@ -614,6 +614,8 @@ impl PerformanceClient {
       .map_err(|e| create_napi_error(&format!("Serialization error: {}", e)))
   }
 
+  // TODO: This JSON-compatible return type cannot preserve MessagePack binary values.
+  // The API return type is subject to change when binary responses are exposed as Buffers.
   #[napi]
   pub async fn batch_post(
     &self,

--- a/baseten-performance-client/python_bindings/Cargo.toml
+++ b/baseten-performance-client/python_bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "baseten_performance_client"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2021"
 
 [dependencies]

--- a/baseten-performance-client/python_bindings/Cargo.toml
+++ b/baseten-performance-client/python_bindings/Cargo.toml
@@ -15,7 +15,6 @@ futures = { workspace = true }
 once_cell = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-rmpv = { workspace = true }
 
 [lib]
 name = "baseten_performance_client"

--- a/baseten-performance-client/python_bindings/Cargo.toml
+++ b/baseten-performance-client/python_bindings/Cargo.toml
@@ -15,6 +15,7 @@ futures = { workspace = true }
 once_cell = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+rmpv = { workspace = true }
 
 [lib]
 name = "baseten_performance_client"

--- a/baseten-performance-client/python_bindings/pyproject.toml
+++ b/baseten-performance-client/python_bindings/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
   "requests"
 ]

--- a/baseten-performance-client/python_bindings/src/lib.rs
+++ b/baseten-performance-client/python_bindings/src/lib.rs
@@ -1346,18 +1346,6 @@ mod tests {
     use std::collections::HashSet;
 
     #[test]
-    fn pythonize_preserves_msgpack_binary_as_bytes() {
-        Python::with_gil(|py| {
-            let value = rmpv::Value::Binary(vec![0xde, 0xad, 0xbe, 0xef]);
-            let object = pythonize::pythonize(py, &value).expect("binary value should pythonize");
-            let bytes = object
-                .downcast::<pyo3::types::PyBytes>()
-                .expect("binary value should become Python bytes");
-            assert_eq!(bytes.as_bytes(), &[0xde, 0xad, 0xbe, 0xef]);
-        });
-    }
-
-    #[test]
     fn request_processing_preference_to_rust_uses_mutated_public_fields() {
         let mut preference = RequestProcessingPreference::new(
             None, None, None, None, None, None, None, None, None, None, None, None, None, None,

--- a/baseten-performance-client/python_bindings/src/lib.rs
+++ b/baseten-performance-client/python_bindings/src/lib.rs
@@ -580,7 +580,10 @@ fn rmpv_to_pyobject(py: Python<'_>, value: &rmpv::Value) -> PyResult<PyObject> {
         }
         rmpv::Value::F32(f) => (*f as f64).to_object(py),
         rmpv::Value::F64(f) => f.to_object(py),
-        rmpv::Value::String(s) => s.as_str().unwrap_or_default().to_object(py),
+        rmpv::Value::String(s) => match s.as_str() {
+            Some(value) => value.to_object(py),
+            None => PyBytes::new(py, s.as_bytes()).to_object(py),
+        },
         rmpv::Value::Binary(b) => PyBytes::new(py, b).to_object(py),
         rmpv::Value::Array(items) => {
             let list = PyList::empty(py);

--- a/baseten-performance-client/python_bindings/src/lib.rs
+++ b/baseten-performance-client/python_bindings/src/lib.rs
@@ -7,7 +7,6 @@ use baseten_performance_client_core::{
     Endpoint as CoreEndpoint, EndpointConfig as CoreEndpointConfig,
     EndpointPool as CoreEndpointPool, EndpointPoolConfig, HttpClientWrapper as HttpClientWrapperRs,
     PerformanceClientCore, RequestProcessingPreference as RustRequestProcessingPreference,
-    ResponseValue,
     DEFAULT_BATCH_SIZE, DEFAULT_CONCURRENCY, DEFAULT_MAX_RETRIES, DEFAULT_REQUEST_TIMEOUT_S,
     DEFAULT_TIMEOUT_IS_NO_VOTE, HEDGE_BUDGET_PERCENTAGE, INITIAL_BACKOFF_MS,
     RETRY_BUDGET_PERCENTAGE,
@@ -608,21 +607,13 @@ fn rmpv_to_pyobject(py: Python<'_>, value: &rmpv::Value) -> PyResult<PyObject> {
     })
 }
 
-fn response_value_to_pyobject(py: Python<'_>, value: &ResponseValue, idx: usize) -> PyResult<PyObject> {
-    match value {
-        ResponseValue::Json(j) => pythonize::pythonize(py, j)
-            .map(|obj| {
-                #[allow(deprecated)]
-                obj.to_object(py)
-            })
-            .map_err(|e| {
-                PyValueError::new_err(format!(
-                    "Failed to pythonize response data at index {}: {}",
-                    idx, e
-                ))
-            }),
-        ResponseValue::Msgpack(m) => rmpv_to_pyobject(py, m),
-    }
+fn response_value_to_pyobject(py: Python<'_>, value: &rmpv::Value, idx: usize) -> PyResult<PyObject> {
+    rmpv_to_pyobject(py, value).map_err(|e| {
+        PyValueError::new_err(format!(
+            "Failed to convert response data at index {}: {}",
+            idx, e
+        ))
+    })
 }
 
 fn rust_preference_from_py(

--- a/baseten-performance-client/python_bindings/src/lib.rs
+++ b/baseten-performance-client/python_bindings/src/lib.rs
@@ -7,6 +7,7 @@ use baseten_performance_client_core::{
     Endpoint as CoreEndpoint, EndpointConfig as CoreEndpointConfig,
     EndpointPool as CoreEndpointPool, EndpointPoolConfig, HttpClientWrapper as HttpClientWrapperRs,
     PerformanceClientCore, RequestProcessingPreference as RustRequestProcessingPreference,
+    ResponseValue,
     DEFAULT_BATCH_SIZE, DEFAULT_CONCURRENCY, DEFAULT_MAX_RETRIES, DEFAULT_REQUEST_TIMEOUT_S,
     DEFAULT_TIMEOUT_IS_NO_VOTE, HEDGE_BUDGET_PERCENTAGE, INITIAL_BACKOFF_MS,
     RETRY_BUDGET_PERCENTAGE,
@@ -561,6 +562,66 @@ impl RequestProcessingPreference {
             extra_headers: self.extra_headers.clone(),
             non_retryable_status_codes,
         }
+    }
+}
+
+
+fn rmpv_to_pyobject(py: Python<'_>, value: &rmpv::Value) -> PyResult<PyObject> {
+    use pyo3::types::{PyBytes, PyDict, PyList};
+    #[allow(deprecated)]
+    Ok(match value {
+        rmpv::Value::Nil => py.None(),
+        rmpv::Value::Boolean(b) => b.to_object(py),
+        rmpv::Value::Integer(i) => {
+            if let Some(v) = i.as_i64() {
+                v.to_object(py)
+            } else if let Some(v) = i.as_u64() {
+                v.to_object(py)
+            } else {
+                return Err(PyValueError::new_err("unrepresentable msgpack integer"));
+            }
+        }
+        rmpv::Value::F32(f) => (*f as f64).to_object(py),
+        rmpv::Value::F64(f) => f.to_object(py),
+        rmpv::Value::String(s) => match s.as_str() {
+            Some(v) => v.to_object(py),
+            None => PyBytes::new(py, s.as_bytes()).to_object(py),
+        },
+        rmpv::Value::Binary(b) => PyBytes::new(py, b).to_object(py),
+        rmpv::Value::Array(items) => {
+            let list = PyList::empty(py);
+            for item in items {
+                list.append(rmpv_to_pyobject(py, item)?)?;
+            }
+            list.to_object(py)
+        }
+        rmpv::Value::Map(entries) => {
+            let dict = PyDict::new(py);
+            for (k, v) in entries {
+                dict.set_item(rmpv_to_pyobject(py, k)?, rmpv_to_pyobject(py, v)?)?;
+            }
+            dict.to_object(py)
+        }
+        rmpv::Value::Ext(tag, data) => {
+            (*tag, PyBytes::new(py, data).to_object(py)).to_object(py)
+        }
+    })
+}
+
+fn response_value_to_pyobject(py: Python<'_>, value: &ResponseValue, idx: usize) -> PyResult<PyObject> {
+    match value {
+        ResponseValue::Json(j) => pythonize::pythonize(py, j)
+            .map(|obj| {
+                #[allow(deprecated)]
+                obj.to_object(py)
+            })
+            .map_err(|e| {
+                PyValueError::new_err(format!(
+                    "Failed to pythonize response data at index {}: {}",
+                    idx, e
+                ))
+            }),
+        ResponseValue::Msgpack(m) => rmpv_to_pyobject(py, m),
     }
 }
 
@@ -1202,14 +1263,7 @@ impl PerformanceClient {
         for (idx, (json_val, headers_map, duration)) in
             response_data_with_times_and_headers.into_iter().enumerate()
         {
-            let py_obj_bound = pythonize::pythonize(py, &json_val).map_err(|e| {
-                PyValueError::new_err(format!(
-                    "Failed to pythonize response data at index {}: {}",
-                    idx, e
-                ))
-            })?;
-            #[allow(deprecated)]
-            results_py.push(py_obj_bound.to_object(py));
+            results_py.push(response_value_to_pyobject(py, &json_val, idx)?);
 
             let headers_py_obj = pythonize::pythonize(py, &headers_map).map_err(|e| {
                 PyValueError::new_err(format!(
@@ -1284,14 +1338,7 @@ impl PerformanceClient {
                 for (idx, (json_val, headers_map, duration)) in
                     response_data_with_times_and_headers.into_iter().enumerate()
                 {
-                    let py_obj_bound = pythonize::pythonize(py_gil, &json_val).map_err(|e| {
-                        PyValueError::new_err(format!(
-                            "Failed to pythonize response data at index {}: {}",
-                            idx, e
-                        ))
-                    })?;
-                    #[allow(deprecated)]
-                    results_py.push(py_obj_bound.into_py(py_gil));
+                    results_py.push(response_value_to_pyobject(py_gil, &json_val, idx)?);
 
                     let headers_py_obj =
                         pythonize::pythonize(py_gil, &headers_map).map_err(|e| {

--- a/baseten-performance-client/python_bindings/src/lib.rs
+++ b/baseten-performance-client/python_bindings/src/lib.rs
@@ -17,7 +17,7 @@ use numpy::{IntoPyArray, PyArray2};
 use once_cell::sync::Lazy;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
-use pyo3::types::PyType;
+use pyo3::types::{PyBytes, PyDict, PyList, PyType};
 use std::collections::HashSet;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -564,9 +564,7 @@ impl RequestProcessingPreference {
     }
 }
 
-
 fn rmpv_to_pyobject(py: Python<'_>, value: &rmpv::Value) -> PyResult<PyObject> {
-    use pyo3::types::{PyBytes, PyDict, PyList};
     #[allow(deprecated)]
     Ok(match value {
         rmpv::Value::Nil => py.None(),
@@ -582,10 +580,7 @@ fn rmpv_to_pyobject(py: Python<'_>, value: &rmpv::Value) -> PyResult<PyObject> {
         }
         rmpv::Value::F32(f) => (*f as f64).to_object(py),
         rmpv::Value::F64(f) => f.to_object(py),
-        rmpv::Value::String(s) => match s.as_str() {
-            Some(v) => v.to_object(py),
-            None => PyBytes::new(py, s.as_bytes()).to_object(py),
-        },
+        rmpv::Value::String(s) => s.as_str().unwrap_or_default().to_object(py),
         rmpv::Value::Binary(b) => PyBytes::new(py, b).to_object(py),
         rmpv::Value::Array(items) => {
             let list = PyList::empty(py);
@@ -601,18 +596,7 @@ fn rmpv_to_pyobject(py: Python<'_>, value: &rmpv::Value) -> PyResult<PyObject> {
             }
             dict.to_object(py)
         }
-        rmpv::Value::Ext(tag, data) => {
-            (*tag, PyBytes::new(py, data).to_object(py)).to_object(py)
-        }
-    })
-}
-
-fn response_value_to_pyobject(py: Python<'_>, value: &rmpv::Value, idx: usize) -> PyResult<PyObject> {
-    rmpv_to_pyobject(py, value).map_err(|e| {
-        PyValueError::new_err(format!(
-            "Failed to convert response data at index {}: {}",
-            idx, e
-        ))
+        rmpv::Value::Ext(tag, data) => (*tag, PyBytes::new(py, data).to_object(py)).to_object(py),
     })
 }
 
@@ -1254,7 +1238,7 @@ impl PerformanceClient {
         for (idx, (json_val, headers_map, duration)) in
             response_data_with_times_and_headers.into_iter().enumerate()
         {
-            results_py.push(response_value_to_pyobject(py, &json_val, idx)?);
+            results_py.push(rmpv_to_pyobject(py, &json_val)?);
 
             let headers_py_obj = pythonize::pythonize(py, &headers_map).map_err(|e| {
                 PyValueError::new_err(format!(
@@ -1329,7 +1313,7 @@ impl PerformanceClient {
                 for (idx, (json_val, headers_map, duration)) in
                     response_data_with_times_and_headers.into_iter().enumerate()
                 {
-                    results_py.push(response_value_to_pyobject(py_gil, &json_val, idx)?);
+                    results_py.push(rmpv_to_pyobject(py_gil, &json_val)?);
 
                     let headers_py_obj =
                         pythonize::pythonize(py_gil, &headers_map).map_err(|e| {

--- a/baseten-performance-client/python_bindings/src/lib.rs
+++ b/baseten-performance-client/python_bindings/src/lib.rs
@@ -17,7 +17,7 @@ use numpy::{IntoPyArray, PyArray2};
 use once_cell::sync::Lazy;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
-use pyo3::types::{PyBytes, PyDict, PyList, PyType};
+use pyo3::types::PyType;
 use std::collections::HashSet;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -562,45 +562,6 @@ impl RequestProcessingPreference {
             non_retryable_status_codes,
         }
     }
-}
-
-fn rmpv_to_pyobject(py: Python<'_>, value: &rmpv::Value) -> PyResult<PyObject> {
-    #[allow(deprecated)]
-    Ok(match value {
-        rmpv::Value::Nil => py.None(),
-        rmpv::Value::Boolean(b) => b.to_object(py),
-        rmpv::Value::Integer(i) => {
-            if let Some(v) = i.as_i64() {
-                v.to_object(py)
-            } else if let Some(v) = i.as_u64() {
-                v.to_object(py)
-            } else {
-                return Err(PyValueError::new_err("unrepresentable msgpack integer"));
-            }
-        }
-        rmpv::Value::F32(f) => (*f as f64).to_object(py),
-        rmpv::Value::F64(f) => f.to_object(py),
-        rmpv::Value::String(s) => match s.as_str() {
-            Some(value) => value.to_object(py),
-            None => PyBytes::new(py, s.as_bytes()).to_object(py),
-        },
-        rmpv::Value::Binary(b) => PyBytes::new(py, b).to_object(py),
-        rmpv::Value::Array(items) => {
-            let list = PyList::empty(py);
-            for item in items {
-                list.append(rmpv_to_pyobject(py, item)?)?;
-            }
-            list.to_object(py)
-        }
-        rmpv::Value::Map(entries) => {
-            let dict = PyDict::new(py);
-            for (k, v) in entries {
-                dict.set_item(rmpv_to_pyobject(py, k)?, rmpv_to_pyobject(py, v)?)?;
-            }
-            dict.to_object(py)
-        }
-        rmpv::Value::Ext(tag, data) => (*tag, PyBytes::new(py, data).to_object(py)).to_object(py),
-    })
 }
 
 fn rust_preference_from_py(
@@ -1241,7 +1202,14 @@ impl PerformanceClient {
         for (idx, (json_val, headers_map, duration)) in
             response_data_with_times_and_headers.into_iter().enumerate()
         {
-            results_py.push(rmpv_to_pyobject(py, &json_val)?);
+            let py_obj_bound = pythonize::pythonize(py, &json_val).map_err(|e| {
+                PyValueError::new_err(format!(
+                    "Failed to pythonize response data at index {}: {}",
+                    idx, e
+                ))
+            })?;
+            #[allow(deprecated)]
+            results_py.push(py_obj_bound.to_object(py));
 
             let headers_py_obj = pythonize::pythonize(py, &headers_map).map_err(|e| {
                 PyValueError::new_err(format!(
@@ -1316,7 +1284,14 @@ impl PerformanceClient {
                 for (idx, (json_val, headers_map, duration)) in
                     response_data_with_times_and_headers.into_iter().enumerate()
                 {
-                    results_py.push(rmpv_to_pyobject(py_gil, &json_val)?);
+                    let py_obj_bound = pythonize::pythonize(py_gil, &json_val).map_err(|e| {
+                        PyValueError::new_err(format!(
+                            "Failed to pythonize response data at index {}: {}",
+                            idx, e
+                        ))
+                    })?;
+                    #[allow(deprecated)]
+                    results_py.push(py_obj_bound.into_py(py_gil));
 
                     let headers_py_obj =
                         pythonize::pythonize(py_gil, &headers_map).map_err(|e| {
@@ -1369,6 +1344,18 @@ fn baseten_performance_client(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<
 mod tests {
     use super::*;
     use std::collections::HashSet;
+
+    #[test]
+    fn pythonize_preserves_msgpack_binary_as_bytes() {
+        Python::with_gil(|py| {
+            let value = rmpv::Value::Binary(vec![0xde, 0xad, 0xbe, 0xef]);
+            let object = pythonize::pythonize(py, &value).expect("binary value should pythonize");
+            let bytes = object
+                .downcast::<pyo3::types::PyBytes>()
+                .expect("binary value should become Python bytes");
+            assert_eq!(bytes.as_bytes(), &[0xde, 0xad, 0xbe, 0xef]);
+        });
+    }
 
     #[test]
     fn request_processing_preference_to_rust_uses_mutated_public_fields() {

--- a/baseten-performance-client/python_bindings/uv.lock
+++ b/baseten-performance-client/python_bindings/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "baseten-performance-client"
-version = "0.1.11"
+version = "0.1.13"
 source = { editable = "." }
 dependencies = [
     { name = "requests" },


### PR DESCRIPTION
## Problem
`parse_response_body` decodes msgpack response bodies into `serde_json::Value`, which cannot represent msgpack `bin` — any raw-bytes encoder response fails with `invalid type: byte array, expected any valid JSON value`. This is why HTTP-attached multimodal encoders must run `encoder_allow_bytes_without_b64: false` (base64, ~+33% payload) while co-located `encoder_dynamo` deployments get raw-bytes (#24826 in the monorepo added that opt-out as a workaround; redacted).

## Fix
Untyped msgpack bodies decode into `rmpv::Value` via a new `ResponseValue` enum. Python bindings convert natively (`bin` → `bytes`). Typed paths, JSON paths, node non-bin behavior, and the reverse proxy are unchanged (`Serialize` impl + `to_json()`).

## Compat
| Response | 0.1.12 | this PR |
|---|---|---|
| JSON | dict | identical |
| msgpack, no bin (b64 mode) | dict | identical (tested) |
| msgpack with bin | **crash** | dict with `bytes` |

Every response whose behavior changes previously threw.

## After release
Bump the `==0.1.12` 

cc @michaelfeil

🤖 Generated with [Claude Code](https://claude.com/claude-code)