### PR TITLE
Keep external_data Dockerfile dest as a POSIX container path

### DIFF
--- a/truss/contexts/image_builder/serving_image_builder.py
+++ b/truss/contexts/image_builder/serving_image_builder.py
@@ -706,8 +706,6 @@ class ServingImageBuilder(ImageBuilder):
             # TODO(pankaj) We probably don't need model framework specific directory.
             build_dir = build_truss_target_directory(model_framework_name)
 
-        data_dir = build_dir / config.data_dir  # type: ignore[operator]
-
         truss_ignore_patterns = []
         if (truss_dir / USER_TRUSS_IGNORE_FILE).exists():
             truss_ignore_patterns = load_trussignore_patterns(

--- a/truss/contexts/image_builder/serving_image_builder.py
+++ b/truss/contexts/image_builder/serving_image_builder.py
@@ -8,7 +8,7 @@ import re
 import shutil
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Dict, List, Optional, Tuple, Type
 
 import boto3
@@ -758,11 +758,13 @@ class ServingImageBuilder(ImageBuilder):
             yaml.dump(config.to_dict(verbose=True), config_file)
 
         external_data_files: list = []
-        data_dir = Path("/app/data/")
+        # Container path. PurePosixPath so a Windows host does not turn
+        # /app/data into C:\app\data via Path.resolve().
+        data_dir = PurePosixPath("/app/data")
         if self._spec.external_data is not None:
             for ext_file in self._spec.external_data.items:
                 external_data_files.append(
-                    (ext_file.url, (data_dir / ext_file.local_data_path).resolve())
+                    (ext_file.url, data_dir / ext_file.local_data_path)
                 )
 
         # No model cache provided, initialize empty

--- a/truss/contexts/image_builder/serving_image_builder.py
+++ b/truss/contexts/image_builder/serving_image_builder.py
@@ -760,11 +760,11 @@ class ServingImageBuilder(ImageBuilder):
         external_data_files: list = []
         # Container path. PurePosixPath so a Windows host does not turn
         # /app/data into C:\app\data via Path.resolve().
-        data_dir = PurePosixPath("/app/data")
+        container_data_dir = PurePosixPath("/app/data")
         if self._spec.external_data is not None:
             for ext_file in self._spec.external_data.items:
                 external_data_files.append(
-                    (ext_file.url, data_dir / ext_file.local_data_path)
+                    (ext_file.url, container_data_dir / ext_file.local_data_path)
                 )
 
         # No model cache provided, initialize empty

--- a/truss/tests/contexts/image_builder/test_serving_image_builder.py
+++ b/truss/tests/contexts/image_builder/test_serving_image_builder.py
@@ -4,7 +4,7 @@ import os
 import subprocess
 import sys
 import time
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
@@ -35,12 +35,13 @@ BASE_DIR = Path(__file__).parent
 
 
 def _external_data_curl_lines(dockerfile: str) -> list[str]:
-    # `curl -L ` (space) avoids the uv bootstrap `curl -LsSf`. Dest can be
-    # Windows-resolved (`C:\app\data\...`) so do not require `/app/data/`.
+    # `curl -L ` (space) avoids the uv bootstrap `curl -LsSf`.
     return [
         line
         for line in dockerfile.splitlines()
-        if line.strip().startswith("RUN") and "curl -L " in line and "model.bin" in line
+        if line.strip().startswith("RUN")
+        and "curl -L " in line
+        and "/app/data/" in line
     ]
 
 
@@ -116,7 +117,7 @@ def test_external_data_url_shell_metacharacters_escaped_in_dockerfile(
 
     expected_url = dockerfile_shell_value(malicious_url)
     expected_dst = dockerfile_shell_value(
-        str((Path("/app/data/") / local_data_path).resolve())
+        str(PurePosixPath("/app/data") / local_data_path)
     )
     assert f"curl -L {expected_url} -o {expected_dst}" in curl_line
     assert "; echo pwned ;" not in curl_line.replace(expected_url, "")
@@ -147,6 +148,25 @@ def test_external_data_url_backticks_escaped_in_dockerfile(
     expected_url = dockerfile_shell_value(malicious_url)
     assert f"curl -L {expected_url}" in curl_line
     assert expected_url == "'http://example.com/`id`'"
+
+
+@patch("platform.machine", return_value="amd")
+def test_external_data_dest_is_posix_container_path(
+    mock_machine, custom_model_truss_dir
+):
+    """Dest must stay /app/data/... on every host OS. Path.resolve() on Windows
+    turns that into C:\\app\\data\\... and curl writes to the wrong place."""
+    local_data_path = "weights/model.bin"
+    curl_line = _render_external_data_curl_line(
+        custom_model_truss_dir, "http://example.com/model.bin", local_data_path
+    )
+    expected_dst = dockerfile_shell_value(
+        str(PurePosixPath("/app/data") / local_data_path)
+    )
+    assert f"-o {expected_dst}" in curl_line
+    assert "/app/data/weights" in curl_line
+    assert ":\\app\\data" not in curl_line
+    assert ":/app/data" not in curl_line
 
 
 def _render_external_data_curl_line(truss_dir, url: str, local_data_path: str) -> str:


### PR DESCRIPTION
## TLDR

On Windows, `truss build` with `external_data` incorrectly puts weights at `C:\app\data\...` inside a Linux image, so the model cannot find them.

## What

`external_data` downloads land at `/app/data/<local_data_path>` in the serving image. The image builder used `Path("/app/data/").resolve()` on the **host** to build that dest.

On Windows, `resolve()` turns `/app/data/weights/model.bin` into `C:\app\data\weights\model.bin`. That string goes into the Dockerfile `curl -o` line. The image is Linux, so the file is not where the model looks.

After this change the dest is always a POSIX path:

```dockerfile
RUN mkdir -p '/app/data/weights'; curl -L 'https://example.com/model.bin' -o '/app/data/weights/model.bin'
```

`truss migrate` already builds the same path with `PurePosixPath`. This matches that.

## Why

I hit this while adding tests for #2616. Windows CI produced `C:\app\data\...`, so those tests stopped requiring `/app/data` just to stay green. The generated Dockerfile was still wrong for anyone running `truss build` on Windows with `external_data`.

## How

Use `PurePosixPath("/app/data") / local_data_path`. Do not `resolve()` on the host.

## Testing

Added `test_external_data_dest_is_posix_container_path`. Existing curl-line tests now assert `/app/data/` on every OS.

```bash
uv run pytest truss/tests/contexts/image_builder/test_serving_image_builder.py::test_external_data_dest_is_posix_container_path -v
uv run pytest truss/tests/contexts/image_builder/test_serving_image_builder.py::test_external_data_url_shell_metacharacters_escaped_in_dockerfile -v
uv run pytest truss/tests/contexts/image_builder/test_serving_image_builder.py::test_external_data_run_line_is_safe_under_posix_sh -v
```

Found during a Hackerbane security review: https://hackerbane.com/reports/hackerbane-HB-AR-2026.2-baseten-truss.html
