### PR TITLE
fix(performance-client): allow opting out of global tracing initialization

### DIFF
--- a/baseten-performance-client/README.md
+++ b/baseten-performance-client/README.md
@@ -26,6 +26,11 @@ cargo add baseten_performance_client_core
 ```
 
 
+The Rust core enables `auto-init-tracing` by default. Applications that install
+their own tracing subscriber should use `default-features = false` and enable
+`rustls` (or `native-tls`) explicitly. This disables automatic subscriber setup
+and logging environment-variable changes; client tracing events remain enabled.
+
 ## Usage
 
 ### Python

--- a/baseten-performance-client/core/Cargo.toml
+++ b/baseten-performance-client/core/Cargo.toml
@@ -28,7 +28,8 @@ ctor = { workspace = true }
 nonempty = { workspace = true }
 
 [features]
-default = ["rustls"]
+default = ["rustls", "auto-init-tracing"]
+auto-init-tracing = []
 native-tls = ["reqwest/default-tls", "reqwest/native-tls-alpn", "dep:openssl"]
 rustls = ["reqwest/rustls-tls", "reqwest/rustls-tls-webpki-roots"]
 

--- a/baseten-performance-client/core/src/lib.rs
+++ b/baseten-performance-client/core/src/lib.rs
@@ -25,6 +25,7 @@ pub use utils::*;
 
 /// Initialize tracing with default WARN level
 /// This is called automatically when the library is loaded
+#[cfg(feature = "auto-init-tracing")]
 #[ctor::ctor]
 fn init_tracing() {
     // Check for PERFORMANCE_CLIENT_LOG_LEVEL first (highest priority)

--- a/baseten-performance-client/core/tests/tracing_initialization.rs
+++ b/baseten-performance-client/core/tests/tracing_initialization.rs
@@ -1,0 +1,11 @@
+use baseten_performance_client_core::PerformanceClientCore;
+
+#[test]
+fn global_tracing_initialization_follows_feature() {
+    assert_eq!(
+        PerformanceClientCore::get_api_key(Some("test".into())).unwrap(),
+        "test"
+    );
+    let result = tracing::subscriber::set_global_default(tracing_subscriber::registry());
+    assert_eq!(result.is_err(), cfg!(feature = "auto-init-tracing"));
+}


### PR DESCRIPTION
## Summary
Add a default-enabled auto-init-tracing feature around the Rust core tracing constructor. Embedders can disable default features and select rustls or native-tls without installing a global subscriber or changing logging environment variables. Existing default behavior is unchanged.

This unblocks embedding the core in Dynamo, whose logging/OTel initialization must own the global subscriber.

## Validation
- cargo fmt check
- tracing_initialization integration test with default features
- same test with --no-default-features --features rustls

No changelog changes. A crate release is needed before Dynamo can consume this fix from crates.io.