### PR TITLE
Remove transfer command from BEI startup

### DIFF
--- a/truss/contexts/image_builder/serving_image_builder.py
+++ b/truss/contexts/image_builder/serving_image_builder.py
@@ -584,7 +584,7 @@ class ServingImageBuilder(ImageBuilder):
         port = 7997
         start_command = " ".join(
             [
-                "truss-transfer-cli && text-embeddings-router",
+                "text-embeddings-router",
                 f"--port {port}",
                 # assert the max_batch_size is within trt-engine limits
                 f"--max-batch-requests {runtime_max_batch_size}",
@@ -631,7 +631,7 @@ class ServingImageBuilder(ImageBuilder):
         port = 7997
         start_command = " ".join(
             [
-                "truss-transfer-cli /tmp/bei-model && text-embeddings-router --model-id /tmp/bei-model",
+                "text-embeddings-router --model-id /tmp/bei-model",
                 f"--port {port}",
                 # assert the max_batch_size is within trt-engine limits
                 f"--max-batch-requests {runtime_max_batch_size}",


### PR DESCRIPTION
## Summary
- start BEI directly with `text-embeddings-router`
- start BEI-BERT directly with its existing `/tmp/bei-model` model ID
- remove the no-longer-needed `truss-transfer-cli` startup step

## Testing
- `uv run ruff check truss/contexts/image_builder/serving_image_builder.py`
- `uv run ruff format truss/contexts/image_builder/serving_image_builder.py`