### PR TITLE
TEST (DO NOT REVIEW) Add Cannery-backed volume commands

### DIFF
--- a/docs/contribute/cannery-volume-mvp.md
+++ b/docs/contribute/cannery-volume-mvp.md
@@ -1,0 +1,54 @@
+# Cannery volume CLI MVP
+
+`truss volume push|ls|show|pull` delegates volume operations to the Cannery
+client binary. This is a local, developer-facing vertical slice for RUN-871;
+Truss does not package the binary yet.
+
+## Temporary configuration
+
+The following environment variables bridge Truss to Cannery:
+
+| Variable | Purpose | Default |
+| --- | --- | --- |
+| `TRUSS_CANNERY_BIN` | Cannery client executable | `cannery` on `PATH` |
+| `TRUSS_CANNERY_API` | Cannery API endpoint | `http://127.0.0.1:8787` |
+| `TRUSS_CANNERY_ORG` | Cannery organization | `dev` |
+| `TRUSS_CANNERY_AUTH_TOKEN_FILE` | Existing Cannery bearer-token file | unset |
+
+This authentication path is temporary pending RUN-869. Truss does not exchange
+a Baseten API token for a Cannery token yet. An explicit token file is required
+for every non-loopback endpoint. Only `localhost`, `127.0.0.0/8`, and `::1`
+endpoints may run without a token, for local development. Truss passes an
+explicit token file to the child as `CANNERY_AUTH_TOKEN_FILE`; this does not
+change Cannery server authentication. Truss forwards the selected organization
+as `CANNERY_ORG`; Cannery versions that no longer need a separate organization
+selector ignore it.
+
+## Local test flow
+
+Build or obtain the matching Cannery client, then start a local Cannery server
+and its object-store dependency as described in the Baseten BDN developer docs.
+Point Truss at the client:
+
+```sh
+export TRUSS_CANNERY_BIN=/path/to/cannery
+export TRUSS_CANNERY_API=http://127.0.0.1:8787
+export TRUSS_CANNERY_ORG=dev
+
+uv run truss volume push ./weights bdn://default/weights:local
+uv run truss volume ls default
+uv run truss volume show bdn://default/weights:local
+uv run truss volume pull bdn://default/weights:local ./downloaded
+```
+
+For a local server that enforces authentication, also set:
+
+```sh
+export TRUSS_CANNERY_AUTH_TOKEN_FILE=/path/to/cannery-token
+```
+
+The subprocess contract is `cannery -o json --progress machine`: one final,
+protocol-versioned JSON object on stdout, plus protocol-versioned NDJSON
+progress events on stderr.
+Use `--output json` on a Truss volume subcommand to preserve the final object on
+stdout for scripts; progress remains on stderr.

--- a/truss/cli/cli.py
+++ b/truss/cli/cli.py
@@ -83,6 +83,11 @@ click.rich_click.COMMAND_GROUPS = {
             "commands": ["loops"],
             "table_styles": {"row_styles": ["cyan"]},  # type: ignore
         },
+        {
+            "name": "Volumes",
+            "commands": ["volume"],
+            "table_styles": {"row_styles": ["blue"]},  # type: ignore
+        },
     ]
 }
 
@@ -1656,4 +1661,5 @@ from truss.cli import (  # noqa: F401
     migrate_commands,
     ssh_commands,
     train_commands,
+    volume_commands,
 )

--- a/truss/cli/volume_commands.py
+++ b/truss/cli/volume_commands.py
@@ -1,0 +1,449 @@
+from __future__ import annotations
+
+import ipaddress
+import json
+import os
+import shutil
+import signal
+import subprocess
+import threading
+from functools import wraps
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional
+from urllib.parse import urlparse
+
+import rich_click as click
+
+from truss.cli.cli import truss_cli
+from truss.cli.utils import common
+from truss.cli.utils.output import console, console_to_stderr
+
+_DEFAULT_API = "http://127.0.0.1:8787"
+_DEFAULT_ORG = "dev"
+_PROTOCOL_VERSION = 1
+_CANCEL_GRACE_SECONDS = 5
+
+
+class CanneryProtocolError(click.ClickException):
+    pass
+
+
+def resolve_cannery_binary() -> str:
+    configured = os.environ.get("TRUSS_CANNERY_BIN")
+    candidate = configured or "cannery"
+    resolved = shutil.which(candidate)
+    if resolved is not None:
+        return resolved
+
+    if configured:
+        raise click.ClickException(
+            f"Cannot execute Cannery binary configured by TRUSS_CANNERY_BIN: "
+            f"{configured!r}. Set it to an executable Cannery client."
+        )
+    raise click.ClickException(
+        "Cannery client binary was not found on PATH. Install or build `cannery`, "
+        "or set TRUSS_CANNERY_BIN to its executable path."
+    )
+
+
+def _is_loopback_endpoint(api: str) -> bool:
+    parsed = urlparse(api)
+    if parsed.scheme not in {"http", "https"} or parsed.hostname is None:
+        raise click.UsageError(
+            "TRUSS_CANNERY_API must be an http(s) URL with a hostname."
+        )
+
+    hostname = parsed.hostname.rstrip(".").lower()
+    if hostname == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(hostname).is_loopback
+    except ValueError:
+        return False
+
+
+def _resolve_token_file(api: str) -> Optional[Path]:
+    configured = os.environ.get("TRUSS_CANNERY_AUTH_TOKEN_FILE")
+    if configured:
+        token_file = Path(configured).expanduser()
+        if not token_file.is_file():
+            raise click.UsageError(
+                "TRUSS_CANNERY_AUTH_TOKEN_FILE must point to an existing token "
+                f"file; got {configured!r}."
+            )
+        return token_file.resolve()
+
+    if _is_loopback_endpoint(api):
+        return None
+
+    # TODO(RUN-869): exchange the configured Baseten credential for a Cannery
+    # token. Until that endpoint exists, remote use must be explicitly supplied
+    # a token file instead of silently attempting unauthenticated access.
+    raise click.UsageError(
+        "A Cannery token is required for non-loopback endpoints. "
+        "Set TRUSS_CANNERY_AUTH_TOKEN_FILE to an existing token file. "
+        "Automatic Baseten-to-Cannery token exchange is pending RUN-869."
+    )
+
+
+def _child_environment(token_file: Optional[Path], org: str) -> Dict[str, str]:
+    env = os.environ.copy()
+    env.pop("CANNERY_AUTH_TOKEN_FILE", None)
+    env["CANNERY_ORG"] = org
+    if token_file is not None:
+        env["CANNERY_AUTH_TOKEN_FILE"] = str(token_file)
+    return env
+
+
+def _event_kind(event: Mapping[str, Any]) -> Optional[str]:
+    for key in ("type", "event", "kind"):
+        value = event.get(key)
+        if isinstance(value, str):
+            return value
+    return None
+
+
+def _event_values(event: Mapping[str, Any]) -> Mapping[str, Any]:
+    progress = event.get("progress")
+    if isinstance(progress, dict):
+        return {**event, **progress}
+    return event
+
+
+def _format_progress_event(event: Mapping[str, Any]) -> Optional[str]:
+    values = _event_values(event)
+    operation = values.get("operation") or values.get("command") or "transfer"
+    phase = values.get("phase")
+    label = f"Cannery {operation}"
+    if isinstance(phase, str):
+        label += f" ({phase})"
+
+    counters = []
+    for noun in ("files", "chunks", "bytes"):
+        done = values.get(f"{noun}_done")
+        if done is None:
+            done = values.get(f"completed_{noun}")
+        total = values.get(f"{noun}_total")
+        if total is None:
+            total = values.get(f"total_{noun}")
+        if done is not None and total is not None:
+            counters.append(f"{done}/{total} {noun}")
+        elif done is not None:
+            counters.append(f"{done} {noun}")
+
+    if not counters:
+        completed = values.get("completed")
+        total = values.get("total")
+        unit = values.get("unit") or "items"
+        if completed is not None and total is not None:
+            counters.append(f"{completed}/{total} {unit}")
+        elif completed is not None:
+            counters.append(f"{completed} {unit}")
+
+    if not counters:
+        return None
+    return f"{label}: {', '.join(counters)}"
+
+
+def _format_status_event(event: Mapping[str, Any]) -> Optional[str]:
+    operation = event.get("operation") or event.get("command")
+    phase = event.get("phase")
+    status = event.get("status") or event.get("state")
+    typed_values = [
+        value for value in (operation, phase, status) if isinstance(value, str)
+    ]
+    if not typed_values:
+        return None
+    rendered = f"Cannery {' — '.join(typed_values)}"
+    message = event.get("message")
+    if isinstance(message, str) and message:
+        rendered += f": {message}"
+    return rendered
+
+
+def _render_machine_event(event: Mapping[str, Any]) -> None:
+    kind = _event_kind(event)
+    rendered = None
+    if kind == "progress":
+        rendered = _format_progress_event(event)
+    elif kind in {"started", "status", "warning"}:
+        rendered = _format_status_event(event)
+    if rendered:
+        click.echo(rendered, err=True)
+
+
+def _validate_machine_event(event: Any) -> Mapping[str, Any]:
+    if not isinstance(event, dict):
+        raise CanneryProtocolError(
+            "Cannery machine progress emitted a JSON value that is not an object."
+        )
+    version = event.get("protocol_version")
+    if type(version) is not int or version != _PROTOCOL_VERSION:
+        raise CanneryProtocolError(
+            "Unsupported Cannery machine progress protocol version "
+            f"{version!r}; Truss requires version {_PROTOCOL_VERSION}."
+        )
+    if _event_kind(event) is None:
+        raise CanneryProtocolError(
+            "Cannery machine progress event is missing its event type."
+        )
+    return event
+
+
+def _drain_machine_events(
+    lines: Iterable[str], events: List[Mapping[str, Any]], errors: List[Exception]
+) -> None:
+    for line_number, line in enumerate(lines, start=1):
+        if not line.strip():
+            continue
+        try:
+            event = _validate_machine_event(json.loads(line))
+            events.append(event)
+            _render_machine_event(event)
+        except json.JSONDecodeError as exc:
+            errors.append(
+                CanneryProtocolError(
+                    "Cannery machine progress emitted invalid NDJSON on stderr "
+                    f"at line {line_number}: {exc.msg}."
+                )
+            )
+        except CanneryProtocolError as exc:
+            errors.append(exc)
+
+
+def _machine_error(events: Iterable[Mapping[str, Any]]) -> Optional[Mapping[str, Any]]:
+    for event in reversed(list(events)):
+        if _event_kind(event) == "error":
+            error = event.get("error")
+            if isinstance(error, dict):
+                return {**event, **error}
+            return event
+    return None
+
+
+def _format_machine_error(error: Optional[Mapping[str, Any]], return_code: int) -> str:
+    if error is None:
+        return (
+            f"Cannery exited with status {return_code} without a machine error event."
+        )
+
+    reason = error.get("reason") or error.get("status")
+    message = error.get("message") or error.get("detail")
+    hint = error.get("hint")
+    parts = []
+    if isinstance(reason, str):
+        parts.append(reason)
+    if isinstance(message, str) and message != reason:
+        parts.append(message)
+    rendered = ": ".join(parts) or f"Cannery exited with status {return_code}"
+    if isinstance(hint, str):
+        rendered += f" Hint: {hint}"
+    return rendered
+
+
+def _parse_result(stdout: str) -> Dict[str, Any]:
+    decoder = json.JSONDecoder()
+    stripped = stdout.lstrip()
+    if not stripped:
+        raise CanneryProtocolError(
+            "Cannery succeeded without emitting its final JSON result."
+        )
+    try:
+        result, end = decoder.raw_decode(stripped)
+    except json.JSONDecodeError as exc:
+        raise CanneryProtocolError(
+            f"Cannery emitted an invalid final JSON result: {exc.msg}."
+        ) from exc
+    if stripped[end:].strip():
+        raise CanneryProtocolError(
+            "Cannery emitted more than one value on result stdout."
+        )
+    if not isinstance(result, dict):
+        raise CanneryProtocolError("Cannery final JSON result must be an object.")
+    version = result.get("protocol_version")
+    if type(version) is not int or version != _PROTOCOL_VERSION:
+        raise CanneryProtocolError(
+            "Unsupported Cannery result protocol version "
+            f"{version!r}; Truss requires version {_PROTOCOL_VERSION}."
+        )
+    return result
+
+
+def _cancel_process(process: "subprocess.Popen[str]") -> None:
+    if process.poll() is not None:
+        return
+    try:
+        process.send_signal(signal.SIGINT)
+        process.wait(timeout=_CANCEL_GRACE_SECONDS)
+        return
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+
+    try:
+        process.terminate()
+        process.wait(timeout=2)
+        return
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+
+    process.kill()
+    process.wait()
+
+
+def run_cannery(arguments: List[str]) -> Dict[str, Any]:
+    api = os.environ.get("TRUSS_CANNERY_API", _DEFAULT_API)
+    org = os.environ.get("TRUSS_CANNERY_ORG", _DEFAULT_ORG)
+    token_file = _resolve_token_file(api)
+    binary = resolve_cannery_binary()
+    argv = [binary, "-o", "json", "--progress", "machine", "--api", api, *arguments]
+
+    try:
+        process = subprocess.Popen(
+            argv,
+            env=_child_environment(token_file, org),
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            bufsize=1,
+        )
+    except OSError as exc:
+        raise click.ClickException(
+            f"Failed to start Cannery binary {binary!r}: {exc}"
+        ) from exc
+
+    if process.stdout is None or process.stderr is None:
+        _cancel_process(process)
+        raise click.ClickException("Failed to capture Cannery subprocess output.")
+
+    events: List[Mapping[str, Any]] = []
+    protocol_errors: List[Exception] = []
+    stderr_thread = threading.Thread(
+        target=_drain_machine_events,
+        args=(process.stderr, events, protocol_errors),
+        name="truss-cannery-stderr",
+        daemon=True,
+    )
+    stderr_thread.start()
+    try:
+        stdout = process.stdout.read()
+        return_code = process.wait()
+    except KeyboardInterrupt:
+        _cancel_process(process)
+        raise click.Abort()
+    finally:
+        if process.poll() is None:
+            _cancel_process(process)
+        stderr_thread.join()
+
+    if protocol_errors:
+        raise protocol_errors[0]
+
+    machine_error = _machine_error(events)
+    if return_code == 2:
+        raise click.UsageError(_format_machine_error(machine_error, return_code))
+    if return_code != 0:
+        raise click.ClickException(_format_machine_error(machine_error, return_code))
+    if machine_error is not None:
+        raise click.ClickException(_format_machine_error(machine_error, return_code))
+    return _parse_result(stdout)
+
+
+def _output_option(function):
+    return click.option(
+        "--output",
+        "output_format",
+        type=click.Choice(["text", "json"]),
+        default="text",
+        show_default=True,
+        help="Output format. Progress and status always go to stderr.",
+    )(function)
+
+
+def _clean_json_stdout(function: Callable[..., Any]) -> Callable[..., Any]:
+    @wraps(function)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        if kwargs.get("output_format") == "json":
+            with console_to_stderr():
+                return function(*args, **kwargs)
+        return function(*args, **kwargs)
+
+    return wrapper
+
+
+def _emit_result(result: Mapping[str, Any], output_format: str) -> None:
+    if output_format == "json":
+        click.echo(json.dumps(result))
+    else:
+        console.print_json(data=dict(result))
+
+
+@click.group()
+def volume() -> None:
+    """Manage Cannery-backed volumes."""
+
+
+truss_cli.add_command(volume)
+
+
+@volume.command(name="push")
+@click.argument("path", type=click.Path(exists=True, file_okay=False, path_type=Path))
+@click.argument("ref", required=False)
+@_output_option
+@_clean_json_stdout
+@common.common_options()
+def push_volume(path: Path, ref: Optional[str], output_format: str) -> None:
+    """Upload PATH as a volume, optionally naming it with REF."""
+    arguments = ["push", str(path)]
+    if ref is not None:
+        arguments.append(ref)
+    _emit_result(run_cannery(arguments), output_format)
+
+
+@volume.command(name="ls")
+@click.argument("namespace", required=False)
+@click.option("--all", "include_all", is_flag=True, help="Include untagged versions.")
+@_output_option
+@_clean_json_stdout
+@common.common_options()
+def list_volumes(
+    namespace: Optional[str], include_all: bool, output_format: str
+) -> None:
+    """List namespaces, or volumes in NAMESPACE."""
+    arguments = ["ls"]
+    if namespace is not None:
+        arguments.append(namespace)
+    if include_all:
+        arguments.append("--all")
+    _emit_result(run_cannery(arguments), output_format)
+
+
+@volume.command(name="show")
+@click.argument("ref")
+@_output_option
+@_clean_json_stdout
+@common.common_options()
+def show_volume(ref: str, output_format: str) -> None:
+    """Show metadata and files for REF."""
+    _emit_result(run_cannery(["show", ref]), output_format)
+
+
+@volume.command(name="pull")
+@click.argument("ref")
+@click.argument("out_dir", type=click.Path(file_okay=False, path_type=Path))
+@click.option(
+    "--discard",
+    is_flag=True,
+    help="Download and verify content without writing files (benchmark mode).",
+)
+@_output_option
+@_clean_json_stdout
+@common.common_options()
+def pull_volume(ref: str, out_dir: Path, discard: bool, output_format: str) -> None:
+    """Download all files from REF into OUT_DIR."""
+    arguments = ["pull", ref, str(out_dir)]
+    if discard:
+        arguments.append("--discard")
+    _emit_result(run_cannery(arguments), output_format)

--- a/truss/tests/cli/test_volume_commands.py
+++ b/truss/tests/cli/test_volume_commands.py
@@ -1,0 +1,357 @@
+import io
+import json
+import signal
+from unittest.mock import Mock
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from truss.cli import volume_commands
+from truss.cli.cli import truss_cli
+
+
+class FakeProcess:
+    def __init__(self, stdout='{"protocol_version":1}', stderr="", return_code=0):
+        self.stdout = io.StringIO(stdout)
+        self.stderr = io.StringIO(stderr)
+        self.returncode = return_code
+        self.signals = []
+        self.terminated = False
+        self.killed = False
+
+    def wait(self, timeout=None):
+        return self.returncode
+
+    def poll(self):
+        return self.returncode
+
+    def send_signal(self, value):
+        self.signals.append(value)
+
+    def terminate(self):
+        self.terminated = True
+
+    def kill(self):
+        self.killed = True
+
+
+@pytest.fixture(autouse=True)
+def clean_cannery_environment(monkeypatch):
+    for variable in (
+        "TRUSS_CANNERY_BIN",
+        "TRUSS_CANNERY_API",
+        "TRUSS_CANNERY_ORG",
+        "TRUSS_CANNERY_AUTH_TOKEN_FILE",
+        "CANNERY_AUTH_TOKEN_FILE",
+    ):
+        monkeypatch.delenv(variable, raising=False)
+
+
+def install_process(monkeypatch, process):
+    popen = Mock(return_value=process)
+    monkeypatch.setattr(
+        volume_commands, "resolve_cannery_binary", lambda: "/bin/cannery"
+    )
+    monkeypatch.setattr(volume_commands.subprocess, "Popen", popen)
+    return popen
+
+
+def test_binary_resolution_prefers_configured_binary(monkeypatch):
+    monkeypatch.setenv("TRUSS_CANNERY_BIN", "/opt/cannery")
+    which = Mock(return_value="/opt/cannery")
+    monkeypatch.setattr(volume_commands.shutil, "which", which)
+
+    assert volume_commands.resolve_cannery_binary() == "/opt/cannery"
+    which.assert_called_once_with("/opt/cannery")
+
+
+def test_binary_resolution_falls_back_to_path(monkeypatch):
+    which = Mock(return_value="/usr/local/bin/cannery")
+    monkeypatch.setattr(volume_commands.shutil, "which", which)
+
+    assert volume_commands.resolve_cannery_binary() == "/usr/local/bin/cannery"
+    which.assert_called_once_with("cannery")
+
+
+def test_binary_resolution_failure_is_actionable(monkeypatch):
+    monkeypatch.setattr(volume_commands.shutil, "which", lambda _: None)
+
+    with pytest.raises(click.ClickException, match="TRUSS_CANNERY_BIN"):
+        volume_commands.resolve_cannery_binary()
+
+
+def test_runner_builds_argv_and_environment(monkeypatch, tmp_path):
+    token_file = tmp_path / "token"
+    token_file.write_text("token")
+    monkeypatch.setenv("TRUSS_CANNERY_API", "https://cannery.example.com")
+    monkeypatch.setenv("TRUSS_CANNERY_ORG", "acme")
+    monkeypatch.setenv("TRUSS_CANNERY_AUTH_TOKEN_FILE", str(token_file))
+    monkeypatch.setenv("CANNERY_AUTH_TOKEN_FILE", "/must/not/leak")
+    popen = install_process(
+        monkeypatch, FakeProcess(stdout='{"protocol_version":1,"refs":[]}')
+    )
+
+    assert volume_commands.run_cannery(["ls", "models", "--all"]) == {
+        "protocol_version": 1,
+        "refs": [],
+    }
+
+    argv = popen.call_args.args[0]
+    assert argv == [
+        "/bin/cannery",
+        "-o",
+        "json",
+        "--progress",
+        "machine",
+        "--api",
+        "https://cannery.example.com",
+        "ls",
+        "models",
+        "--all",
+    ]
+    assert popen.call_args.kwargs["env"]["CANNERY_ORG"] == "acme"
+    assert popen.call_args.kwargs["env"]["CANNERY_AUTH_TOKEN_FILE"] == str(token_file)
+
+
+@pytest.mark.parametrize(
+    "api",
+    [
+        "http://localhost:8787",
+        "http://127.0.0.1:8787",
+        "http://127.42.0.1:8787",
+        "http://[::1]:8787",
+    ],
+)
+def test_loopback_endpoint_allows_no_token(monkeypatch, api):
+    monkeypatch.setenv("TRUSS_CANNERY_API", api)
+    popen = install_process(monkeypatch, FakeProcess())
+
+    volume_commands.run_cannery(["ls"])
+
+    assert "CANNERY_AUTH_TOKEN_FILE" not in popen.call_args.kwargs["env"]
+
+
+def test_default_api_and_org_are_local_dev(monkeypatch):
+    popen = install_process(monkeypatch, FakeProcess())
+
+    volume_commands.run_cannery(["ls"])
+
+    argv = popen.call_args.args[0]
+    assert argv[argv.index("--api") + 1] == "http://127.0.0.1:8787"
+    assert popen.call_args.kwargs["env"]["CANNERY_ORG"] == "dev"
+
+
+def test_non_loopback_endpoint_rejected_without_token(monkeypatch):
+    monkeypatch.setenv("TRUSS_CANNERY_API", "https://cannery.example.com")
+    popen = Mock()
+    monkeypatch.setattr(volume_commands.subprocess, "Popen", popen)
+
+    with pytest.raises(click.UsageError, match="RUN-869"):
+        volume_commands.run_cannery(["ls"])
+
+    popen.assert_not_called()
+
+
+def test_missing_explicit_token_file_rejected_before_subprocess(monkeypatch, tmp_path):
+    monkeypatch.setenv("TRUSS_CANNERY_AUTH_TOKEN_FILE", str(tmp_path / "missing-token"))
+    popen = Mock()
+    monkeypatch.setattr(volume_commands.subprocess, "Popen", popen)
+
+    with pytest.raises(click.UsageError, match="existing token file"):
+        volume_commands.run_cannery(["ls"])
+
+    popen.assert_not_called()
+
+
+def test_result_parser_requires_one_final_object(monkeypatch):
+    install_process(
+        monkeypatch, FakeProcess(stdout='  {"protocol_version":1,"digest":"b3:abc"}\n')
+    )
+
+    assert volume_commands.run_cannery(["show", "bdn://dev/model"]) == {
+        "protocol_version": 1,
+        "digest": "b3:abc",
+    }
+
+
+@pytest.mark.parametrize("stdout", ["", "[]", "{}", '{"protocol_version":2}', "{}\n{}"])
+def test_result_parser_rejects_invalid_result_contract(monkeypatch, stdout):
+    install_process(monkeypatch, FakeProcess(stdout=stdout))
+
+    with pytest.raises(volume_commands.CanneryProtocolError):
+        volume_commands.run_cannery(["ls"])
+
+
+def test_protocol_mismatch_fails(monkeypatch):
+    event = json.dumps({"protocol_version": 2, "type": "status", "phase": "start"})
+    install_process(monkeypatch, FakeProcess(stderr=f"{event}\n"))
+
+    with pytest.raises(
+        volume_commands.CanneryProtocolError, match="requires version 1"
+    ):
+        volume_commands.run_cannery(["ls"])
+
+
+def test_ndjson_progress_is_drained_and_rendered(monkeypatch, capsys):
+    events = [
+        {
+            "protocol_version": 1,
+            "type": "status",
+            "operation": "push",
+            "phase": "scanning",
+        },
+        {
+            "protocol_version": 1,
+            "type": "progress",
+            "operation": "push",
+            "phase": "upload",
+            "files_done": 2,
+            "files_total": 5,
+            "bytes_done": 100,
+            "bytes_total": 400,
+            "message": "human text must not be used",
+        },
+    ]
+    stderr = "".join(f"{json.dumps(event)}\n" for event in events)
+    install_process(monkeypatch, FakeProcess(stderr=stderr))
+
+    volume_commands.run_cannery(["push", "/tmp/model"])
+
+    captured = capsys.readouterr()
+    assert "Cannery push — scanning" in captured.err
+    assert "2/5 files" in captured.err
+    assert "100/400 bytes" in captured.err
+    assert "human text must not be used" not in captured.err
+    assert captured.out == ""
+
+
+def test_invalid_ndjson_fails_loudly(monkeypatch):
+    install_process(monkeypatch, FakeProcess(stderr="not-json\n"))
+
+    with pytest.raises(volume_commands.CanneryProtocolError, match="invalid NDJSON"):
+        volume_commands.run_cannery(["ls"])
+
+
+def test_machine_error_and_exit_one_become_click_exception(monkeypatch):
+    event = {
+        "protocol_version": 1,
+        "type": "error",
+        "reason": "unauthorized",
+        "message": "token expired",
+        "hint": "create a new token",
+    }
+    install_process(
+        monkeypatch, FakeProcess(stderr=f"{json.dumps(event)}\n", return_code=1)
+    )
+
+    with pytest.raises(
+        click.ClickException, match="unauthorized.*token expired"
+    ) as exc:
+        volume_commands.run_cannery(["ls"])
+
+    assert "Hint: create a new token" in str(exc.value)
+
+
+def test_exit_two_becomes_usage_error(monkeypatch):
+    event = {
+        "protocol_version": 1,
+        "type": "error",
+        "reason": "invalid_ref",
+        "message": "bad volume ref",
+    }
+    install_process(
+        monkeypatch, FakeProcess(stderr=f"{json.dumps(event)}\n", return_code=2)
+    )
+
+    with pytest.raises(click.UsageError, match="invalid_ref"):
+        volume_commands.run_cannery(["show", "bad-ref"])
+
+
+def test_cancellation_is_forwarded_to_child(monkeypatch):
+    process = FakeProcess(return_code=None)
+
+    class InterruptingStdout:
+        def read(self):
+            raise KeyboardInterrupt
+
+    process.stdout = InterruptingStdout()
+
+    def finish_on_signal(value):
+        process.signals.append(value)
+        process.returncode = 130
+
+    process.send_signal = finish_on_signal
+    install_process(monkeypatch, process)
+
+    with pytest.raises(click.Abort):
+        volume_commands.run_cannery(["pull", "bdn://dev/model", "/tmp/out"])
+
+    assert process.signals == [signal.SIGINT]
+
+
+@pytest.mark.parametrize(
+    ("arguments", "expected"),
+    [
+        (["ls", "models", "--all"], ["ls", "models", "--all"]),
+        (["show", "bdn://models/weights"], ["show", "bdn://models/weights"]),
+        (
+            ["pull", "bdn://models/weights", "output", "--discard"],
+            ["pull", "bdn://models/weights", "output", "--discard"],
+        ),
+    ],
+)
+def test_volume_commands_are_registered_and_forward_arguments(
+    monkeypatch, arguments, expected
+):
+    run = Mock(return_value={"ok": True})
+    monkeypatch.setattr(volume_commands, "run_cannery", run)
+    monkeypatch.setattr(volume_commands.common, "maybe_upgrade_dialogue", lambda: None)
+
+    result = CliRunner().invoke(truss_cli, ["volume", *arguments, "--output", "json"])
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout) == {"ok": True}
+    run.assert_called_once_with(expected)
+
+
+def test_push_command_forwards_optional_ref(monkeypatch, tmp_path):
+    source = tmp_path / "weights"
+    source.mkdir()
+    run = Mock(return_value={"digest": "b3:abc"})
+    monkeypatch.setattr(volume_commands, "run_cannery", run)
+    monkeypatch.setattr(volume_commands.common, "maybe_upgrade_dialogue", lambda: None)
+
+    result = CliRunner().invoke(
+        truss_cli,
+        ["volume", "push", str(source), "bdn://models/weights:dev", "--output", "json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    run.assert_called_once_with(["push", str(source), "bdn://models/weights:dev"])
+
+
+def test_json_output_keeps_status_off_stdout(monkeypatch):
+    monkeypatch.setattr(
+        volume_commands, "run_cannery", lambda _: {"protocol_version": 1}
+    )
+    monkeypatch.setattr(
+        volume_commands.common,
+        "maybe_upgrade_dialogue",
+        lambda: volume_commands.console.print("upgrade available"),
+    )
+
+    result = CliRunner().invoke(truss_cli, ["volume", "ls", "--output", "json"])
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout) == {"protocol_version": 1}
+    assert "upgrade available" not in result.stdout
+    assert "upgrade available" in result.stderr
+
+
+def test_volume_help_lists_all_mvp_commands():
+    result = CliRunner().invoke(truss_cli, ["volume", "--help"])
+
+    assert result.exit_code == 0
+    for command in ("push", "ls", "show", "pull"):
+        assert command in result.output


### PR DESCRIPTION
## :rocket: What

Add a testable `truss volume push|ls|show|pull` vertical slice for [RUN-871](https://linear.app/baseten/issue/RUN-871/volume-commands-in-the-truss-and-baseten-clis-push-ls-show-pull).

Companion Cannery process-contract PR: [basetenlabs/baseten#26536](https://github.com/basetenlabs/baseten/pull/26536).

## :computer: How

- Invokes the existing Rust Cannery transfer client through a versioned JSON/NDJSON process contract.
- Streams typed progress from stderr while preserving one final JSON result on stdout.
- Adds cancellation forwarding, protocol validation, and structured error mapping.
- Uses `TRUSS_CANNERY_BIN`, `TRUSS_CANNERY_API`, and an optional explicit token file for the MVP.
- Allows missing tokens only for loopback endpoints; non-loopback use fails before execution until RUN-869 provides automatic exchange.

## :microscope: Testing

- 29 focused volume command tests.
- 61 existing core CLI tests (implementation run).
- Ruff lint and format checks.
- Live local push/list/show/pull against Cannery; pulled files were byte-identical.

Known draft limitations: Cannery binary packaging, production token exchange, subset pull, and Baseten CLI integration remain follow-up work.

Made with [Cursor](https://cursor.com)