### PR TITLE
Add BDN access and hotload configuration under BND section

### DIFF
--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -686,6 +686,7 @@ class BDNAccessGrant(str, enum.Enum):
     PUSH = "push"
     TAG = "tag"
     INSPECT = "inspect"
+    DELETE = "delete"
 
 
 class BDNAccess(custom_types.ConfigModel):

--- a/truss/base/truss_config.py
+++ b/truss/base/truss_config.py
@@ -679,12 +679,63 @@ class BDNVolumeMount(custom_types.ConfigModel):
         return _normalize_bdn_mount_path(value)
 
 
+class BDNAccessGrant(str, enum.Enum):
+    """An operation a deployment may perform in a BDN namespace."""
+
+    PULL = "pull"
+    PUSH = "push"
+    TAG = "tag"
+    INSPECT = "inspect"
+
+
+class BDNAccess(custom_types.ConfigModel):
+    """Access grants for a BDN namespace."""
+
+    namespace: Annotated[str, pydantic.StringConstraints(min_length=1)] = (
+        pydantic.Field(..., description="BDN namespace to grant access to.")
+    )
+    grants: list[BDNAccessGrant] = pydantic.Field(
+        ..., min_length=1, description="Operations granted in this namespace."
+    )
+
+    @pydantic.field_validator("namespace")
+    @classmethod
+    def _validate_namespace(cls, namespace: str) -> str:
+        _validate_bdn_identifier("namespace", namespace)
+        return namespace
+
+    @pydantic.field_validator("grants")
+    @classmethod
+    def _validate_unique_grants(
+        cls, grants: list[BDNAccessGrant]
+    ) -> list[BDNAccessGrant]:
+        if len(grants) != len(set(grants)):
+            raise ValueError("BDN access grants must be unique within a namespace")
+        return grants
+
+
+class BDNHotload(custom_types.ConfigModel):
+    """Configuration for loading BDN data while a deployment is running."""
+
+    enabled: bool = pydantic.Field(
+        default=False, description="If true, enables BDN hot-loading."
+    )
+
+
 class BDNConfig(custom_types.ConfigModel):
-    """Configuration for mounting BDN volumes."""
+    """Configuration for BDN mounts, access grants, and hot-loading."""
 
     mounts: list[BDNVolumeMount] = pydantic.Field(
         default_factory=list,
         description="Existing BDN volumes to mount when the model starts.",
+    )
+    access: list[BDNAccess] = pydantic.Field(
+        default_factory=list,
+        description="Namespace-level BDN access grants for the deployment.",
+    )
+    hotload: BDNHotload = pydantic.Field(
+        default_factory=BDNHotload,
+        description="Configure loading BDN data while the deployment is running.",
     )
 
     @pydantic.field_validator("mounts")
@@ -701,6 +752,16 @@ class BDNConfig(custom_types.ConfigModel):
                 )
             mount_paths.add(volume_mount.path)
         return mounts
+
+    @pydantic.field_validator("access")
+    @classmethod
+    def _validate_unique_access_namespaces(
+        cls, access: list[BDNAccess]
+    ) -> list[BDNAccess]:
+        namespaces = [entry.namespace for entry in access]
+        if len(namespaces) != len(set(namespaces)):
+            raise ValueError("BDN access namespaces must be unique")
+        return access
 
 
 class AutoscalingMetric(pydantic.BaseModel):
@@ -1518,7 +1579,8 @@ class TrussConfig(custom_types.ConfigModel):
         description="Configure Baseten Delivery Network (BDN) for model weight delivery with multi-tier caching.",
     )
     bdn: BDNConfig = pydantic.Field(
-        default_factory=BDNConfig, description="Configure BDN volume mounts."
+        default_factory=BDNConfig,
+        description="Configure BDN volume mounts, access grants, and hot-loading.",
     )
     trt_llm: Optional[trt_llm_config.TRTLLMConfiguration] = pydantic.Field(
         default=None,

--- a/truss/config.schema.json
+++ b/truss/config.schema.json
@@ -79,7 +79,8 @@
         "pull",
         "push",
         "tag",
-        "inspect"
+        "inspect",
+        "delete"
       ],
       "title": "BDNAccessGrant",
       "type": "string"

--- a/truss/config.schema.json
+++ b/truss/config.schema.json
@@ -46,9 +46,47 @@
       "title": "AutoscalingMetric",
       "type": "object"
     },
+    "BDNAccess": {
+      "additionalProperties": true,
+      "description": "Access grants for a BDN namespace.",
+      "properties": {
+        "namespace": {
+          "description": "BDN namespace to grant access to.",
+          "minLength": 1,
+          "title": "Namespace",
+          "type": "string"
+        },
+        "grants": {
+          "description": "Operations granted in this namespace.",
+          "items": {
+            "$ref": "#/$defs/BDNAccessGrant"
+          },
+          "minItems": 1,
+          "title": "Grants",
+          "type": "array"
+        }
+      },
+      "required": [
+        "namespace",
+        "grants"
+      ],
+      "title": "BDNAccess",
+      "type": "object"
+    },
+    "BDNAccessGrant": {
+      "description": "An operation a deployment may perform in a BDN namespace.",
+      "enum": [
+        "pull",
+        "push",
+        "tag",
+        "inspect"
+      ],
+      "title": "BDNAccessGrant",
+      "type": "string"
+    },
     "BDNConfig": {
       "additionalProperties": true,
-      "description": "Configuration for mounting BDN volumes.",
+      "description": "Configuration for BDN mounts, access grants, and hot-loading.",
       "properties": {
         "mounts": {
           "description": "Existing BDN volumes to mount when the model starts.",
@@ -57,9 +95,35 @@
           },
           "title": "Mounts",
           "type": "array"
+        },
+        "access": {
+          "description": "Namespace-level BDN access grants for the deployment.",
+          "items": {
+            "$ref": "#/$defs/BDNAccess"
+          },
+          "title": "Access",
+          "type": "array"
+        },
+        "hotload": {
+          "$ref": "#/$defs/BDNHotload",
+          "description": "Configure loading BDN data while the deployment is running."
         }
       },
       "title": "BDNConfig",
+      "type": "object"
+    },
+    "BDNHotload": {
+      "additionalProperties": true,
+      "description": "Configuration for loading BDN data while a deployment is running.",
+      "properties": {
+        "enabled": {
+          "default": false,
+          "description": "If true, enables BDN hot-loading.",
+          "title": "Enabled",
+          "type": "boolean"
+        }
+      },
+      "title": "BDNHotload",
       "type": "object"
     },
     "BDNVolumeMount": {
@@ -2362,7 +2426,7 @@
     },
     "bdn": {
       "$ref": "#/$defs/BDNConfig",
-      "description": "Configure BDN volume mounts."
+      "description": "Configure BDN volume mounts, access grants, and hot-loading."
     },
     "trt_llm": {
       "anyOf": [

--- a/truss/tests/test_config.py
+++ b/truss/tests/test_config.py
@@ -2039,7 +2039,7 @@ class TestTrussConfigVolumeMounts:
             - namespace: weights
               grants: [pull]
             - namespace: checkpoints
-              grants: [pull, push, tag, inspect]
+              grants: [pull, push, tag, inspect, delete]
           hotload:
             enabled: true
         """
@@ -2062,6 +2062,7 @@ class TestTrussConfigVolumeMounts:
                     BDNAccessGrant.PUSH,
                     BDNAccessGrant.TAG,
                     BDNAccessGrant.INSPECT,
+                    BDNAccessGrant.DELETE,
                 ],
             ),
         ]
@@ -2166,7 +2167,7 @@ class TestTrussConfigVolumeMounts:
 
         assert access.grants == [grant]
 
-    @pytest.mark.parametrize("grant", ["admin", "delete", "tags", "write"])
+    @pytest.mark.parametrize("grant", ["admin", "tags", "write"])
     def test_bdn_access_rejects_unknown_grants(self, grant):
         with pytest.raises(pydantic.ValidationError):
             BDNAccess(namespace="weights", grants=[grant])

--- a/truss/tests/test_config.py
+++ b/truss/tests/test_config.py
@@ -15,7 +15,10 @@ from truss.base.truss_config import (
     Accelerator,
     AcceleratorSpec,
     BaseImage,
+    BDNAccess,
+    BDNAccessGrant,
     BDNConfig,
+    BDNHotload,
     BDNVolumeMount,
     Build,
     CacheInternal,
@@ -2026,12 +2029,19 @@ class TestTrussConfigWeights:
 
 
 class TestTrussConfigVolumeMounts:
-    def test_bdn_mounts_from_yaml(self, tmp_path):
+    def test_bdn_from_yaml(self, tmp_path):
         yaml_content = """
         bdn:
           mounts:
             - source: bdn:weights/some-model:mytag
               path: /models/some-model
+          access:
+            - namespace: weights
+              grants: [pull]
+            - namespace: checkpoints
+              grants: [pull, push, tag, inspect]
+          hotload:
+            enabled: true
         """
         config_path = tmp_path / "config.yaml"
         config_path.write_text(yaml_content)
@@ -2043,15 +2053,35 @@ class TestTrussConfigVolumeMounts:
                 source="bdn:weights/some-model:mytag", path="/models/some-model"
             )
         ]
+        assert config.bdn.access == [
+            BDNAccess(namespace="weights", grants=[BDNAccessGrant.PULL]),
+            BDNAccess(
+                namespace="checkpoints",
+                grants=[
+                    BDNAccessGrant.PULL,
+                    BDNAccessGrant.PUSH,
+                    BDNAccessGrant.TAG,
+                    BDNAccessGrant.INSPECT,
+                ],
+            ),
+        ]
+        assert config.bdn.hotload == BDNHotload(enabled=True)
 
-    def test_bdn_mounts_serialization_roundtrip(self, tmp_path):
+    def test_bdn_serialization_roundtrip(self, tmp_path):
         config = TrussConfig(
             bdn=BDNConfig(
                 mounts=[
                     BDNVolumeMount(
                         source="bdn:weights/some-model:mytag", path="/models/some-model"
                     )
-                ]
+                ],
+                access=[
+                    BDNAccess(
+                        namespace="checkpoints",
+                        grants=[BDNAccessGrant.PULL, BDNAccessGrant.PUSH],
+                    )
+                ],
+                hotload=BDNHotload(enabled=True),
             )
         )
         config_path = tmp_path / "config.yaml"
@@ -2061,7 +2091,9 @@ class TestTrussConfigVolumeMounts:
         assert serialized["bdn"] == {
             "mounts": [
                 {"source": "bdn:weights/some-model:mytag", "path": "/models/some-model"}
-            ]
+            ],
+            "access": [{"namespace": "checkpoints", "grants": ["pull", "push"]}],
+            "hotload": {"enabled": True},
         }
         parsed_config = TrussConfig.from_yaml(config_path)
         assert parsed_config.bdn == config.bdn
@@ -2127,6 +2159,37 @@ class TestTrussConfigVolumeMounts:
                     BDNVolumeMount(source="bdn:weights/mistral:prod", path="/models/"),
                 ]
             )
+
+    @pytest.mark.parametrize("grant", list(BDNAccessGrant))
+    def test_bdn_access_accepts_supported_grants(self, grant):
+        access = BDNAccess(namespace="weights", grants=[grant.value])
+
+        assert access.grants == [grant]
+
+    @pytest.mark.parametrize("grant", ["admin", "delete", "tags", "write"])
+    def test_bdn_access_rejects_unknown_grants(self, grant):
+        with pytest.raises(pydantic.ValidationError):
+            BDNAccess(namespace="weights", grants=[grant])
+
+    def test_bdn_access_requires_grants(self):
+        with pytest.raises(pydantic.ValidationError):
+            BDNAccess(namespace="weights", grants=[])
+
+    def test_bdn_access_grants_must_be_unique(self):
+        with pytest.raises(pydantic.ValidationError, match="grants must be unique"):
+            BDNAccess(namespace="weights", grants=["pull", "pull"])
+
+    def test_bdn_access_namespaces_must_be_unique(self):
+        with pytest.raises(pydantic.ValidationError, match="namespaces must be unique"):
+            BDNConfig(
+                access=[
+                    BDNAccess(namespace="weights", grants=["pull"]),
+                    BDNAccess(namespace="weights", grants=["inspect"]),
+                ]
+            )
+
+    def test_bdn_hotload_defaults_to_disabled(self):
+        assert BDNConfig().hotload.enabled is False
 
     @pytest.mark.parametrize(
         "source",


### PR DESCRIPTION
## Summary

Add configuration support for namespace-level BDN access grants and hot-loading.

Example:

```yaml
bdn:
  mounts:
    - source: bdn:weights/llama-8b:prod
      path: /models/llama
  access:
    - namespace: weights
      grants: [pull]
    - namespace: checkpoints
      grants: [pull, push, tag, inspect]
  hotload:
    enabled: true
Changes
- Add bdn.access entries with a namespace and one or more grants.
- Support pull, push, tag, and inspect grants.
- Add bdn.hotload.enabled, defaulting to false.
- Validate duplicate namespaces and grants.
- Update the generated configuration schema.
- Add parsing, validation, and serialization coverage.
Testing
- uv run ruff check truss/base/truss_config.py truss/tests/test_config.py
- uv run pytest truss/tests/test_config.py -v
- uv run bin/generate_truss_config_schema.py --check
All 290 configuration tests pass.
