### PR TITLE
feat(cli): use CUDA 12.9 as the workstation default

### DIFF
--- a/truss/cli/train/workstation.py
+++ b/truss/cli/train/workstation.py
@@ -21,6 +21,7 @@ from truss_train.definitions import (
 )
 
 DEFAULT_BASE_IMAGE = "nvidia/cuda:12.8.1-devel-ubuntu24.04"
+B200_BASE_IMAGE = "nvidia/cuda:12.9.1-devel-ubuntu24.04"
 B300_BASE_IMAGE = "nvidia/cuda:13.0.3-devel-ubuntu24.04"
 SUPPORTED_WORKSTATION_ACCELERATORS = [
     acc.value for acc in Accelerator if acc.value != Accelerator._B10.value
@@ -28,6 +29,8 @@ SUPPORTED_WORKSTATION_ACCELERATORS = [
 
 
 def default_base_image(accelerator: str) -> str:
+    if accelerator == Accelerator.B200.value:
+        return B200_BASE_IMAGE
     if accelerator in (Accelerator.B300.value, Accelerator.GB300.value):
         return B300_BASE_IMAGE
     return DEFAULT_BASE_IMAGE

--- a/truss/cli/train/workstation.py
+++ b/truss/cli/train/workstation.py
@@ -20,8 +20,7 @@ from truss_train.definitions import (
     TrainingProject,
 )
 
-DEFAULT_BASE_IMAGE = "nvidia/cuda:12.8.1-devel-ubuntu24.04"
-B200_BASE_IMAGE = "nvidia/cuda:12.9.1-devel-ubuntu24.04"
+DEFAULT_BASE_IMAGE = "nvidia/cuda:12.9.1-devel-ubuntu24.04"
 B300_BASE_IMAGE = "nvidia/cuda:13.0.3-devel-ubuntu24.04"
 SUPPORTED_WORKSTATION_ACCELERATORS = [
     acc.value for acc in Accelerator if acc.value != Accelerator._B10.value
@@ -29,8 +28,6 @@ SUPPORTED_WORKSTATION_ACCELERATORS = [
 
 
 def default_base_image(accelerator: str) -> str:
-    if accelerator == Accelerator.B200.value:
-        return B200_BASE_IMAGE
     if accelerator in (Accelerator.B300.value, Accelerator.GB300.value):
         return B300_BASE_IMAGE
     return DEFAULT_BASE_IMAGE

--- a/truss/tests/cli/train/test_workstation.py
+++ b/truss/tests/cli/train/test_workstation.py
@@ -12,6 +12,7 @@ from truss.cli.train.workstation import (
     SUPPORTED_WORKSTATION_ACCELERATORS,
     build_workstation_project,
     copy_workstation_templates,
+    default_base_image,
 )
 from truss.remote.baseten.custom_types import TeamType
 from truss.remote.baseten.remote import BasetenRemote
@@ -26,6 +27,19 @@ EXPECTED_TEMPLATE_FILES = [
     "setup_controller.sh",
     "setup_worker.sh",
 ]
+
+
+@pytest.mark.parametrize(
+    ("accelerator", "expected_image"),
+    [
+        ("H100", "nvidia/cuda:12.8.1-devel-ubuntu24.04"),
+        ("B200", "nvidia/cuda:12.9.1-devel-ubuntu24.04"),
+        ("B300", "nvidia/cuda:13.0.3-devel-ubuntu24.04"),
+        ("GB300", "nvidia/cuda:13.0.3-devel-ubuntu24.04"),
+    ],
+)
+def test_default_base_image(accelerator, expected_image):
+    assert default_base_image(accelerator) == expected_image
 
 
 def test_build_workstation_project_defaults():

--- a/truss/tests/cli/train/test_workstation.py
+++ b/truss/tests/cli/train/test_workstation.py
@@ -32,7 +32,7 @@ EXPECTED_TEMPLATE_FILES = [
 @pytest.mark.parametrize(
     ("accelerator", "expected_image"),
     [
-        ("H100", "nvidia/cuda:12.8.1-devel-ubuntu24.04"),
+        ("H100", "nvidia/cuda:12.9.1-devel-ubuntu24.04"),
         ("B200", "nvidia/cuda:12.9.1-devel-ubuntu24.04"),
         ("B300", "nvidia/cuda:13.0.3-devel-ubuntu24.04"),
         ("GB300", "nvidia/cuda:13.0.3-devel-ubuntu24.04"),


### PR DESCRIPTION
## Summary
- change the default training workstation image to `nvidia/cuda:12.9.1-devel-ubuntu24.04`
- retain CUDA 13.0.3 for B300/GB300
- cover default and accelerator-specific image selection with explicit tests

## Why
HybridEP runtime-JIT kernels require CUDA 12.9's CCCL/libcu++ headers. The current workstation default is CUDA 12.8.1, so the pinned DeepEP HybridEP kernel fails to compile at startup on B200.

This also covers the `devbox-up` workflow, which launches boxes through `truss train workstation` without an image override.

Companion production-image PR: https://github.com/basetenlabs/trainers/pull/1262

## Validation
- `uv run ruff format truss/cli/train/workstation.py truss/tests/cli/train/test_workstation.py`
- `uv run ruff check truss/cli/train/workstation.py truss/tests/cli/train/test_workstation.py`
- `uv run pytest truss/tests/cli/train/test_workstation.py -v` (26 passed)