### PR TITLE
Print follow-up hints in the invoking CLI's vocabulary

### DIFF
--- a/truss/cli/train_commands.py
+++ b/truss/cli/train_commands.py
@@ -37,7 +37,7 @@ from truss.cli.train.workstation import (
     build_workstation_project,
     copy_workstation_templates,
 )
-from truss.cli.utils import common
+from truss.cli.utils import common, invoking_cli
 from truss.cli.utils.output import console, error_console
 from truss.remote.baseten.core import get_training_job_logs_with_pagination
 from truss.remote.baseten.custom_types import TeamType
@@ -73,13 +73,13 @@ def _print_training_job_success_message(
     if should_print_cache_summary:
         cache_summary_snippet = (
             f"📁 View cache summary via "
-            f"[cyan]'truss train cache summarize \"{project_name}\"'[/cyan]\n"
+            f"[cyan]'{invoking_cli.train_cache_summarize(project_name)}'[/cyan]\n"
         )
     console.print(
         f"🪵 View logs for your job via "
-        f"[cyan]'truss train logs --job-id {job_id} --tail'[/cyan]\n"
+        f"[cyan]'{invoking_cli.train_logs(job_id)}'[/cyan]\n"
         f"🔍 View metrics for your job via "
-        f"[cyan]'truss train metrics --job-id {job_id}'[/cyan]\n"
+        f"[cyan]'{invoking_cli.train_metrics(job_id)}'[/cyan]\n"
         f"{cache_summary_snippet}"
         f"🌐 View job in the UI: {common.format_link(core.status_page_url(remote_provider.remote_url, project_id, job_id))}"
     )
@@ -94,12 +94,12 @@ def _handle_post_create_logic(
     if job_resp.get("current_status") == "TRAINING_JOB_PENDING":
         console.print(
             f"🟡 Training job is pending — waiting for GPU capacity. "
-            f"Check status: 'truss train view --job-id={job_id}'.",
+            f"Check status: '{invoking_cli.train_view(job_id)}'.",
             style="yellow",
         )
     elif job_resp.get("current_status") == "TRAINING_JOB_QUEUED":
         console.print(
-            f"🟢 Training job is queued. You can check the status of your job by running 'truss train view --job-id={job_id}'.",
+            f"🟢 Training job is queued. You can check the status of your job by running '{invoking_cli.train_view(job_id)}'.",
             style="green",
         )
     else:
@@ -1351,14 +1351,14 @@ def workstation(
         f"{ssh_lines}\n"
         f"\n"
         f"If you haven't set up SSH yet, run:\n"
-        f"  [cyan]truss ssh setup[/cyan]\n"
+        f"  [cyan]{invoking_cli.ssh_setup()}[/cyan]\n"
         f"{multi_node_hint}"
         f"\n"
         f"View logs:\n"
-        f"  [cyan]truss train logs --job-id {job_id} --tail[/cyan]\n"
+        f"  [cyan]{invoking_cli.train_logs(job_id)}[/cyan]\n"
         f"\n"
         f"Stop the workstation:\n"
-        f"  [cyan]truss train stop --job-id {job_id}[/cyan]"
+        f"  [cyan]{invoking_cli.train_stop(job_id)}[/cyan]"
     )
 
     if tail:

--- a/truss/cli/utils/invoking_cli.py
+++ b/truss/cli/utils/invoking_cli.py
@@ -1,0 +1,57 @@
+"""Follow-up command vocabulary for truss vs the baseten CLI.
+
+When baseten-cli shells out to truss, it sets BASETEN_TRUSS_INVOKING_CLI=baseten
+so success text names commands the user can actually run. Unset or any other
+value keeps the existing truss wording.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Literal
+
+INVOKING_CLI_ENV = "BASETEN_TRUSS_INVOKING_CLI"
+InvokingCLI = Literal["truss", "baseten"]
+
+
+def invoking_cli() -> InvokingCLI:
+    raw = os.environ.get(INVOKING_CLI_ENV, "").strip().lower()
+    if raw == "baseten":
+        return "baseten"
+    return "truss"
+
+
+def train_logs(job_id: str) -> str:
+    if invoking_cli() == "baseten":
+        return f"baseten train job logs --job-id {job_id} --tail"
+    return f"truss train logs --job-id {job_id} --tail"
+
+
+def train_metrics(job_id: str) -> str:
+    if invoking_cli() == "baseten":
+        return f"baseten train job metrics --job-id {job_id}"
+    return f"truss train metrics --job-id {job_id}"
+
+
+def train_view(job_id: str) -> str:
+    if invoking_cli() == "baseten":
+        return f"baseten train job describe --job-id {job_id}"
+    return f"truss train view --job-id={job_id}"
+
+
+def train_stop(job_id: str) -> str:
+    if invoking_cli() == "baseten":
+        return f"baseten train job stop --job-id {job_id}"
+    return f"truss train stop --job-id {job_id}"
+
+
+def train_cache_summarize(project_name: str) -> str:
+    if invoking_cli() == "baseten":
+        return f"baseten train project cache describe --project {project_name}"
+    return f'truss train cache summarize "{project_name}"'
+
+
+def ssh_setup() -> str:
+    if invoking_cli() == "baseten":
+        return "baseten ssh setup"
+    return "truss ssh setup"

--- a/truss/tests/cli/test_invoking_cli.py
+++ b/truss/tests/cli/test_invoking_cli.py
@@ -1,0 +1,80 @@
+import pytest
+
+from truss.cli.utils import invoking_cli
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        (None, "truss"),
+        ("", "truss"),
+        ("  ", "truss"),
+        ("truss", "truss"),
+        ("other", "truss"),
+        ("baseten", "baseten"),
+        ("BASETEN", "baseten"),
+        ("  Baseten  ", "baseten"),
+    ],
+)
+def test_invoking_cli_reads_env(monkeypatch, raw, expected):
+    if raw is None:
+        monkeypatch.delenv(invoking_cli.INVOKING_CLI_ENV, raising=False)
+    else:
+        monkeypatch.setenv(invoking_cli.INVOKING_CLI_ENV, raw)
+    assert invoking_cli.invoking_cli() == expected
+
+
+@pytest.mark.parametrize(
+    "builder,job_id,truss_cmd,baseten_cmd",
+    [
+        (
+            invoking_cli.train_logs,
+            "job-1",
+            "truss train logs --job-id job-1 --tail",
+            "baseten train job logs --job-id job-1 --tail",
+        ),
+        (
+            invoking_cli.train_metrics,
+            "job-1",
+            "truss train metrics --job-id job-1",
+            "baseten train job metrics --job-id job-1",
+        ),
+        (
+            invoking_cli.train_view,
+            "job-1",
+            "truss train view --job-id=job-1",
+            "baseten train job describe --job-id job-1",
+        ),
+        (
+            invoking_cli.train_stop,
+            "job-1",
+            "truss train stop --job-id job-1",
+            "baseten train job stop --job-id job-1",
+        ),
+    ],
+)
+def test_follow_up_commands(monkeypatch, builder, job_id, truss_cmd, baseten_cmd):
+    monkeypatch.delenv(invoking_cli.INVOKING_CLI_ENV, raising=False)
+    assert builder(job_id) == truss_cmd
+    monkeypatch.setenv(invoking_cli.INVOKING_CLI_ENV, "baseten")
+    assert builder(job_id) == baseten_cmd
+
+
+def test_train_cache_summarize(monkeypatch):
+    monkeypatch.delenv(invoking_cli.INVOKING_CLI_ENV, raising=False)
+    assert (
+        invoking_cli.train_cache_summarize("my-project")
+        == 'truss train cache summarize "my-project"'
+    )
+    monkeypatch.setenv(invoking_cli.INVOKING_CLI_ENV, "baseten")
+    assert (
+        invoking_cli.train_cache_summarize("my-project")
+        == "baseten train project cache describe --project my-project"
+    )
+
+
+def test_ssh_setup(monkeypatch):
+    monkeypatch.delenv(invoking_cli.INVOKING_CLI_ENV, raising=False)
+    assert invoking_cli.ssh_setup() == "truss ssh setup"
+    monkeypatch.setenv(invoking_cli.INVOKING_CLI_ENV, "baseten")
+    assert invoking_cli.ssh_setup() == "baseten ssh setup"


### PR DESCRIPTION
## TLDR

`baseten train push` shells out to truss and prints truss's success text. That text still says `truss train logs --tail`. Users who only have the baseten CLI cannot run those commands.

## What

When `BASETEN_TRUSS_INVOKING_CLI=baseten` is set, follow-up hints use the baseten command tree. Unset or any other value keeps the current `truss ...` wording.

Mapped commands:

| truss | baseten |
| --- | --- |
| `truss train logs --job-id X --tail` | `baseten train job logs --job-id X --tail` |
| `truss train metrics --job-id X` | `baseten train job metrics --job-id X` |
| `truss train view --job-id=X` | `baseten train job describe --job-id X` |
| `truss train stop --job-id X` | `baseten train job stop --job-id X` |
| `truss train cache summarize "proj"` | `baseten train project cache describe --project proj` |
| `truss ssh setup` | `baseten ssh setup` |

Used from `train push` (success, pending, queued) and `train workstation create`. Other `truss ...` strings (SSH proxy errors, log-watcher exit text) are left alone. Those are not the delegated success path.

## Why

Filed as [basetenlabs/baseten-cli#64](https://github.com/basetenlabs/baseten-cli/issues/64). The Go CLI cannot rewrite truss stdout without breaking the passthrough contract. Truss has to pick the wording.

## How

New helper `truss/cli/utils/invoking_cli.py`. Train success/workstation copy calls it. No CLI flag. Env var name matches the existing `BASETEN_TRUSS_*` set.

Follow-up that sets the env var: [basetenlabs/baseten-cli#70](https://github.com/basetenlabs/baseten-cli/pull/70).

## Testing

```
uv run pytest truss/tests/cli/test_invoking_cli.py -v
```

Covers default / empty / unknown / case-insensitive env values, and both vocabularies for each mapped command.

