### PR TITLE
feat(cli): add JSON output to `truss train workstation`

### DIFF
--- a/truss/cli/train/workstation.py
+++ b/truss/cli/train/workstation.py
@@ -44,6 +44,26 @@ def copy_workstation_templates(target_dir: Path) -> None:
 
 ORCHESTRATOR_START_COMMANDS = {"slurm": "bash /b10/workspace/setup_slurm.sh"}
 
+SSH_HOSTNAME_SUFFIX = "ssh.baseten.co"
+# Remote name that `truss` (and therefore ~/.trussrc) uses by default.
+DEFAULT_SSH_REMOTE = "baseten"
+
+
+def workstation_ssh_hostnames(
+    job_id: str, node_count: int, remote: Optional[str] = None
+) -> list[str]:
+    """SSH hostnames for a workstation's nodes, ordered by node rank.
+
+    The remote segment is optional in the hostname grammar that
+    `truss.cli.proxy_command` parses. It is only needed to disambiguate when
+    ~/.trussrc holds several remotes, so it is omitted for the default remote to
+    keep the common case short.
+    """
+    host_suffix = SSH_HOSTNAME_SUFFIX
+    if remote and remote != DEFAULT_SSH_REMOTE:
+        host_suffix = f"{remote}.{SSH_HOSTNAME_SUFFIX}"
+    return [f"training-job-{job_id}-{rank}.{host_suffix}" for rank in range(node_count)]
+
 
 def build_workstation_project(
     accelerator: str,

--- a/truss/cli/train_commands.py
+++ b/truss/cli/train_commands.py
@@ -36,9 +36,10 @@ from truss.cli.train.workstation import (
     SUPPORTED_WORKSTATION_ACCELERATORS,
     build_workstation_project,
     copy_workstation_templates,
+    workstation_ssh_hostnames,
 )
 from truss.cli.utils import common
-from truss.cli.utils.output import console, error_console
+from truss.cli.utils.output import console, error_console, json_command
 from truss.remote.baseten.core import get_training_job_logs_with_pagination
 from truss.remote.baseten.custom_types import TeamType
 from truss.remote.baseten.remote import BasetenRemote
@@ -1182,6 +1183,74 @@ def update_capacity(
     )
 
 
+def _print_workstation_text(job_id: str, hostnames: list[str], node_count: int) -> None:
+    ssh_lines = "\n".join(
+        f"  [cyan]ssh {hostname}[/cyan]"
+        + (" (leader)" if node_count > 1 and rank == 0 else "")
+        for rank, hostname in enumerate(hostnames)
+    )
+
+    multi_node_hint = ""
+    if node_count > 1:
+        multi_node_hint = (
+            "\n"
+            "Multi-node env vars available on each node:\n"
+            "  BT_LEADER_ADDR, BT_NODE_RANK, BT_GROUP_SIZE\n"
+        )
+
+    console.print(
+        f"\n[green]Workstation created![/green]\n"
+        f"\n"
+        f"Once the job is running, SSH in with:\n"
+        f"{ssh_lines}\n"
+        f"\n"
+        f"If you haven't set up SSH yet, run:\n"
+        f"  [cyan]truss ssh setup[/cyan]\n"
+        f"{multi_node_hint}"
+        f"\n"
+        f"View logs:\n"
+        f"  [cyan]truss train logs --job-id {job_id} --tail[/cyan]\n"
+        f"\n"
+        f"Stop the workstation:\n"
+        f"  [cyan]truss train stop --job-id {job_id}[/cyan]"
+    )
+
+
+def _print_workstation_json(
+    *,
+    job_resp: dict,
+    hostnames: list[str],
+    accelerator: str,
+    gpu_count: int,
+    node_count: int,
+    orchestrator: str,
+) -> None:
+    """Emit the workstation's node addresses as JSON on stdout.
+
+    Note that the nodes are not reachable yet when this is printed: the job is
+    queued, not running. Callers should poll the job's status (e.g.
+    `truss train view --job-id <id>`) before connecting.
+    """
+    project = job_resp.get("training_project") or {}
+    output = {
+        "job_id": job_resp["id"],
+        "project": {"id": project.get("id"), "name": project.get("name")},
+        "accelerator": accelerator,
+        "gpu_count": gpu_count,
+        "node_count": node_count,
+        # Only meaningful for multi-node; single-node workstations just sleep.
+        "orchestrator": orchestrator if node_count > 1 else None,
+        "nodes": [
+            {"rank": rank, "hostname": hostname, "is_leader": rank == 0}
+            for rank, hostname in enumerate(hostnames)
+        ],
+        "job": job_resp,
+    }
+    # Flushed explicitly: with --tail the process keeps streaming logs after
+    # this, and a block-buffered pipe would otherwise withhold the payload.
+    print(json.dumps(output, indent=2), flush=True)
+
+
 @train.command(name="workstation")
 @click.option(
     "--accelerator",
@@ -1248,7 +1317,19 @@ def update_capacity(
     help="Team name for the workstation project",
 )
 @click.option("--tail", is_flag=True, help="Tail for status + logs after push.")
+@click.option(
+    "-o",
+    "--output-format",
+    "output_format",
+    type=click.Choice(["text", "json"], case_sensitive=False),
+    default="text",
+    help=(
+        "Output format. 'json' emits structured JSON to stdout and all other "
+        "output (progress, logs) to stderr."
+    ),
+)
 @common.common_options()
+@json_command
 def workstation(
     accelerator: str,
     gpu_count: Optional[int],
@@ -1263,6 +1344,7 @@ def workstation(
     remote: Optional[str],
     provided_team_name: Optional[str],
     tail: bool,
+    output_format: str,
 ):
     """Spin up an SSH workstation on Baseten training infrastructure."""
     import tempfile
@@ -1290,6 +1372,12 @@ def workstation(
     remote_provider: BasetenRemote = cast(
         BasetenRemote, RemoteFactory.create(remote=remote)
     )
+    if output_format == "json":
+        # The REST client prints 4xx messages straight to stdout, which would
+        # corrupt the JSON stream. Let them surface as exceptions instead, so
+        # json_command can render them as a structured error.
+        remote_provider.api.suppress_error_print = True
+
     # Use config team as fallback if --team not provided
     effective_team_name = provided_team_name or RemoteFactory.get_remote_team(remote)
     _, team_id = _resolve_team_name(
@@ -1328,38 +1416,19 @@ def workstation(
         )
 
     job_id = job_resp["id"]
-    ssh_lines = f"  [cyan]ssh training-job-{job_id}-0.ssh.baseten.co[/cyan]"
-    if node_count > 1:
-        ssh_lines += " (leader)"
-        for i in range(1, node_count):
-            ssh_lines += (
-                f"\n  [cyan]ssh training-job-{job_id}-{i}.ssh.baseten.co[/cyan]"
-            )
+    hostnames = workstation_ssh_hostnames(job_id, node_count, remote=remote)
 
-    multi_node_hint = ""
-    if node_count > 1:
-        multi_node_hint = (
-            "\n"
-            "Multi-node env vars available on each node:\n"
-            "  BT_LEADER_ADDR, BT_NODE_RANK, BT_GROUP_SIZE\n"
+    if output_format == "json":
+        _print_workstation_json(
+            job_resp=job_resp,
+            hostnames=hostnames,
+            accelerator=accelerator,
+            gpu_count=gpu_count,
+            node_count=node_count,
+            orchestrator=orchestrator,
         )
-
-    console.print(
-        f"\n[green]Workstation created![/green]\n"
-        f"\n"
-        f"Once the job is running, SSH in with:\n"
-        f"{ssh_lines}\n"
-        f"\n"
-        f"If you haven't set up SSH yet, run:\n"
-        f"  [cyan]truss ssh setup[/cyan]\n"
-        f"{multi_node_hint}"
-        f"\n"
-        f"View logs:\n"
-        f"  [cyan]truss train logs --job-id {job_id} --tail[/cyan]\n"
-        f"\n"
-        f"Stop the workstation:\n"
-        f"  [cyan]truss train stop --job-id {job_id}[/cyan]"
-    )
+    else:
+        _print_workstation_text(job_id, hostnames, node_count)
 
     if tail:
         project_resp_id = job_resp["training_project"]["id"]

--- a/truss/tests/cli/train/test_workstation.py
+++ b/truss/tests/cli/train/test_workstation.py
@@ -1,3 +1,4 @@
+import json
 import os
 import tempfile
 from pathlib import Path
@@ -13,6 +14,7 @@ from truss.cli.train.workstation import (
     build_workstation_project,
     copy_workstation_templates,
     default_base_image,
+    workstation_ssh_hostnames,
 )
 from truss.remote.baseten.custom_types import TeamType
 from truss.remote.baseten.remote import BasetenRemote
@@ -103,6 +105,29 @@ def test_workstation_template_dir_exists():
         assert (WORKSTATION_TEMPLATE_DIR / name).exists(), f"Missing template {name}"
 
 
+@pytest.mark.parametrize("remote", [None, "baseten"])
+def test_workstation_ssh_hostnames_omits_default_remote(remote):
+    assert workstation_ssh_hostnames("job123", 1, remote=remote) == [
+        "training-job-job123-0.ssh.baseten.co"
+    ]
+
+
+def test_workstation_ssh_hostnames_includes_non_default_remote():
+    # Needed so the proxy command resolves the right ~/.trussrc entry when the
+    # user has several remotes configured.
+    assert workstation_ssh_hostnames("job123", 1, remote="dev") == [
+        "training-job-job123-0.dev.ssh.baseten.co"
+    ]
+
+
+def test_workstation_ssh_hostnames_one_per_node_in_rank_order():
+    assert workstation_ssh_hostnames("job123", 3) == [
+        "training-job-job123-0.ssh.baseten.co",
+        "training-job-job123-1.ssh.baseten.co",
+        "training-job-job123-2.ssh.baseten.co",
+    ]
+
+
 class TestWorkstationTeamResolution:
     @staticmethod
     def _setup_mock_remote(teams, existing_projects=None):
@@ -178,3 +203,152 @@ class TestWorkstationTeamResolution:
         assert result.exit_code == 1
         assert "does not exist" in result.output
         mock_push.assert_not_called()
+
+
+class TestWorkstationJsonOutput:
+    PUSH_RESPONSE = {
+        "id": "job123",
+        "training_project": {"id": "proj123", "name": "workstation-H100"},
+    }
+
+    @staticmethod
+    def _setup_mock_remote():
+        mock_remote = Mock(spec=BasetenRemote)
+        mock_api = Mock()
+        mock_remote.api = mock_api
+        mock_api.get_teams.return_value = {
+            "team-a": TeamType(id="team1", name="team-a", default=True)
+        }
+        mock_api.list_training_projects.return_value = []
+        return mock_remote
+
+    @staticmethod
+    def _invoke(runner, *extra_args):
+        return runner.invoke(
+            truss_cli,
+            [
+                "train",
+                "workstation",
+                "--remote",
+                "test_remote",
+                "--output-format",
+                "json",
+                *extra_args,
+            ],
+        )
+
+    @patch("truss_train.public_api.push")
+    @patch("truss.cli.train_commands.RemoteFactory.get_remote_team")
+    @patch("truss.cli.train_commands.RemoteFactory.create")
+    def test_json_output_carries_node_addresses(
+        self, mock_remote_factory, mock_get_remote_team, mock_push
+    ):
+        mock_remote_factory.return_value = self._setup_mock_remote()
+        mock_get_remote_team.return_value = None
+        mock_push.return_value = self.PUSH_RESPONSE
+
+        result = self._invoke(CliRunner())
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.stdout)
+        assert payload["job_id"] == "job123"
+        assert payload["project"] == {"id": "proj123", "name": "workstation-H100"}
+        assert payload["accelerator"] == "H100"
+        assert payload["gpu_count"] == 1
+        assert payload["node_count"] == 1
+        assert payload["orchestrator"] is None
+        assert payload["nodes"] == [
+            {
+                "rank": 0,
+                "hostname": "training-job-job123-0.test_remote.ssh.baseten.co",
+                "is_leader": True,
+            }
+        ]
+        assert payload["job"] == self.PUSH_RESPONSE
+
+    @patch("truss_train.public_api.push")
+    @patch("truss.cli.train_commands.RemoteFactory.get_remote_team")
+    @patch("truss.cli.train_commands.RemoteFactory.create")
+    def test_json_output_multi_node(
+        self, mock_remote_factory, mock_get_remote_team, mock_push
+    ):
+        mock_remote_factory.return_value = self._setup_mock_remote()
+        mock_get_remote_team.return_value = None
+        mock_push.return_value = self.PUSH_RESPONSE
+
+        result = self._invoke(CliRunner(), "--node-count", "2")
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.stdout)
+        assert payload["node_count"] == 2
+        assert payload["gpu_count"] == 8
+        assert payload["orchestrator"] == "slurm"
+        assert [node["rank"] for node in payload["nodes"]] == [0, 1]
+        assert [node["is_leader"] for node in payload["nodes"]] == [True, False]
+
+    @patch("truss_train.public_api.push")
+    @patch("truss.cli.train_commands.RemoteFactory.get_remote_team")
+    @patch("truss.cli.train_commands.RemoteFactory.create")
+    def test_json_mode_keeps_progress_output_off_stdout(
+        self, mock_remote_factory, mock_get_remote_team, mock_push
+    ):
+        mock_remote_factory.return_value = self._setup_mock_remote()
+        mock_get_remote_team.return_value = None
+        mock_push.return_value = self.PUSH_RESPONSE
+
+        result = self._invoke(CliRunner())
+
+        assert result.exit_code == 0, result.output
+        # stdout parses as a single JSON document, nothing else interleaved.
+        json.loads(result.stdout)
+        assert "Launching workstation" in result.stderr
+
+    @patch("truss_train.public_api.push")
+    @patch("truss.cli.train_commands.RemoteFactory.get_remote_team")
+    @patch("truss.cli.train_commands.RemoteFactory.create")
+    def test_json_mode_suppresses_rest_client_error_print(
+        self, mock_remote_factory, mock_get_remote_team, mock_push
+    ):
+        mock_remote = self._setup_mock_remote()
+        mock_remote_factory.return_value = mock_remote
+        mock_get_remote_team.return_value = None
+        mock_push.return_value = self.PUSH_RESPONSE
+
+        result = self._invoke(CliRunner())
+
+        assert result.exit_code == 0, result.output
+        # Otherwise 4xx messages land on stdout and corrupt the JSON stream.
+        assert mock_remote.api.suppress_error_print is True
+
+    @patch("truss_train.public_api.push")
+    @patch("truss.cli.train_commands.RemoteFactory.get_remote_team")
+    @patch("truss.cli.train_commands.RemoteFactory.create")
+    def test_json_mode_reports_failures_as_structured_error(
+        self, mock_remote_factory, mock_get_remote_team, mock_push
+    ):
+        mock_remote_factory.return_value = self._setup_mock_remote()
+        mock_get_remote_team.return_value = None
+        mock_push.side_effect = RuntimeError("no capacity")
+
+        result = self._invoke(CliRunner())
+
+        assert result.exit_code == 1
+        assert json.loads(result.stdout) == {"error": {"message": "no capacity"}}
+
+    @patch("truss_train.public_api.push")
+    @patch("truss.cli.train_commands.RemoteFactory.get_remote_team")
+    @patch("truss.cli.train_commands.RemoteFactory.create")
+    def test_text_mode_is_unchanged_by_default(
+        self, mock_remote_factory, mock_get_remote_team, mock_push
+    ):
+        mock_remote_factory.return_value = self._setup_mock_remote()
+        mock_get_remote_team.return_value = None
+        mock_push.return_value = self.PUSH_RESPONSE
+
+        result = CliRunner().invoke(
+            truss_cli, ["train", "workstation", "--remote", "test_remote"]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Workstation created!" in result.output
+        assert "ssh training-job-job123-0.test_remote.ssh.baseten.co" in result.output


### PR DESCRIPTION
## :rocket: What

Adds `-o/--output-format json` to `truss train workstation`, so scripts can read the provisioned node SSH addresses programmatically instead of scraping the rich-formatted text block.

```console
$ truss train workstation --node-count 2 -o json
{
  "job_id": "abc1234",
  "project": {"id": "proj123", "name": "workstation-H100"},
  "accelerator": "H100",
  "gpu_count": 8,
  "node_count": 2,
  "orchestrator": "slurm",
  "nodes": [
    {"rank": 0, "hostname": "training-job-abc1234-0.ssh.baseten.co", "is_leader": true},
    {"rank": 1, "hostname": "training-job-abc1234-1.ssh.baseten.co", "is_leader": false}
  ],
  "job": { ... raw push response ... }
}
```

Text output is unchanged apart from the remote-segment fix noted below.

## :computer: How

Follows the `@json_command` pattern already used by `truss push` (`truss/cli/cli.py:748`) rather than the read-only commands' `cli-table|csv|json` branch, because this command mutates state and emits output it doesn't own (`truss_train/deployment.py` push progress, `--tail` log streaming). The flag is spelled `-o/--output-format` to match the rest of the `train` group; `json_command` keys off the `output_format` destination, so the two compose.

Three details worth review:

- **`suppress_error_print`.** `RestAPIClient._handle_error` prints 4xx messages with a bare `print()` to stdout, which `console_to_stderr()` cannot redirect. Both `upsert_training_project` and `create_training_job` go through that client, so JSON mode sets `suppress_error_print = True` and lets the error surface as an exception for `json_command` to render — same as `truss push` does.

- **JSON is printed before `--tail`, with an explicit flush.** `truss push --watch --output json` prints its payload *after* watch mode returns. That ordering doesn't work here: the addresses are the point of the command and tailing may never end. Printing first means the payload can sit in a block-buffered pipe indefinitely, hence `flush=True`.

- **Hostnames now include the remote segment for non-default remotes.** Construction moved into `workstation_ssh_hostnames()` so text and JSON render from one list. The old inline string always omitted the remote, so a workstation launched with `--remote dev` printed an address that `resolve_remote()` can only resolve if the user has exactly one remote or has stamped `dev` as their default — otherwise it errors out. The segment is still omitted for the default `baseten` remote to keep the common case short.

The payload also carries the raw push response under `job`, so consumers aren't blocked on us adding fields.

Note the nodes are not reachable when the JSON is emitted — the job is queued, not running. Callers still need to poll status before connecting. Happy to add a `--wait-for-running` flag in a follow-up if scripts end up reimplementing that poll.

## :microscope: Testing

`uv run pytest truss/tests/cli -q` → 591 passed.

New tests in `truss/tests/cli/train/test_workstation.py`:
- `workstation_ssh_hostnames()` unit tests: default remote omitted, non-default remote included, one hostname per node in rank order.
- Single-node and multi-node JSON payloads (ranks, `is_leader`, `orchestrator` null for single-node, raw `job` passthrough).
- stdout parses as one JSON document with progress output confirmed on stderr.
- `suppress_error_print` set in JSON mode.
- A failing push yields `{"error": {"message": ...}}` on stdout with exit 1.
- Text mode output unchanged by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
