### PR TITLE
fix(trt_llm): warn when python_version is ignored

### DIFF
--- a/truss/base/trt_llm_config.py
+++ b/truss/base/trt_llm_config.py
@@ -849,6 +849,15 @@ def trt_llm_common_validation(config: "TrussConfig"):
     from truss.base import truss_config
 
     assert config.trt_llm, "TRT-LLM configuration is required for TRT-LLM models"
+    default_python_version = truss_config.TrussConfig.model_fields[
+        "python_version"
+    ].default
+    if config.python_version != default_python_version:
+        logger.warning(
+            f"`python_version: {config.python_version}` has no effect on TRT-LLM models: "
+            "the TRT-LLM base image ships its own fixed Python interpreter, independent of "
+            "this setting."
+        )
     trt_llm_config: TRTLLMConfigurationV1 | TRTLLMConfigurationV2 = config.trt_llm.root
     base_model = (
         trt_llm_config.build.base_model

--- a/truss/tests/trt_llm/test_trt_llm_config.py
+++ b/truss/tests/trt_llm/test_trt_llm_config.py
@@ -12,6 +12,7 @@ from truss.base.trt_llm_config import (
     TrussTRTLLMBuildConfiguration,
     TrussTRTLLMRuntimeConfiguration,
 )
+from truss.base.truss_config import TrussConfig
 
 
 def test_trt_llm_config_init_from_pydantic_models(trtllm_config):
@@ -246,3 +247,30 @@ def test_trt_llm_config_additional_fields(trtllm_config_v2):
 
     assert config.inference_stack == "v2"
     assert isinstance(config.build, TrussTRTLLMBuildConfiguration)
+
+
+def test_trt_llm_non_default_python_version_warns(trtllm_config, caplog):
+    """python_version has no effect on TRT-LLM models: the TRT-LLM base image ships
+    its own fixed Python interpreter. Setting a non-default value should warn."""
+    trtllm_config["python_version"] = "py311"
+
+    with caplog.at_level("WARNING"):
+        TrussConfig.from_dict(trtllm_config)
+
+    assert "has no effect on TRT-LLM models" in caplog.text
+
+
+def test_trt_llm_default_python_version_no_warning(trtllm_config, caplog):
+    with caplog.at_level("WARNING"):
+        TrussConfig.from_dict(trtllm_config)
+
+    assert "has no effect on TRT-LLM models" not in caplog.text
+
+
+def test_trt_llm_v2_non_default_python_version_warns(trtllm_config_v2, caplog):
+    trtllm_config_v2["python_version"] = "py311"
+
+    with caplog.at_level("WARNING"):
+        TrussConfig.from_dict(trtllm_config_v2)
+
+    assert "has no effect on TRT-LLM models" in caplog.text


### PR DESCRIPTION
<!--
  What does this PR add, remove, and/or change?
-->
## :rocket: What

Adds a warning when `python_version` is set on a TRT-LLM model, since it currently has no effect there.

Fixes #2168

**Problem:** for any TRT-LLM model (decoder/Briton, encoder/BEI, encoder-bert, or v2), `_fill_trt_llm_versions` (`truss/contexts/docker_build_setup.py:34-84`) forces `config.base_image` + a fixed `python_executable_path` — `/usr/local/briton/venv/bin/python` for decoder, `/usr/bin/python3` for the others. Once `config.base_image` is set this way, `serving_image_builder.py:970-975` skips the `python_version`-derived image tag entirely, and `server.Dockerfile.jinja:32-34` symlinks `python` to that fixed path. So `python_version` is accepted, validated, and stored — but has zero effect on the running container, with no indication to the user. Reproduced directly against `TrussConfig`:

```
$ uv run python -c "
from truss.base.truss_config import TrussConfig
from truss.base.constants import TRTLLM_PYTHON_EXECUTABLE
cfg = TrussConfig.from_dict({
    'model_name': 'repro', 'python_version': 'py39',
    'model_metadata': {'tags': ['openai-compatible']},
    'resources': {'accelerator': 'A100', 'use_gpu': True},
    'trt_llm': {'build': {'max_seq_len': 1000, 'max_batch_size': 1, 'base_model': 'decoder',
        'checkpoint_repository': {'repo': 'TinyLlama/TinyLlama-1.1B-Chat-v1.0', 'source': 'HF'}}},
})
print('accepted python_version =', cfg.python_version)
print('but forced to run on:', TRTLLM_PYTHON_EXECUTABLE)
"
accepted python_version = py39
but forced to run on: /usr/local/briton/venv/bin/python
```
No warning was logged for this mismatch on `main`.

This override is intentional (traced to #1548 — TRT-LLM base images are backend-supplied with their own bundled Python/TensorRT-LLM runtime), so this PR doesn't change that behavior. It only surfaces it, since nothing currently does.

<!--
  How was the change described above implemented?
-->
## :computer: How

Added a `logger.warning` in `trt_llm_common_validation()` (`truss/base/trt_llm_config.py`), which already runs for every TRT-LLM config (both v1 and v2, via `trt_llm_validation`) and already contains a similar warning for another misconfiguration (`WEIGHTS_ONLY_INT8` quantization on A100). The new check fires when `config.python_version` differs from the field's default, using the same idiom already established in this function.

Considered raising a `ValueError` instead, since a few other checks in this function do raise. Went with a warning because setting `python_version` alongside `trt_llm` isn't actually invalid — just inert — so hard-failing would break any existing config that harmlessly sets both. Happy to switch to a hard error if you'd prefer that here.

<!--
  How have I ensured release and ongoing quality of this change?
-->
## :microscope: Testing

Added 3 tests to `truss/tests/trt_llm/test_trt_llm_config.py`, reusing the existing `trtllm_config`/`trtllm_config_v2` fixtures and the `caplog.at_level("WARNING")` pattern already used in `truss/tests/test_config.py`:

- `test_trt_llm_non_default_python_version_warns` — fails on `main` (no warning exists), passes with this change.
- `test_trt_llm_default_python_version_no_warning` — the default (`py313`) config produces no warning; guards against noise on the common case.
- `test_trt_llm_v2_non_default_python_version_warns` — same check against a v2 config, since `trt_llm_common_validation` is shared between both inference stacks.

```
truss/tests/trt_llm/ -q → 24 passed, 1 skipped
```

Also ran the full non-integration suite: `1651 passed, 19 skipped, 0 failed` (no regressions vs. the `main` baseline of 1648 passed, 19 skipped), plus `ruff check .`, `ruff format . --check`, and `pre-commit run --all-files` (mypy-local, uv-lock, config-schema) — all clean.

**Out of scope:** the original issue also reported a `torch.compile`/Triton `InductorError` crash on newer PyTorch/Triton versions — per the issue thread itself, that's a deployment-environment issue, not something fixable in `truss`, so this PR only addresses the `python_version` part.
