### PR TITLE
Speed up ignored path traversal in watch mode

### DIFF
--- a/truss/tests/patch/test_calc_patch.py
+++ b/truss/tests/patch/test_calc_patch.py
@@ -919,14 +919,17 @@ def test_calc_unignored_paths():
     assert unignored_paths == {"config.yaml", "model/model.py"}
 
 
-def test_calc_unignored_paths_matches_directory_patterns_with_trailing_slash():
-    root_relative_paths = {"ignored", "ignored/file.txt", "model/model.py"}
+def test_calc_truss_patch_ignores_old_signature_directory_entry(
+    custom_model_truss_dir: Path,
+):
+    previous_signature = calc_truss_signature(custom_model_truss_dir)
+    previous_signature.content_hashes_by_path["model/cache"] = None
 
-    unignored_paths = _calc_unignored_paths(
-        root_relative_paths, ["ignored/"], directory_paths={"ignored"}
+    patches = calc_truss_patch(
+        custom_model_truss_dir, previous_signature, ignore_patterns=["cache/"]
     )
 
-    assert unignored_paths == {"model/model.py"}
+    assert patches == []
 
 
 def test_calc_changed_paths_prunes_ignored_dirs(tmp_path, monkeypatch):

--- a/truss/tests/patch/test_calc_patch.py
+++ b/truss/tests/patch/test_calc_patch.py
@@ -23,6 +23,7 @@ from truss.templates.control.control.helpers.truss_patch.model_code_patch_applie
     apply_code_patch,
 )
 from truss.truss_handle.patch.calc_patch import (
+    _calc_changed_paths,
     _calc_python_requirements_patches,
     _calc_unignored_paths,
     calc_truss_patch,
@@ -916,6 +917,41 @@ def test_calc_unignored_paths():
 
     unignored_paths = _calc_unignored_paths(root_relative_paths, ignore_patterns)
     assert unignored_paths == {"config.yaml", "model/model.py"}
+
+
+def test_calc_unignored_paths_matches_directory_patterns_with_trailing_slash():
+    root_relative_paths = {"ignored", "ignored/file.txt", "model/model.py"}
+
+    unignored_paths = _calc_unignored_paths(
+        root_relative_paths, ["ignored/"], directory_paths={"ignored"}
+    )
+
+    assert unignored_paths == {"model/model.py"}
+
+
+def test_calc_changed_paths_prunes_ignored_dirs(tmp_path, monkeypatch):
+    (tmp_path / "model").mkdir()
+    (tmp_path / "model" / "model.py").touch()
+    (tmp_path / "ignored" / "deep").mkdir(parents=True)
+    (tmp_path / "ignored" / "deep" / "large.bin").touch()
+
+    walked_dirs = []
+    original_walk = os.walk
+
+    def tracking_walk(*args, **kwargs):
+        for entry in original_walk(*args, **kwargs):
+            walked_dirs.append(Path(entry[0]).relative_to(tmp_path))
+            yield entry
+
+    monkeypatch.setattr("truss.util.path.os.walk", tracking_walk)
+
+    changed_paths = _calc_changed_paths(tmp_path, {}, ["ignored/"])
+
+    assert set(changed_paths["added"]) == {"model", os.path.join("model", "model.py")}
+    assert changed_paths["updated"] == []
+    assert changed_paths["removed"] == []
+    assert Path("ignored") not in walked_dirs
+    assert Path("ignored/deep") not in walked_dirs
 
 
 def _apply_config_change_and_calc_patches(

--- a/truss/tests/util/test_path.py
+++ b/truss/tests/util/test_path.py
@@ -322,3 +322,28 @@ def test_get_ignored_relative_paths_from_root(custom_model_truss_dir_with_hidden
         all_relative_path_strs
         == ignored_relative_paths_strs | unignored_relative_path_strs
     )
+
+
+def test_get_unignored_relative_paths_from_root_prunes_ignored_dirs(
+    tmp_path, monkeypatch
+):
+    (tmp_path / "keep").mkdir()
+    (tmp_path / "keep" / "model.py").touch()
+    (tmp_path / "ignored" / "deep").mkdir(parents=True)
+    (tmp_path / "ignored" / "deep" / "large.bin").touch()
+
+    walked_dirs = []
+    original_walk = path.os.walk
+
+    def tracking_walk(*args, **kwargs):
+        for entry in original_walk(*args, **kwargs):
+            walked_dirs.append(Path(entry[0]).relative_to(tmp_path))
+            yield entry
+
+    monkeypatch.setattr(path.os, "walk", tracking_walk)
+
+    result = path.get_unignored_relative_paths_from_root(tmp_path, ["ignored/"])
+
+    assert result == {Path("keep"), Path("keep/model.py")}
+    assert Path("ignored") not in walked_dirs
+    assert Path("ignored/deep") not in walked_dirs

--- a/truss/truss_handle/patch/calc_patch.py
+++ b/truss/truss_handle/patch/calc_patch.py
@@ -29,7 +29,10 @@ from truss.templates.control.control.helpers.truss_patch.system_packages import 
 )
 from truss.truss_handle.patch.custom_types import ChangedPaths, TrussSignature
 from truss.truss_handle.patch.hash import file_content_hash_str
-from truss.util.path import get_ignored_relative_paths
+from truss.util.path import (
+    get_ignored_relative_paths,
+    get_unignored_relative_paths_from_root,
+)
 
 logger: logging.Logger = logging.getLogger(__name__)
 PYCACHE_IGNORE_PATTERNS = ["**/__pycache__/**/*", "**/__pycache__/**"]
@@ -203,15 +206,19 @@ def _calc_changed_paths(
     """
     TODO(pankaj) add support for directory creation in patch
     """
-    root_relative_new_paths = set(
-        (str(path.relative_to(root)) for path in root.glob("**/*"))
-    )
-    unignored_new_paths = _calc_unignored_paths(
-        root_relative_new_paths, ignore_patterns
+    unignored_new_paths = set(
+        str(path)
+        for path in get_unignored_relative_paths_from_root(root, ignore_patterns)
     )
     previous_root_relative_paths = set(previous_root_path_content_hashes.keys())
     unignored_prev_paths = _calc_unignored_paths(
-        previous_root_relative_paths, ignore_patterns
+        previous_root_relative_paths,
+        ignore_patterns,
+        directory_paths={
+            path
+            for path, content_hash in previous_root_path_content_hashes.items()
+            if content_hash is None
+        },
     )
 
     added_paths = unignored_new_paths - unignored_prev_paths
@@ -235,10 +242,24 @@ def _calc_changed_paths(
 
 
 def _calc_unignored_paths(
-    root_relative_paths: Set[str], ignore_patterns: Optional[List[str]] = None
+    root_relative_paths: Set[str],
+    ignore_patterns: Optional[List[str]] = None,
+    directory_paths: Optional[Set[str]] = None,
 ) -> Set[str]:
+    """Filter stored paths, matching directory-only patterns with a trailing slash."""
     ignored_paths = set(
         get_ignored_relative_paths(root_relative_paths, ignore_patterns)
+    )
+    directory_paths_by_match_path = {
+        f"{Path(path).as_posix()}/": path for path in directory_paths or set()
+    }
+    ignored_directory_match_paths = set(
+        get_ignored_relative_paths(directory_paths_by_match_path, ignore_patterns)
+    )
+    ignored_paths.update(
+        path
+        for match_path, path in directory_paths_by_match_path.items()
+        if match_path in ignored_directory_match_paths
     )
     return root_relative_paths - ignored_paths  # type: ignore
 

--- a/truss/util/path.py
+++ b/truss/util/path.py
@@ -210,10 +210,10 @@ def get_ignored_relative_paths(
 def get_unignored_relative_paths_from_root(
     root: Path, ignore_patterns: Optional[List[str]] = None
 ) -> Set[Path]:
-    """Given a root directory, returns an iterator of the relative paths that do not match ignore_patterns."""
-    root_relative_paths = set(path.relative_to(root) for path in root.glob("**/*"))
-
-    ignored_paths = set(
-        get_ignored_relative_paths(root_relative_paths, ignore_patterns)
-    )
-    return root_relative_paths - ignored_paths  # type: ignore
+    """Return relative paths while pruning ignored directories during traversal."""
+    paths: Set[Path] = set()
+    for dirpath, dirs, filenames in walk_filtered(root, ignore_patterns):
+        relative_root = Path(dirpath).relative_to(root)
+        paths.update(relative_root / dirname for dirname in dirs)
+        paths.update(relative_root / filename for filename in filenames)
+    return paths


### PR DESCRIPTION
## :rocket: What

Speed up `truss watch` patch calculation by pruning ignored directories during traversal. The current hash, signature, and change-detection paths recursively scan ignored trees before filtering them.

## :computer: How

- Reuse `walk_filtered()` when collecting paths for hashes and signatures.
- Use the same pruned traversal when calculating changed paths.
- Normalize directory-only ignore patterns when reading existing signatures so old deployments do not produce false removal patches.

## :stopwatch: Benchmark

Synthetic tree with 50,000 ignored `.venv` files and 200 included model files. Median of 10 path-discovery runs on macOS arm64 with Python 3.13:

- Before: 803.5 ms
- After: 1.3 ms
- Speedup: 626.6x

## :microscope: Testing

- `uv run pytest truss/tests/util/test_path.py truss/tests/patch/test_hash.py truss/tests/patch/test_dir_signature.py truss/tests/patch/test_calc_patch.py -q`
  - 80 passed
- `uv run pytest -m "not integration" -q`
  - 1667 passed, 32 skipped, 232 deselected
- `uv run pre-commit run --all-files`
  - passed