### PR TITLE
fix(chains): release the client and response when a stream is abandoned

### DIFF
--- a/truss-chains/tests/test_remote_chainlet.py
+++ b/truss-chains/tests/test_remote_chainlet.py
@@ -1,12 +1,121 @@
 import asyncio
+import contextlib
 import logging
 import re
 import threading
 import time
 
 import pytest
+from aiohttp import web
 
 import truss_chains as chains
+
+
+async def _endless_stream(request):
+    """A dependency chainlet mid-generation: it never completes on its own."""
+    response = web.StreamResponse()
+    await response.prepare(request)
+    try:
+        while True:
+            await response.write(b"chunk")
+            await asyncio.sleep(0.01)
+    except (OSError, asyncio.CancelledError):
+        pass
+    return response
+
+
+@contextlib.asynccontextmanager
+async def _serve_stub(handler, concurrency_limit: int):
+    """Runs `handler` on loopback and yields a stub pointed at it."""
+    app = web.Application()
+    app.router.add_post("/", handler)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    stub = chains.StubBase(
+        service_descriptor=chains.DeployedServiceDescriptor(
+            name="TestChainlet",
+            internal_url=None,
+            predict_url=f"http://127.0.0.1:{runner.addresses[0][1]}/",
+            options=chains.RPCOptions(concurrency_limit=concurrency_limit),
+            display_name="TestChainlet",
+        ),
+        api_key="dummy-API-key",
+    )
+    try:
+        yield stub
+    finally:
+        # Drop client-side sockets first, so streaming handlers observe the
+        # disconnect and return instead of holding shutdown open.
+        if stub._cached_async_client:
+            await stub._cached_async_client[0].close()
+        with contextlib.suppress(asyncio.TimeoutError):
+            await asyncio.wait_for(runner.cleanup(), timeout=5)
+
+
+@pytest.mark.asyncio
+async def test_predict_async_stream_holds_semaphore_while_streaming():
+    """The concurrency slot must stay held until the caller is done reading, not
+    released as soon as the response headers arrive."""
+    async with _serve_stub(_endless_stream, concurrency_limit=2) as stub:
+        stream = await stub.predict_async_stream({})
+        await stream.__anext__()
+
+        assert stub._async_semaphore_wrapper.ongoing_requests == 1
+
+        await stream.aclose()
+        assert stub._async_semaphore_wrapper.ongoing_requests == 0
+
+
+@pytest.mark.asyncio
+async def test_predict_async_stream_releases_slot_when_consumer_is_cancelled():
+    """Cancelling the consumer mid-stream (what a client disconnect does) must
+    release the slot, and only then."""
+    async with _serve_stub(_endless_stream, concurrency_limit=2) as stub:
+        started = asyncio.Event()
+
+        async def consume():
+            stream = await stub.predict_async_stream({})
+            async for _ in stream:
+                started.set()
+
+        task = asyncio.create_task(consume())
+        await asyncio.wait_for(started.wait(), timeout=5)
+
+        assert stub._async_semaphore_wrapper.ongoing_requests == 1
+
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+        assert stub._async_semaphore_wrapper.ongoing_requests == 0
+
+
+@pytest.mark.asyncio
+async def test_cancelled_stream_does_not_wedge_the_stub():
+    """The user-visible symptom: after `concurrency_limit` cancellations the stub
+    could no longer reach its dependency at all."""
+    limit = 2
+    async with _serve_stub(_endless_stream, concurrency_limit=limit) as stub:
+        for _ in range(limit):
+            started = asyncio.Event()
+
+            async def consume():
+                stream = await stub.predict_async_stream({})
+                async for _ in stream:
+                    started.set()
+
+            task = asyncio.create_task(consume())
+            await asyncio.wait_for(started.wait(), timeout=5)
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+        stream = await asyncio.wait_for(stub.predict_async_stream({}), timeout=5)
+        try:
+            assert await stream.__anext__() == b"chunk"
+        finally:
+            await stream.aclose()
 
 
 @pytest.fixture

--- a/truss-chains/truss_chains/remote_chainlet/stub.py
+++ b/truss-chains/truss_chains/remote_chainlet/stub.py
@@ -415,10 +415,22 @@ class StubBase(BasetenSession, abc.ABC):
 
         async def _rpc() -> AsyncIterator[bytes]:
             client: "aiohttp.ClientSession"
-            async with self._client_async() as client:
-                response = await client.post(self._target_url, **params)
+            # The response outlives this function, so the generator below owns the
+            # client context and releases it when exhausted or closed.
+            async with contextlib.AsyncExitStack() as stack:
+                client = await stack.enter_async_context(self._client_async())
+                response = await stack.enter_async_context(
+                    client.post(self._target_url, **params)
+                )
                 await utils.async_response_raise_errors(response, self.name)
-                return response.content.iter_any()
+                owned = stack.pop_all()
+
+            async def _stream() -> AsyncIterator[bytes]:
+                async with owned:
+                    async for chunk in response.content.iter_any():
+                        yield chunk
+
+            return _stream()
 
         try:
             return await retry(_rpc)


### PR DESCRIPTION
## :rocket: What

`predict_async_stream` returns the response iterator from inside the `async with self._client_async()` block, so the client context exits while the caller is still reading, releasing the concurrency slot early and leaving the aiohttp response checked out of the pool with nothing to release it.

This hands ownership of the client context and the response to the generator the caller iterates, so both are released when it is exhausted or closed.

```
BEFORE                                   AFTER

_rpc()                                   _rpc()
 └─ async with _client_async()            └─ async with _client_async()
      ├─ post() -> response                    ├─ post() -> response
      └─ return iter_any() ───┐                └─ pop_all() ──────┐
    (context exits here)      │                                   │
      ✗ slot released         │                     generator ────┘
      ✗ response orphaned     │                      ├─ yields chunks
                              ▼                      └─ on close/exhaust:
    caller reads stream ──────┘                           ✓ response released
                                                          ✓ slot released
```

The practical effect is a stream that ends by cancellation, which is what happens whenever an end user closes the tab mid-generation: uvicorn cancels the parent chainlet's response generator, that propagates into `async for data in await self.predict_async_stream(...)`, and the abandoned response never returns its connection. Each one permanently consumes a slot in `TCPConnector(limit=concurrency_limit)`. After `concurrency_limit` of them the stub cannot reach that dependency at all until the session is cycled an hour later. `ongoing_requests` reads `0` throughout, so the gauge reports idle while the stub is wedged.

Measured against a local server with the real `StubBase`, `concurrency_limit=2`, two consumers cancelled mid-stream:

| | next call to the dependency | `ongoing_requests` mid-stream |
|---|---|---|
| before | wedged, still blocked at 6s | 0 |
| after | succeeds immediately | 1 |

`gc.collect()` does not rescue it, so this is not something the garbage collector cleans up later.

## :computer: How

`contextlib.AsyncExitStack` acquires the client context and the response, `pop_all()` transfers ownership once the request has succeeded, and the generator releases them in its own `async with`. Errors raised during setup still close the stack before propagating, so retries do not accumulate connections.

The request stays eager rather than moving into the generator, because `RPCOptions.retries` is documented as only retrying before results stream back, and `code_gen.py` emits `async for data in await self.predict_async_stream(...)`, which cannot await a plain async generator.

**One behavior change worth flagging:** the slot is now held for the life of the stream, which is what `predict_async` already does. Concurrency is unchanged in count, since `TCPConnector(limit=...)` already capped it, but a caller that exceeds the limit now waits on the semaphore instead of failing with `TimeoutError` after `timeout_sec`. At the default `concurrency_limit=300` that needs 300 concurrent streams to one dependency; at `concurrency_limit=1` a chainlet that calls the same stub while consuming a stream from it would deadlock.

## :microscope: Testing

Three tests in `truss-chains/tests/test_remote_chainlet.py`, all against a loopback aiohttp server, no credentials or network. Each fails on `main` and passes here:

- the slot is held while streaming and released on `aclose()` (`assert 0 == 1` on `main`)
- cancelling the consumer mid-stream releases the slot
- after `concurrency_limit` cancellations the stub can still reach its dependency (hangs out the timeout on `main`)

`truss-chains` unit suite: 177 passed, 1 skipped. `ruff check`, `ruff format --check` and `mypy` clean on both files.
