### PR TITLE
Fix msgpack round-trip of UTC datetimes on Python 3.9/3.10

### DIFF
--- a/truss/templates/shared/serialization.py
+++ b/truss/templates/shared/serialization.py
@@ -33,10 +33,7 @@ def _truss_msgpack_encoder(
     chain: Optional[Callable] = None,
 ) -> dict:
     if isinstance(obj, datetime):
-        r = obj.isoformat()
-        if r.endswith("+00:00"):
-            r = r[:-6] + "Z"
-        return {b"__dt_datetime_iso__": True, b"data": r}
+        return {b"__dt_datetime_iso__": True, b"data": obj.isoformat()}
     elif isinstance(obj, date):
         r = obj.isoformat()
         return {b"__dt_date_iso__": True, b"data": r}
@@ -61,7 +58,9 @@ def _truss_msgpack_encoder(
 def _truss_msgpack_decoder(obj: Any, chain=None):
     try:
         if b"__dt_datetime_iso__" in obj:
-            return datetime.fromisoformat(obj[b"data"])
+            # Older servers spell UTC as "Z", which `fromisoformat` only
+            # accepts from Python 3.11 on.
+            return datetime.fromisoformat(obj[b"data"].replace("Z", "+00:00"))
         elif b"__dt_date_iso__" in obj:
             return date.fromisoformat(obj[b"data"])
         elif b"__dt_time_iso__" in obj:

--- a/truss/tests/templates/core/server/test_serialization.py
+++ b/truss/tests/templates/core/server/test_serialization.py
@@ -1,0 +1,27 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from truss.templates.shared import serialization
+
+
+@pytest.mark.parametrize(
+    "dt",
+    [
+        datetime(2024, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+        datetime(2024, 1, 2, 3, 4, 5, tzinfo=timezone(timedelta(hours=2))),
+        datetime(2024, 1, 2, 3, 4, 5, 123456),
+    ],
+)
+def test_msgpack_datetime_roundtrip(dt):
+    payload = serialization.truss_msgpack_serialize({"ts": dt})
+    assert serialization.truss_msgpack_deserialize(payload) == {"ts": dt}
+
+
+def test_msgpack_decodes_legacy_utc_z_suffix():
+    # Older truss servers spell a UTC offset as "Z", which
+    # `datetime.fromisoformat` only accepts from Python 3.11 on.
+    decoded = serialization._truss_msgpack_decoder(
+        {b"__dt_datetime_iso__": True, b"data": "2024-01-02T03:04:05Z"}
+    )
+    assert decoded == datetime(2024, 1, 2, 3, 4, 5, tzinfo=timezone.utc)


### PR DESCRIPTION
## :rocket: What

A UTC-aware `datetime` sent or returned through the binary (msgpack) path fails to decode when the receiving side runs Python 3.9 or 3.10:

    ValueError: Invalid isoformat string: '2024-01-02T03:04:05Z'

On the server this surfaces as a 500 ("Unhandled exception: ValueError") for a valid request; on the client `TrussHandle.predict(..., binary=True)` and chains stubs raise. Datetimes with any other offset, and naive datetimes, are unaffected.

## :computer: How

`_truss_msgpack_encoder` rewrote a `+00:00` offset to `Z` (carried over from Django's JSON encoder, where it exists for JavaScript consumers), but `_truss_msgpack_decoder` reads it back with `datetime.fromisoformat`, which only accepts `Z` from Python 3.11 on. Nothing but this decoder reads the msgpack datetime field.

- Encoder now emits `isoformat()` unchanged, which every supported Python parses.
- Decoder normalizes a trailing `Z` to `+00:00`, so payloads from already deployed servers still decode on 3.9/3.10 clients.

## :microscope: Testing

Added `truss/tests/templates/core/server/test_serialization.py`: msgpack round-trip of UTC, +02:00 and naive datetimes, plus decoding of the legacy `Z` form. Before the fix, on Python 3.10:

    FAILED ...::test_msgpack_datetime_roundtrip[dt0]
    FAILED ...::test_msgpack_decodes_legacy_utc_z_suffix
    2 failed, 2 passed

After: 4 passed on 3.9, 3.10, 3.11 and 3.13. `pre-commit run --files` (ruff, ruff format, mypy) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011vZKTbRaDh8FuXSbVpQomD
