### PR TITLE
Make docker_server nginx max payload size configurable

### DIFF
--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -1193,6 +1193,17 @@ class DockerServer(custom_types.ConfigModel):
         default=None,
         description="Skip the build step and deploy the base image as-is. Baseten copies the image to its container registry without running docker build or modifying the image in any way.",
     )
+    max_payload_size: Optional[str] = pydantic.Field(
+        default=None,
+        description="The maximum inbound request body size for the container's reverse proxy. Accepts nginx size syntax, such as 64M, 128M, or 1G. Defaults to 64M.",
+    )
+
+    @pydantic.field_validator("max_payload_size")
+    @classmethod
+    def _validate_max_payload_size(cls, v: Optional[str]) -> Optional[str]:
+        if v is not None and not re.fullmatch(r"[0-9]+[kKmMgG]?", v):
+            raise ValueError(f"Invalid max_payload_size {v!r}.")
+        return v
 
     @pydantic.field_validator("run_as_user_id")
     @classmethod

--- a/truss/config.schema.json
+++ b/truss/config.schema.json
@@ -415,6 +415,19 @@
           "default": null,
           "description": "Skip the build step and deploy the base image as-is. Baseten copies the image to its container registry without running docker build or modifying the image in any way.",
           "title": "No Build"
+        },
+        "max_payload_size": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The maximum inbound request body size for the container's reverse proxy. Accepts nginx size syntax, such as 64M, 128M, or 1G. Defaults to 64M.",
+          "title": "Max Payload Size"
         }
       },
       "required": [

--- a/truss/contexts/image_builder/serving_image_builder.py
+++ b/truss/contexts/image_builder/serving_image_builder.py
@@ -458,7 +458,9 @@ def generate_docker_server_nginx_config(build_dir, config):
         readiness_endpoint=config.docker_server.readiness_endpoint,
         liveness_endpoint=config.docker_server.liveness_endpoint,
         server_port=config.docker_server.server_port,
-        client_max_body_size=TRUSSLESS_MAX_PAYLOAD_SIZE,
+        client_max_body_size=config.docker_server.max_payload_size
+        if config.docker_server.max_payload_size is not None
+        else TRUSSLESS_MAX_PAYLOAD_SIZE,
         transport_kind=config.runtime.transport.kind,
     )
     nginx_filepath = build_dir / "proxy.conf"

--- a/truss/tests/contexts/image_builder/test_serving_image_builder.py
+++ b/truss/tests/contexts/image_builder/test_serving_image_builder.py
@@ -1033,7 +1033,12 @@ python main.py --gpus $PARALLEL
         assert cfg.has_section("eventlistener:quit_on_failure")
 
 
-def test_nginx_config_disables_disk_writes(tmp_path):
+@pytest.mark.parametrize(
+    "max_payload_size,expected_max_payload_size", [(None, "64M"), ("128M", "128M")]
+)
+def test_nginx_config_disables_disk_writes(
+    tmp_path, max_payload_size, expected_max_payload_size
+):
     """Test that nginx configuration disables all disk writes."""
 
     class MockDockerServer:
@@ -1041,6 +1046,9 @@ def test_nginx_config_disables_disk_writes(tmp_path):
         readiness_endpoint = "/readiness"
         liveness_endpoint = "/health"
         server_port = 8090
+        max_payload_size = None
+
+    MockDockerServer.max_payload_size = max_payload_size
 
     class MockTransport:
         kind = "http"
@@ -1060,6 +1068,7 @@ def test_nginx_config_disables_disk_writes(tmp_path):
     # Verify logging is disabled
     assert "access_log off;" in nginx_config
     assert "error_log /dev/null;" in nginx_config
+    assert f"client_max_body_size {expected_max_payload_size};" in nginx_config
 
     # Verify temp paths use /dev/shm (in-memory filesystem)
     assert "client_body_temp_path /dev/shm/nginx_client_temp;" in nginx_config

--- a/truss/tests/test_config.py
+++ b/truss/tests/test_config.py
@@ -1421,6 +1421,20 @@ def test_docker_server_run_as_user_id(run_as_user_id, expected, raises):
         assert docker_server.run_as_user_id == expected
 
 
+def test_docker_server_invalid_max_payload_size():
+    with pytest.raises(
+        pydantic.ValidationError, match="Invalid max_payload_size '64MB'"
+    ):
+        DockerServer(
+            start_command="python main.py",
+            server_port=8000,
+            predict_endpoint="/predict",
+            readiness_endpoint="/health",
+            liveness_endpoint="/health",
+            max_payload_size="64MB",
+        )
+
+
 # =============================================================================
 # Weights Configuration Tests
 # =============================================================================


### PR DESCRIPTION
## Problem

The nginx reverse proxy Truss generates in front of a `docker_server` (custom server) container hardcodes `client_max_body_size` to `64M`:

- `truss/base/constants.py:34` — `TRUSSLESS_MAX_PAYLOAD_SIZE = "64M"`
- `truss/contexts/image_builder/serving_image_builder.py:461` — passed into `proxy.conf.jinja`

Custom-server users get a `413` at exactly 64 MiB with no way to raise it. It reads like a platform ingress limit (our docs say the ingress cap is 100 MB), but it is generated into the customer's own image, so nothing on their side or in their Truss config controls it.

This came from a customer who bracketed it precisely: highest accepted body 66,837,864 B (63.74 MiB), lowest rejected 67,850,445 B (64.71 MiB). `64M` = 67,108,864 B sits inside that bracket. A request trace confirmed every Baseten hop passed the full body through and the 413 was generated after dispatch into the model pod.

## Change

Adds an optional `docker_server.max_payload_size`, validated against nginx size syntax (integer with optional `k`/`m`/`g` suffix), threaded into the nginx template. Falls back to `TRUSSLESS_MAX_PAYLOAD_SIZE` when unset.

```yaml
docker_server:
  start_command: python main.py
  server_port: 8000
  predict_endpoint: /predict
  readiness_endpoint: /health
  liveness_endpoint: /health
  max_payload_size: 128M
```

Default behavior is unchanged — a config without the field renders byte-identical nginx output.

## Sizing caveat for reviewers

This is why the field is opt-in and the default is untouched.

`proxy.conf.jinja` sets `client_body_buffer_size 4M` and points `client_body_temp_path` at `/dev/shm`, so any body over 4 MB spills into pod memory. `/dev/shm` is an explicit memory-backed `emptyDir` (operator `model.service.template.yaml.jinja:283-286`, mounted at `:906-907`) and its `sizeLimit` scales with GPU count, not instance RAM (`operator/core/utils/workload_utils.py:120-138`):

| tier | shm per GPU |
| --- | --- |
| CPU-only | 1 GiB flat, regardless of RAM |
| T4 / A10G / L4 / L40S / A100 / V100 | 1 GiB x N |
| H100 / H200 / RTX-PRO-6000 | 8 GiB x N |
| B200 / B300 / GB300 | 32 GiB x N |

The tmpfs counts against the container memory limit — `actions.py:1687` says so directly ("the tempfs usage is limited by the container memory limit"). So oversizing this gives you ENOSPC past `sizeLimit`, or an OOMKill if shm growth blows the cgroup. The template also sets `error_log /dev/null`, so that failure is silent.

That is the argument against simply raising `TRUSSLESS_MAX_PAYLOAD_SIZE`. The constant is baked into every `docker_server` image: on the 1 GiB tier, 128 MiB bodies cap out around 8 concurrent, and there are ~6,400 CPU-only `docker_server` models on `1x2` (1 GiB shm inside a 2 GiB cgroup) plus ~1,800 on single-GPU L4/A10G/T4. An opt-in field leaves all of them untouched.

Open question for reviewers: should the validator enforce an upper bound instead of accepting `1G`? A safer long-term fix may be moving `client_body_temp_path` off `/dev/shm` onto a small disk-backed `emptyDir` — #2163 moved it to `/dev/shm` only to dodge read-only filesystems, which a dedicated emptyDir also solves.

Note this does not by itself raise the end-to-end ceiling: the WP ingress controller is `proxy-body-size: 100m`, so 100 MiB is the most that is reachable over the public path today.

## Test plan

- `truss/tests/test_config.py::test_docker_server_invalid_max_payload_size` — rejects `64MB`
- `truss/tests/contexts/image_builder/test_serving_image_builder.py::test_nginx_config_disables_disk_writes` — parametrized: default renders `64M`, explicit `128M` renders `128M`

`uv run pytest truss/tests/test_config.py truss/tests/contexts/image_builder/test_serving_image_builder.py -m 'not integration'` — 287 passed, 3 skipped. `ruff check` / `ruff format --check` clean. `bin/generate_truss_config_schema.py --check` up to date.

Draft — opening for direction on the sizing questions above before marking ready.