### PR TITLE
Tolerate an empty teams list during team resolution

### DIFF
--- a/truss/cli/remote_cli.py
+++ b/truss/cli/remote_cli.py
@@ -120,7 +120,9 @@ def inquire_team(
     existing_teams: Optional[dict[str, TeamType]] = None,
     prompt: str = "👥 Which team do you want to push to?",
 ) -> Optional[str]:
-    if existing_teams is not None:
+    # Teams can be None (not fetched) or empty (fetched, but the account/API key
+    # has none). Neither gives us anything to prompt with, so disallow either.
+    if existing_teams:
         if not check_is_interactive():
             available_teams_str = format_available_teams(existing_teams)
             raise click.UsageError(

--- a/truss/cli/resolvers/model_team_resolver.py
+++ b/truss/cli/resolvers/model_team_resolver.py
@@ -200,6 +200,11 @@ def resolve_model_team_name(
         return (single_team_name, _get_team_id(single_team_name))
 
     if not allow_interactive:
+        if not existing_teams:
+            raise ValueError(
+                "No teams are available for this account. The API key in use may not "
+                "have permission to deploy models."
+            )
         available_teams_str = remote_cli.format_available_teams(existing_teams)
         raise ValueError(
             "Multiple teams available. Please specify a team name via the "

--- a/truss/tests/cli/test_model_team_resolver.py
+++ b/truss/tests/cli/test_model_team_resolver.py
@@ -306,6 +306,18 @@ class TestModelTeamResolver:
         else:
             mock_remote.api.get_teams.assert_not_called()
 
+    def test_no_teams_resolves_to_no_team(self):
+        # With no teams there is nothing to prompt with, so push proceeds without a
+        # team and lets the backend report why the API key has none.
+        mock_remote = self._setup_mock_remote({})
+
+        team_name, team_id = resolve_model_team_name(
+            remote_provider=mock_remote, provided_team_name=None
+        )
+
+        assert team_name is None
+        assert team_id is None
+
     @pytest.mark.parametrize(
         "existing_model_name,should_call_models_api",
         [(None, False), ("some-model", True)],


### PR DESCRIPTION
## :rocket: What

- `truss push` with an account whose GraphQL `teams` list comes back empty (e.g. an API-key-management key) crashed with `InvalidArgument: argument choices cannot be empty`, or dead-ended on `Available teams: none`.
- Team resolution now propagates no team in that case, so the push reaches the backend and gets a real permission error.

## :computer: How

- `inquire_team` guarded on `existing_teams is not None`, so an empty dict entered the prompt branch and handed InquirerPy zero choices. Changed to `if existing_teams:`, which routes it to the pre-existing no-teams branch that returns `None`. Covers models, chains, and train, since all call sites share this function.
- `resolve_model_team_name` raised "Multiple teams available" for zero teams on the `allow_interactive=False` path. Zero teams now gets its own message.
- `--team <name>` with no teams still errors, unchanged.

## :microscope: Testing

- Added a resolver test for the empty-teams case.