### PR TITLE
fix(server): register model module with fully-qualified name in sys.modules

### DIFF
--- a/truss/templates/server/model_wrapper.py
+++ b/truss/templates/server/model_wrapper.py
@@ -488,12 +488,20 @@ class ModelWrapper:
         if model_class_file_path.exists():
             self._logger.info("Loading truss model from file.")
             module_path = pathlib.Path(model_class_file_path).resolve()
-            module_name = module_path.stem  # Use the file's name as the module name
             if not os.path.isfile(module_path):
                 raise ImportError(
                     f"`{module_path}` is not a file. You must point to a python file where "
                     "the entrypoint chainlet is defined."
                 )
+            # Use the fully-qualified module name (e.g. "model.model") so the
+            # loaded module is registered under the correct key in sys.modules
+            # and does not shadow the model package itself.  Using just the
+            # file stem ("model") caused an AttributeError when any code inside
+            # the model file or its helpers did `import model; model.Model`,
+            # because sys.modules["model"] would resolve to the package
+            # (model/__init__.py) rather than the file being loaded.
+            model_module_dir = self._config["model_module_dir"]
+            module_name = f"{model_module_dir}.{module_path.stem}"
             import_error_msg = f"Could not import `{module_path}`. Check path."
             spec = importlib.util.spec_from_file_location(module_name, module_path)
             if not spec:
@@ -501,19 +509,13 @@ class ModelWrapper:
             if not spec.loader:
                 raise ImportError(import_error_msg)
             module = importlib.util.module_from_spec(spec)
+            # Register in sys.modules before exec_module so that circular or
+            # self-referential imports within the model file resolve correctly.
+            sys.modules[module_name] = module
             try:
                 spec.loader.exec_module(module)
-            except ImportError as e:
-                if "attempted relative import" in str(e):
-                    raise ImportError(
-                        f"During import of `{model_class_file_path}`. "
-                        f"Since Truss v0.9.36 relative imports (starting with '.') in "
-                        "the top-level model file are no longer supported. Please "
-                        "replace them with absolute imports. For guidance on importing "
-                        "custom packages refer to our documentation "
-                        "https://docs.baseten.co/truss-reference/config#packages"
-                    ) from e
-
+            except Exception:
+                sys.modules.pop(module_name, None)
                 raise
 
             model_class = getattr(module, self._config["model_class_name"])

--- a/truss/tests/templates/server/test_model_wrapper.py
+++ b/truss/tests/templates/server/test_model_wrapper.py
@@ -258,3 +258,59 @@ def _remove_model_load_sys_modules():
         del sys.modules["model.model"]
     if "model_wrapper" in sys.modules:
         del sys.modules["model_wrapper"]
+
+
+def test_model_module_registered_with_full_name(truss_container_fs: Path, helpers: Any):
+    """Model module must be registered as 'model.model' in sys.modules.
+
+    When model.py is loaded with just the file stem ('model') as the module
+    name, any code that does ``import model; model.Model`` resolves to the
+    model *package* (model/__init__.py), which does not define Model, raising
+    ``AttributeError: module 'model' has no attribute 'Model'``.
+
+    The fix registers the module under its fully-qualified name ('model.model')
+    so that the correct class can always be located.
+    """
+    app_path = truss_container_fs / "app"
+    with (
+        _clear_model_load_modules(),
+        helpers.sys_path(app_path),
+        _change_directory(app_path),
+    ):
+        model_wrapper_module = importlib.import_module("model_wrapper")
+        model_wrapper_class = getattr(model_wrapper_module, "ModelWrapper")
+        config = yaml.safe_load((app_path / "config.yaml").read_text())
+
+        model_wrapper = model_wrapper_class(config, sdk_trace.NoOpTracer())
+        model_wrapper._load_impl()
+
+        # The module must be registered under its full qualified name so that
+        # any downstream ``import model.model`` or ``from model.model import Model``
+        # resolves to the same loaded instance.
+        assert "model.model" in sys.modules
+        assert "Model" in dir(sys.modules["model.model"])
+
+
+def test_model_module_name_uses_qualified_path(truss_container_fs: Path, helpers: Any):
+    """The module __name__ for model.py must be the fully-qualified 'model.model'.
+
+    Using only the stem 'model' as __name__ conflicts with the model package and
+    can cause AttributeError when the user code resolves 'model' to the package.
+    """
+    app_path = truss_container_fs / "app"
+    with (
+        _clear_model_load_modules(),
+        helpers.sys_path(app_path),
+        _change_directory(app_path),
+    ):
+        model_wrapper_module = importlib.import_module("model_wrapper")
+        model_wrapper_class = getattr(model_wrapper_module, "ModelWrapper")
+        config = yaml.safe_load((app_path / "config.yaml").read_text())
+
+        model_wrapper = model_wrapper_class(config, sdk_trace.NoOpTracer())
+        model_wrapper._load_impl()
+
+        loaded_module = sys.modules.get("model.model")
+        assert loaded_module is not None
+        # The module's __name__ should reflect its place in the package hierarchy.
+        assert loaded_module.__name__ == "model.model"


### PR DESCRIPTION
## Summary

- `_load_impl` used `spec_from_file_location` with just the file stem (`"model"`) as the module name instead of the fully-qualified `"model.model"`
- The loaded module was not registered in `sys.modules`, so any import inside `model.py` that triggered `import model` resolved to the empty `model` package (`model/__init__.py`), causing `AttributeError: module 'model' has no attribute 'Model'`
- Fix uses the fully-qualified name `model.model` (derived from `config["model_module_dir"]` + file stem) and registers the module in `sys.modules` before `exec_module`, consistent with how `hot_reload` already works
- On error during `exec_module`, the module is removed from `sys.modules` to avoid leaving a partial entry behind

## Test plan

- [x] All 37 existing tests in `truss/tests/templates/server/` pass
- [x] Two new regression tests verify `model.model` is registered in `sys.modules` with the correct `__name__` after loading

Fixes #924