### PR TITLE
fix(trt-llm): Add LoRA cache runtime settings

### DIFF
--- a/truss/base/trt_llm_config.py
+++ b/truss/base/trt_llm_config.py
@@ -203,6 +203,22 @@ class TrussTRTLLMRuntimeConfiguration(PydanticTrTBaseModel):
     kv_cache_host_memory_bytes: Optional[Annotated[int, Field(strict=True, ge=1)]] = (
         None
     )
+    # maximum LoRA rank supported by the cache
+    lora_cache_max_adapter_size: Optional[Annotated[int, Field(strict=True, ge=1)]] = (
+        None
+    )
+    # LoRA rank used to size cache pages
+    lora_cache_optimal_adapter_size: Optional[
+        Annotated[int, Field(strict=True, ge=1)]
+    ] = None
+    # fraction of GPU memory available after engine load reserved for the LoRA cache
+    lora_cache_gpu_memory_fraction: Optional[
+        Annotated[float, Field(strict=True, gt=0, le=1)]
+    ] = None
+    # host memory reserved for the LoRA cache (in bytes)
+    lora_cache_host_memory_bytes: Optional[Annotated[int, Field(strict=True, ge=1)]] = (
+        None
+    )
     # wheter to
     enable_chunked_context: bool = True
     batch_scheduler_policy: TrussTRTLLMBatchSchedulerPolicy = (
@@ -220,6 +236,19 @@ class TrussTRTLLMRuntimeConfiguration(PydanticTrTBaseModel):
     webserver_default_route: Optional[
         Literal["/v1/embeddings", "/rerank", "/predict", "/predict_tokens"]
     ] = None
+
+    @model_validator(mode="after")
+    def validate_lora_cache_adapter_sizes(self):
+        if (
+            self.lora_cache_max_adapter_size is not None
+            and self.lora_cache_optimal_adapter_size is not None
+            and self.lora_cache_optimal_adapter_size > self.lora_cache_max_adapter_size
+        ):
+            raise ValueError(
+                "lora_cache_optimal_adapter_size cannot be greater than "
+                "lora_cache_max_adapter_size"
+            )
+        return self
 
 
 class TRTLLMRuntimeConfigurationV2(PydanticTrTBaseModel):
@@ -313,6 +342,26 @@ class TrussTRTLLMBuildConfiguration(PydanticTrTBaseModel):
     # for v2, skip the build step and use a engine that you e.g. provider otherwise
     # e.g. via model_cache.
     skip_build_result: bool = False
+
+    @model_validator(mode="before")
+    @classmethod
+    def reject_runtime_lora_cache_fields(cls, data):
+        if isinstance(data, dict):
+            misplaced_fields = sorted(
+                {
+                    "lora_cache_max_adapter_size",
+                    "lora_cache_optimal_adapter_size",
+                    "lora_cache_gpu_memory_fraction",
+                    "lora_cache_host_memory_bytes",
+                }
+                & data.keys()
+            )
+            if misplaced_fields:
+                raise ValueError(
+                    f"{', '.join(misplaced_fields)} must be configured under "
+                    "trt_llm.runtime, not trt_llm.build"
+                )
+        return data
 
     def __init__(self, **data):
         super().__init__(**data)

--- a/truss/config.schema.json
+++ b/truss/config.schema.json
@@ -1149,6 +1149,10 @@
           "default": {
             "kv_cache_free_gpu_mem_fraction": 0.9,
             "kv_cache_host_memory_bytes": null,
+            "lora_cache_max_adapter_size": null,
+            "lora_cache_optimal_adapter_size": null,
+            "lora_cache_gpu_memory_fraction": null,
+            "lora_cache_host_memory_bytes": null,
             "enable_chunked_context": true,
             "batch_scheduler_policy": "guaranteed_no_evict",
             "request_default_max_tokens": null,
@@ -1360,6 +1364,10 @@
           "default": {
             "kv_cache_free_gpu_mem_fraction": 0.9,
             "kv_cache_host_memory_bytes": null,
+            "lora_cache_max_adapter_size": null,
+            "lora_cache_optimal_adapter_size": null,
+            "lora_cache_gpu_memory_fraction": null,
+            "lora_cache_host_memory_bytes": null,
             "enable_chunked_context": true,
             "batch_scheduler_policy": "guaranteed_no_evict",
             "request_default_max_tokens": null,
@@ -1706,6 +1714,59 @@
           ],
           "default": null,
           "title": "Kv Cache Host Memory Bytes"
+        },
+        "lora_cache_max_adapter_size": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Lora Cache Max Adapter Size"
+        },
+        "lora_cache_optimal_adapter_size": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Lora Cache Optimal Adapter Size"
+        },
+        "lora_cache_gpu_memory_fraction": {
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "maximum": 1,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Lora Cache Gpu Memory Fraction"
+        },
+        "lora_cache_host_memory_bytes": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Lora Cache Host Memory Bytes"
         },
         "enable_chunked_context": {
           "default": true,

--- a/truss/tests/cli/train/test_workstation.py
+++ b/truss/tests/cli/train/test_workstation.py
@@ -1,3 +1,4 @@
+import inspect
 import json
 import os
 import tempfile
@@ -223,8 +224,12 @@ class TestWorkstationJsonOutput:
         return mock_remote
 
     @staticmethod
-    def _invoke(runner, *extra_args):
-        return runner.invoke(
+    def _invoke(*extra_args):
+        runner_kwargs = {}
+        if "mix_stderr" in inspect.signature(CliRunner.__init__).parameters:
+            runner_kwargs["mix_stderr"] = False
+
+        return CliRunner(**runner_kwargs).invoke(
             truss_cli,
             [
                 "train",
@@ -247,7 +252,7 @@ class TestWorkstationJsonOutput:
         mock_get_remote_team.return_value = None
         mock_push.return_value = self.PUSH_RESPONSE
 
-        result = self._invoke(CliRunner())
+        result = self._invoke()
 
         assert result.exit_code == 0, result.output
         payload = json.loads(result.stdout)
@@ -276,7 +281,7 @@ class TestWorkstationJsonOutput:
         mock_get_remote_team.return_value = None
         mock_push.return_value = self.PUSH_RESPONSE
 
-        result = self._invoke(CliRunner(), "--node-count", "2")
+        result = self._invoke("--node-count", "2")
 
         assert result.exit_code == 0, result.output
         payload = json.loads(result.stdout)
@@ -296,7 +301,7 @@ class TestWorkstationJsonOutput:
         mock_get_remote_team.return_value = None
         mock_push.return_value = self.PUSH_RESPONSE
 
-        result = self._invoke(CliRunner())
+        result = self._invoke()
 
         assert result.exit_code == 0, result.output
         # stdout parses as a single JSON document, nothing else interleaved.
@@ -314,7 +319,7 @@ class TestWorkstationJsonOutput:
         mock_get_remote_team.return_value = None
         mock_push.return_value = self.PUSH_RESPONSE
 
-        result = self._invoke(CliRunner())
+        result = self._invoke()
 
         assert result.exit_code == 0, result.output
         # Otherwise 4xx messages land on stdout and corrupt the JSON stream.
@@ -330,7 +335,7 @@ class TestWorkstationJsonOutput:
         mock_get_remote_team.return_value = None
         mock_push.side_effect = RuntimeError("no capacity")
 
-        result = self._invoke(CliRunner())
+        result = self._invoke()
 
         assert result.exit_code == 1
         assert json.loads(result.stdout) == {"error": {"message": "no capacity"}}

--- a/truss/tests/trt_llm/test_trt_llm_config.py
+++ b/truss/tests/trt_llm/test_trt_llm_config.py
@@ -96,6 +96,55 @@ def test_trt_llm_config_init_with_lora(trtllm_config):
         print(build_config2.lora_adapters)
 
 
+def test_trt_llm_lora_cache_runtime_configuration():
+    runtime_config = TrussTRTLLMRuntimeConfiguration(
+        lora_cache_max_adapter_size=128,
+        lora_cache_optimal_adapter_size=16,
+        lora_cache_gpu_memory_fraction=0.2,
+        lora_cache_host_memory_bytes=20 * 1024**3,
+    )
+
+    assert runtime_config.model_dump(exclude_unset=True) == {
+        "lora_cache_max_adapter_size": 128,
+        "lora_cache_optimal_adapter_size": 16,
+        "lora_cache_gpu_memory_fraction": 0.2,
+        "lora_cache_host_memory_bytes": 20 * 1024**3,
+    }
+
+
+@pytest.mark.parametrize(
+    "runtime_config",
+    [
+        {"lora_cache_max_adapter_size": 0},
+        {"lora_cache_optimal_adapter_size": 0},
+        {"lora_cache_gpu_memory_fraction": 0},
+        {"lora_cache_gpu_memory_fraction": 1.1},
+        {"lora_cache_host_memory_bytes": 0},
+        {"lora_cache_max_adapter_size": 8, "lora_cache_optimal_adapter_size": 16},
+    ],
+)
+def test_trt_llm_lora_cache_runtime_configuration_validation(runtime_config):
+    with pytest.raises(pydantic.ValidationError):
+        TrussTRTLLMRuntimeConfiguration(**runtime_config)
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "lora_cache_max_adapter_size",
+        "lora_cache_optimal_adapter_size",
+        "lora_cache_gpu_memory_fraction",
+        "lora_cache_host_memory_bytes",
+    ],
+)
+def test_trt_llm_lora_cache_configuration_rejects_build_fields(field):
+    with pytest.raises(
+        pydantic.ValidationError,
+        match=f"{field} must be configured under trt_llm.runtime",
+    ):
+        TrussTRTLLMBuildConfiguration(**{field: 1})
+
+
 def test_trt_llm_configuration_init_and_migrate_deprecated_runtime_fields(
     deprecated_trtllm_config,
 ):


### PR DESCRIPTION
## :rocket: What

Expose the TRT-LLM LoRA cache sizing and memory controls in `trt_llm.runtime`:

- `lora_cache_max_adapter_size`
- `lora_cache_optimal_adapter_size`
- `lora_cache_gpu_memory_fraction`
- `lora_cache_host_memory_bytes`

This makes the cache capacity configurable instead of leaving Briton on its built-in defaults.

## :computer: How

- Add typed, optional runtime fields with positive/range validation.
- Validate that the optimal adapter size does not exceed the maximum adapter size when both are configured.
- Fail with a targeted error when these runtime-only fields are placed under `trt_llm.build`, which was the configuration shape in the reported failure.

## :microscope: Testing

- `uv run ruff check truss/base/trt_llm_config.py truss/tests/trt_llm/test_trt_llm_config.py`
- `uv run ruff format --check truss/base/trt_llm_config.py truss/tests/trt_llm/test_trt_llm_config.py`
- `uv run pytest truss/tests/trt_llm/test_trt_llm_config.py -q` (24 passed, 1 skipped)
