### PR TITLE
feat(perf-client): env flags to suppress cache-busting headers

### DIFF
--- a/baseten-performance-client/README.md
+++ b/baseten-performance-client/README.md
@@ -921,6 +921,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
   - Default: `warn`
   - Priority: `PERFORMANCE_CLIENT_LOG_LEVEL` > `RUST_LOG` > default
 - `PERFORMANCE_CLIENT_REQUEST_ID_PREFIX`: Custom prefix for request IDs (default: "perfclient")
+- `PERFORMANCE_CLIENT_DISABLE_TIMEOUT_HEADERS`: When set to a truthy value (`1`, `true`, `yes`, `on`), suppresses the `Request-Timeout-Ms` and `Request-Deadline-Ms` request headers. Useful when a downstream cache hashes request headers — `Request-Deadline-Ms` is time-based and would bust the cache key on every request. Default: headers emitted.
+- `PERFORMANCE_CLIENT_DISABLE_REQUEST_ID_HEADER`: When set to a truthy value, suppresses the `x-baseten-customer-request-id` request header. That header is unique per request (UUID + batch/retry/hedge counters), so it also breaks header-based caching. Suppressing it does not affect internal retry/hedge/tracing behavior, only the emitted header. Default: header emitted.
 
 ### Logging Examples
 

--- a/baseten-performance-client/core/src/constants.rs
+++ b/baseten-performance-client/core/src/constants.rs
@@ -45,3 +45,7 @@ pub(crate) const REQUEST_DEADLINE_HEADER_NAME: &str = "Request-Deadline-Ms";
 // Logging constants
 pub const DEFAULT_LOG_LEVEL: &str = "warn";
 pub const LOG_LEVEL_ENV_VAR: &str = "PERFORMANCE_CLIENT_LOG_LEVEL";
+
+// Header suppression flags (truthy values: 1, true, yes, on). Default: headers emitted.
+pub const DISABLE_TIMEOUT_HEADERS_ENV_VAR: &str = "PERFORMANCE_CLIENT_DISABLE_TIMEOUT_HEADERS";
+pub const DISABLE_REQUEST_ID_HEADER_ENV_VAR: &str = "PERFORMANCE_CLIENT_DISABLE_REQUEST_ID_HEADER";

--- a/baseten-performance-client/core/src/http_client.rs
+++ b/baseten-performance-client/core/src/http_client.rs
@@ -11,13 +11,41 @@ use reqwest::{
 };
 use std::collections::HashSet;
 use std::sync::atomic::Ordering;
+use std::sync::OnceLock;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tracing;
+
+/// Parse a truthy env var (1, true, yes, on — case-insensitive).
+fn env_flag_enabled(env_var: &str) -> bool {
+    match std::env::var(env_var) {
+        Ok(v) => {
+            let v = v.trim().to_ascii_lowercase();
+            matches!(v.as_str(), "1" | "true" | "yes" | "on")
+        }
+        Err(_) => false,
+    }
+}
+
+static DISABLE_TIMEOUT_HEADERS: OnceLock<bool> = OnceLock::new();
+static DISABLE_REQUEST_ID_HEADER: OnceLock<bool> = OnceLock::new();
+
+/// Whether to suppress `Request-Timeout-Ms` / `Request-Deadline-Ms` headers.
+fn disable_timeout_headers() -> bool {
+    *DISABLE_TIMEOUT_HEADERS.get_or_init(|| env_flag_enabled(DISABLE_TIMEOUT_HEADERS_ENV_VAR))
+}
+
+/// Whether to suppress the `x-baseten-customer-request-id` header.
+fn disable_request_id_header() -> bool {
+    *DISABLE_REQUEST_ID_HEADER.get_or_init(|| env_flag_enabled(DISABLE_REQUEST_ID_HEADER_ENV_VAR))
+}
 
 fn add_timeout_headers(
     request_builder: reqwest::RequestBuilder,
     request_timeout: Duration,
 ) -> reqwest::RequestBuilder {
+    if disable_timeout_headers() {
+        return request_builder;
+    }
     let timeout_ms = ((request_timeout.as_secs_f64() * 1000.0).ceil() as u64).to_string();
     let now_ms = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -49,8 +77,12 @@ where
             .post(attempt_url)
             .bearer_auth(&api_key)
             .json(&payload)
-            .timeout(request_timeout)
-            .header(CUSTOMER_HEADER_NAME, &customer_request_id_header);
+            .timeout(request_timeout);
+
+        if !disable_request_id_header() {
+            request_builder =
+                request_builder.header(CUSTOMER_HEADER_NAME, &customer_request_id_header);
+        }
 
         request_builder = add_timeout_headers(request_builder, request_timeout);
         request_builder = add_response_negotiation_headers(request_builder, config);
@@ -102,8 +134,12 @@ where
         let mut request_builder = client
             .request(method.into(), attempt_url)
             .bearer_auth(&api_key)
-            .timeout(request_timeout)
-            .header(CUSTOMER_HEADER_NAME, &customer_request_id_header);
+            .timeout(request_timeout);
+
+        if !disable_request_id_header() {
+            request_builder =
+                request_builder.header(CUSTOMER_HEADER_NAME, &customer_request_id_header);
+        }
 
         request_builder = add_timeout_headers(request_builder, request_timeout);
 
@@ -492,5 +528,40 @@ fn is_retryable_status(status: u16, config: &RequestProcessingConfig) -> bool {
         400..=499 => false,
         // Unexpected status codes
         _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_env_flag_enabled_parsing() {
+        // Use a dedicated var and run sequentially to avoid races with other tests.
+        let var = "PERFCLIENT_TEST_FLAG_ENV_PARSE";
+        for &val in &[
+            "1", "true", "TRUE", "True", "yes", "Yes", "on", "ON", "  true  ",
+        ] {
+            std::env::set_var(var, val);
+            assert!(env_flag_enabled(var), "expected truthy for {val:?}");
+        }
+        for &val in &["", "0", "false", "no", "off", "maybe", "2", "random"] {
+            std::env::set_var(var, val);
+            assert!(!env_flag_enabled(var), "expected falsy for {val:?}");
+        }
+        std::env::remove_var(var);
+        assert!(!env_flag_enabled(var));
+    }
+
+    #[test]
+    fn test_disable_flag_constants_naming() {
+        assert_eq!(
+            DISABLE_TIMEOUT_HEADERS_ENV_VAR,
+            "PERFORMANCE_CLIENT_DISABLE_TIMEOUT_HEADERS"
+        );
+        assert_eq!(
+            DISABLE_REQUEST_ID_HEADER_ENV_VAR,
+            "PERFORMANCE_CLIENT_DISABLE_REQUEST_ID_HEADER"
+        );
     }
 }


### PR DESCRIPTION
## Summary

The performance client emits two headers that vary per request and break header-based downstream caching (e.g. when a cache server SHA-hashes request headers as the cache key):

- `Request-Deadline-Ms` — time-based (`now + timeout`), recomputed every request (`core/src/http_client.rs`)
- `x-baseten-customer-request-id` — unique per request (UUID + batch/retry/hedge counters)

When the user has no control over the cache server, the only lever is to stop emitting these headers at the client. This adds two opt-in env flags (default behavior unchanged):

- `PERFORMANCE_CLIENT_DISABLE_TIMEOUT_HEADERS` — suppresses `Request-Timeout-Ms` / `Request-Deadline-Ms`
- `PERFORMANCE_CLIENT_DISABLE_REQUEST_ID_HEADER` — suppresses `x-baseten-customer-request-id` (internal retry/hedge/tracing behavior is unaffected; only the emitted header is skipped)

Truthy values: `1`, `true`, `yes`, `on` (case-insensitive). Values are read once and cached via `OnceLock` to avoid a syscall per request.

## Changes
- `core/src/constants.rs`: new env var name constants
- `core/src/http_client.rs`: `env_flag_enabled` helper + cached flags; `add_timeout_headers` and both `CUSTOMER_HEADER_NAME` injection sites are now gated
- `README.md`: document the two new env vars

## Test plan
- [x] `cargo test -p baseten_performance_client_core` (49 passed, incl. new `http_client::tests`*`)
- [x] `cargo clippy -p baseten_performance_client_core --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo check` for python + node bindings (no public API change)

## Notes
- No API/builder changes, so Python/Node bindings require no updates.
- Suppression is env-var-only per the requested design.