### PR TITLE
Truss: support updated training auth config (OIDC, AssumeRole)

### DIFF
--- a/truss-train/tests/test_definitions.py
+++ b/truss-train/tests/test_definitions.py
@@ -5,6 +5,7 @@ from truss.base import truss_config
 from truss_train.definitions import (
     AvailabilityModel,
     AWSAssumeRoleDockerAuth,
+    AWSIAMDockerAuth,
     AWSOIDCDockerAuth,
     BasetenCheckpoint,
     CheckpointList,
@@ -16,7 +17,9 @@ from truss_train.definitions import (
     LoopsCheckpoint,
     LoRACheckpoint,
     ModelWeightsFormat,
+    RegistrySecretDockerAuth,
     Runtime,
+    SecretReference,
     TrainingJob,
 )
 
@@ -157,16 +160,53 @@ def test_gcp_oidc_docker_auth_serializes_in_training_image():
 @pytest.mark.parametrize(
     ("auth_method", "expected_field"),
     [
+        (truss_config.DockerAuthType.AWS_IAM, "aws_iam_docker_auth"),
         (truss_config.DockerAuthType.AWS_OIDC, "aws_oidc_docker_auth"),
         (truss_config.DockerAuthType.AWS_ASSUME_ROLE, "aws_assume_role_docker_auth"),
         (truss_config.DockerAuthType.GCP_OIDC, "gcp_oidc_docker_auth"),
+        (
+            truss_config.DockerAuthType.GCP_SERVICE_ACCOUNT_JSON,
+            "gcp_service_account_json_docker_auth",
+        ),
+        (truss_config.DockerAuthType.REGISTRY_SECRET, "registry_secret_docker_auth"),
     ],
 )
-def test_oidc_and_assume_role_docker_auth_require_matching_config(
-    auth_method, expected_field
-):
+def test_docker_auth_requires_matching_config(auth_method, expected_field):
     with pytest.raises(ValidationError, match=f"{expected_field} must be provided"):
         DockerAuth(auth_method=auth_method, registry="registry.example.com")
+
+
+@pytest.mark.parametrize(
+    ("auth_config_type", "kwargs"),
+    [
+        (AWSOIDCDockerAuth, {"role_arn": "", "region": "us-west-2"}),
+        (
+            AWSOIDCDockerAuth,
+            {"role_arn": "arn:aws:iam::123456789012:role/image-pull", "region": ""},
+        ),
+        (AWSAssumeRoleDockerAuth, {"role_arn": "", "region": "us-west-2"}),
+        (
+            AWSAssumeRoleDockerAuth,
+            {"role_arn": "arn:aws:iam::123456789012:role/image-pull", "region": ""},
+        ),
+        (
+            GCPOIDCDockerAuth,
+            {"service_account": "", "workload_identity_provider": "provider"},
+        ),
+        (
+            GCPOIDCDockerAuth,
+            {
+                "service_account": "image-pull@example.iam.gserviceaccount.com",
+                "workload_identity_provider": "",
+            },
+        ),
+    ],
+)
+def test_docker_auth_config_rejects_empty_required_fields(auth_config_type, kwargs):
+    with pytest.raises(
+        ValidationError, match="String should have at least 1 character"
+    ):
+        auth_config_type(**kwargs)
 
 
 def test_oidc_docker_auth_rejects_conflicting_config():
@@ -185,6 +225,41 @@ def test_oidc_docker_auth_rejects_conflicting_config():
                 workload_identity_provider=(
                     "projects/123/locations/global/workloadIdentityPools/pool/providers/provider"
                 ),
+            ),
+        )
+
+
+def test_oidc_docker_auth_rejects_legacy_config():
+    with pytest.raises(
+        ValidationError, match="registry_secret_docker_auth cannot be specified"
+    ):
+        DockerAuth(
+            auth_method=truss_config.DockerAuthType.AWS_OIDC,
+            registry="registry.example.com",
+            aws_oidc_docker_auth=AWSOIDCDockerAuth(
+                role_arn="arn:aws:iam::123456789012:role/training-image-pull",
+                region="us-west-2",
+            ),
+            registry_secret_docker_auth=RegistrySecretDockerAuth(
+                secret_ref=SecretReference(name="registry-secret")
+            ),
+        )
+
+
+def test_legacy_docker_auth_rejects_oidc_config():
+    with pytest.raises(
+        ValidationError, match="aws_oidc_docker_auth cannot be specified"
+    ):
+        DockerAuth(
+            auth_method=truss_config.DockerAuthType.AWS_IAM,
+            registry="registry.example.com",
+            aws_iam_docker_auth=AWSIAMDockerAuth(
+                access_key_secret_ref=SecretReference(name="aws-access-key"),
+                secret_access_key_secret_ref=SecretReference(name="aws-secret-key"),
+            ),
+            aws_oidc_docker_auth=AWSOIDCDockerAuth(
+                role_arn="arn:aws:iam::123456789012:role/training-image-pull",
+                region="us-west-2",
             ),
         )
 

--- a/truss-train/tests/test_definitions.py
+++ b/truss-train/tests/test_definitions.py
@@ -4,9 +4,13 @@ from pydantic import ValidationError
 from truss.base import truss_config
 from truss_train.definitions import (
     AvailabilityModel,
+    AWSAssumeRoleDockerAuth,
+    AWSOIDCDockerAuth,
     BasetenCheckpoint,
     CheckpointList,
     Compute,
+    DockerAuth,
+    GCPOIDCDockerAuth,
     Image,
     LoadCheckpointConfig,
     LoopsCheckpoint,
@@ -83,6 +87,108 @@ class TestComputeAvailabilityModel:
             Compute(availability_model="on_demand")
 
 
+def test_aws_oidc_docker_auth_serializes_in_training_image():
+    image = Image(
+        base_image="123456789012.dkr.ecr.us-west-2.amazonaws.com/training:latest",
+        docker_auth=DockerAuth(
+            auth_method=truss_config.DockerAuthType.AWS_OIDC,
+            registry="123456789012.dkr.ecr.us-west-2.amazonaws.com",
+            aws_oidc_docker_auth=AWSOIDCDockerAuth(
+                role_arn="arn:aws:iam::123456789012:role/training-image-pull",
+                region="us-west-2",
+            ),
+        ),
+    )
+
+    dumped = image.model_dump()
+
+    assert dumped["docker_auth"]["auth_method"] == "AWS_OIDC"
+    assert dumped["docker_auth"]["aws_oidc_docker_auth"] == {
+        "role_arn": "arn:aws:iam::123456789012:role/training-image-pull",
+        "region": "us-west-2",
+    }
+
+
+def test_aws_assume_role_docker_auth_serializes_in_training_image():
+    image = Image(
+        base_image="123456789012.dkr.ecr.us-west-2.amazonaws.com/training:latest",
+        docker_auth=DockerAuth(
+            auth_method=truss_config.DockerAuthType.AWS_ASSUME_ROLE,
+            registry="123456789012.dkr.ecr.us-west-2.amazonaws.com",
+            aws_assume_role_docker_auth=AWSAssumeRoleDockerAuth(
+                role_arn="arn:aws:iam::123456789012:role/training-image-pull",
+                region="us-west-2",
+            ),
+        ),
+    )
+
+    dumped = image.model_dump()
+
+    assert dumped["docker_auth"]["auth_method"] == "AWS_ASSUME_ROLE"
+    assert dumped["docker_auth"]["aws_assume_role_docker_auth"] == {
+        "role_arn": "arn:aws:iam::123456789012:role/training-image-pull",
+        "region": "us-west-2",
+    }
+
+
+def test_gcp_oidc_docker_auth_serializes_in_training_image():
+    image = Image(
+        base_image="us-west1-docker.pkg.dev/project/repository/training:latest",
+        docker_auth=DockerAuth(
+            auth_method=truss_config.DockerAuthType.GCP_OIDC,
+            registry="us-west1-docker.pkg.dev",
+            gcp_oidc_docker_auth=GCPOIDCDockerAuth(
+                service_account="image-pull@example.iam.gserviceaccount.com",
+                workload_identity_provider=(
+                    "projects/123/locations/global/workloadIdentityPools/pool/providers/provider"
+                ),
+            ),
+        ),
+    )
+
+    dumped = image.model_dump()
+
+    assert dumped["docker_auth"]["auth_method"] == "GCP_OIDC"
+    assert dumped["docker_auth"]["gcp_oidc_docker_auth"]["service_account"] == (
+        "image-pull@example.iam.gserviceaccount.com"
+    )
+
+
+@pytest.mark.parametrize(
+    ("auth_method", "expected_field"),
+    [
+        (truss_config.DockerAuthType.AWS_OIDC, "aws_oidc_docker_auth"),
+        (truss_config.DockerAuthType.AWS_ASSUME_ROLE, "aws_assume_role_docker_auth"),
+        (truss_config.DockerAuthType.GCP_OIDC, "gcp_oidc_docker_auth"),
+    ],
+)
+def test_oidc_and_assume_role_docker_auth_require_matching_config(
+    auth_method, expected_field
+):
+    with pytest.raises(ValidationError, match=f"{expected_field} must be provided"):
+        DockerAuth(auth_method=auth_method, registry="registry.example.com")
+
+
+def test_oidc_docker_auth_rejects_conflicting_config():
+    with pytest.raises(
+        ValidationError, match="gcp_oidc_docker_auth cannot be specified"
+    ):
+        DockerAuth(
+            auth_method=truss_config.DockerAuthType.AWS_OIDC,
+            registry="registry.example.com",
+            aws_oidc_docker_auth=AWSOIDCDockerAuth(
+                role_arn="arn:aws:iam::123456789012:role/training-image-pull",
+                region="us-west-2",
+            ),
+            gcp_oidc_docker_auth=GCPOIDCDockerAuth(
+                service_account="image-pull@example.iam.gserviceaccount.com",
+                workload_identity_provider=(
+                    "projects/123/locations/global/workloadIdentityPools/pool/providers/provider"
+                ),
+            ),
+        )
+
+
 def _minimal_job(**kwargs):
     return TrainingJob(
         image=Image(base_image="hello-world"),
@@ -93,62 +199,58 @@ def _minimal_job(**kwargs):
 
 
 class TestTrainingJobWeightsAuthValidation:
-    """Training jobs only allow CUSTOM_SECRET with auth_secret_name for weights; OIDC is not supported."""
+    """Training jobs allow the weight auth methods supported by the training API."""
 
-    def test_weights_with_aws_oidc_raises(self):
-        with pytest.raises(
-            ValidationError, match="weight s3://bucket/path.*CUSTOM_SECRET"
-        ):
-            _minimal_job(
-                weights=[
-                    truss_config.WeightsSource(
-                        source="s3://bucket/path",
-                        mount_location="/weights",
-                        auth=truss_config.WeightsAuth(
-                            auth_method=truss_config.WeightsAuthMethod.AWS_OIDC,
-                            aws_oidc_role_arn="arn:aws:iam::123:role/foo",
-                            aws_oidc_region="us-west-2",
-                        ),
-                    )
-                ]
-            )
+    def test_weights_with_aws_oidc_are_accepted(self):
+        job = _minimal_job(
+            weights=[
+                truss_config.WeightsSource(
+                    source="s3://bucket/path",
+                    mount_location="/weights",
+                    auth=truss_config.WeightsAuth(
+                        auth_method=truss_config.WeightsAuthMethod.AWS_OIDC,
+                        aws_oidc_role_arn="arn:aws:iam::123:role/foo",
+                        aws_oidc_region="us-west-2",
+                    ),
+                )
+            ]
+        )
+        assert job.model_dump()["weights"][0]["auth"]["auth_method"] == "AWS_OIDC"
 
-    def test_weights_with_gcp_oidc_raises(self):
-        with pytest.raises(
-            ValidationError, match="weight gs://bucket/path.*CUSTOM_SECRET"
-        ):
-            _minimal_job(
-                weights=[
-                    truss_config.WeightsSource(
-                        source="gs://bucket/path",
-                        mount_location="/weights",
-                        auth=truss_config.WeightsAuth(
-                            auth_method=truss_config.WeightsAuthMethod.GCP_OIDC,
-                            gcp_oidc_service_account="my-sa@project.iam.gserviceaccount.com",
-                            gcp_oidc_workload_id_provider="projects/123/locations/global/workloadIdentityPools/pool/providers/provider",
-                        ),
-                    )
-                ]
-            )
+    def test_weights_with_gcp_oidc_are_accepted(self):
+        job = _minimal_job(
+            weights=[
+                truss_config.WeightsSource(
+                    source="gs://bucket/path",
+                    mount_location="/weights",
+                    auth=truss_config.WeightsAuth(
+                        auth_method=truss_config.WeightsAuthMethod.GCP_OIDC,
+                        gcp_oidc_service_account="my-sa@project.iam.gserviceaccount.com",
+                        gcp_oidc_workload_id_provider="projects/123/locations/global/workloadIdentityPools/pool/providers/provider",
+                    ),
+                )
+            ]
+        )
+        assert job.model_dump()["weights"][0]["auth"]["auth_method"] == "GCP_OIDC"
 
-    def test_weights_with_aws_assume_role_raises(self):
-        with pytest.raises(
-            ValidationError, match="weight s3://bucket/path.*CUSTOM_SECRET"
-        ):
-            _minimal_job(
-                weights=[
-                    truss_config.WeightsSource(
-                        source="s3://bucket/path",
-                        mount_location="/weights",
-                        auth=truss_config.WeightsAuth(
-                            auth_method=truss_config.WeightsAuthMethod.AWS_ASSUME_ROLE,
-                            aws_assume_role_arn="arn:aws:iam::123:role/foo",
-                            aws_assume_role_region="us-west-2",
-                            aws_assume_role_external_id_secret_name="my_external_id",
-                        ),
-                    )
-                ]
-            )
+    def test_weights_with_aws_assume_role_are_accepted(self):
+        job = _minimal_job(
+            weights=[
+                truss_config.WeightsSource(
+                    source="s3://bucket/path",
+                    mount_location="/weights",
+                    auth=truss_config.WeightsAuth(
+                        auth_method=truss_config.WeightsAuthMethod.AWS_ASSUME_ROLE,
+                        aws_assume_role_arn="arn:aws:iam::123:role/foo",
+                        aws_assume_role_region="us-west-2",
+                    ),
+                )
+            ]
+        )
+        dumped_auth = job.model_dump()["weights"][0]["auth"]
+        assert dumped_auth["auth_method"] == "AWS_ASSUME_ROLE"
+        assert dumped_auth["aws_assume_role_arn"] == "arn:aws:iam::123:role/foo"
+        assert dumped_auth["aws_assume_role_region"] == "us-west-2"
 
     def test_weights_with_custom_secret_auth_accepted(self):
         job = _minimal_job(

--- a/truss-train/truss_train/__init__.py
+++ b/truss-train/truss_train/__init__.py
@@ -1,7 +1,9 @@
 from truss.base.truss_config import WeightsSource
 from truss_train.definitions import (
     AvailabilityModel,
+    AWSAssumeRoleDockerAuth,
     AWSIAMDockerAuth,
+    AWSOIDCDockerAuth,
     BasetenCheckpoint,
     CacheConfig,
     CheckpointingConfig,
@@ -11,6 +13,7 @@ from truss_train.definitions import (
     DeployCheckpointsRuntime,
     DockerAuth,
     FullCheckpoint,
+    GCPOIDCDockerAuth,
     GCPServiceAccountJSONDockerAuth,
     Image,
     LoadCheckpointConfig,
@@ -44,7 +47,10 @@ __all__ = [
     "LoRADetails",
     "CheckpointingConfig",
     "CacheConfig",
+    "AWSAssumeRoleDockerAuth",
     "AWSIAMDockerAuth",
+    "AWSOIDCDockerAuth",
+    "GCPOIDCDockerAuth",
     "GCPServiceAccountJSONDockerAuth",
     "RegistrySecretDockerAuth",
     "LoadCheckpointConfig",

--- a/truss-train/truss_train/definitions.py
+++ b/truss-train/truss_train/definitions.py
@@ -1,6 +1,6 @@
 import enum
 from abc import ABC
-from typing import Dict, List, Literal, Optional, Union
+from typing import Annotated, Dict, List, Literal, Optional, Union
 
 import pydantic
 from pydantic import ValidationError, model_validator
@@ -208,18 +208,18 @@ class AWSIAMDockerAuth(custom_types.SafeModelNoExtra):
 
 
 class AWSOIDCDockerAuth(custom_types.SafeModelNoExtra):
-    role_arn: str
-    region: str
+    role_arn: Annotated[str, pydantic.StringConstraints(min_length=1)]
+    region: Annotated[str, pydantic.StringConstraints(min_length=1)]
 
 
 class AWSAssumeRoleDockerAuth(custom_types.SafeModelNoExtra):
-    role_arn: str
-    region: str
+    role_arn: Annotated[str, pydantic.StringConstraints(min_length=1)]
+    region: Annotated[str, pydantic.StringConstraints(min_length=1)]
 
 
 class GCPOIDCDockerAuth(custom_types.SafeModelNoExtra):
-    service_account: str
-    workload_identity_provider: str
+    service_account: Annotated[str, pydantic.StringConstraints(min_length=1)]
+    workload_identity_provider: Annotated[str, pydantic.StringConstraints(min_length=1)]
 
 
 class GCPServiceAccountJSONDockerAuth(custom_types.SafeModelNoExtra):
@@ -246,15 +246,20 @@ class DockerAuth(custom_types.SafeModelNoExtra):
     @model_validator(mode="after")
     def validate_auth_fields(self) -> "DockerAuth":
         auth_fields = {
+            truss_config.DockerAuthType.AWS_IAM: "aws_iam_docker_auth",
             truss_config.DockerAuthType.AWS_OIDC: "aws_oidc_docker_auth",
             truss_config.DockerAuthType.AWS_ASSUME_ROLE: (
                 "aws_assume_role_docker_auth"
             ),
             truss_config.DockerAuthType.GCP_OIDC: "gcp_oidc_docker_auth",
+            truss_config.DockerAuthType.GCP_SERVICE_ACCOUNT_JSON: (
+                "gcp_service_account_json_docker_auth"
+            ),
+            truss_config.DockerAuthType.REGISTRY_SECRET: (
+                "registry_secret_docker_auth"
+            ),
         }
-        required_field = auth_fields.get(self.auth_method)
-        if required_field is None:
-            return self
+        required_field = auth_fields[self.auth_method]
 
         if getattr(self, required_field) is None:
             raise ValueError(
@@ -311,10 +316,12 @@ class TrainingJob(custom_types.SafeModelNoExtra):
         for w in self.weights:
             if w.auth is not None:
                 if w.auth.auth_method not in supported_auth_methods:
+                    supported = ", ".join(
+                        sorted(method.value for method in supported_auth_methods)
+                    )
                     raise ValueError(
                         f"weight {w.source}: auth_method {w.auth.auth_method.value} is not "
-                        "supported for training jobs. Supported auth methods: AWS_ASSUME_ROLE, "
-                        "AWS_OIDC, CUSTOM_SECRET, GCP_OIDC."
+                        f"supported for training jobs. Supported auth methods: {supported}."
                     )
         return self
 

--- a/truss-train/truss_train/definitions.py
+++ b/truss-train/truss_train/definitions.py
@@ -207,6 +207,21 @@ class AWSIAMDockerAuth(custom_types.SafeModelNoExtra):
     secret_access_key_secret_ref: SecretReference
 
 
+class AWSOIDCDockerAuth(custom_types.SafeModelNoExtra):
+    role_arn: str
+    region: str
+
+
+class AWSAssumeRoleDockerAuth(custom_types.SafeModelNoExtra):
+    role_arn: str
+    region: str
+
+
+class GCPOIDCDockerAuth(custom_types.SafeModelNoExtra):
+    service_account: str
+    workload_identity_provider: str
+
+
 class GCPServiceAccountJSONDockerAuth(custom_types.SafeModelNoExtra):
     service_account_json_secret_ref: SecretReference
 
@@ -219,10 +234,46 @@ class DockerAuth(custom_types.SafeModelNoExtra):
     auth_method: truss_config.DockerAuthType
     registry: str
     aws_iam_docker_auth: Optional[AWSIAMDockerAuth] = None
+    aws_oidc_docker_auth: Optional[AWSOIDCDockerAuth] = None
+    aws_assume_role_docker_auth: Optional[AWSAssumeRoleDockerAuth] = None
+    gcp_oidc_docker_auth: Optional[GCPOIDCDockerAuth] = None
     gcp_service_account_json_docker_auth: Optional[GCPServiceAccountJSONDockerAuth] = (
         None
     )
     registry_secret_docker_auth: Optional[RegistrySecretDockerAuth] = None
+
+    # model validator enforces the relationship between auth discriminator and its extra nested configuration
+    @model_validator(mode="after")
+    def validate_auth_fields(self) -> "DockerAuth":
+        auth_fields = {
+            truss_config.DockerAuthType.AWS_OIDC: "aws_oidc_docker_auth",
+            truss_config.DockerAuthType.AWS_ASSUME_ROLE: (
+                "aws_assume_role_docker_auth"
+            ),
+            truss_config.DockerAuthType.GCP_OIDC: "gcp_oidc_docker_auth",
+        }
+        required_field = auth_fields.get(self.auth_method)
+        if required_field is None:
+            return self
+
+        if getattr(self, required_field) is None:
+            raise ValueError(
+                f"{required_field} must be provided when auth_method is "
+                f"{self.auth_method.value}"
+            )
+
+        conflicting_fields = [
+            field
+            for field in auth_fields.values()
+            if field != required_field and getattr(self, field) is not None
+        ]
+        if conflicting_fields:
+            raise ValueError(
+                f"{', '.join(conflicting_fields)} cannot be specified when "
+                f"auth_method is {self.auth_method.value}"
+            )
+
+        return self
 
 
 class Image(custom_types.SafeModelNoExtra):
@@ -249,14 +300,21 @@ class TrainingJob(custom_types.SafeModelNoExtra):
     enable_baseten_workdir: bool = True
 
     @model_validator(mode="after")
-    def _validate_weights_auth_only_custom_secret(self) -> "TrainingJob":
-        """Training jobs only support CUSTOM_SECRET with auth_secret_name for weights; OIDC is not supported."""
+    def _validate_weights_auth_method(self) -> "TrainingJob":
+        """Validate that weight authentication is supported for training jobs."""
+        supported_auth_methods = {
+            truss_config.WeightsAuthMethod.CUSTOM_SECRET,
+            truss_config.WeightsAuthMethod.AWS_ASSUME_ROLE,
+            truss_config.WeightsAuthMethod.AWS_OIDC,
+            truss_config.WeightsAuthMethod.GCP_OIDC,
+        }
         for w in self.weights:
             if w.auth is not None:
-                if w.auth.auth_method != truss_config.WeightsAuthMethod.CUSTOM_SECRET:
+                if w.auth.auth_method not in supported_auth_methods:
                     raise ValueError(
-                        f"weight {w.source}: only auth_method CUSTOM_SECRET with auth_secret_name is supported for training jobs. "
-                        "OIDC and assume-role methods (AWS_OIDC, GCP_OIDC, AWS_ASSUME_ROLE) are not supported."
+                        f"weight {w.source}: auth_method {w.auth.auth_method.value} is not "
+                        "supported for training jobs. Supported auth methods: AWS_ASSUME_ROLE, "
+                        "AWS_OIDC, CUSTOM_SECRET, GCP_OIDC."
                     )
         return self
 


### PR DESCRIPTION
## Context
Support `OIDC` and `AWS_ASSUME_ROLE` for training jobs in Truss.

## Content
- Add type defs (needed for extra nested config for each auth type) and DockerAuth validations to ensure `auth_method` matches the extra config (e.g. `auth_method=truss_config.DockerAuthType.AWS_ASSUME_ROLE` -> `aws_assume_role_docker_auth=definitions.AWSAssumeRoleDockerAuth(...)`).
- Update tests to reflect new auth.