### PR TITLE
Isolate docker server dependencies from base image uv config

### DIFF
--- a/truss/templates/server.Dockerfile.jinja
+++ b/truss/templates/server.Dockerfile.jinja
@@ -138,7 +138,7 @@ COPY --chown={{ default_owner }} ./docker_server_requirements.txt ${APP_HOME}/do
 {# NB(nikhil): Use the same python version for custom server proxy as the control server, for consistency. #}
 RUN {{ clean_uv_env }} uv python install {{ control_python_version }}
 RUN {{ clean_uv_env }} uv venv /docker_server/.venv --python {{ control_python_version }}
-RUN {{ uv_cache_mount }}{{ clean_uv_env }} uv pip install --python /docker_server/.venv/bin/python -r /app/docker_server_requirements.txt{{ py_no_cache_dir }}
+RUN {{ uv_cache_mount }}{{ clean_uv_env }} uv pip install --no-config --python /docker_server/.venv/bin/python -r /app/docker_server_requirements.txt{{ py_no_cache_dir }}
 {% set proxy_config_path = "/etc/nginx/conf.d/proxy.conf" %}
 {% set supervisor_config_path = "/etc/supervisor/supervisord.conf" %}
 {% set supervisor_server_url = "http://localhost:8080" %}

--- a/truss/templates/server.Dockerfile.jinja
+++ b/truss/templates/server.Dockerfile.jinja
@@ -138,7 +138,7 @@ COPY --chown={{ default_owner }} ./docker_server_requirements.txt ${APP_HOME}/do
 {# NB(nikhil): Use the same python version for custom server proxy as the control server, for consistency. #}
 RUN {{ clean_uv_env }} uv python install {{ control_python_version }}
 RUN {{ clean_uv_env }} uv venv /docker_server/.venv --python {{ control_python_version }}
-RUN {{ uv_cache_mount }}{{ clean_uv_env }} uv pip install --no-config --python /docker_server/.venv/bin/python -r /app/docker_server_requirements.txt{{ py_no_cache_dir }}
+RUN {{ uv_cache_mount }}{{ clean_uv_env }} uv --no-config pip install --python /docker_server/.venv/bin/python -r /app/docker_server_requirements.txt{{ py_no_cache_dir }}
 {% set proxy_config_path = "/etc/nginx/conf.d/proxy.conf" %}
 {% set supervisor_config_path = "/etc/supervisor/supervisord.conf" %}
 {% set supervisor_server_url = "http://localhost:8080" %}

--- a/truss/tests/contexts/image_builder/test_serving_image_builder.py
+++ b/truss/tests/contexts/image_builder/test_serving_image_builder.py
@@ -264,7 +264,7 @@ def test_cache_mount_id_enabled_with_system_pkgs_ssh_and_docker_server(
         'HTTP_PROXY="$HTTP_PROXY" HTTPS_PROXY="$HTTPS_PROXY" NO_PROXY="$NO_PROXY" '
         'SSL_CERT_FILE="$SSL_CERT_FILE" REQUESTS_CA_BUNDLE="$REQUESTS_CA_BUNDLE" PIP_CERT="$PIP_CERT" '
         'UV_CACHE_DIR="$UV_CACHE_DIR" PIP_CACHE_DIR="$PIP_CACHE_DIR" '
-        "uv pip install --no-config --python /docker_server/.venv/bin/python "
+        "uv --no-config pip install --python /docker_server/.venv/bin/python "
         "-r /app/docker_server_requirements.txt"
     ) in dockerfile
     # Sanity: no --no-cache-dir anywhere, no list cleanup anywhere, no

--- a/truss/tests/contexts/image_builder/test_serving_image_builder.py
+++ b/truss/tests/contexts/image_builder/test_serving_image_builder.py
@@ -264,7 +264,7 @@ def test_cache_mount_id_enabled_with_system_pkgs_ssh_and_docker_server(
         'HTTP_PROXY="$HTTP_PROXY" HTTPS_PROXY="$HTTPS_PROXY" NO_PROXY="$NO_PROXY" '
         'SSL_CERT_FILE="$SSL_CERT_FILE" REQUESTS_CA_BUNDLE="$REQUESTS_CA_BUNDLE" PIP_CERT="$PIP_CERT" '
         'UV_CACHE_DIR="$UV_CACHE_DIR" PIP_CACHE_DIR="$PIP_CACHE_DIR" '
-        "uv pip install --python /docker_server/.venv/bin/python "
+        "uv pip install --no-config --python /docker_server/.venv/bin/python "
         "-r /app/docker_server_requirements.txt"
     ) in dockerfile
     # Sanity: no --no-cache-dir anywhere, no list cleanup anywhere, no


### PR DESCRIPTION
## :rocket: What

Prevent uv configuration inherited from a custom base image from changing Truss's internal legacy `docker_server` dependencies.

For example, a base image can configure uv to override a pinned setuptools version with a newer release that no longer provides `pkg_resources`, causing supervisord to fail during container startup.

## :computer: How

Pass `--no-config` when installing the platform-owned `/docker_server/.venv` requirements. User dependency installation remains unchanged and can continue to use project or user uv configuration.

## :microscope: Testing

- End-to-end deployment test passed using Truss `v0.18.26rc2`.
- `uv run pytest truss/tests/contexts/image_builder/test_serving_image_builder.py::test_cache_mount_id_enabled_with_system_pkgs_ssh_and_docker_server truss/tests/contexts/image_builder/test_serving_image_builder.py::TestDockerServerSlimBuild::test_legacy_dockerfile_unchanged_when_flag_off -v`
- `uv run ruff check truss/tests/contexts/image_builder/test_serving_image_builder.py`
- `uv run ruff format --check truss/tests/contexts/image_builder/test_serving_image_builder.py`

Made with [Cursor](https://cursor.com)