### PR TITLE
Use relative references for BDN volume mounts

### DIFF
--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -579,9 +579,9 @@ class Weights(pydantic.RootModel[list[WeightsSource]]):
         return self
 
 
-_BDN_PREFIX = "bdn://"
+_BDN_PREFIX = "bdn:"
 _BDN_VOLUME_SOURCE_REGEX = re.compile(
-    r"bdn://(?P<namespace>[^/:@\x00]+)/(?P<volume>[^/:@\x00]+)"
+    r"bdn:(?P<namespace>[^/:@\x00]+)/(?P<volume>[^/:@\x00]+)"
     r"(?::(?P<tag>[^/:@\x00]+)|@(?:b3:)?(?P<digest>[0-9a-fA-F]+))?"
 )
 _MIN_BDN_DIGEST_PREFIX_LENGTH = 12
@@ -615,7 +615,7 @@ def _normalize_bdn_mount_path(value: str) -> str:
 class BDNVolumeMount(custom_types.ConfigModel):
     """An existing BDN volume mounted into a model container.
 
-    BDN vocabulary, read off a reference like `bdn://weights/llama-8b:prod`:
+    BDN vocabulary, read off a reference like `bdn:weights/llama-8b:prod`:
 
     - A *namespace* (`weights`) groups volumes within your organization, and is
       the unit that access grants and storage are scoped to. Names are
@@ -630,14 +630,14 @@ class BDNVolumeMount(custom_types.ConfigModel):
     ```
     bdn:
       mounts:
-        - source: bdn://weights/llama-8b:prod
+        - source: bdn:weights/llama-8b:prod
           path: /models/llama
     ```
     """
 
     source: Annotated[str, pydantic.StringConstraints(min_length=1)] = pydantic.Field(
         ...,
-        description="BDN volume reference to mount (for example, bdn://weights/llama-8b:prod).",
+        description="BDN volume reference to mount (for example, bdn:weights/llama-8b:prod).",
     )
     path: Annotated[str, pydantic.StringConstraints(min_length=1)] = pydantic.Field(
         ..., description="Absolute path where the volume will be mounted at runtime."
@@ -647,13 +647,13 @@ class BDNVolumeMount(custom_types.ConfigModel):
     @classmethod
     def _validate_source(cls, value: str) -> str:
         if not value.startswith(_BDN_PREFIX):
-            raise ValueError(f"Volume source must use the bdn:// scheme, got: {value}")
+            raise ValueError(f"Volume source must use the bdn: scheme, got: {value}")
 
         match = _BDN_VOLUME_SOURCE_REGEX.fullmatch(value)
         if match is None:
             raise ValueError(
                 f"Invalid BDN volume source: '{value}'. "
-                "Expected format: bdn://namespace/volume[:tag|@digest]"
+                "Expected format: bdn:namespace/volume[:tag|@digest]"
             )
 
         _validate_bdn_identifier("namespace", match.group("namespace"))

--- a/truss/config.schema.json
+++ b/truss/config.schema.json
@@ -64,10 +64,10 @@
     },
     "BDNVolumeMount": {
       "additionalProperties": true,
-      "description": "An existing BDN volume mounted into a model container.\n\nBDN vocabulary, read off a reference like `bdn://weights/llama-8b:prod`:\n\n- A *namespace* (`weights`) groups volumes within your organization, and is\n  the unit that access grants and storage are scoped to. Names are\n  lowercase alphanumeric plus hyphens, at least two characters, and may not\n  begin with a digit; `namespaces` and `resolve` are reserved.\n- A *volume* (`llama-8b`) is one versioned collection of files. Every\n  published version is immutable and identified by its content digest.\n- A *tag* (`prod`) is a mutable, case-sensitive name pointing at one\n  version, repointed as newer versions are published. A reference carrying\n  neither tag nor digest resolves to the volume's head, its latest version.\n\n```\nbdn:\n  mounts:\n    - source: bdn://weights/llama-8b:prod\n      path: /models/llama\n```",
+      "description": "An existing BDN volume mounted into a model container.\n\nBDN vocabulary, read off a reference like `bdn:weights/llama-8b:prod`:\n\n- A *namespace* (`weights`) groups volumes within your organization, and is\n  the unit that access grants and storage are scoped to. Names are\n  lowercase alphanumeric plus hyphens, at least two characters, and may not\n  begin with a digit; `namespaces` and `resolve` are reserved.\n- A *volume* (`llama-8b`) is one versioned collection of files. Every\n  published version is immutable and identified by its content digest.\n- A *tag* (`prod`) is a mutable, case-sensitive name pointing at one\n  version, repointed as newer versions are published. A reference carrying\n  neither tag nor digest resolves to the volume's head, its latest version.\n\n```\nbdn:\n  mounts:\n    - source: bdn:weights/llama-8b:prod\n      path: /models/llama\n```",
       "properties": {
         "source": {
-          "description": "BDN volume reference to mount (for example, bdn://weights/llama-8b:prod).",
+          "description": "BDN volume reference to mount (for example, bdn:weights/llama-8b:prod).",
           "minLength": 1,
           "title": "Source",
           "type": "string"

--- a/truss/tests/test_config.py
+++ b/truss/tests/test_config.py
@@ -2030,7 +2030,7 @@ class TestTrussConfigVolumeMounts:
         yaml_content = """
         bdn:
           mounts:
-            - source: bdn://weights/some-model:mytag
+            - source: bdn:weights/some-model:mytag
               path: /models/some-model
         """
         config_path = tmp_path / "config.yaml"
@@ -2040,7 +2040,7 @@ class TestTrussConfigVolumeMounts:
 
         assert config.bdn.mounts == [
             BDNVolumeMount(
-                source="bdn://weights/some-model:mytag", path="/models/some-model"
+                source="bdn:weights/some-model:mytag", path="/models/some-model"
             )
         ]
 
@@ -2049,8 +2049,7 @@ class TestTrussConfigVolumeMounts:
             bdn=BDNConfig(
                 mounts=[
                     BDNVolumeMount(
-                        source="bdn://weights/some-model:mytag",
-                        path="/models/some-model",
+                        source="bdn:weights/some-model:mytag", path="/models/some-model"
                     )
                 ]
             )
@@ -2061,10 +2060,7 @@ class TestTrussConfigVolumeMounts:
         serialized = yaml.safe_load(config_path.read_text())
         assert serialized["bdn"] == {
             "mounts": [
-                {
-                    "source": "bdn://weights/some-model:mytag",
-                    "path": "/models/some-model",
-                }
+                {"source": "bdn:weights/some-model:mytag", "path": "/models/some-model"}
             ]
         }
         parsed_config = TrussConfig.from_yaml(config_path)
@@ -2075,18 +2071,20 @@ class TestTrussConfigVolumeMounts:
         [
             "weights/llama:prod",
             "ftp://weights/llama",
-            "bdn://foo",
-            "bdn:///llama:prod",
-            "bdn://weights/:prod",
-            "bdn://weights/llama:",
-            "bdn://weights/models/llama:prod",
-            "bdn://weights/llama:prod:extra",
-            "bdn://weights/llama@not-a-digest",
-            "bdn://weights/llama@abcdef01234",
-            "bdn://weights/llama@b3:abcdef01234",
-            f"bdn://weights/llama@{'a' * 65}",
-            f"bdn://weights/llama@b3:{'a' * 65}",
-            "bdn://weights/llama@b3:",
+            "bdn://weights/llama:prod",
+            "bdn:foo",
+            "bdn:/llama:prod",
+            "bdn:weights/:prod",
+            "bdn:weights/llama:",
+            "bdn:weights/models/llama:prod",
+            "bdn:weights/llama:prod:extra",
+            "bdn:weights/llama@not-a-digest",
+            "bdn:weights/llama@abcdef01234",
+            "bdn:weights/llama@b3:abcdef01234",
+            f"bdn:weights/llama@{'a' * 65}",
+            f"bdn:weights/llama@b3:{'a' * 65}",
+            "bdn:weights/llama@b3:",
+            "bdn:weights/llama@abcdef012345:prod",
         ],
     )
     def test_volume_source_rejects_invalid_reference(self, source):
@@ -2096,11 +2094,11 @@ class TestTrussConfigVolumeMounts:
     @pytest.mark.parametrize(
         "source",
         [
-            "bdn://weights/llama",
-            "bdn://weights/llama:prod",
-            "bdn://weights/llama@abcdef012345",
-            "bdn://weights/llama@b3:ABCDEF012345",
-            f"bdn://weights/llama@{'a' * 64}",
+            "bdn:weights/llama",
+            "bdn:weights/llama:prod",
+            "bdn:weights/llama@abcdef012345",
+            "bdn:weights/llama@b3:ABCDEF012345",
+            f"bdn:weights/llama@{'a' * 64}",
         ],
     )
     def test_volume_source_accepts_supported_references(self, source):
@@ -2110,11 +2108,11 @@ class TestTrussConfigVolumeMounts:
 
     def test_volume_mount_requires_absolute_path(self):
         with pytest.raises(pydantic.ValidationError, match="absolute path"):
-            BDNVolumeMount(source="bdn://weights/llama:prod", path="models/llama")
+            BDNVolumeMount(source="bdn:weights/llama:prod", path="models/llama")
 
     def test_volume_mount_normalizes_path(self):
         volume_mount = BDNVolumeMount(
-            source="bdn://weights/llama:prod", path="/models/./llama/"
+            source="bdn:weights/llama:prod", path="/models/./llama/"
         )
 
         assert volume_mount.path == "/models/llama"
@@ -2125,10 +2123,8 @@ class TestTrussConfigVolumeMounts:
         ):
             BDNConfig(
                 mounts=[
-                    BDNVolumeMount(source="bdn://weights/llama:prod", path="/models"),
-                    BDNVolumeMount(
-                        source="bdn://weights/mistral:prod", path="/models/"
-                    ),
+                    BDNVolumeMount(source="bdn:weights/llama:prod", path="/models"),
+                    BDNVolumeMount(source="bdn:weights/mistral:prod", path="/models/"),
                 ]
             )
 
@@ -2146,9 +2142,7 @@ class TestTrussConfigVolumeMounts:
         ],
     )
     def test_volume_mount_rejects_external_source(self, source):
-        with pytest.raises(
-            pydantic.ValidationError, match="must use the bdn:// scheme"
-        ):
+        with pytest.raises(pydantic.ValidationError, match="must use the bdn: scheme"):
             BDNVolumeMount(source=source, path="/models/external")
 
 


### PR DESCRIPTION
## Summary

- switch BDN volume mount sources from `bdn://namespace/volume` to the canonical relative `bdn:namespace/volume` form
- preserve head, tag, and digest selectors
- reject the legacy `bdn://` form
- update the generated configuration schema and validation tests

## Testing

- `uv run pytest truss/tests/test_config.py -q` (278 passed)
- `uv run ruff check truss/base/truss_config.py truss/tests/test_config.py`
- `uv run ruff format --check truss/base/truss_config.py truss/tests/test_config.py`
- `uv run mypy truss/base/truss_config.py truss/tests/test_config.py`
- `uv run bin/generate_truss_config_schema.py --check`
