### PR TITLE
Warn only once per process when keyring write fails

### DIFF
--- a/truss/remote/remote_factory.py
+++ b/truss/remote/remote_factory.py
@@ -284,11 +284,14 @@ def _offload_secrets_from_config(remote_config: RemoteConfig) -> None:
     try:
         keyring.set_password(KEYRING_SERVICE, remote_config.name, payload)
     except keyring.errors.KeyringError as exc:
-        logger.warning(
-            "Warning: keyring write failed for %s (%s); leaving secret in plaintext.",
-            remote_config.name,
-            exc,
-        )
+        if not _keyring_fallback_warned:
+            logger.warning(
+                "Warning: keyring write failed for %s (%s); leaving secret in "
+                "plaintext.",
+                remote_config.name,
+                exc,
+            )
+            _keyring_fallback_warned = True
         return
     for key in _INLINE_SECRET_KEYS:
         configs.pop(key, None)

--- a/truss/tests/conftest.py
+++ b/truss/tests/conftest.py
@@ -1091,6 +1091,13 @@ class _InMemoryKeyring(keyring.backend.KeyringBackend):
             raise keyring.errors.PasswordDeleteError(str(exc)) from exc
 
 
+class _WriteErrorKeyring(_InMemoryKeyring):
+    # A usable backend whose writes always fail, like a macOS keychain that
+    # rejects the item.
+    def set_password(self, service, username, password):
+        raise keyring.errors.PasswordSetError("nope")
+
+
 @pytest.fixture
 def trussrc(tmp_path, monkeypatch):
     path = tmp_path / "trussrc"
@@ -1108,6 +1115,16 @@ def memory_keyring(trussrc):
     keyring.set_keyring(backend)
     try:
         yield backend
+    finally:
+        keyring.set_keyring(prior)
+
+
+@pytest.fixture
+def write_error_keyring(trussrc):
+    prior = keyring.get_keyring()
+    keyring.set_keyring(_WriteErrorKeyring())
+    try:
+        yield
     finally:
         keyring.set_keyring(prior)
 

--- a/truss/tests/remote/test_remote_factory.py
+++ b/truss/tests/remote/test_remote_factory.py
@@ -337,6 +337,35 @@ def test_unusable_backend_warns_and_keeps_inline(fail_keyring, trussrc, caplog):
     assert loaded.configs["oauth_access_token"] == "access"
 
 
+def test_write_failure_warns_once_per_process(write_error_keyring, trussrc, caplog):
+    def update(token):
+        RemoteFactory.update_remote_config(
+            RemoteConfig(
+                name="baseten",
+                configs={
+                    "remote_provider": "baseten",
+                    "auth_type": "oauth",
+                    "oauth_access_token": token,
+                    "oauth_refresh_token": "refresh",
+                    "oauth_expires_at": "123",
+                    "remote_url": "http://x",
+                },
+            )
+        )
+
+    with caplog.at_level("WARNING", logger=rf_module.logger.name):
+        update("access1")
+        update("access2")
+        update("access3")
+
+    # A long-running command refreshes its OAuth token repeatedly; only the
+    # first failed write should be reported.
+    warnings = [r for r in caplog.records if "keyring write failed" in r.message]
+    assert len(warnings) == 1
+    # Every refresh still persists to the trussrc.
+    assert "oauth_access_token = access3" in trussrc.read_text()
+
+
 def test_load_raises_when_secret_missing_and_keyring_unavailable(fail_keyring, trussrc):
     trussrc.write_text(
         "[baseten]\n"


### PR DESCRIPTION
## :rocket: What

When using oauth + long-running command, refresh token repeatedly used and so keyring write repeatedly attempted, but showing a warning each time on failed write.

## :computer: How

Also gate the keyring write error to once per process same as we do with keyring obtaining error

## :microscope: Testing

Added tests to replicate write error and confirm only one warning