### PR TITLE
Support authenticating truss via env vars as an alternative to the trussrc

### DIFF
--- a/truss/cli/auth.py
+++ b/truss/cli/auth.py
@@ -14,9 +14,11 @@ from truss.remote.baseten.api import resolve_rest_api_url
 from truss.remote.baseten.oauth import OAuthCredential, OAuthError
 from truss.remote.remote_factory import (
     _INLINE_SECRET_KEYS,
+    API_KEY_ENV,
     USER_TRUSSRC_PATH,
     AuthType,
     RemoteFactory,
+    env_remote_config,
     load_config,
 )
 from truss.remote.truss_remote import RemoteConfig
@@ -63,7 +65,10 @@ def auth_logout(remote: Optional[str]) -> None:
         )
         oauth.revoke(resolve_rest_api_url(cfg.configs["remote_url"]), credential)
 
-    RemoteFactory.remove_remote_config(remote_name)
+    try:
+        RemoteFactory.remove_remote_config(remote_name)
+    except ValueError as exc:
+        raise click.ClickException(str(exc))
     console.print(f"👋 Logged out of remote `{remote_name}`.")
 
 
@@ -78,6 +83,17 @@ def auth_logout(remote: Optional[str]) -> None:
 def auth_status(remote: Optional[str]) -> None:
     """Show the active authentication for a remote."""
     remote_name = remote or inquire_remote_name(allow_create=False)
+    if env_config := env_remote_config():
+        if remote_name != env_config.name:
+            raise click.ClickException(
+                f"Cannot show remote {remote_name!r}: {API_KEY_ENV} is set, which "
+                "takes precedence over the trussrc."
+            )
+        console.print(f"remote: {env_config.name}")
+        console.print(f"remote_url: {env_config.configs['remote_url']}")
+        console.print("auth_type: api_key")
+        console.print(f"source: {API_KEY_ENV}")
+        return
     if not USER_TRUSSRC_PATH.exists():
         raise click.ClickException(f"No trussrc found at {USER_TRUSSRC_PATH}.")
     raw = load_config()

--- a/truss/remote/baseten/auth.py
+++ b/truss/remote/baseten/auth.py
@@ -13,6 +13,10 @@ class ApiKeyCredential(pydantic.BaseModel):
     model_config = pydantic.ConfigDict(frozen=True)
 
     api_key: str = pydantic.Field(min_length=1)
+    # Send as `Bearer` rather than the legacy `Api-Key`. Set for env-supplied
+    # tokens, which may be an API key or an OAuth access token; trussrc remotes
+    # keep the legacy scheme.
+    use_bearer: bool = False
 
 
 class OAuthSession(pydantic.BaseModel):
@@ -45,7 +49,8 @@ class AuthService:
             with self._refresh_lock:
                 session = self._refresh_if_expired(self._credential)
             return {"Authorization": f"Bearer {session.credential.access_token}"}
-        return {"Authorization": f"Api-Key {self._credential.api_key}"}
+        scheme = "Bearer" if self._credential.use_bearer else "Api-Key"
+        return {"Authorization": f"{scheme} {self._credential.api_key}"}
 
     def _refresh_if_expired(self, session: OAuthSession) -> OAuthSession:
         if not session.credential.is_expired():

--- a/truss/remote/baseten/remote.py
+++ b/truss/remote/baseten/remote.py
@@ -126,6 +126,7 @@ class BasetenRemote(TrussRemote):
         remote_url: str,
         api_key: Optional[str] = None,
         *,
+        api_key_use_bearer: bool = False,
         oauth_remote_name: Optional[str] = None,
         oauth_access_token: Optional[str] = None,
         oauth_refresh_token: Optional[str] = None,
@@ -159,7 +160,9 @@ class BasetenRemote(TrussRemote):
             api_key = api_key or os.environ.get("BASETEN_API_KEY")
             if not api_key:
                 raise AuthorizationError("No credentials provided.")
-            self._auth_service = AuthService(ApiKeyCredential(api_key=api_key))
+            self._auth_service = AuthService(
+                ApiKeyCredential(api_key=api_key, use_bearer=api_key_use_bearer)
+            )
         self._api = BasetenApi(remote_url, self._auth_service)
 
     def fetch_auth_header(self) -> dict[str, str]:

--- a/truss/remote/remote_factory.py
+++ b/truss/remote/remote_factory.py
@@ -30,6 +30,12 @@ logger = logging.getLogger(__name__)
 KEYRING_SERVICE = "baseten-truss"
 KEYRING_DISABLED_ENV = "BASETEN_TRUSS_AUTH_KEYRING_DISABLED"
 
+REMOTE_URL_ENV = "BASETEN_TRUSS_AUTH_REMOTE_URL"
+API_KEY_ENV = "BASETEN_TRUSS_AUTH_API_KEY"
+# Name of the remote synthesized from the env vars above. Never typed by users,
+# only shown in output; the brackets avoid colliding with a trussrc section.
+ENV_REMOTE_NAME = "<environment>"
+
 
 class AuthType(str, enum.Enum):
     API_KEY = "api_key"
@@ -62,6 +68,46 @@ def update_config(config: ConfigParser):
         config.write(configfile)
 
 
+def env_remote_config() -> Optional[RemoteConfig]:
+    """Build a remote config from the environment, or None if not configured.
+
+    BASETEN_TRUSS_AUTH_REMOTE_URL and BASETEN_TRUSS_AUTH_API_KEY together fully
+    define a remote, bypassing the trussrc and the keyring. Setting just one of
+    them is an error.
+    """
+    remote_url = os.environ.get(REMOTE_URL_ENV)
+    api_key = os.environ.get(API_KEY_ENV)
+    if not remote_url and not api_key:
+        return None
+    if not remote_url or not api_key:
+        missing, present = (
+            (REMOTE_URL_ENV, API_KEY_ENV)
+            if not remote_url
+            else (API_KEY_ENV, REMOTE_URL_ENV)
+        )
+        raise ValueError(f"{present} is set but {missing} is not; set both or neither.")
+    return RemoteConfig(
+        name=ENV_REMOTE_NAME,
+        configs={
+            "remote_provider": "baseten",
+            "remote_url": remote_url,
+            "api_key": api_key,
+            "api_key_use_bearer": True,
+        },
+    )
+
+
+def _reject_env_remote_name(remote_name: str) -> None:
+    """Guard the trussrc writers against the env-configured remote, which has
+    no section to write to or delete."""
+    if remote_name == ENV_REMOTE_NAME:
+        raise ValueError(
+            f"Remote {ENV_REMOTE_NAME} comes from {REMOTE_URL_ENV} and "
+            f"{API_KEY_ENV}, so it is not stored in the trussrc. Unset them to "
+            "manage saved remotes."
+        )
+
+
 class RemoteFactory:
     """
     A factory for instantiating a TrussRemote from a .trussrc file and a user-specified remote config name
@@ -71,6 +117,10 @@ class RemoteFactory:
 
     @staticmethod
     def get_available_config_names() -> List[str]:
+        # An env-configured remote hides the trussrc, so it is the only choice.
+        if env_remote_config():
+            return [ENV_REMOTE_NAME]
+
         if not USER_TRUSSRC_PATH.exists():
             return []
 
@@ -82,6 +132,17 @@ class RemoteFactory:
         """
         Load and validate a remote config from the .trussrc file
         """
+        if env_config := env_remote_config():
+            # Only `get_available_config_names` hands out ENV_REMOTE_NAME, so
+            # any other name was typed as `--remote` and cannot be honored.
+            if remote_name != ENV_REMOTE_NAME:
+                raise ValueError(
+                    f"Cannot use remote {remote_name!r}: {REMOTE_URL_ENV} and "
+                    f"{API_KEY_ENV} are set, which takes precedence over the "
+                    "trussrc. Unset them to select a remote by name."
+                )
+            return env_config
+
         if not USER_TRUSSRC_PATH.exists():
             raise FileNotFoundError("No ~/.trussrc file found.")
 
@@ -101,6 +162,7 @@ class RemoteFactory:
         """
         Load and validate a remote config from the .trussrc file
         """
+        _reject_env_remote_name(remote_config.name)
         remote_config = RemoteConfig(
             name=remote_config.name, configs=dict(remote_config.configs)
         )
@@ -127,6 +189,7 @@ class RemoteFactory:
         ``truss auth login`` adds a remote section; ``truss auth logout`` is the
         inverse. Caller is expected to have verified the remote exists.
         """
+        _reject_env_remote_name(remote_name)
         if not _keyring_disabled_by_env() and _keyring_backend_usable():
             try:
                 keyring.delete_password(KEYRING_SERVICE, remote_name)

--- a/truss/tests/cli/test_auth_cli.py
+++ b/truss/tests/cli/test_auth_cli.py
@@ -192,3 +192,32 @@ def test_login_prints_success_message(memory_keyring, trussrc):
     assert result.exit_code == 0, result.output
     assert "Logged in to remote" in result.output
     assert "alt" in result.output
+
+
+def test_status_reports_env_remote(trussrc, monkeypatch):
+    monkeypatch.setenv(rf_module.REMOTE_URL_ENV, "https://app.test.com")
+    monkeypatch.setenv(rf_module.API_KEY_ENV, "env_key")
+    result = CliRunner().invoke(truss_cli, ["auth", "status"])
+    assert result.exit_code == 0, result.output
+    assert f"remote: {rf_module.ENV_REMOTE_NAME}" in result.output
+    assert "remote_url: https://app.test.com" in result.output
+    assert f"source: {rf_module.API_KEY_ENV}" in result.output
+
+
+def test_status_named_remote_errors_with_env_remote(trussrc, monkeypatch):
+    trussrc.write_text(
+        "[baseten]\nremote_provider = baseten\nremote_url = http://x\napi_key = plain\n"
+    )
+    monkeypatch.setenv(rf_module.REMOTE_URL_ENV, "https://app.test.com")
+    monkeypatch.setenv(rf_module.API_KEY_ENV, "env_key")
+    result = CliRunner().invoke(truss_cli, ["auth", "status", "--remote", "baseten"])
+    assert result.exit_code != 0
+    assert rf_module.API_KEY_ENV in result.output
+
+
+def test_logout_env_remote_errors(trussrc, monkeypatch):
+    monkeypatch.setenv(rf_module.REMOTE_URL_ENV, "https://app.test.com")
+    monkeypatch.setenv(rf_module.API_KEY_ENV, "env_key")
+    result = CliRunner().invoke(truss_cli, ["auth", "logout"])
+    assert result.exit_code != 0
+    assert rf_module.API_KEY_ENV in result.output

--- a/truss/tests/conftest.py
+++ b/truss/tests/conftest.py
@@ -1104,6 +1104,8 @@ def trussrc(tmp_path, monkeypatch):
     monkeypatch.setattr(remote_factory, "USER_TRUSSRC_PATH", path)
     monkeypatch.setattr("truss.cli.auth.USER_TRUSSRC_PATH", path)
     monkeypatch.delenv(remote_factory.KEYRING_DISABLED_ENV, raising=False)
+    monkeypatch.delenv(remote_factory.REMOTE_URL_ENV, raising=False)
+    monkeypatch.delenv(remote_factory.API_KEY_ENV, raising=False)
     monkeypatch.setattr(remote_factory, "_keyring_fallback_warned", False)
     return path
 

--- a/truss/tests/remote/baseten/test_auth.py
+++ b/truss/tests/remote/baseten/test_auth.py
@@ -12,6 +12,11 @@ def test_api_key_auth_header():
     assert auth_service.fetch_auth_header() == {"Authorization": "Api-Key test_key"}
 
 
+def test_api_key_auth_header_use_bearer():
+    auth_service = AuthService(ApiKeyCredential(api_key="test_key", use_bearer=True))
+    assert auth_service.fetch_auth_header() == {"Authorization": "Bearer test_key"}
+
+
 def test_api_key_credential_rejects_empty():
     with pytest.raises(pydantic.ValidationError):
         ApiKeyCredential(api_key="")

--- a/truss/tests/remote/test_remote_factory.py
+++ b/truss/tests/remote/test_remote_factory.py
@@ -426,3 +426,63 @@ def test_remove_remote_config_missing_is_noop(memory_keyring, trussrc):
     trussrc.write_text("[other]\nremote_provider = baseten\n")
     RemoteFactory.remove_remote_config("baseten")
     assert "[other]" in trussrc.read_text()
+
+
+@pytest.fixture
+def env_remote(monkeypatch):
+    monkeypatch.setenv(rf_module.REMOTE_URL_ENV, "https://app.test.com")
+    monkeypatch.setenv(rf_module.API_KEY_ENV, "env_key")
+
+
+def test_env_remote_config_unset_is_none(trussrc):
+    assert rf_module.env_remote_config() is None
+
+
+@pytest.mark.parametrize("set_env", [rf_module.REMOTE_URL_ENV, rf_module.API_KEY_ENV])
+def test_env_remote_config_partial_raises(trussrc, monkeypatch, set_env):
+    monkeypatch.setenv(set_env, "value")
+    with pytest.raises(ValueError, match="set both or neither"):
+        rf_module.env_remote_config()
+
+
+def test_load_remote_config_from_env_without_trussrc(trussrc, env_remote):
+    config = RemoteFactory.load_remote_config(rf_module.ENV_REMOTE_NAME)
+    assert config.configs == {
+        "remote_provider": "baseten",
+        "remote_url": "https://app.test.com",
+        "api_key": "env_key",
+        "api_key_use_bearer": True,
+    }
+    assert not trussrc.exists()
+
+
+def test_load_remote_config_from_env_shadows_trussrc(trussrc, env_remote):
+    trussrc.write_text(SAMPLE_TRUSSRC)
+    config = RemoteFactory.load_remote_config(rf_module.ENV_REMOTE_NAME)
+    assert config.configs["remote_url"] == "https://app.test.com"
+
+
+def test_load_remote_config_from_env_rejects_named_remote(trussrc, env_remote):
+    trussrc.write_text(SAMPLE_TRUSSRC)
+    with pytest.raises(ValueError, match=rf_module.REMOTE_URL_ENV):
+        RemoteFactory.load_remote_config("test")
+
+
+def test_get_available_config_names_from_env(trussrc, env_remote):
+    trussrc.write_text(SAMPLE_TRUSSRC)
+    assert RemoteFactory.get_available_config_names() == [rf_module.ENV_REMOTE_NAME]
+
+
+def test_create_from_env_sends_bearer(trussrc, env_remote):
+    remote = RemoteFactory.create(rf_module.ENV_REMOTE_NAME)
+    assert remote.fetch_auth_header() == {"Authorization": "Bearer env_key"}
+
+
+def test_env_remote_cannot_be_written_or_removed(trussrc, env_remote):
+    with pytest.raises(ValueError, match=rf_module.API_KEY_ENV):
+        RemoteFactory.remove_remote_config(rf_module.ENV_REMOTE_NAME)
+    with pytest.raises(ValueError, match=rf_module.API_KEY_ENV):
+        RemoteFactory.update_remote_config(
+            RemoteConfig(name=rf_module.ENV_REMOTE_NAME, configs={})
+        )
+    assert not trussrc.exists()


### PR DESCRIPTION
## :rocket: What

- Truss can authenticate from `BASETEN_TRUSS_AUTH_REMOTE_URL` + `BASETEN_TRUSS_AUTH_API_KEY` instead of a trussrc, so a tool that already holds credentials can drive a truss it never configured.
- Both required; setting one errors rather than falling back to the trussrc.
- No behavior change when unset.

## :computer: How

- Synthesizes a `RemoteConfig` named `<environment>`, intercepted in `get_available_config_names` and `load_remote_config` so existing callers need no changes. Explicit `--remote <name>` errors.
- Sent as `Bearer` (may be an API key or OAuth token); trussrc remotes still send `Api-Key`.

## :microscope: Testing

- Unit tests for the new paths; existing `truss/tests/remote/` and `truss/tests/cli/` pass.