### PR TITLE
fix(chains): decode str streams across chunk boundaries

### DIFF
--- a/truss-chains/tests/test_remote_chainlet.py
+++ b/truss-chains/tests/test_remote_chainlet.py
@@ -3,10 +3,13 @@ import logging
 import re
 import threading
 import time
+from collections.abc import AsyncIterator
 
 import pytest
 
 import truss_chains as chains
+from truss_chains import framework
+from truss_chains.deployment import code_gen
 
 
 @pytest.fixture
@@ -160,3 +163,64 @@ async def test_no_waiting_logging_async(stub_session, caplog):
     logs = [r.message for r in caplog.records]
 
     assert any("No queueing" in m for m in logs), logs
+
+
+def _generated_stub_cls(chainlet_cls: type) -> type:
+    """Builds the stub class that codegen emits for callers of `chainlet_cls`."""
+    framework.raise_validation_errors()
+    source = code_gen._gen_stub_src(framework.get_descriptor(chainlet_cls))
+    namespace: dict = {}
+    exec("\n".join(sorted(source.imports)) + "\n" + source.src, namespace)
+    return namespace[chainlet_cls.__name__]
+
+
+def _make_stub(stub_cls: type, wire_chunks: list[bytes]) -> chains.StubBase:
+    stub = stub_cls(
+        service_descriptor=chains.DeployedServiceDescriptor(
+            name=stub_cls.__name__,
+            display_name=stub_cls.__name__,
+            predict_url="dummy-URL",
+            options=chains.RPCOptions(),
+        ),
+        api_key="dummy-API-key",
+    )
+
+    async def fake_stream(*_args, **_kwargs):
+        async def chunks():
+            for chunk in wire_chunks:
+                yield chunk
+
+        return chunks()
+
+    stub.predict_async_stream = fake_stream
+    return stub
+
+
+@pytest.mark.asyncio
+async def test_str_stream_stub_decodes_utf8_split_across_chunks():
+    class _Utf8StreamChainlet(chains.ChainletBase):
+        async def run_remote(self) -> AsyncIterator[str]:
+            yield "héllo 🌍"
+
+    payload = "héllo 🌍".encode()
+    # Cut inside the 4-byte emoji, as TCP segmentation might.
+    wire_chunks = [payload[:-2], payload[-2:]]
+    stub = _make_stub(_generated_stub_cls(_Utf8StreamChainlet), wire_chunks)
+
+    received = [text async for text in stub.run_remote()]
+
+    assert "".join(received) == "héllo 🌍"
+    assert "" not in received
+
+
+@pytest.mark.asyncio
+async def test_str_stream_stub_raises_on_truncated_utf8():
+    class _TruncatedUtf8StreamChainlet(chains.ChainletBase):
+        async def run_remote(self) -> AsyncIterator[str]:
+            yield "🌍"
+
+    wire_chunks = ["🌍".encode()[:-1]]
+    stub = _make_stub(_generated_stub_cls(_TruncatedUtf8StreamChainlet), wire_chunks)
+
+    with pytest.raises(UnicodeDecodeError):
+        [text async for text in stub.run_remote()]

--- a/truss-chains/truss_chains/deployment/code_gen.py
+++ b/truss-chains/truss_chains/deployment/code_gen.py
@@ -312,13 +312,13 @@ def _stub_endpoint_body_src(
 
     else:
         if endpoint.is_async:
-            parts.append(
-                f"async for data in await self.predict_async_stream({inputs}):"
-            )
+            stream_src = f"await self.predict_async_stream({inputs})"
             if endpoint.streaming_type.is_string:
-                parts.append(_indent("yield data.decode()"))
-            else:
-                parts.append(_indent("yield data"))
+                # Network chunks can split multi-byte UTF-8 characters.
+                imports.add("from truss_chains.remote_chainlet import utils")
+                stream_src = f"utils.decode_str_stream({stream_src})"
+            parts.append(f"async for data in {stream_src}:")
+            parts.append(_indent("yield data"))
         else:
             raise NotImplementedError(
                 "`Streaming endpoints (containing `yield` statements) are only "

--- a/truss-chains/truss_chains/remote_chainlet/utils.py
+++ b/truss-chains/truss_chains/remote_chainlet/utils.py
@@ -1,5 +1,6 @@
 import asyncio
 import builtins
+import codecs
 import collections
 import contextlib
 import contextvars
@@ -455,6 +456,15 @@ def pydantic_set_field_dict(obj: pydantic.BaseModel) -> dict[str, pydantic.BaseM
 
     """
     return {name: getattr(obj, name) for name in obj.model_fields_set}
+
+
+async def decode_str_stream(stream: AsyncIterator[bytes]) -> AsyncIterator[str]:
+    """Decodes a UTF-8 byte stream whose chunk boundaries may split a character."""
+    decoder = codecs.getincrementaldecoder("utf-8")()
+    async for data in stream:
+        if text := decoder.decode(data):
+            yield text
+    decoder.decode(b"", final=True)  # Raises on a truncated trailing character.
 
 
 # Error Propagation Utils. #############################################################


### PR DESCRIPTION
## :rocket: What

The stub that chains code-gen emits for a dependency with an `AsyncIterator[str]` endpoint does `yield data.decode()` on every chunk from `predict_async_stream`. Those chunks come from aiohttp's `iter_any()`, which yields whatever bytes arrived on the socket, so a multi-byte UTF-8 character (accents, CJK, emoji) can be split between two chunks. Decoding each chunk on its own then raises in the calling chainlet and kills the stream:

    UnicodeDecodeError: 'utf-8' codec can't decode bytes in position 7-8: unexpected end of data

`AsyncIterator[bytes]` stubs are unaffected. This is the chains-side twin of #2551, which fixed the same split-codepoint decode on the server's gathered-generator path.

## :computer: How

- `remote_chainlet/utils.py`: add `decode_str_stream`, an incremental UTF-8 decoder (`codecs.getincrementaldecoder`) that carries a partial character over to the next chunk, skips empty output, and still raises on a truncated trailing character.
- `deployment/code_gen.py`: the generated stub now iterates `utils.decode_str_stream(await self.predict_async_stream(...))` and yields the text as-is. `utils` is already imported by every generated `model.py`.

Generated code before / after:

    async for data in await self.predict_async_stream({}):
        yield data.decode()

    async for data in utils.decode_str_stream(await self.predict_async_stream({})):
        yield data

## :microscope: Testing

- `test_str_stream_stub_decodes_utf8_split_across_chunks`: generates the stub for an `AsyncIterator[str]` chainlet via `code_gen._gen_stub_src`, feeds it `"héllo 🌍"` cut inside the emoji, asserts the joined text and that no empty chunks are yielded. Fails on `main` with the `UnicodeDecodeError` above, passes here.
- `test_str_stream_stub_raises_on_truncated_utf8`: a stream ending mid-character still raises `UnicodeDecodeError` (no silent data loss).
- `uv run pytest truss-chains/tests --ignore=truss-chains/tests/test_e2e.py`: 174 passed, 1 skipped. `pre-commit run --files` (ruff, ruff format, mypy) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011vZKTbRaDh8FuXSbVpQomD
