### PR TITLE
Fix shell injection in external_data Dockerfile curl RUN lines

### DIFF
--- a/truss/templates/server.Dockerfile.jinja
+++ b/truss/templates/server.Dockerfile.jinja
@@ -54,7 +54,7 @@ RUN {{ uv_cache_mount }}{{ sys_pip_install_command }} -r {{ server_requirements_
 
 {%- if external_data_files %}
 {% for url, dst in external_data_files %}
-RUN mkdir -p {{ dst.parent | string | dockerfile_env_value }}; curl -L {{ url | dockerfile_env_value }} -o {{ dst | string | dockerfile_env_value }}
+RUN mkdir -p {{ dst.parent | string | dockerfile_shell_value }}; curl -L {{ url | dockerfile_shell_value }} -o {{ dst | string | dockerfile_shell_value }}
 {% endfor %} {#- endfor external_data_files #}
 {%- endif %} {#- endif external_data_files #}
 

--- a/truss/templates/server.Dockerfile.jinja
+++ b/truss/templates/server.Dockerfile.jinja
@@ -54,7 +54,7 @@ RUN {{ uv_cache_mount }}{{ sys_pip_install_command }} -r {{ server_requirements_
 
 {%- if external_data_files %}
 {% for url, dst in external_data_files %}
-RUN mkdir -p {{ dst.parent }}; curl -L "{{ url }}" -o {{ dst }}
+RUN mkdir -p {{ dst.parent | string | dockerfile_env_value }}; curl -L {{ url | dockerfile_env_value }} -o {{ dst | string | dockerfile_env_value }}
 {% endfor %} {#- endfor external_data_files #}
 {%- endif %} {#- endif external_data_files #}
 

--- a/truss/tests/contexts/image_builder/test_serving_image_builder.py
+++ b/truss/tests/contexts/image_builder/test_serving_image_builder.py
@@ -81,6 +81,34 @@ def test_apt_mirror_url_override(mock_machine, custom_model_truss_dir, monkeypat
 
 
 @patch("platform.machine", return_value="amd")
+def test_external_data_url_shell_metacharacters_escaped_in_dockerfile(
+    mock_machine, custom_model_truss_dir
+):
+    """external_data URLs are embedded in a shell RUN curl; metacharacters must not break out."""
+    malicious_url = 'http://example.com/model" ; echo pwned ; echo "'
+    local_data_path = "weights/model.bin"
+    th = TrussHandle(custom_model_truss_dir)
+    th.update_python_version("py313")
+    th.set_base_image("baseten/truss-server-base:3.13-v0.4.3", "/usr/local/bin/python3")
+    th.add_external_data_item(url=malicious_url, local_data_path=local_data_path)
+    image_builder = ServingImageBuilderContext.run(th.spec.truss_dir)
+
+    with TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir)
+        image_builder.prepare_image_build_dir(tmp_path)
+        dockerfile = (tmp_path / "Dockerfile").read_text()
+
+    curl_lines = [line for line in dockerfile.splitlines() if "curl -L" in line]
+    assert len(curl_lines) == 1
+    curl_line = curl_lines[0]
+
+    expected_url = dockerfile_env_value(malicious_url)
+    expected_dst = dockerfile_env_value(f"/app/data/{local_data_path}")
+    assert f"curl -L {expected_url} -o {expected_dst}" in curl_line
+    assert "; echo pwned ;" not in curl_line.replace(expected_url, "")
+
+
+@patch("platform.machine", return_value="amd")
 def test_clean_uv_env_passes_proxy_and_ca_vars(mock_machine, custom_model_truss_dir):
     th = TrussHandle(custom_model_truss_dir)
     th.update_python_version("py313")

--- a/truss/tests/contexts/image_builder/test_serving_image_builder.py
+++ b/truss/tests/contexts/image_builder/test_serving_image_builder.py
@@ -2,6 +2,7 @@ import filecmp
 import json
 import os
 import subprocess
+import sys
 import time
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -31,6 +32,16 @@ from truss.truss_handle.truss_handle import TrussHandle
 from truss.util.jinja import dockerfile_env_value, dockerfile_shell_value
 
 BASE_DIR = Path(__file__).parent
+
+
+def _external_data_curl_lines(dockerfile: str) -> list[str]:
+    # `curl -L ` (space) avoids the uv bootstrap `curl -LsSf`. Dest can be
+    # Windows-resolved (`C:\app\data\...`) so do not require `/app/data/`.
+    return [
+        line
+        for line in dockerfile.splitlines()
+        if line.strip().startswith("RUN") and "curl -L " in line and "model.bin" in line
+    ]
 
 
 @patch("platform.machine", return_value="amd")
@@ -99,16 +110,14 @@ def test_external_data_url_shell_metacharacters_escaped_in_dockerfile(
         image_builder.prepare_image_build_dir(tmp_path)
         dockerfile = (tmp_path / "Dockerfile").read_text()
 
-    curl_lines = [
-        line
-        for line in dockerfile.splitlines()
-        if line.strip().startswith("RUN") and "curl -L" in line and "/app/data/" in line
-    ]
+    curl_lines = _external_data_curl_lines(dockerfile)
     assert len(curl_lines) == 1
     curl_line = curl_lines[0]
 
     expected_url = dockerfile_shell_value(malicious_url)
-    expected_dst = dockerfile_shell_value(f"/app/data/{local_data_path}")
+    expected_dst = dockerfile_shell_value(
+        str((Path("/app/data/") / local_data_path).resolve())
+    )
     assert f"curl -L {expected_url} -o {expected_dst}" in curl_line
     assert "; echo pwned ;" not in curl_line.replace(expected_url, "")
 
@@ -131,11 +140,7 @@ def test_external_data_url_backticks_escaped_in_dockerfile(
         image_builder.prepare_image_build_dir(tmp_path)
         dockerfile = (tmp_path / "Dockerfile").read_text()
 
-    curl_lines = [
-        line
-        for line in dockerfile.splitlines()
-        if line.strip().startswith("RUN") and "curl -L" in line and "/app/data/" in line
-    ]
+    curl_lines = _external_data_curl_lines(dockerfile)
     assert len(curl_lines) == 1
     curl_line = curl_lines[0]
 
@@ -154,16 +159,13 @@ def _render_external_data_curl_line(truss_dir, url: str, local_data_path: str) -
         tmp_path = Path(tmp_dir)
         image_builder.prepare_image_build_dir(tmp_path)
         dockerfile = (tmp_path / "Dockerfile").read_text()
-    curl_lines = [
-        line
-        for line in dockerfile.splitlines()
-        if line.strip().startswith("RUN") and "curl -L" in line and "/app/data/" in line
-    ]
+    curl_lines = _external_data_curl_lines(dockerfile)
     assert len(curl_lines) == 1
     return curl_lines[0]
 
 
 @patch("platform.machine", return_value="amd")
+@pytest.mark.skipif(sys.platform == "win32", reason="/bin/sh is not on Windows CI")
 @pytest.mark.parametrize(
     "url",
     [
@@ -188,7 +190,9 @@ def test_external_data_run_line_is_safe_under_posix_sh(
         curl_line = _render_external_data_curl_line(
             custom_model_truss_dir, resolved_url, "weights/model.bin"
         )
-        run_body = curl_line.strip().removeprefix("RUN ").replace("/app/data", str(data_root))
+        run_body = (
+            curl_line.strip().removeprefix("RUN ").replace("/app/data", str(data_root))
+        )
         curl = tmp_path / "curl"
         curl.write_text(f"#!/bin/sh\nprintf '%s\\0' \"$@\" > '{argv_file}'\n")
         curl.chmod(0o755)

--- a/truss/tests/contexts/image_builder/test_serving_image_builder.py
+++ b/truss/tests/contexts/image_builder/test_serving_image_builder.py
@@ -98,7 +98,11 @@ def test_external_data_url_shell_metacharacters_escaped_in_dockerfile(
         image_builder.prepare_image_build_dir(tmp_path)
         dockerfile = (tmp_path / "Dockerfile").read_text()
 
-    curl_lines = [line for line in dockerfile.splitlines() if "curl -L" in line]
+    curl_lines = [
+        line
+        for line in dockerfile.splitlines()
+        if line.strip().startswith("RUN") and "curl -L" in line and "/app/data/" in line
+    ]
     assert len(curl_lines) == 1
     curl_line = curl_lines[0]
 

--- a/truss/tests/contexts/image_builder/test_serving_image_builder.py
+++ b/truss/tests/contexts/image_builder/test_serving_image_builder.py
@@ -1,6 +1,7 @@
 import filecmp
 import json
 import os
+import subprocess
 import time
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -27,7 +28,7 @@ from truss.contexts.image_builder.serving_image_builder import (
 from truss.tests.test_testing_utilities_for_other_tests import ensure_kill_all
 from truss.truss_handle.build import init_directory
 from truss.truss_handle.truss_handle import TrussHandle
-from truss.util.jinja import dockerfile_env_value
+from truss.util.jinja import dockerfile_env_value, dockerfile_shell_value
 
 BASE_DIR = Path(__file__).parent
 
@@ -106,10 +107,99 @@ def test_external_data_url_shell_metacharacters_escaped_in_dockerfile(
     assert len(curl_lines) == 1
     curl_line = curl_lines[0]
 
-    expected_url = dockerfile_env_value(malicious_url)
-    expected_dst = dockerfile_env_value(f"/app/data/{local_data_path}")
+    expected_url = dockerfile_shell_value(malicious_url)
+    expected_dst = dockerfile_shell_value(f"/app/data/{local_data_path}")
     assert f"curl -L {expected_url} -o {expected_dst}" in curl_line
     assert "; echo pwned ;" not in curl_line.replace(expected_url, "")
+
+
+@patch("platform.machine", return_value="amd")
+def test_external_data_url_backticks_escaped_in_dockerfile(
+    mock_machine, custom_model_truss_dir
+):
+    """dockerfile_env_value leaves backticks live in RUN; shlex quoting must not."""
+    malicious_url = "http://example.com/`id`"
+    local_data_path = "weights/model.bin"
+    th = TrussHandle(custom_model_truss_dir)
+    th.update_python_version("py313")
+    th.set_base_image("baseten/truss-server-base:3.13-v0.4.3", "/usr/local/bin/python3")
+    th.add_external_data_item(url=malicious_url, local_data_path=local_data_path)
+    image_builder = ServingImageBuilderContext.run(th.spec.truss_dir)
+
+    with TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir)
+        image_builder.prepare_image_build_dir(tmp_path)
+        dockerfile = (tmp_path / "Dockerfile").read_text()
+
+    curl_lines = [
+        line
+        for line in dockerfile.splitlines()
+        if line.strip().startswith("RUN") and "curl -L" in line and "/app/data/" in line
+    ]
+    assert len(curl_lines) == 1
+    curl_line = curl_lines[0]
+
+    expected_url = dockerfile_shell_value(malicious_url)
+    assert f"curl -L {expected_url}" in curl_line
+    assert expected_url == "'http://example.com/`id`'"
+
+
+def _render_external_data_curl_line(truss_dir, url: str, local_data_path: str) -> str:
+    th = TrussHandle(truss_dir)
+    th.update_python_version("py313")
+    th.set_base_image("baseten/truss-server-base:3.13-v0.4.3", "/usr/local/bin/python3")
+    th.add_external_data_item(url=url, local_data_path=local_data_path)
+    image_builder = ServingImageBuilderContext.run(th.spec.truss_dir)
+    with TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir)
+        image_builder.prepare_image_build_dir(tmp_path)
+        dockerfile = (tmp_path / "Dockerfile").read_text()
+    curl_lines = [
+        line
+        for line in dockerfile.splitlines()
+        if line.strip().startswith("RUN") and "curl -L" in line and "/app/data/" in line
+    ]
+    assert len(curl_lines) == 1
+    return curl_lines[0]
+
+
+@patch("platform.machine", return_value="amd")
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://example.com/model.bin",
+        'http://example.com/x" ; touch PWNED ; echo "',
+        "http://example.com/`touch PWNED`",
+        "http://example.com/$(touch PWNED)",
+        "http://example.com/$HOME/weights.bin",
+        "http://example.com/it's.bin",
+    ],
+)
+def test_external_data_run_line_is_safe_under_posix_sh(
+    mock_machine, custom_model_truss_dir, url
+):
+    """Execute the generated RUN under /bin/sh (dash here; Docker's default)."""
+    with TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        pwned = tmp_path / "pwned"
+        data_root = tmp_path / "data"
+        argv_file = tmp_path / "argv"
+        resolved_url = url.replace("PWNED", str(pwned))
+        curl_line = _render_external_data_curl_line(
+            custom_model_truss_dir, resolved_url, "weights/model.bin"
+        )
+        run_body = curl_line.strip().removeprefix("RUN ").replace("/app/data", str(data_root))
+        curl = tmp_path / "curl"
+        curl.write_text(f"#!/bin/sh\nprintf '%s\\0' \"$@\" > '{argv_file}'\n")
+        curl.chmod(0o755)
+        env = os.environ.copy()
+        env["PATH"] = f"{tmp_path}:{env['PATH']}"
+        subprocess.run(
+            ["/bin/sh", "-c", run_body], env=env, check=True, capture_output=True
+        )
+        argv = [a.decode() for a in argv_file.read_bytes().split(b"\0") if a]
+        assert argv[1] == resolved_url
+        assert pwned.exists() is False
 
 
 @patch("platform.machine", return_value="amd")

--- a/truss/tests/util/test_jinja.py
+++ b/truss/tests/util/test_jinja.py
@@ -1,6 +1,33 @@
+import os
+import shlex
+import subprocess
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
 import pytest
 
-from truss.util.jinja import dockerfile_env_value
+from truss.util.jinja import dockerfile_env_value, dockerfile_shell_value
+
+
+def _posix_sh_curl_argv(quote, url: str) -> tuple[list[str], bool, str]:
+    """Run `curl -L <quoted url> -o <quoted dest>` under /bin/sh with a stub curl.
+
+    Returns (curl argv, whether a canary file the payload tried to write exists).
+    """
+    with TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        argv_file = tmp_path / "argv"
+        pwned = tmp_path / "pwned"
+        curl = tmp_path / "curl"
+        curl.write_text(f"#!/bin/sh\nprintf '%s\\0' \"$@\" > '{argv_file}'\n")
+        curl.chmod(0o755)
+        env = os.environ.copy()
+        env["PATH"] = f"{tmp_path}:{env['PATH']}"
+        url = url.replace("PWNED", str(pwned))
+        cmd = f"curl -L {quote(url)} -o {quote(str(tmp_path / 'out'))}"
+        subprocess.run(["/bin/sh", "-c", cmd], env=env, check=True, capture_output=True)
+        argv = [a.decode() for a in argv_file.read_bytes().split(b"\0") if a]
+        return argv, pwned.exists(), url
 
 
 def test_plain_value_is_double_quoted():
@@ -39,6 +66,49 @@ def test_line_breaks_rejected_without_echoing_value(value):
 
 def test_shell_injection_metacharacters_in_url():
     url = 'http://example.com/file" ; echo pwned ; echo "'
-    assert dockerfile_env_value(url) == (
-        '"http://example.com/file\\" ; echo pwned ; echo \\""'
+    quoted = dockerfile_shell_value(url)
+    assert quoted == shlex.quote(url)
+    assert quoted.startswith("'") and quoted.endswith("'")
+
+
+def test_shell_value_quotes_backticks():
+    url = "http://example.com/`id`"
+    quoted = dockerfile_shell_value(url)
+    assert quoted == shlex.quote(url)
+    assert quoted == "'http://example.com/`id`'"
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://example.com/model.bin",
+        'http://example.com/x" ; touch PWNED ; echo "',
+        "http://example.com/`touch PWNED`",
+        "http://example.com/$(touch PWNED)",
+        "http://example.com/$HOME/weights.bin",
+        "http://example.com/${HOME}",
+        "http://example.com/file#token",
+        "http://example.com/it's.bin",
+        "http://example.com/a b.bin",
+    ],
+)
+def test_shell_value_is_one_posix_sh_word(url):
+    argv, pwned, resolved_url = _posix_sh_curl_argv(dockerfile_shell_value, url)
+    assert argv == ["-L", resolved_url, "-o", argv[3]]
+    assert pwned is False
+
+
+def test_env_filter_still_executes_backticks_in_posix_sh():
+    """Cretz's review: ENV quoting leaves backticks live when the value is in RUN."""
+    argv, pwned, _resolved = _posix_sh_curl_argv(
+        dockerfile_env_value, "http://example.com/`touch PWNED`"
     )
+    assert pwned is True
+    assert argv[1] == "http://example.com/"
+
+
+@pytest.mark.parametrize("value", ["line1\nline2", "line1\rline2", "line1\r\nline2"])
+def test_shell_value_line_breaks_rejected_without_echoing_value(value):
+    with pytest.raises(ValueError, match="line break") as exc_info:
+        dockerfile_shell_value(value)
+    assert "line1" not in str(exc_info.value)

--- a/truss/tests/util/test_jinja.py
+++ b/truss/tests/util/test_jinja.py
@@ -1,6 +1,7 @@
 import os
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -78,6 +79,7 @@ def test_shell_value_quotes_backticks():
     assert quoted == "'http://example.com/`id`'"
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="/bin/sh is not on Windows CI")
 @pytest.mark.parametrize(
     "url",
     [
@@ -98,6 +100,7 @@ def test_shell_value_is_one_posix_sh_word(url):
     assert pwned is False
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="/bin/sh is not on Windows CI")
 def test_env_filter_still_executes_backticks_in_posix_sh():
     """Cretz's review: ENV quoting leaves backticks live when the value is in RUN."""
     argv, pwned, _resolved = _posix_sh_curl_argv(

--- a/truss/tests/util/test_jinja.py
+++ b/truss/tests/util/test_jinja.py
@@ -35,3 +35,10 @@ def test_line_breaks_rejected_without_echoing_value(value):
     with pytest.raises(ValueError, match="line break") as exc_info:
         dockerfile_env_value(value)
     assert "line1" not in str(exc_info.value)
+
+
+def test_shell_injection_metacharacters_in_url():
+    url = 'http://example.com/file" ; echo pwned ; echo "'
+    assert dockerfile_env_value(url) == (
+        '"http://example.com/file\\" ; echo pwned ; echo \\""'
+    )

--- a/truss/util/jinja.py
+++ b/truss/util/jinja.py
@@ -1,3 +1,4 @@
+import shlex
 from pathlib import Path
 
 from jinja2 import Environment, FileSystemLoader, Template
@@ -17,8 +18,22 @@ def dockerfile_env_value(value: str) -> str:
     return f'"{escaped}"'
 
 
+def dockerfile_shell_value(value: str) -> str:
+    """Quote a string as one POSIX shell word in a Dockerfile RUN.
+
+    `dockerfile_env_value` follows buildkit ENV grammar. RUN still goes
+    through /bin/sh, so backticks and other shell substitutions remain live
+    there. `shlex.quote` uses single quotes, which stops that.
+    """
+    if "\n" in value or "\r" in value:
+        # Deliberately not echoing the value: URLs and paths can embed secrets.
+        raise ValueError("Dockerfile RUN values cannot contain line breaks.")
+    return shlex.quote(value)
+
+
 def read_template_from_fs(base_dir: Path, template_file_name: str) -> Template:
     template_loader = FileSystemLoader(str(base_dir))
     template_env = Environment(loader=template_loader)
     template_env.filters["dockerfile_env_value"] = dockerfile_env_value
+    template_env.filters["dockerfile_shell_value"] = dockerfile_shell_value
     return template_env.get_template(template_file_name)


### PR DESCRIPTION
## What

Truss can download remote files at **image build time** via `external_data` in `config.yaml`. The serving image builder turns each entry into a Dockerfile `RUN` line that shells out to `curl`:

```dockerfile
RUN mkdir -p /app/data/weights; curl -L "http://example.com/model.bin" -o /app/data/weights/model.bin
```

The `url` field is interpolated into that shell command with no escaping beyond wrapping it in double quotes. If the URL contains `"`, the shell treats everything after the quote as a new command. A config like this:

```yaml
external_data:
  - url: 'http://example.com/x" ; malicious_command ; echo "'
    local_data_path: weights/model.bin
```

generates:

```dockerfile
RUN mkdir -p /app/data/weights; curl -L "http://example.com/x" ; malicious_command ; echo "" -o /app/data/weights/model.bin
```

`malicious_command` runs during `truss build` / `docker build`, inside the build container, with the builder's permissions.

This is a build-time injection in user-supplied config. It matters when the person running the build did not write every field in `config.yaml` themselves: a forked truss repo, a shared template, a third-party example, or a compromised config checked into source control.

After the fix, the same URL stays inside one quoted argument:

```dockerfile
RUN mkdir -p "/app/data/weights"; curl -L "http://example.com/x\" ; malicious_command ; echo \"" -o "/app/data/weights/model.bin"
```

Related to #2486, which fixes path traversal in the runtime download path (`download.py`). This PR covers the separate Dockerfile build path.

## Why

I was trying Truss with `external_data` to pull model weights from a URL, same pattern I use in other serving setups. Before pushing, I looked at the generated Dockerfile to see what actually runs during build. The `curl` line embeds the URL directly in a shell `RUN` with no escaping, so I tried a URL with a `"` in it and confirmed it breaks out of the quoted argument.

## How

Apply the existing `dockerfile_env_value` Jinja filter (already used for `ENV SERVER_START_CMD`) to the URL, destination path, and `mkdir` target in `server.Dockerfile.jinja`. That filter escapes `"`, `\`, and `$` for double-quoted shell/ENV contexts. No new escaping helper.

## Testing

Added:

- `test_shell_injection_metacharacters_in_url` in `truss/tests/util/test_jinja.py`
- `test_external_data_url_shell_metacharacters_escaped_in_dockerfile` in `truss/tests/contexts/image_builder/test_serving_image_builder.py`

```bash
uv run pytest truss/tests/util/test_jinja.py -v
uv run pytest truss/tests/contexts/image_builder/test_serving_image_builder.py::test_external_data_url_shell_metacharacters_escaped_in_dockerfile -v
uv run pytest truss/tests/contexts/image_builder/test_serving_image_builder.py::test_serving_image_dockerfile_from_user_base_image -v
```

Found during a Hackerbane security review: https://hackerbane.com/reports/hackerbane-HB-AR-2026.2-baseten-truss.html
