### PR TITLE
feat(cli): default B300/GB300 workstations to CUDA 13 image

### DIFF
--- a/truss/cli/train/workstation.py
+++ b/truss/cli/train/workstation.py
@@ -21,9 +21,16 @@ from truss_train.definitions import (
 )
 
 DEFAULT_BASE_IMAGE = "nvidia/cuda:12.8.1-devel-ubuntu24.04"
+B300_BASE_IMAGE = "nvidia/cuda:13.0.3-devel-ubuntu24.04"
 SUPPORTED_WORKSTATION_ACCELERATORS = [
     acc.value for acc in Accelerator if acc.value != Accelerator._B10.value
 ]
+
+
+def default_base_image(accelerator: str) -> str:
+    if accelerator in (Accelerator.B300.value, Accelerator.GB300.value):
+        return B300_BASE_IMAGE
+    return DEFAULT_BASE_IMAGE
 
 
 def copy_workstation_templates(target_dir: Path) -> None:
@@ -42,7 +49,7 @@ def build_workstation_project(
     accelerator: str,
     gpu_count: int,
     project_id: str,
-    base_image: str = DEFAULT_BASE_IMAGE,
+    base_image: Optional[str] = None,
     node_count: int = 1,
     orchestrator: str = "slurm",
     enable_checkpointing: bool = False,
@@ -90,7 +97,7 @@ def build_workstation_project(
     )
 
     job = TrainingJob(
-        image=Image(base_image=base_image),
+        image=Image(base_image=base_image or default_base_image(accelerator)),
         compute=compute,
         runtime=runtime,
         interactive_session=interactive_session,

--- a/truss/cli/train_commands.py
+++ b/truss/cli/train_commands.py
@@ -33,7 +33,6 @@ from truss.cli.train.cache import (
     SORT_ORDER_DESC,
 )
 from truss.cli.train.workstation import (
-    DEFAULT_BASE_IMAGE,
     SUPPORTED_WORKSTATION_ACCELERATORS,
     build_workstation_project,
     copy_workstation_templates,
@@ -1215,12 +1214,7 @@ def update_capacity(
     default="slurm",
     help="Multi-node orchestrator (default: slurm).",
 )
-@click.option(
-    "--image",
-    type=str,
-    required=False,
-    help="Custom Docker base image (default: nvidia/cuda:12.8.1-devel-ubuntu24.04).",
-)
+@click.option("--image", type=str, required=False, help="Custom Docker base image.")
 @click.option(
     "--enable-checkpointing",
     is_flag=True,
@@ -1302,12 +1296,11 @@ def workstation(
         remote_provider, effective_team_name, existing_project_name=project_id
     )
 
-    base_image = image or DEFAULT_BASE_IMAGE
     training_project = build_workstation_project(
         accelerator=accelerator,
         gpu_count=gpu_count,
         project_id=project_id,
-        base_image=base_image,
+        base_image=image,
         node_count=node_count,
         orchestrator=orchestrator,
         enable_checkpointing=enable_checkpointing,


### PR DESCRIPTION
## Summary

- `truss train workstation --accelerator B300` (and `GB300`) now defaults to `nvidia/cuda:13.0.3-devel-ubuntu24.04` instead of the global CUDA 12.8.1 default
- other accelerators are unchanged; `--image` still overrides everything

## Why

The 12.8.1 devel image cannot build the cu13 torch stack used by current trainer environments: `torch.utils.cpp_extension` rejects the nvcc 12.8 / torch cu13 mismatch, so source builds (e.g. fast-hadamard-transform) fail on B300 workstations. The 13.0.3 tag matches the image already used by the trainers cu13 Dockerfile.

## Test plan

- `pytest truss/tests/cli/train/test_workstation.py` — 22 passed
- `ruff check` / `ruff format` clean